### PR TITLE
feat(ui): WS5-B · nav chrome, useIpcQuery, allowlist +4

### DIFF
--- a/packages/ui/src-tauri/src/gateway_bridge.rs
+++ b/packages/ui/src-tauri/src/gateway_bridge.rs
@@ -14,12 +14,18 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::time::sleep;
 
 pub const ALLOWED_METHODS: &[&str] = &[
+    // Sub-project A
     "diag.snapshot",
     "connector.list",
     "connector.startAuth",
     "engine.askStream",
     "db.getMeta",
     "db.setMeta",
+    // Sub-project B additions
+    "connector.listStatus",
+    "index.metrics",
+    "audit.list",
+    "consent.respond",
 ];
 
 pub fn is_method_allowed(method: &str) -> bool {
@@ -197,7 +203,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn allowlist_contains_expected_methods() {
+    fn allowlist_ws5a_methods() {
         assert!(is_method_allowed("diag.snapshot"));
         assert!(is_method_allowed("connector.list"));
         assert!(is_method_allowed("connector.startAuth"));
@@ -207,11 +213,28 @@ mod tests {
     }
 
     #[test]
-    fn allowlist_rejects_sensitive_methods() {
+    fn allowlist_ws5b_additions() {
+        assert!(is_method_allowed("connector.listStatus"));
+        assert!(is_method_allowed("index.metrics"));
+        assert!(is_method_allowed("audit.list"));
+        assert!(is_method_allowed("consent.respond"));
+    }
+
+    #[test]
+    fn allowlist_rejects_vault_and_raw_db_writes() {
         assert!(!is_method_allowed("vault.get"));
         assert!(!is_method_allowed("vault.set"));
-        assert!(!is_method_allowed("db.query"));
-        assert!(!is_method_allowed("engine.ask"));
+        assert!(!is_method_allowed("vault.list"));
+        assert!(!is_method_allowed("db.put"));
+        assert!(!is_method_allowed("db.delete"));
+        assert!(!is_method_allowed("config.set"));
+        assert!(!is_method_allowed("index.rebuild"));
+    }
+
+    #[test]
+    fn allowlist_exact_size() {
+        // Prevents accidental additions without an updated test.
+        assert_eq!(ALLOWED_METHODS.len(), 10);
     }
 
     #[test]

--- a/packages/ui/src/components/chrome/NavItem.tsx
+++ b/packages/ui/src/components/chrome/NavItem.tsx
@@ -5,7 +5,7 @@ interface NavItemProps {
   to: string;
   icon: string;
   label: string;
-  badge?: number;
+  badge?: number | undefined;
 }
 
 function formatBadge(n: number): string {

--- a/packages/ui/src/components/chrome/NavItem.tsx
+++ b/packages/ui/src/components/chrome/NavItem.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { NavLink } from "react-router-dom";
+
+interface NavItemProps {
+  to: string;
+  icon: string;
+  label: string;
+  badge?: number;
+}
+
+function formatBadge(n: number): string {
+  return n > 9 ? "9+" : String(n);
+}
+
+export function NavItem({ to, icon, label, badge }: NavItemProps): ReactNode {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `flex items-center gap-2 px-3 h-[44px] text-sm text-[var(--color-fg-muted)] hover:bg-white/5 ${
+          isActive
+            ? "bg-[rgba(120,144,255,0.15)] text-[var(--color-fg)] border-l-2 border-[var(--color-accent)]"
+            : ""
+        }`
+      }
+      end={to === "/"}
+    >
+      <span aria-hidden="true" className="w-4 text-center">
+        {icon}
+      </span>
+      <span className="flex-1">{label}</span>
+      {badge !== undefined && badge > 0 && (
+        <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 rounded-full bg-[var(--color-accent)] text-white text-[10px]">
+          {formatBadge(badge)}
+        </span>
+      )}
+    </NavLink>
+  );
+}

--- a/packages/ui/src/components/chrome/PageHeader.tsx
+++ b/packages/ui/src/components/chrome/PageHeader.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { useNimbusStore } from "../../store";
+import { ProfileHealthPill } from "./ProfileHealthPill";
+
+interface Props {
+  title: string;
+  profile?: string;
+}
+
+export function PageHeader({ title, profile = "default" }: Props): ReactNode {
+  const aggregateHealth = useNimbusStore((s) => s.trayIcon);
+  return (
+    <header className="flex items-center justify-between px-6 h-12 border-b border-[var(--color-border)]">
+      <h1 className="text-base font-medium text-[var(--color-fg)]">{title}</h1>
+      <ProfileHealthPill profile={profile} aggregateHealth={aggregateHealth} />
+    </header>
+  );
+}

--- a/packages/ui/src/components/chrome/ProfileHealthPill.tsx
+++ b/packages/ui/src/components/chrome/ProfileHealthPill.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  profile: string;
+  aggregateHealth: "normal" | "amber" | "red";
+}
+
+function dotColour(h: Props["aggregateHealth"]): string {
+  switch (h) {
+    case "normal":
+      return "bg-[var(--color-ok)]";
+    case "amber":
+      return "bg-[var(--color-amber)]";
+    case "red":
+      return "bg-[var(--color-error)]";
+  }
+}
+
+function statusText(h: Props["aggregateHealth"]): string {
+  if (h === "red") return "unavailable";
+  if (h === "amber") return "degraded";
+  return "all healthy";
+}
+
+export function ProfileHealthPill({ profile, aggregateHealth }: Props): ReactNode {
+  return (
+    <span className="inline-flex items-center gap-2 text-xs text-[var(--color-fg-muted)] bg-[var(--color-bg)] border border-[var(--color-border)] rounded-full px-3 py-1">
+      <span>{profile}</span>
+      <span>·</span>
+      <span
+        aria-hidden="true"
+        className={`inline-block w-2 h-2 rounded-full ${dotColour(aggregateHealth)}`}
+      />
+      <span>{statusText(aggregateHealth)}</span>
+    </span>
+  );
+}

--- a/packages/ui/src/components/chrome/Sidebar.tsx
+++ b/packages/ui/src/components/chrome/Sidebar.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+import { useNimbusStore } from "../../store";
+import { NavItem } from "./NavItem";
+
+const ENTRIES: ReadonlyArray<{ to: string; icon: string; label: string }> = [
+  { to: "/", icon: "▦", label: "Dashboard" },
+  { to: "/hitl", icon: "⚠", label: "HITL" },
+  { to: "/marketplace", icon: "⚙", label: "Marketplace" },
+  { to: "/watchers", icon: "👁", label: "Watchers" },
+  { to: "/workflows", icon: "▶", label: "Workflows" },
+  { to: "/settings", icon: "⚙", label: "Settings" },
+];
+
+export function Sidebar(): ReactNode {
+  const pendingHitl = useNimbusStore((s) => s.hitlBadgeCount);
+  return (
+    <nav
+      aria-label="Primary"
+      className="w-[150px] bg-[var(--color-bg)] border-r border-[var(--color-border)] py-2 flex flex-col"
+    >
+      {ENTRIES.map((e) => (
+        <NavItem
+          key={e.to}
+          to={e.to}
+          icon={e.icon}
+          label={e.label}
+          badge={e.to === "/hitl" ? pendingHitl : undefined}
+        />
+      ))}
+    </nav>
+  );
+}

--- a/packages/ui/src/hooks/useIpcQuery.ts
+++ b/packages/ui/src/hooks/useIpcQuery.ts
@@ -42,8 +42,10 @@ export function useIpcQuery<T>(
     } finally {
       if (gen === generationRef.current) setIsLoading(false);
     }
-    // paramsKey in deps so the ref identity changes with params shape
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Use the stringified key in deps so the callback identity tracks param
+    // shape changes — object identity of `params` alone would re-fire on every
+    // render even when the shape is stable.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: paramsKey proxies params
   }, [method, paramsKey]);
 
   useEffect(() => {

--- a/packages/ui/src/hooks/useIpcQuery.ts
+++ b/packages/ui/src/hooks/useIpcQuery.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createIpcClient } from "../ipc/client";
+import { useNimbusStore } from "../store";
+
+export interface UseIpcQueryResult<T> {
+  data: T | null;
+  error: string | null;
+  isLoading: boolean;
+  refetch: () => void;
+}
+
+interface Options {
+  enabled?: boolean;
+}
+
+export function useIpcQuery<T>(
+  method: string,
+  intervalMs: number,
+  params?: Record<string, unknown>,
+  opts: Options = {},
+): UseIpcQueryResult<T> {
+  const enabled = opts.enabled ?? true;
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const paramsKey = JSON.stringify(params ?? {});
+  const generationRef = useRef(0);
+  const connectionState = useNimbusStore((s) => s.connectionState);
+
+  const run = useCallback(async () => {
+    const gen = ++generationRef.current;
+    setIsLoading(true);
+    try {
+      const res = await createIpcClient().call<T>(method, params ?? {});
+      if (gen !== generationRef.current) return;
+      setData(res);
+      setError(null);
+    } catch (e) {
+      if (gen !== generationRef.current) return;
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (gen === generationRef.current) setIsLoading(false);
+    }
+    // paramsKey in deps so the ref identity changes with params shape
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [method, paramsKey]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (connectionState !== "connected") return;
+    if (document.visibilityState === "hidden") return;
+
+    void run();
+    const id = setInterval(() => {
+      if (document.visibilityState === "hidden") return;
+      if (connectionState !== "connected") return;
+      void run();
+    }, intervalMs);
+
+    const onVis = () => {
+      if (document.visibilityState === "visible") void run();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, [enabled, connectionState, intervalMs, run]);
+
+  return { data, error, isLoading, refetch: run };
+}

--- a/packages/ui/src/hooks/useIpcSubscription.ts
+++ b/packages/ui/src/hooks/useIpcSubscription.ts
@@ -1,0 +1,23 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useEffect } from "react";
+
+export function useIpcSubscription<T = unknown>(
+  event: string,
+  handler: (payload: T) => void,
+): void {
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
+    void listen<T>(event, (e) => handler(e.payload)).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [event, handler]);
+}

--- a/packages/ui/src/ipc/client.ts
+++ b/packages/ui/src/ipc/client.ts
@@ -1,8 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import {
+  type AuditEntry,
   type ConnectionState,
+  type ConnectorStatus,
   GatewayOfflineError,
+  type IndexMetrics,
   JsonRpcError,
   type JsonRpcErrorPayload,
   type JsonRpcNotification,
@@ -13,6 +16,10 @@ export interface NimbusIpcClient {
   call<TResult>(method: string, params?: unknown): Promise<TResult>;
   subscribe(handler: (n: JsonRpcNotification) => void): Promise<() => void>;
   onConnectionState(handler: (s: ConnectionState) => void): Promise<() => void>;
+  connectorListStatus(): Promise<ConnectorStatus[]>;
+  indexMetrics(): Promise<IndexMetrics>;
+  auditList(limit?: number): Promise<AuditEntry[]>;
+  consentRespond(requestId: string, approved: boolean): Promise<void>;
 }
 
 function parseError(err: unknown): Error {
@@ -59,6 +66,27 @@ export function createIpcClient(): NimbusIpcClient {
     },
     async onConnectionState(handler): Promise<() => void> {
       return listen<ConnectionState>("gateway://connection-state", (evt) => handler(evt.payload));
+    },
+    async connectorListStatus(): Promise<ConnectorStatus[]> {
+      const res = await this.call<unknown>("connector.listStatus", {});
+      if (!Array.isArray(res)) throw new Error("connector.listStatus: expected array");
+      return res as ConnectorStatus[];
+    },
+    async indexMetrics(): Promise<IndexMetrics> {
+      const res = await this.call<unknown>("index.metrics", {});
+      if (typeof res !== "object" || res === null)
+        throw new Error("index.metrics: expected object");
+      return res as IndexMetrics;
+    },
+    async auditList(limit = 25): Promise<AuditEntry[]> {
+      const res = await this.call<unknown>("audit.list", { limit });
+      if (!Array.isArray(res)) throw new Error("audit.list: expected array");
+      return res as AuditEntry[];
+    },
+    async consentRespond(requestId: string, approved: boolean): Promise<void> {
+      await this.call<unknown>("consent.respond", { requestId, approved });
+      // Notify Rust to clear its inbox and fan `consent://resolved` out to all windows.
+      await invoke("hitl_resolved", { requestId, approved });
     },
   };
   singleton = client;

--- a/packages/ui/src/ipc/types.ts
+++ b/packages/ui/src/ipc/types.ts
@@ -49,3 +49,36 @@ export class JsonRpcError extends Error {
     this.name = "JsonRpcError";
   }
 }
+
+// ---- WS5-B additions ----
+
+export type ConnectorStatus = {
+  name: string;
+  health: ConnectorHealth;
+  lastSyncAt?: string;
+  degradationReason?: string;
+  itemCount?: number;
+};
+
+export interface IndexMetrics {
+  itemsTotal: number;
+  embeddingCoveragePct: number;
+  queryP95Ms: number;
+  indexSizeBytes: number;
+}
+
+export interface AuditEntry {
+  id: number;
+  ts: string;
+  action: string;
+  outcome: "approved" | "rejected" | "auto" | "info";
+  subject?: string;
+  hitlRejectReason?: string;
+}
+
+export interface HitlRequest {
+  requestId: string;
+  prompt: string;
+  details?: Record<string, unknown>;
+  receivedAtMs: number;
+}

--- a/packages/ui/src/layouts/RootLayout.tsx
+++ b/packages/ui/src/layouts/RootLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from "react-router-dom";
+import { Sidebar } from "../components/chrome/Sidebar";
 import { GatewayOfflineBanner } from "../components/GatewayOfflineBanner";
 import { HotkeyFailedBanner } from "../components/HotkeyFailedBanner";
 import { useNimbusStore } from "../store";
@@ -7,11 +8,14 @@ export function RootLayout() {
   const connectionState = useNimbusStore((s) => s.connectionState);
   const offline = connectionState === "disconnected";
   return (
-    <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
+    <div className="h-screen flex flex-col">
       {offline && <GatewayOfflineBanner />}
       <HotkeyFailedBanner />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
-        <Outlet />
+      <div className="flex flex-1 min-h-0">
+        <Sidebar />
+        <main className="flex-1 overflow-auto">
+          <Outlet />
+        </main>
       </div>
     </div>
   );

--- a/packages/ui/test/components/chrome/PageHeader.test.tsx
+++ b/packages/ui/test/components/chrome/PageHeader.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/store", () => ({
+  useNimbusStore: (sel: (s: { trayIcon: "normal" | "amber" | "red" }) => unknown) =>
+    sel({ trayIcon: "normal" }),
+}));
+
+import { PageHeader } from "../../../src/components/chrome/PageHeader";
+
+describe("PageHeader", () => {
+  it("renders the title and profile name", () => {
+    render(<PageHeader title="Dashboard" profile="work" />);
+    expect(screen.getByRole("heading", { level: 1, name: /Dashboard/ })).toBeInTheDocument();
+    expect(screen.getByText(/work/)).toBeInTheDocument();
+  });
+
+  it("shows 'all healthy' when aggregate is normal", () => {
+    render(<PageHeader title="Dashboard" profile="work" />);
+    expect(screen.getByText(/all healthy/i)).toBeInTheDocument();
+  });
+
+  it("falls back to 'default' profile when prop is absent", () => {
+    render(<PageHeader title="Dashboard" />);
+    expect(screen.getByText(/default/)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/test/components/chrome/Sidebar.test.tsx
+++ b/packages/ui/test/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/store", () => ({
+  useNimbusStore: (sel: (s: { hitlBadgeCount: number }) => unknown) => sel({ hitlBadgeCount: 3 }),
+}));
+
+import { Sidebar } from "../../../src/components/chrome/Sidebar";
+
+describe("Sidebar", () => {
+  it("renders all six top-level nav entries", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("link", { name: /Dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /HITL/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Marketplace/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Watchers/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Workflows/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Settings/i })).toBeInTheDocument();
+  });
+
+  it("shows the pending-HITL badge when count > 0", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/test/hooks/useIpcQuery.test.ts
+++ b/packages/ui/test/hooks/useIpcQuery.test.ts
@@ -1,0 +1,79 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/ipc/client");
+vi.mock("../../src/store", () => ({
+  useNimbusStore: (selector: (s: { connectionState: string }) => unknown) =>
+    selector({ connectionState: "connected" }),
+}));
+
+import { useIpcQuery } from "../../src/hooks/useIpcQuery";
+import { callMock } from "../../src/ipc/__mocks__/client";
+
+describe("useIpcQuery", () => {
+  beforeEach(() => {
+    callMock.mockReset();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls the method once on mount", async () => {
+    callMock.mockResolvedValue({ ok: 1 });
+    const { result } = renderHook(() => useIpcQuery<{ ok: number }>("x", 30_000));
+    await waitFor(() => expect(result.current.data).toEqual({ ok: 1 }));
+    expect(callMock).toHaveBeenCalledTimes(1);
+    expect(callMock).toHaveBeenCalledWith("x", {});
+  });
+
+  it("re-calls at interval", async () => {
+    callMock.mockResolvedValue("y");
+    renderHook(() => useIpcQuery<string>("m", 1_000));
+    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(1));
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("pauses while tab hidden", async () => {
+    callMock.mockResolvedValue("y");
+    renderHook(() => useIpcQuery<string>("m", 1_000));
+    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(1));
+
+    Object.defineProperty(document, "visibilityState", { value: "hidden" });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(callMock).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", { value: "visible" });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("exposes error on rejection", async () => {
+    callMock.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useIpcQuery<string>("m", 30_000));
+    await waitFor(() => expect(result.current.error).toBe("boom"));
+  });
+
+  it("refetch() fires an immediate call", async () => {
+    callMock.mockResolvedValue("v");
+    const { result } = renderHook(() => useIpcQuery<string>("m", 30_000));
+    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(1));
+    act(() => {
+      result.current.refetch();
+    });
+    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/packages/ui/test/hooks/useIpcSubscription.test.ts
+++ b/packages/ui/test/hooks/useIpcSubscription.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const listeners = new Map<string, Array<(payload: unknown) => void>>();
+
+const { mockListen } = vi.hoisted(() => {
+  const mockListen = vi.fn(async (event: string, handler: (e: { payload: unknown }) => void) => {
+    const arr = listeners.get(event) ?? [];
+    const cb = (p: unknown) => handler({ payload: p });
+    arr.push(cb);
+    listeners.set(event, arr);
+    return () => {
+      const current = listeners.get(event) ?? [];
+      listeners.set(
+        event,
+        current.filter((f) => f !== cb),
+      );
+    };
+  });
+  return { mockListen };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mockListen,
+}));
+
+import { useIpcSubscription } from "../../src/hooks/useIpcSubscription";
+
+describe("useIpcSubscription", () => {
+  it("attaches a listener for the event", async () => {
+    const handler = vi.fn();
+    renderHook(() => useIpcSubscription("connector://health-changed", handler));
+    // flush microtasks
+    await Promise.resolve();
+    expect(mockListen).toHaveBeenCalledWith("connector://health-changed", expect.any(Function));
+  });
+
+  it("invokes the handler when the event fires", async () => {
+    const handler = vi.fn();
+    renderHook(() => useIpcSubscription("topic://x", handler));
+    await Promise.resolve();
+    const cbs = listeners.get("topic://x") ?? [];
+    cbs.forEach((cb) => cb({ foo: 1 }));
+    expect(handler).toHaveBeenCalledWith({ foo: 1 });
+  });
+});

--- a/packages/ui/test/hooks/useIpcSubscription.test.ts
+++ b/packages/ui/test/hooks/useIpcSubscription.test.ts
@@ -40,7 +40,7 @@ describe("useIpcSubscription", () => {
     renderHook(() => useIpcSubscription("topic://x", handler));
     await Promise.resolve();
     const cbs = listeners.get("topic://x") ?? [];
-    cbs.forEach((cb) => cb({ foo: 1 }));
+    for (const cb of cbs) cb({ foo: 1 });
     expect(handler).toHaveBeenCalledWith({ foo: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- Labelled sidebar + PageHeader chrome wired into RootLayout
- `useIpcQuery` + `useIpcSubscription` hooks with pause-on-hidden/disconnected
- ALLOWED_METHODS gains `connector.listStatus`, `index.metrics`, `audit.list`, `consent.respond`
- Typed IPC wrappers + new shared types (ConnectorStatus, IndexMetrics, AuditEntry, HitlRequest)

## Plan discrepancies resolved during implementation
- Existing `ConnectorHealth` uses `"paused"` (not `"unknown"` as plan originally stated) — aligned with Gateway's canonical `ConnectorHealthState`. Spec/plan corrected on umbrella before B1 started.
- Existing client API is `createIpcClient().call(...)` (not `getClient().rpc(...)`). Hook and tests use the real pattern.
- Existing Zustand store is flat — `s.connectionState` (not `s.connection.state`), `s.hitlBadgeCount` (not `s.tray.pendingHitl`). B3 Task 18 will rename the tray slice fields if desired.
- `PageHeader` takes `profile` as a prop (no diag slice exists yet).

## Test plan
- [x] `cd packages/ui && bunx vitest run` — 59/59 pass
- [x] `bun run typecheck` — 0 errors across all packages
- [x] `bun run lint` — clean
- [ ] `cd packages/ui/src-tauri && cargo test --lib` — **not run locally** (cargo not installed on this machine); expect CI to exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)