### PR TITLE
feat(ui): WS5-B · Dashboard page

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -7,12 +7,12 @@ import {
   RouterProvider,
 } from "react-router-dom";
 import { RootLayout } from "./layouts/RootLayout";
+import { Dashboard } from "./pages/Dashboard";
 import { Onboarding } from "./pages/Onboarding";
 import { Connect } from "./pages/onboarding/Connect";
 import { Syncing } from "./pages/onboarding/Syncing";
 import { Welcome } from "./pages/onboarding/Welcome";
 import { QuickQuery } from "./pages/QuickQuery";
-import { DashboardStub } from "./pages/stubs/DashboardStub";
 import { HitlStub } from "./pages/stubs/HitlStub";
 import { MarketplaceStub } from "./pages/stubs/MarketplaceStub";
 import { SettingsStub } from "./pages/stubs/SettingsStub";
@@ -33,7 +33,7 @@ const router = createBrowserRouter(
         </Wrapper>
       }
     >
-      <Route index element={<DashboardStub />} />
+      <Route index element={<Dashboard />} />
       <Route path="onboarding" element={<Onboarding />}>
         <Route index element={<Navigate to="welcome" replace />} />
         <Route path="welcome" element={<Welcome />} />

--- a/packages/ui/src/components/dashboard/AuditFeed.tsx
+++ b/packages/ui/src/components/dashboard/AuditFeed.tsx
@@ -17,7 +17,6 @@ function outcomeColour(o: AuditEntry["outcome"]): string {
       return "text-[var(--color-error)]";
     case "auto":
       return "text-[var(--color-accent)]";
-    case "info":
     default:
       return "text-[var(--color-fg-muted)]";
   }

--- a/packages/ui/src/components/dashboard/AuditFeed.tsx
+++ b/packages/ui/src/components/dashboard/AuditFeed.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { useIpcQuery } from "../../hooks/useIpcQuery";
+import type { AuditEntry } from "../../ipc/types";
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? "--:--"
+    : d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+function outcomeColour(o: AuditEntry["outcome"]): string {
+  switch (o) {
+    case "approved":
+      return "text-[var(--color-ok)]";
+    case "rejected":
+      return "text-[var(--color-error)]";
+    case "auto":
+      return "text-[var(--color-accent)]";
+    case "info":
+    default:
+      return "text-[var(--color-fg-muted)]";
+  }
+}
+
+export function AuditFeed(): ReactNode {
+  const { data } = useIpcQuery<AuditEntry[]>("audit.list", 10_000, { limit: 25 });
+  const entries = data ?? [];
+  if (entries.length === 0) {
+    return (
+      <section aria-label="Recent activity" className="text-[var(--color-fg-muted)] text-sm">
+        No recent activity.
+      </section>
+    );
+  }
+  return (
+    <section
+      aria-label="Recent activity"
+      className="max-h-80 overflow-auto border border-[var(--color-border)] rounded-md"
+    >
+      <ul className="divide-y divide-[var(--color-border)]">
+        {entries.map((e) => (
+          <li key={e.id} className="px-3 py-2 flex items-center gap-3 text-xs">
+            <time className="text-[var(--color-fg-muted)] w-12 font-mono">{formatTime(e.ts)}</time>
+            <span className="text-[var(--color-fg)]">{e.action}</span>
+            {e.subject && (
+              <span className="text-[var(--color-fg-muted)] truncate">{e.subject}</span>
+            )}
+            <span className={`ml-auto ${outcomeColour(e.outcome)}`}>{e.outcome}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/ui/src/components/dashboard/ConnectorGrid.tsx
+++ b/packages/ui/src/components/dashboard/ConnectorGrid.tsx
@@ -1,0 +1,59 @@
+import { type ReactNode, useCallback, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useIpcQuery } from "../../hooks/useIpcQuery";
+import { useIpcSubscription } from "../../hooks/useIpcSubscription";
+import type { ConnectorStatus } from "../../ipc/types";
+import { useNimbusStore } from "../../store";
+import { ConnectorTile } from "./ConnectorTile";
+
+interface HealthChangedPayload {
+  name: string;
+  health: ConnectorStatus["health"];
+  degradationReason?: string;
+}
+
+export function ConnectorGrid(): ReactNode {
+  const setConnectors = useNimbusStore((s) => s.setConnectors);
+  const patchConnector = useNimbusStore((s) => s.patchConnector);
+  const connectors = useNimbusStore((s) => s.connectors);
+  const highlight = useNimbusStore((s) => s.highlightConnector);
+
+  const { data } = useIpcQuery<ConnectorStatus[]>("connector.listStatus", 30_000);
+  useEffect(() => {
+    if (data && data !== connectors) setConnectors(data);
+  }, [data, connectors, setConnectors]);
+
+  const onHealth = useCallback(
+    (payload: HealthChangedPayload) => {
+      patchConnector(payload.name, {
+        health: payload.health,
+        degradationReason: payload.degradationReason,
+      });
+    },
+    [patchConnector],
+  );
+  useIpcSubscription<HealthChangedPayload>("connector://health-changed", onHealth);
+
+  if (connectors.length === 0) {
+    return (
+      <section aria-label="Connectors" className="text-[var(--color-fg-muted)] text-sm">
+        No connectors configured.{" "}
+        <Link to="/onboarding" className="underline">
+          Open onboarding
+        </Link>
+        .
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Connectors"
+      className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3"
+    >
+      {connectors.map((c) => (
+        <ConnectorTile key={c.name} status={c} highlighted={c.name === highlight} />
+      ))}
+    </section>
+  );
+}

--- a/packages/ui/src/components/dashboard/ConnectorTile.tsx
+++ b/packages/ui/src/components/dashboard/ConnectorTile.tsx
@@ -17,7 +17,6 @@ function dotColour(h: ConnectorStatus["health"]): string {
     case "error":
     case "unauthenticated":
       return "bg-[var(--color-error)]";
-    case "paused":
     default:
       return "bg-[var(--color-fg-muted)]";
   }

--- a/packages/ui/src/components/dashboard/ConnectorTile.tsx
+++ b/packages/ui/src/components/dashboard/ConnectorTile.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from "react";
+import type { ConnectorStatus } from "../../ipc/types";
+import { formatRelative } from "./format";
+
+interface Props {
+  status: ConnectorStatus;
+  highlighted: boolean;
+}
+
+function dotColour(h: ConnectorStatus["health"]): string {
+  switch (h) {
+    case "healthy":
+      return "bg-[var(--color-ok)]";
+    case "degraded":
+    case "rate_limited":
+      return "bg-[var(--color-amber)]";
+    case "error":
+    case "unauthenticated":
+      return "bg-[var(--color-error)]";
+    case "paused":
+    default:
+      return "bg-[var(--color-fg-muted)]";
+  }
+}
+
+const DISPLAY_NAMES: Record<string, string> = {
+  drive: "Google Drive",
+  gmail: "Gmail",
+  photos: "Google Photos",
+  onedrive: "OneDrive",
+  outlook: "Outlook",
+  teams: "Microsoft Teams",
+  github: "GitHub",
+  gitlab: "GitLab",
+  bitbucket: "Bitbucket",
+  slack: "Slack",
+  discord: "Discord",
+  linear: "Linear",
+  jira: "Jira",
+  notion: "Notion",
+  confluence: "Confluence",
+  jenkins: "Jenkins",
+  "github-actions": "GitHub Actions",
+  circleci: "CircleCI",
+  "gitlab-ci": "GitLab CI",
+  aws: "AWS",
+  azure: "Azure",
+  gcp: "GCP",
+  iac: "IaC",
+  kubernetes: "Kubernetes",
+  pagerduty: "PagerDuty",
+  grafana: "Grafana",
+  sentry: "Sentry",
+  "new-relic": "New Relic",
+  datadog: "Datadog",
+  filesystem: "Filesystem",
+};
+
+function displayName(name: string): string {
+  return DISPLAY_NAMES[name] ?? name;
+}
+
+export function ConnectorTile({ status, highlighted }: Props): ReactNode {
+  return (
+    <div
+      data-connector={status.name}
+      className={`bg-[var(--color-surface)] border border-[var(--color-border)] rounded-md p-3 ${
+        highlighted ? "ring-2 ring-[var(--color-accent)]" : ""
+      }`}
+      title={status.degradationReason ?? ""}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className={`inline-block w-2 h-2 rounded-full ${dotColour(status.health)}`}
+        />
+        <span className="text-[var(--color-fg)] text-sm">{displayName(status.name)}</span>
+      </div>
+      <div className="text-[var(--color-fg-muted)] text-xs mt-1">
+        {status.lastSyncAt ? formatRelative(status.lastSyncAt) : "not synced yet"}
+      </div>
+      {status.degradationReason && (
+        <div className="text-[var(--color-amber)] text-xs mt-1 truncate">
+          {status.degradationReason}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/dashboard/IndexMetricsStrip.tsx
+++ b/packages/ui/src/components/dashboard/IndexMetricsStrip.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { useIpcQuery } from "../../hooks/useIpcQuery";
+import type { IndexMetrics } from "../../ipc/types";
+import { formatBytes, formatCount, formatMs, formatPercent } from "./format";
+
+function Tile({ label, value }: { label: string; value: string }): ReactNode {
+  return (
+    <div className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-md p-4">
+      <div className="text-[var(--color-fg)] text-2xl font-medium">{value}</div>
+      <div className="text-[var(--color-fg-muted)] text-xs mt-1">{label}</div>
+    </div>
+  );
+}
+
+export function IndexMetricsStrip(): ReactNode {
+  const { data } = useIpcQuery<IndexMetrics>("index.metrics", 30_000);
+  const items = data ? formatCount(data.itemsTotal) : "—";
+  const cov = data ? formatPercent(data.embeddingCoveragePct) : "—";
+  const p95 = data ? formatMs(data.queryP95Ms) : "—";
+  const size = data ? formatBytes(data.indexSizeBytes) : "—";
+  return (
+    <section className="grid grid-cols-4 gap-4" aria-label="Index metrics">
+      <Tile label="items" value={items} />
+      <Tile label="embeddings" value={cov} />
+      <Tile label="p95 query" value={p95} />
+      <Tile label="index size" value={size} />
+    </section>
+  );
+}

--- a/packages/ui/src/components/dashboard/format.ts
+++ b/packages/ui/src/components/dashboard/format.ts
@@ -1,0 +1,38 @@
+export function formatCount(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+export function formatPercent(n: number): string {
+  return `${Math.round(n)}%`;
+}
+
+export function formatMs(n: number): string {
+  return `${formatCount(Math.round(n))} ms`;
+}
+
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let val = n / 1024;
+  let i = 0;
+  while (val >= 1024 && i < units.length - 1) {
+    val /= 1024;
+    i++;
+  }
+  return `${val.toFixed(1)} ${units[i]}`;
+}
+
+export function formatRelative(iso: string, nowMs = Date.now()): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "—";
+  const diff = Math.max(0, nowMs - t);
+  const s = Math.floor(diff / 1000);
+  if (s < 2) return "just now";
+  if (s < 60) return `${s} s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m} m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} h ago`;
+  const d = Math.floor(h / 24);
+  return `${d} d ago`;
+}

--- a/packages/ui/src/hooks/useIpcQuery.ts
+++ b/packages/ui/src/hooks/useIpcQuery.ts
@@ -28,6 +28,10 @@ export function useIpcQuery<T>(
   const generationRef = useRef(0);
   const connectionState = useNimbusStore((s) => s.connectionState);
 
+  // paramsKey is the stringified form of params — using it in the dep list
+  // tracks shape changes without re-firing on every render from object
+  // identity changes when the caller passes an inline literal.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: paramsKey proxies params
   const run = useCallback(async () => {
     const gen = ++generationRef.current;
     setIsLoading(true);
@@ -42,10 +46,6 @@ export function useIpcQuery<T>(
     } finally {
       if (gen === generationRef.current) setIsLoading(false);
     }
-    // Use the stringified key in deps so the callback identity tracks param
-    // shape changes — object identity of `params` alone would re-fire on every
-    // render even when the shape is stable.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: paramsKey proxies params
   }, [method, paramsKey]);
 
   useEffect(() => {

--- a/packages/ui/src/pages/Dashboard.tsx
+++ b/packages/ui/src/pages/Dashboard.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { PageHeader } from "../components/chrome/PageHeader";
+import { AuditFeed } from "../components/dashboard/AuditFeed";
+import { ConnectorGrid } from "../components/dashboard/ConnectorGrid";
+import { IndexMetricsStrip } from "../components/dashboard/IndexMetricsStrip";
+
+export function Dashboard(): ReactNode {
+  return (
+    <>
+      <PageHeader title="Dashboard" />
+      <div className="p-6 space-y-6">
+        <IndexMetricsStrip />
+        <ConnectorGrid />
+        <AuditFeed />
+      </div>
+    </>
+  );
+}

--- a/packages/ui/src/pages/stubs/DashboardStub.tsx
+++ b/packages/ui/src/pages/stubs/DashboardStub.tsx
@@ -1,3 +1,0 @@
-export function DashboardStub() {
-  return <section style={{ padding: 24 }}>Dashboard — coming in Sub-project B</section>;
-}

--- a/packages/ui/src/store/index.ts
+++ b/packages/ui/src/store/index.ts
@@ -1,14 +1,20 @@
 import { create } from "zustand";
 import { type ConnectionSlice, createConnectionSlice } from "./slices/connection";
+import { createDashboardSlice, type DashboardSlice } from "./slices/dashboard";
 import { createOnboardingSlice, type OnboardingSlice } from "./slices/onboarding";
 import { createQuickQuerySlice, type QuickQuerySlice } from "./slices/quickQuery";
 import { createTraySlice, type TraySlice } from "./slices/tray";
 
-export type NimbusStore = ConnectionSlice & TraySlice & QuickQuerySlice & OnboardingSlice;
+export type NimbusStore = ConnectionSlice &
+  TraySlice &
+  QuickQuerySlice &
+  OnboardingSlice &
+  DashboardSlice;
 
 export const useNimbusStore = create<NimbusStore>()((...a) => ({
   ...createConnectionSlice(...a),
   ...createTraySlice(...a),
   ...createQuickQuerySlice(...a),
   ...createOnboardingSlice(...a),
+  ...createDashboardSlice(...a),
 }));

--- a/packages/ui/src/store/slices/dashboard.ts
+++ b/packages/ui/src/store/slices/dashboard.ts
@@ -1,0 +1,37 @@
+import type { StateCreator } from "zustand";
+import type { AuditEntry, ConnectorStatus, IndexMetrics } from "../../ipc/types";
+
+export interface DashboardSlice {
+  metrics: IndexMetrics | null;
+  metricsError: string | null;
+  connectors: ConnectorStatus[];
+  audit: AuditEntry[];
+  highlightConnector: string | null;
+  setMetrics(m: IndexMetrics): void;
+  setMetricsError(e: string | null): void;
+  setConnectors(c: ConnectorStatus[]): void;
+  patchConnector(name: string, patch: Partial<ConnectorStatus>): void;
+  setAudit(a: AuditEntry[]): void;
+  requestHighlight(name: string): void;
+  clearHighlight(): void;
+}
+
+export const createDashboardSlice: StateCreator<DashboardSlice, [], [], DashboardSlice> = (
+  set,
+) => ({
+  metrics: null,
+  metricsError: null,
+  connectors: [],
+  audit: [],
+  highlightConnector: null,
+  setMetrics: (m) => set({ metrics: m }),
+  setMetricsError: (e) => set({ metricsError: e }),
+  setConnectors: (c) => set({ connectors: c }),
+  patchConnector: (name, patch) =>
+    set((s) => ({
+      connectors: s.connectors.map((x) => (x.name === name ? { ...x, ...patch } : x)),
+    })),
+  setAudit: (a) => set({ audit: a }),
+  requestHighlight: (name) => set({ highlightConnector: name }),
+  clearHighlight: () => set({ highlightConnector: null }),
+});

--- a/packages/ui/test/components/dashboard/AuditFeed.test.tsx
+++ b/packages/ui/test/components/dashboard/AuditFeed.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AuditFeed } from "../../../src/components/dashboard/AuditFeed";
+
+const hookState = { data: null as unknown, error: null as string | null, isLoading: false };
+vi.mock("../../../src/hooks/useIpcQuery", () => ({ useIpcQuery: () => hookState }));
+
+describe("AuditFeed", () => {
+  it("renders recent entries", () => {
+    hookState.data = [
+      {
+        id: 1,
+        ts: new Date().toISOString(),
+        action: "file.create",
+        outcome: "approved",
+        subject: "doc.md",
+      },
+      {
+        id: 2,
+        ts: new Date().toISOString(),
+        action: "email.draft.send",
+        outcome: "rejected",
+        subject: "to:a@b",
+      },
+    ];
+    render(<AuditFeed />);
+    expect(screen.getByText("file.create")).toBeInTheDocument();
+    expect(screen.getByText("email.draft.send")).toBeInTheDocument();
+    expect(screen.getByText(/approved/)).toBeInTheDocument();
+    expect(screen.getByText(/rejected/)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no entries", () => {
+    hookState.data = [];
+    render(<AuditFeed />);
+    expect(screen.getByText(/No recent activity/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/test/components/dashboard/ConnectorGrid.test.tsx
+++ b/packages/ui/test/components/dashboard/ConnectorGrid.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectorGrid } from "../../../src/components/dashboard/ConnectorGrid";
+import type { ConnectorStatus } from "../../../src/ipc/types";
+
+const store: {
+  connectors: ConnectorStatus[];
+  highlightConnector: string | null;
+  setConnectors: (c: ConnectorStatus[]) => void;
+  patchConnector: (name: string, patch: Partial<ConnectorStatus>) => void;
+} = {
+  connectors: [{ name: "drive", health: "healthy" }],
+  highlightConnector: null,
+  setConnectors: () => undefined,
+  patchConnector: () => undefined,
+};
+
+vi.mock("../../../src/store", () => ({
+  useNimbusStore: (sel: (s: typeof store) => unknown) => sel(store),
+}));
+
+vi.mock("../../../src/hooks/useIpcQuery", () => ({
+  useIpcQuery: () => ({ data: store.connectors, error: null, isLoading: false }),
+}));
+
+vi.mock("../../../src/hooks/useIpcSubscription", () => ({
+  useIpcSubscription: () => undefined,
+}));
+
+describe("ConnectorGrid", () => {
+  it("renders one tile per connector", () => {
+    store.connectors = [{ name: "drive", health: "healthy" }];
+    render(
+      <MemoryRouter>
+        <ConnectorGrid />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/Google Drive/)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no connectors", () => {
+    store.connectors = [];
+    render(
+      <MemoryRouter>
+        <ConnectorGrid />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/No connectors configured/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/test/components/dashboard/ConnectorTile.test.tsx
+++ b/packages/ui/test/components/dashboard/ConnectorTile.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ConnectorTile } from "../../../src/components/dashboard/ConnectorTile";
+import type { ConnectorStatus } from "../../../src/ipc/types";
+
+describe("ConnectorTile", () => {
+  it("shows the connector name and last-sync relative time", () => {
+    const c: ConnectorStatus = {
+      name: "drive",
+      health: "healthy",
+      lastSyncAt: new Date(Date.now() - 120_000).toISOString(),
+    };
+    render(<ConnectorTile status={c} highlighted={false} />);
+    expect(screen.getByText(/Google Drive/)).toBeInTheDocument();
+    expect(screen.getByText(/m ago/)).toBeInTheDocument();
+  });
+
+  it("renders degradation reason for degraded state", () => {
+    const c: ConnectorStatus = {
+      name: "slack",
+      health: "rate_limited",
+      degradationReason: "rate-limited by upstream",
+    };
+    render(<ConnectorTile status={c} highlighted={false} />);
+    expect(screen.getByText(/rate-limited/i)).toBeInTheDocument();
+  });
+
+  it("shows 'not synced yet' when lastSyncAt is missing", () => {
+    const c: ConnectorStatus = { name: "gmail", health: "healthy" };
+    render(<ConnectorTile status={c} highlighted={false} />);
+    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
+  });
+
+  it("applies a highlight ring when highlighted=true", () => {
+    const c: ConnectorStatus = { name: "notion", health: "healthy" };
+    const { container } = render(<ConnectorTile status={c} highlighted={true} />);
+    const el = container.querySelector('[data-connector="notion"]');
+    expect(el?.className).toMatch(/ring/);
+  });
+});

--- a/packages/ui/test/components/dashboard/IndexMetricsStrip.test.tsx
+++ b/packages/ui/test/components/dashboard/IndexMetricsStrip.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IndexMetricsStrip } from "../../../src/components/dashboard/IndexMetricsStrip";
+
+const hookState = { data: null as unknown, error: null as string | null, isLoading: false };
+
+vi.mock("../../../src/hooks/useIpcQuery", () => ({
+  useIpcQuery: () => hookState,
+}));
+
+describe("IndexMetricsStrip", () => {
+  it("renders 4 metric tiles with values", () => {
+    hookState.data = {
+      itemsTotal: 124_387,
+      embeddingCoveragePct: 83,
+      queryP95Ms: 42,
+      indexSizeBytes: 2_147_483_648,
+    };
+    render(<IndexMetricsStrip />);
+    expect(screen.getByText("124,387")).toBeInTheDocument();
+    expect(screen.getByText("83%")).toBeInTheDocument();
+    expect(screen.getByText("42 ms")).toBeInTheDocument();
+    expect(screen.getByText("2.0 GB")).toBeInTheDocument();
+  });
+
+  it("renders em-dashes when no data and error is present", () => {
+    hookState.data = null;
+    hookState.error = "boom";
+    render(<IndexMetricsStrip />);
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/ui/test/components/dashboard/format.test.ts
+++ b/packages/ui/test/components/dashboard/format.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatBytes,
+  formatCount,
+  formatMs,
+  formatPercent,
+  formatRelative,
+} from "../../../src/components/dashboard/format";
+
+describe("format", () => {
+  it("formats counts with thousand separators", () => {
+    expect(formatCount(124_387)).toBe("124,387");
+    expect(formatCount(0)).toBe("0");
+  });
+  it("formats percent with zero decimals for integers", () => {
+    expect(formatPercent(83)).toBe("83%");
+    expect(formatPercent(83.4)).toBe("83%");
+    expect(formatPercent(100)).toBe("100%");
+  });
+  it("formats ms with unit", () => {
+    expect(formatMs(42)).toBe("42 ms");
+    expect(formatMs(1_245)).toBe("1,245 ms");
+  });
+  it("formats bytes to human units", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(2_147_483_648)).toBe("2.0 GB");
+  });
+  it("formats relative time", () => {
+    const now = Date.now();
+    expect(formatRelative(new Date(now - 1_000).toISOString(), now)).toMatch(/just now|1 s ago/);
+    expect(formatRelative(new Date(now - 120_000).toISOString(), now)).toBe("2 m ago");
+    expect(formatRelative(new Date(now - 3_600_000).toISOString(), now)).toBe("1 h ago");
+  });
+});

--- a/packages/ui/test/pages/Dashboard.test.tsx
+++ b/packages/ui/test/pages/Dashboard.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { Dashboard } from "../../src/pages/Dashboard";
+
+vi.mock("../../src/hooks/useIpcQuery", () => ({
+  useIpcQuery: () => ({ data: null, error: null, isLoading: false }),
+}));
+vi.mock("../../src/hooks/useIpcSubscription", () => ({
+  useIpcSubscription: () => undefined,
+}));
+
+vi.mock("../../src/store", () => ({
+  useNimbusStore: (
+    sel: (s: {
+      connectors: never[];
+      highlightConnector: null;
+      setConnectors: () => void;
+      patchConnector: () => void;
+      trayIcon: "normal" | "amber" | "red";
+    }) => unknown,
+  ) =>
+    sel({
+      connectors: [],
+      highlightConnector: null,
+      setConnectors: () => undefined,
+      patchConnector: () => undefined,
+      trayIcon: "normal",
+    }),
+}));
+
+describe("Dashboard", () => {
+  it("renders PageHeader + three panels", () => {
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { level: 1, name: /Dashboard/ })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Index metrics/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Connectors/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Recent activity/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/test/store/dashboard.test.ts
+++ b/packages/ui/test/store/dashboard.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { create } from "zustand";
+import { createDashboardSlice, type DashboardSlice } from "../../src/store/slices/dashboard";
+
+describe("dashboard slice", () => {
+  let useStore: ReturnType<typeof create<DashboardSlice>>;
+  beforeEach(() => {
+    useStore = create<DashboardSlice>()((...a) => createDashboardSlice(...a));
+  });
+
+  it("starts empty", () => {
+    const s = useStore.getState();
+    expect(s.metrics).toBeNull();
+    expect(s.connectors).toEqual([]);
+    expect(s.audit).toEqual([]);
+    expect(s.highlightConnector).toBeNull();
+  });
+
+  it("setConnectors replaces the list", () => {
+    useStore.getState().setConnectors([{ name: "drive", health: "healthy" }]);
+    expect(useStore.getState().connectors).toHaveLength(1);
+  });
+
+  it("patchConnector updates by name", () => {
+    useStore.getState().setConnectors([
+      { name: "drive", health: "healthy" },
+      { name: "gmail", health: "healthy" },
+    ]);
+    useStore.getState().patchConnector("gmail", { health: "degraded", degradationReason: "rate" });
+    const c = useStore.getState().connectors.find((x) => x.name === "gmail");
+    expect(c?.health).toBe("degraded");
+    expect(c?.degradationReason).toBe("rate");
+    const d = useStore.getState().connectors.find((x) => x.name === "drive");
+    expect(d?.health).toBe("healthy");
+  });
+
+  it("patchConnector on unknown name is a no-op", () => {
+    useStore.getState().patchConnector("nonexistent", { health: "error" });
+    expect(useStore.getState().connectors).toEqual([]);
+  });
+
+  it("requestHighlight/clearHighlight round-trip", () => {
+    useStore.getState().requestHighlight("drive");
+    expect(useStore.getState().highlightConnector).toBe("drive");
+    useStore.getState().clearHighlight();
+    expect(useStore.getState().highlightConnector).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Dashboard page replaces `DashboardStub` at `/`
- 4 composable tiles: IndexMetricsStrip, ConnectorGrid, ConnectorTile, AuditFeed
- Pure format helpers (count, percent, ms, bytes, relative time)
- `dashboard` store slice: metrics · connectors · audit · highlightConnector
- ConnectorGrid subscribes to `connector://health-changed` and patches tiles live
- Uses existing `s.trayIcon` (B3 Task 18 will rename to `aggregateHealth` if desired)

## Stacked on PR-B1
Base branch is `dev/ws5b-chrome-ipc` so the diff shows only B2-specific changes. When B1 merges, GitHub will auto-retarget to the umbrella branch.

## Test plan
- [x] `cd packages/ui && bunx vitest run` — 80/80 pass
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)