### PR TITLE
feat(ui): WS5-B · tray health colour, badge, connectors submenu

### DIFF
--- a/packages/ui/src-tauri/src/lib.rs
+++ b/packages/ui/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             gateway_bridge::rpc_call,
             gateway_bridge::shell_start_gateway,
+            tray::set_connectors_menu,
         ])
         .setup(|app| {
             if cfg!(debug_assertions) {

--- a/packages/ui/src-tauri/src/tray.rs
+++ b/packages/ui/src-tauri/src/tray.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use tauri::image::Image;
-use tauri::menu::{MenuBuilder, MenuItemBuilder};
+use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Emitter, Listener, Manager};
 
@@ -19,6 +19,12 @@ struct TrayStateChange {
     badge: u32,
 }
 
+#[derive(Deserialize, Debug, Clone)]
+pub struct ConnectorMenuEntry {
+    pub name: String,
+    pub health: String,
+}
+
 fn icon_bytes(state: TrayIconState) -> &'static [u8] {
     match state {
         TrayIconState::Normal => include_bytes!("../icons/tray-normal.png"),
@@ -27,14 +33,79 @@ fn icon_bytes(state: TrayIconState) -> &'static [u8] {
     }
 }
 
-pub fn init_tray(app: &AppHandle) -> tauri::Result<()> {
+fn health_glyph(h: &str) -> &'static str {
+    match h {
+        "healthy" => "●",
+        "degraded" | "rate_limited" => "◐",
+        "error" | "unauthenticated" => "○",
+        _ => "·",
+    }
+}
+
+fn handle_menu_event(app_handle: &AppHandle, id: &str) {
+    match id {
+        "open-dashboard" => focus_main(app_handle),
+        "quick-query" => {
+            let _ = crate::quick_query::spawn_or_focus(app_handle);
+        }
+        "settings" => {
+            focus_main(app_handle);
+            let _ = app_handle.emit("tray://navigate", "/settings");
+        }
+        "quit" => app_handle.exit(0),
+        _ if id.starts_with("conn:") => {
+            let name = id.trim_start_matches("conn:").to_string();
+            focus_main(app_handle);
+            let _ = app_handle.emit("tray://open-connector", serde_json::json!({ "name": name }));
+        }
+        _ => {}
+    }
+}
+
+fn build_menu(
+    app: &AppHandle,
+    items: &[ConnectorMenuEntry],
+) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
     let open = MenuItemBuilder::with_id("open-dashboard", "Open Dashboard").build(app)?;
     let quick = MenuItemBuilder::with_id("quick-query", "Quick Query\tCtrl+Shift+N").build(app)?;
     let settings = MenuItemBuilder::with_id("settings", "Settings").build(app)?;
     let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
-    let menu = MenuBuilder::new(app)
-        .items(&[&open, &quick, &settings, &quit])
-        .build()?;
+
+    let mut connectors_sub = SubmenuBuilder::new(app, "Connectors");
+    for c in items {
+        let id = format!("conn:{}", c.name);
+        let label = format!("{} {} — {}", health_glyph(&c.health), c.name, c.health);
+        let item = MenuItemBuilder::with_id(id, label).build(app)?;
+        connectors_sub = connectors_sub.item(&item);
+    }
+    let connectors_submenu = connectors_sub.build()?;
+
+    MenuBuilder::new(app)
+        .item(&open)
+        .item(&quick)
+        .separator()
+        .item(&connectors_submenu)
+        .separator()
+        .item(&settings)
+        .separator()
+        .item(&quit)
+        .build()
+}
+
+#[tauri::command]
+pub async fn set_connectors_menu(
+    app: AppHandle,
+    items: Vec<ConnectorMenuEntry>,
+) -> Result<(), String> {
+    let menu = build_menu(&app, &items).map_err(|e| e.to_string())?;
+    if let Some(tray) = app.tray_by_id("nimbus-tray") {
+        tray.set_menu(Some(menu)).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+pub fn init_tray(app: &AppHandle) -> tauri::Result<()> {
+    let menu = build_menu(app, &[])?;
 
     #[cfg(target_os = "macos")]
     let icon_is_template = true;
@@ -49,18 +120,7 @@ pub fn init_tray(app: &AppHandle) -> tauri::Result<()> {
         })?)
         .icon_as_template(icon_is_template)
         .menu(&menu)
-        .on_menu_event(|app_handle, event| match event.id().as_ref() {
-            "open-dashboard" => focus_main(app_handle),
-            "quick-query" => {
-                let _ = crate::quick_query::spawn_or_focus(app_handle);
-            }
-            "settings" => {
-                focus_main(app_handle);
-                let _ = app_handle.emit("tray://navigate", "/settings");
-            }
-            "quit" => app_handle.exit(0),
-            _ => {}
-        })
+        .on_menu_event(|app_handle, event| handle_menu_event(app_handle, event.id().as_ref()))
         .on_tray_icon_event(|_icon, _event: TrayIconEvent| {})
         .build(app)?;
 

--- a/packages/ui/src/components/chrome/PageHeader.tsx
+++ b/packages/ui/src/components/chrome/PageHeader.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export function PageHeader({ title, profile = "default" }: Props): ReactNode {
-  const aggregateHealth = useNimbusStore((s) => s.trayIcon);
+  const aggregateHealth = useNimbusStore((s) => s.aggregateHealth);
   return (
     <header className="flex items-center justify-between px-6 h-12 border-b border-[var(--color-border)]">
       <h1 className="text-base font-medium text-[var(--color-fg)]">{title}</h1>

--- a/packages/ui/src/components/chrome/Sidebar.tsx
+++ b/packages/ui/src/components/chrome/Sidebar.tsx
@@ -12,7 +12,7 @@ const ENTRIES: ReadonlyArray<{ to: string; icon: string; label: string }> = [
 ];
 
 export function Sidebar(): ReactNode {
-  const pendingHitl = useNimbusStore((s) => s.hitlBadgeCount);
+  const pendingHitl = useNimbusStore((s) => s.pendingHitl);
   return (
     <nav
       aria-label="Primary"

--- a/packages/ui/src/components/dashboard/ConnectorGrid.tsx
+++ b/packages/ui/src/components/dashboard/ConnectorGrid.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { type ReactNode, useCallback, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useIpcQuery } from "../../hooks/useIpcQuery";
@@ -17,18 +18,30 @@ export function ConnectorGrid(): ReactNode {
   const patchConnector = useNimbusStore((s) => s.patchConnector);
   const connectors = useNimbusStore((s) => s.connectors);
   const highlight = useNimbusStore((s) => s.highlightConnector);
+  const recomputeAggregate = useNimbusStore((s) => s.recomputeAggregate);
+  const setConnectorsMenu = useNimbusStore((s) => s.setConnectorsMenu);
 
   const { data } = useIpcQuery<ConnectorStatus[]>("connector.listStatus", 30_000);
   useEffect(() => {
     if (data && data !== connectors) setConnectors(data);
   }, [data, connectors, setConnectors]);
 
+  useEffect(() => {
+    recomputeAggregate(connectors);
+    const items = connectors.map((c) => ({ name: c.name, health: c.health }));
+    setConnectorsMenu(items);
+    void invoke("set_connectors_menu", { items }).catch(() => {
+      // Non-fatal: tray will pick up state on the next refresh.
+    });
+  }, [connectors, recomputeAggregate, setConnectorsMenu]);
+
   const onHealth = useCallback(
     (payload: HealthChangedPayload) => {
-      patchConnector(payload.name, {
-        health: payload.health,
-        degradationReason: payload.degradationReason,
-      });
+      const patch: Partial<ConnectorStatus> = { health: payload.health };
+      if (payload.degradationReason !== undefined) {
+        patch.degradationReason = payload.degradationReason;
+      }
+      patchConnector(payload.name, patch);
     },
     [patchConnector],
   );

--- a/packages/ui/src/layouts/RootLayout.tsx
+++ b/packages/ui/src/layouts/RootLayout.tsx
@@ -1,12 +1,33 @@
-import { Outlet } from "react-router-dom";
+import { emit } from "@tauri-apps/api/event";
+import { useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
 import { Sidebar } from "../components/chrome/Sidebar";
 import { GatewayOfflineBanner } from "../components/GatewayOfflineBanner";
 import { HotkeyFailedBanner } from "../components/HotkeyFailedBanner";
+import { useIpcSubscription } from "../hooks/useIpcSubscription";
 import { useNimbusStore } from "../store";
 
 export function RootLayout() {
   const connectionState = useNimbusStore((s) => s.connectionState);
+  const aggregateHealth = useNimbusStore((s) => s.aggregateHealth);
+  const pendingHitl = useNimbusStore((s) => s.pendingHitl);
+  const requestHighlight = useNimbusStore((s) => s.requestHighlight);
+  const clearHighlight = useNimbusStore((s) => s.clearHighlight);
   const offline = connectionState === "disconnected";
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    void emit("tray://state-changed", { icon: aggregateHealth, badge: pendingHitl }).catch(() => {
+      // Non-fatal; tray will pick up the next change.
+    });
+  }, [aggregateHealth, pendingHitl]);
+
+  useIpcSubscription<{ name: string }>("tray://open-connector", (p) => {
+    void navigate("/");
+    requestHighlight(p.name);
+    setTimeout(() => clearHighlight(), 1500);
+  });
+
   return (
     <div className="h-screen flex flex-col">
       {offline && <GatewayOfflineBanner />}

--- a/packages/ui/src/store/slices/tray.ts
+++ b/packages/ui/src/store/slices/tray.ts
@@ -1,17 +1,33 @@
 import type { StateCreator } from "zustand";
+import type { ConnectorStatus } from "../../ipc/types";
 
 export type TrayIconState = "normal" | "amber" | "red";
 
+export interface ConnectorsMenuEntry {
+  readonly name: string;
+  readonly health: ConnectorStatus["health"];
+}
+
 export interface TraySlice {
-  readonly trayIcon: TrayIconState;
-  readonly hitlBadgeCount: number;
-  setTrayIcon: (icon: TrayIconState) => void;
-  setHitlBadgeCount: (n: number) => void;
+  readonly aggregateHealth: TrayIconState;
+  readonly pendingHitl: number;
+  readonly connectorsMenu: ConnectorsMenuEntry[];
+  setAggregateHealth: (icon: TrayIconState) => void;
+  setPendingHitl: (n: number) => void;
+  setConnectorsMenu: (items: ConnectorsMenuEntry[]) => void;
+  recomputeAggregate: (connectors: ConnectorStatus[]) => void;
 }
 
 export const createTraySlice: StateCreator<TraySlice, [], [], TraySlice> = (set) => ({
-  trayIcon: "normal",
-  hitlBadgeCount: 0,
-  setTrayIcon: (trayIcon) => set({ trayIcon }),
-  setHitlBadgeCount: (hitlBadgeCount) => set({ hitlBadgeCount: Math.max(0, hitlBadgeCount) }),
+  aggregateHealth: "normal",
+  pendingHitl: 0,
+  connectorsMenu: [],
+  setAggregateHealth: (aggregateHealth) => set({ aggregateHealth }),
+  setPendingHitl: (n) => set({ pendingHitl: Math.max(0, n) }),
+  setConnectorsMenu: (items) => set({ connectorsMenu: items }),
+  recomputeAggregate: (connectors) => {
+    const hasRed = connectors.some((c) => c.health === "error" || c.health === "unauthenticated");
+    const hasAmber = connectors.some((c) => c.health === "degraded" || c.health === "rate_limited");
+    set({ aggregateHealth: hasRed ? "red" : hasAmber ? "amber" : "normal" });
+  },
 });

--- a/packages/ui/test/components/chrome/PageHeader.test.tsx
+++ b/packages/ui/test/components/chrome/PageHeader.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/store", () => ({
-  useNimbusStore: (sel: (s: { trayIcon: "normal" | "amber" | "red" }) => unknown) =>
-    sel({ trayIcon: "normal" }),
+  useNimbusStore: (sel: (s: { aggregateHealth: "normal" | "amber" | "red" }) => unknown) =>
+    sel({ aggregateHealth: "normal" }),
 }));
 
 import { PageHeader } from "../../../src/components/chrome/PageHeader";

--- a/packages/ui/test/components/chrome/Sidebar.test.tsx
+++ b/packages/ui/test/components/chrome/Sidebar.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/store", () => ({
-  useNimbusStore: (sel: (s: { hitlBadgeCount: number }) => unknown) => sel({ hitlBadgeCount: 3 }),
+  useNimbusStore: (sel: (s: { pendingHitl: number }) => unknown) => sel({ pendingHitl: 3 }),
 }));
 
 import { Sidebar } from "../../../src/components/chrome/Sidebar";

--- a/packages/ui/test/components/dashboard/ConnectorGrid.test.tsx
+++ b/packages/ui/test/components/dashboard/ConnectorGrid.test.tsx
@@ -1,19 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
-import { ConnectorGrid } from "../../../src/components/dashboard/ConnectorGrid";
 import type { ConnectorStatus } from "../../../src/ipc/types";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async () => undefined),
+}));
 
 const store: {
   connectors: ConnectorStatus[];
   highlightConnector: string | null;
   setConnectors: (c: ConnectorStatus[]) => void;
   patchConnector: (name: string, patch: Partial<ConnectorStatus>) => void;
+  recomputeAggregate: (c: ConnectorStatus[]) => void;
+  setConnectorsMenu: (items: Array<{ name: string; health: ConnectorStatus["health"] }>) => void;
 } = {
   connectors: [{ name: "drive", health: "healthy" }],
   highlightConnector: null,
   setConnectors: () => undefined,
   patchConnector: () => undefined,
+  recomputeAggregate: () => undefined,
+  setConnectorsMenu: () => undefined,
 };
 
 vi.mock("../../../src/store", () => ({
@@ -27,6 +34,8 @@ vi.mock("../../../src/hooks/useIpcQuery", () => ({
 vi.mock("../../../src/hooks/useIpcSubscription", () => ({
   useIpcSubscription: () => undefined,
 }));
+
+import { ConnectorGrid } from "../../../src/components/dashboard/ConnectorGrid";
 
 describe("ConnectorGrid", () => {
   it("renders one tile per connector", () => {

--- a/packages/ui/test/layouts/RootLayout.test.tsx
+++ b/packages/ui/test/layouts/RootLayout.test.tsx
@@ -3,7 +3,10 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
-vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+  emit: vi.fn(async () => undefined),
+}));
 
 import { RootLayout } from "../../src/layouts/RootLayout";
 import { useNimbusStore } from "../../src/store";

--- a/packages/ui/test/pages/Dashboard.test.tsx
+++ b/packages/ui/test/pages/Dashboard.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
-import { Dashboard } from "../../src/pages/Dashboard";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async () => undefined),
+}));
 
 vi.mock("../../src/hooks/useIpcQuery", () => ({
   useIpcQuery: () => ({ data: null, error: null, isLoading: false }),
@@ -17,7 +20,9 @@ vi.mock("../../src/store", () => ({
       highlightConnector: null;
       setConnectors: () => void;
       patchConnector: () => void;
-      trayIcon: "normal" | "amber" | "red";
+      recomputeAggregate: () => void;
+      setConnectorsMenu: () => void;
+      aggregateHealth: "normal" | "amber" | "red";
     }) => unknown,
   ) =>
     sel({
@@ -25,9 +30,13 @@ vi.mock("../../src/store", () => ({
       highlightConnector: null,
       setConnectors: () => undefined,
       patchConnector: () => undefined,
-      trayIcon: "normal",
+      recomputeAggregate: () => undefined,
+      setConnectorsMenu: () => undefined,
+      aggregateHealth: "normal",
     }),
 }));
+
+import { Dashboard } from "../../src/pages/Dashboard";
 
 describe("Dashboard", () => {
   it("renders PageHeader + three panels", () => {

--- a/packages/ui/test/store/tray.extended.test.ts
+++ b/packages/ui/test/store/tray.extended.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { create } from "zustand";
+import { createTraySlice, type TraySlice } from "../../src/store/slices/tray";
+
+describe("tray slice WS5-B extensions", () => {
+  let useStore: ReturnType<typeof create<TraySlice>>;
+  beforeEach(() => {
+    useStore = create<TraySlice>()((...a) => createTraySlice(...a));
+  });
+
+  it("aggregateHealth=red when any connector is unauthenticated", () => {
+    useStore.getState().recomputeAggregate([
+      { name: "a", health: "healthy" },
+      { name: "b", health: "unauthenticated" },
+    ]);
+    expect(useStore.getState().aggregateHealth).toBe("red");
+  });
+
+  it("aggregateHealth=amber when any connector is degraded and none is red", () => {
+    useStore.getState().recomputeAggregate([
+      { name: "a", health: "healthy" },
+      { name: "b", health: "degraded" },
+    ]);
+    expect(useStore.getState().aggregateHealth).toBe("amber");
+  });
+
+  it("aggregateHealth=normal when all healthy", () => {
+    useStore.getState().recomputeAggregate([{ name: "a", health: "healthy" }]);
+    expect(useStore.getState().aggregateHealth).toBe("normal");
+  });
+
+  it("setPendingHitl updates badge count and floors at 0", () => {
+    useStore.getState().setPendingHitl(2);
+    expect(useStore.getState().pendingHitl).toBe(2);
+    useStore.getState().setPendingHitl(-1);
+    expect(useStore.getState().pendingHitl).toBe(0);
+  });
+
+  it("setConnectorsMenu replaces the menu", () => {
+    useStore.getState().setConnectorsMenu([{ name: "drive", health: "healthy" }]);
+    expect(useStore.getState().connectorsMenu).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Tray slice gains `aggregateHealth` + `pendingHitl` + `connectorsMenu` (renames `trayIcon`/`hitlBadgeCount` → same values, clearer semantics)
- `recomputeAggregate(connectors)` — red if any error/unauthenticated, amber if any degraded/rate_limited, else normal
- ConnectorGrid calls `recomputeAggregate` + `setConnectorsMenu` + `invoke("set_connectors_menu", ...)` on every connector update
- RootLayout emits `tray://state-changed { icon, badge }` whenever aggregateHealth or pendingHitl changes; handles `tray://open-connector` by navigating to `/` and flashing the matching tile via `highlightConnector` (1.5 s)
- Rust tray rebuilds menu via `build_menu` helper; `set_connectors_menu` command re-applies menu with per-connector items; clicking a `conn:<name>` entry emits `tray://open-connector { name }`

## Deferred
- **500 ms icon debounce** — existing `tray://state-changed` listener already processes one-shot events; debounce is a polish item. Punted to a follow-up.
- **Local Rust verification** — this machine has no `cargo` installed; Rust changes pass visual review but need CI to compile/test. Flag in PR discussion if CI fails.

## Stacked on PR-B2
Base branch is `dev/ws5b-dashboard`. When B1 and B2 merge, GitHub auto-retargets.

## Test plan
- [x] `cd packages/ui && bunx vitest run` — 85/85 pass
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — clean
- [ ] `cd packages/ui/src-tauri && cargo test --lib` — not run locally (no cargo); CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)