### PR TITLE
feat(ws5d-polish): watcher history, workflow run history + audit deep-link, "Run with params..."

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -209,13 +211,14 @@ jobs:
             script: "test:coverage:sdk"
     steps:
       - name: Harden Runner
-        if: runner.os == 'Linux'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -99,9 +99,13 @@ jobs:
           use_oidc: true
           files: coverage/lcov.info
 
-      - name: SonarCloud analysis
+      - name: SonarQube Cloud analysis
+        # SonarCloud rebranded to SonarQube Cloud; sonarcloud-github-action is
+        # deprecated and delegates to sonarqube-scan-action. We invoke the new
+        # action directly so its SHA pin is visible (the repo enforces
+        # sha_pinning_required=true, which blocks transitively-unpinned actions).
         if: runner.os == 'Linux' && env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v3.1.0
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1 (Node 24 runtime)
         id: changes
         with:
@@ -75,6 +77,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Rust + Tauri checks
         uses: ./.github/actions/setup-rust-tauri
@@ -96,6 +100,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -138,13 +144,14 @@ jobs:
 
     steps:
       - name: Harden Runner
-        if: runner.os == 'Linux'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Rust + Tauri checks
         uses: ./.github/actions/setup-rust-tauri
@@ -172,6 +179,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -232,13 +241,14 @@ jobs:
 
     steps:
       - name: Harden Runner
-        if: runner.os == 'Linux'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,26 +11,65 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (JavaScript / TypeScript)
-    runs-on: ubuntu-22.04
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     permissions:
       security-events: write
       contents: read
       actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            runner: ubuntu-22.04
+            build-mode: none
+          # Tauri shell, IPC bridge, updater signature verification, LAN crypto.
+          # CodeQL Rust support is GA on github-hosted Linux; manual build mode lets us
+          # control toolchain (matches setup-rust-tauri) and skip Tauri's heavy GTK deps.
+          - language: rust
+            runner: ubuntu-22.04
+            build-mode: manual
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Linux libs for Tauri (Rust only)
+        if: matrix.language == 'rust'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+            librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
+            libsecret-1-dev
+
+      - name: Setup Rust (Rust only)
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
-          languages: javascript-typescript
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
-      - name: Autobuild
+      - name: Autobuild (JS/TS)
+        if: matrix.language == 'javascript-typescript'
         uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+
+      - name: Build Tauri (Rust)
+        if: matrix.language == 'rust'
+        shell: bash
+        working-directory: packages/ui/src-tauri
+        run: cargo build --all-features --locked
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Setup Rust (Rust only)
         if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (SHA-pinned; version driven by input below)
+        with:
+          toolchain: "1.88.0"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -14,13 +14,33 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      # Required for npm provenance (sigstore signature backed by GitHub OIDC).
+      # Lets consumers verify the package was built by this workflow on this commit
+      # via `npm audit signatures`.
+      id-token: write
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
+
+      # Pin Node so npm CLI version is predictable for `npm publish --provenance`
+      # (provenance requires npm >= 9.5; the runner default is fine, but pinning
+      # avoids surprises when GitHub bumps the runner image).
+      - name: Setup Node (for npm publish --provenance)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Build client (dist ESM + CJS)
         run: bun run --filter @nimbus-dev/client build
@@ -33,8 +53,15 @@ jobs:
         env:
           CI: "true"
 
-      - name: Publish to npm
+      # Use `npm publish --provenance` (not `bun publish`) so the published tarball
+      # carries an npm provenance attestation. Bun's publish does not yet emit one.
+      #
+      # Migration to npm trusted publishing (token-less): once configured at
+      # https://www.npmjs.com/package/@nimbus-dev/client/access (Trusted Publisher
+      # for this repo + workflow), the NODE_AUTH_TOKEN env can be dropped. id-token:
+      # write above is already in place.
+      - name: Publish to npm with provenance
         working-directory: packages/client
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --access public
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Needed when using the default GITHUB_TOKEN (no RELEASE_PLEASE_PAT). Optional PAT keeps
     # the same scopes off the automatic token if you add secret RELEASE_PLEASE_PAT later.
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -85,13 +87,14 @@ jobs:
 
     steps:
       - name: Harden Runner
-        if: runner.os == 'Linux'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -184,13 +187,14 @@ jobs:
 
     steps:
       - name: Harden Runner
-        if: runner.os == 'Linux'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -223,9 +227,12 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     # Keep GITHUB_TOKEN read-only here; GitHub Release API uses RELEASE_PAT (fine-grained: Contents RW).
+    # id-token: write is required by anchore/sbom-action to attach an OIDC-signed attestation.
     permissions:
       contents: read
       actions: read
+      id-token: write
+      attestations: write
 
     steps:
       - name: Harden Runner
@@ -235,6 +242,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Require release PAT
         env:
@@ -266,6 +275,28 @@ jobs:
           V="${GITHUB_REF_NAME#v}"
           bun scripts/package-linux-installers.ts --bundle dist/headless-bundle --version "$V"
 
+      # Generate a CycloneDX SBOM of the source tree. Captures Bun + Cargo
+      # dependency graphs that produced the binaries downloaded above. Output is
+      # attached to the release for downstream consumers and signed via OIDC by
+      # the anchore action's call to attest-build-provenance.
+      - name: Generate SBOM (CycloneDX)
+        id: sbom
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
+        with:
+          path: .
+          format: cyclonedx-json
+          artifact-name: nimbus-${{ github.ref_name }}-sbom.cdx.json
+          # Don't auto-attach to GitHub Release (we do it explicitly below to control filename).
+          upload-release-assets: false
+          upload-artifact: true
+
+      - name: Stage SBOM for release
+        shell: bash
+        run: |
+          set -e
+          mkdir -p dist/sbom
+          cp "${{ steps.sbom.outputs.fileName }}" "dist/sbom/nimbus-${GITHUB_REF_NAME}-sbom.cdx.json"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@c95fe1489396fe8a21967200391e1b9067ad0ba5 # v2.6.2
         with:
@@ -274,6 +305,7 @@ jobs:
             dist/nimbus-gateway-*/nimbus-gateway-*
             dist/nimbus-cli-*/nimbus-cli-*
             dist/installers/nimbus-headless*
+            dist/sbom/nimbus-*-sbom.cdx.json
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
@@ -282,10 +314,17 @@ jobs:
     name: Publish updater manifest
     needs: publish-release
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     permissions:
-      contents: write
+      contents: read
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-nimbus-ci
         with:
           verify-lock: "false"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -211,13 +211,17 @@ jobs:
           toolchain: "1.88.0"
 
       - name: Run cargo deny
-        # Action pinned to a SHA. Walks deny.toml in the working dir.
-        uses: EmbarkStudios/cargo-deny-action@e2f4ede4a4e60ea15ff31bc0647485d80c66cfba # v2.0.4
+        # NOTE: pinned to the floating `v2` tag rather than a SHA.
+        # The previous SHA (e2f4ede, v2.0.4) bundled a cargo-deny version
+        # that can't parse CVSS 4.0 vectors, causing advisory-db sync to
+        # fail on e.g. RUSTSEC-2025-0138. Follow-up: re-pin to a fresh SHA
+        # that resolves to v2.0.12+ for supply-chain hygiene.
+        uses: EmbarkStudios/cargo-deny-action@v2
         with:
           manifest-path: packages/ui/src-tauri/Cargo.toml
           # `all` = check advisories, bans, licenses, sources.
           command: check all
-          arg: --hide-inclusion-graph
+          command-arguments: --hide-inclusion-graph
 
   gitleaks:
     name: Gitleaks secret scan

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -168,7 +168,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (SHA-pinned; version driven by input below)
+        with:
+          toolchain: "1.88.0"
 
       - name: Cache cargo-audit binary
         id: cargo-audit-cache
@@ -204,7 +206,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (SHA-pinned; version driven by input below)
+        with:
+          toolchain: "1.88.0"
 
       - name: Run cargo deny
         # Action pinned to a SHA. Walks deny.toml in the working dir.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -52,6 +54,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Trivy's Bun detector expects node_modules (see INFO in scan logs); matches the audit job and improves
       # lockfile / dependency graph accuracy. node_modules remains excluded from traversal via skip-dirs.
@@ -130,6 +134,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
@@ -158,6 +164,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -176,3 +184,63 @@ jobs:
       - name: Run cargo audit (packages/ui/src-tauri)
         working-directory: packages/ui/src-tauri
         run: cargo audit
+
+  cargo-deny:
+    name: Cargo deny (licenses + advisories + bans)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Run cargo deny
+        # Action pinned to a SHA. Walks deny.toml in the working dir.
+        uses: EmbarkStudios/cargo-deny-action@e2f4ede4a4e60ea15ff31bc0647485d80c66cfba # v2.0.4
+        with:
+          manifest-path: packages/ui/src-tauri/Cargo.toml
+          # `all` = check advisories, bans, licenses, sources.
+          command: check all
+          arg: --hide-inclusion-graph
+
+  gitleaks:
+    name: Gitleaks secret scan
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # PR comments + status check from gitleaks.
+      pull-requests: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history so gitleaks can diff against base.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run gitleaks
+        # Free for public repos; org/private repos require GITLEAKS_LICENSE secret.
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
+          GITLEAKS_ENABLE_SUMMARY: "true"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -211,12 +211,11 @@ jobs:
           toolchain: "1.88.0"
 
       - name: Run cargo deny
-        # NOTE: pinned to the floating `v2` tag rather than a SHA.
-        # The previous SHA (e2f4ede, v2.0.4) bundled a cargo-deny version
-        # that can't parse CVSS 4.0 vectors, causing advisory-db sync to
-        # fail on e.g. RUSTSEC-2025-0138. Follow-up: re-pin to a fresh SHA
-        # that resolves to v2.0.12+ for supply-chain hygiene.
-        uses: EmbarkStudios/cargo-deny-action@v2
+        # Pinned to v2.0.17 (cargo-deny 0.19.2). The previous pin at
+        # e2f4ede (v2.0.4) bundled a cargo-deny version that couldn't
+        # parse CVSS 4.0 vectors, causing advisory-db sync to fail on
+        # e.g. RUSTSEC-2025-0138.
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
           manifest-path: packages/ui/src-tauri/Cargo.toml
           # `all` = check advisories, bans, licenses, sources.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict
 **Linter:** Biome
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · S2 graph-aware watchers ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · S2 graph-aware watchers ✅)
 
 **Gemini CLI:** [`GEMINI.md`](./GEMINI.md) mirrors this file for the same repository — update both when changing commands, roadmap rows, or non-negotiables.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict  
 **Linter:** Biome  
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)  
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · S2 graph-aware watchers ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · S2 graph-aware watchers ✅)
 
 Companion context for other agents: [`CLAUDE.md`](./CLAUDE.md) (same project facts; keep both files aligned when changing commands, roadmap rows, or non-negotiables).
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -207,7 +207,55 @@ For workflow and token hygiene used in CI, see [`security-hardening.md`](./secur
 Automated vulnerability scans run on every PR and nightly:
 
 - **`bun audit`** — npm dependency advisory checks
-- **`trivy`** — filesystem and container vulnerability scanning
-- **`CodeQL`** — static analysis for JS/TS
+- **`cargo audit`** — Rust dependency advisory checks (Tauri shell)
+- **`cargo deny`** — license compatibility (AGPL-3.0 inbound), unmaintained-crate bans, registry pinning
+- **`trivy`** — filesystem vulnerability scanning, SARIF uploaded to GitHub Security tab
+- **`CodeQL`** — static analysis for JS/TS *and* Rust (security-extended queries)
+- **`gitleaks`** — committed-secret detection on PRs and nightly
+- **`OpenSSF Scorecard`** — supply-chain posture, weekly + on default-branch push
+- **`@nimbus-dev/client`** is published with **npm provenance** (sigstore signature backed by GitHub OIDC); verify with `npm audit signatures`
 
 HIGH and CRITICAL findings block merges when branch protection checks are required. Dependabot opens update PRs automatically for outdated dependencies.
+
+Release binaries (Gateway + CLI, all four platform builds) carry a **GitHub build provenance attestation** (`actions/attest-build-provenance`) and a **CycloneDX SBOM**, both attached to the GitHub Release. Verify with:
+
+```bash
+gh attestation verify nimbus-gateway-linux-x64 --owner nimbus-dev
+```
+
+---
+
+## Updater Signing Key Lifecycle
+
+Nimbus auto-updates are gated on an **Ed25519 signature over SHA-256 of each binary**. The public key is embedded in the binary at build time (`packages/gateway/src/updater/public-key.ts`); the private key lives only in the `UPDATER_SIGNING_KEY` repository secret and is never present on a developer machine.
+
+### Rotation procedure
+
+Plan a rotation at least once every 12 months, and immediately on any of these triggers:
+
+- A maintainer with secret-read access leaves the project.
+- A CI run is suspected of having leaked the key (e.g., a workflow added an unintended `echo "$UPDATER_SIGNING_KEY"`).
+- A new key algorithm becomes the default for the project.
+
+**Steps (must all happen in the same release cycle):**
+
+1. **Generate the new keypair** locally on an air-gapped or hardened workstation:
+   ```bash
+   bun scripts/generate-ed25519-keypair.ts > new-updater-key.json
+   ```
+2. **Update the embedded public key** in `packages/gateway/src/updater/public-key.ts` (and the test override `NIMBUS_DEV_UPDATER_PUBLIC_KEY` if used) on a feature branch. Land via PR.
+3. **Cut a transitional release** that ships *both* the old and new public key as trusted (the updater accepts either signature). This release must be signed with the **old** key.
+4. **Rotate the secret**: replace `UPDATER_SIGNING_KEY` in repository secrets with the new private key. Delete the local copy of the new private key from the workstation immediately after upload.
+5. **Cut a second release** signed with the new key. Verify clients on N-1, N, and N+1 all auto-update successfully.
+6. **Remove the old public key** from `public-key.ts` in the next release. Document the rotation in `docs/SECURITY.md` change history.
+
+### Compromise response
+
+If the active signing key is suspected to be compromised:
+
+1. **Disable auto-update server-side** by setting the `latest.json` manifest's `version` to a pinned safe value and the `forcedUpdate` flag to `false`.
+2. Generate a new keypair and ship a transitional release within 24 hours. Notify users via the GitHub Security advisory channel.
+3. Revoke the leaked key by removing it from `public-key.ts` in the immediate follow-up release.
+4. Audit the GitHub Actions workflow run logs for the period the key was active — look for any step that read `UPDATER_SIGNING_KEY` outside `scripts/sign-ed25519.ts`.
+
+**Long-term mitigation:** the project is tracking migration to **sigstore/cosign with GitHub OIDC** for keyless updater signing, eliminating the long-lived secret entirely. Tracked under Phase 4 release-infra hardening.

--- a/docs/phase-4-plan.md
+++ b/docs/phase-4-plan.md
@@ -1843,7 +1843,7 @@ Use `[x] code` when the implementation exists. Use `[x] verified` only after man
 
 ## WS5-D — Marketplace, Watchers & Workflows (Implementation Tasks)
 
-> **Status (2026-04-22):** WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · **WS5-D 🔵 Active**
+> **Status (2026-04-22):** WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅
 
 **Goal:** Replace the three `*Stub.tsx` placeholder pages with fully-tested implementations that talk to the existing Gateway `automation-rpc` handlers.
 

--- a/docs/release/v0.1.0-finish-plan.md
+++ b/docs/release/v0.1.0-finish-plan.md
@@ -1,0 +1,348 @@
+# v0.1.0 Finish Plan — Remaining Phase 4 Work
+
+> **Purpose:** Define the remaining Phase 4 workstreams after WS1–WS4 and WS5-A through WS5-D merged, split into what must ship *in* `v0.1.0` and what slips to a `v0.1.1` point release.
+> **Companion docs:** [`phase-4-plan.md`](../phase-4-plan.md) (original design, 3,393 lines); [`v0.1.0-prerequisites.md`](./v0.1.0-prerequisites.md) (procurement runbook).
+> **Scope:** Engineering work only. Certificates, domain, and publisher accounts are covered by the prerequisites runbook.
+> **Status:** Drafted 2026-04-22.
+
+---
+
+## 1. Cut-line Decision
+
+`v0.1.0` ships with **Linux binaries GPG-signed** and **macOS + Windows binaries unsigned**. Code-signing certificates for Apple ($99/yr) and Windows EV ($350–700/yr + ~$120–$240/yr service fees) are deferred to a later point release, not `v0.1.1`, until the maintainer judges the product stable enough to justify recurring procurement spend. Until then, macOS and Windows users follow a documented unsigned-install bypass procedure — the integrity guarantee for non-Linux platforms comes from **GPG-signed `SHA256SUMS.asc`**, not platform-native signatures.
+
+**v0.1.0 ships with:** WS6 (Rich TUI), WS7 (VS Code extension), Linux GPG-signed installers + `SHA256SUMS.asc`, voice cross-platform verification, WS5-D polish, documented unsigned-install instructions for macOS + Windows, and the release-gate checklist passed on all three platforms — where "passed" for macOS/Windows means *installs and runs correctly after the documented bypass*, not *passes Gatekeeper/SmartScreen*.
+
+**v0.1.1 adds:** SQLCipher at rest, Workflow branching, built-in Meeting Prep agent, and the first five community-extension seed packages.
+
+**Later point release** (trigger: explicit maintainer decision to fund certs): macOS Gatekeeper notarization + Windows Authenticode signing.
+
+---
+
+## 2. Status Snapshot
+
+### ✅ Done (merged to `main`)
+
+| Workstream | Delivered |
+|---|---|
+| WS1 — Local LLM + Multi-Agent | `OllamaProvider`, `LlamaCppProvider`, `LlmRouter`, `LlmRegistry`, `GpuArbiter`, `AgentCoordinator`, `runSubAgent`, `engine.askStream`, V16 + V17 migrations |
+| WS2 — Voice Interface | `VoiceService`, `NativeTtsProvider`, `voice.*` IPC, `nimbus doctor` voice checks |
+| WS3 — Data Sovereignty | `nimbus data export/import/delete`, `nimbus audit verify/export`, BLAKE3 chain, V18 migration, BIP39 recovery |
+| WS4 — Release Infrastructure (code) | Ed25519 updater + `nimbus update`, Plugin API v1 frozen, LAN RPC, V19 migration |
+| WS5-A — App Shell | React 19 / Tailwind v4 / Radix / Zustand; Tauri bridge; tray + Quick Query; onboarding wizard |
+| WS5-B — Tray & Dashboard | Health-aggregated tray, `IndexMetricsStrip`, `ConnectorGrid`, `AuditFeed`, HITL popup |
+| WS5-C — Settings Shell | 7 panels (Profiles, Telemetry, Connectors, Model, Audit, Updates, Data) |
+| WS5-D — Marketplace / Watchers / Workflows | Extension install-from-dir manager, graph-aware watcher condition builder, workflow list + dry-run |
+| Automation S2 | Graph-aware watcher conditions (`owned_by` / `upstream_of` / `downstream_of`), V22 migration |
+
+### 🔄 Open in v0.1.0
+
+| Item | Est. size | Parallelisable? |
+|---|---|---|
+| WS6 — Rich TUI (Ink) | L (new package surface) | With WS7 |
+| WS7 — VS Code extension | L (new package) | With WS6 |
+| WS5-D polish (Watcher history drawer, Workflow run history, parameter override) | S | Yes |
+| Linux GPG signing + `SHA256SUMS.asc` + unsigned-install docs (macOS & Windows) | M | Yes |
+| Voice 3-platform manual verification | S | After WS6 lands (TUI voice test path) |
+| Release gate execution (3-platform matrix) | M | Last |
+
+### 🕒 Deferred to v0.1.1
+
+| Item | Trigger |
+|---|---|
+| SQLite encryption at rest (SQLCipher, opt-in `[db.encrypt]`) | No external blocker — engineering work |
+| Workflow branching / conditionals (`if` / `else` / `switch`) | No external blocker — engineering work |
+| Built-in `nimbus prep` (Meeting preparation agent) | WS6 streams (`engine.askStream`) battle-tested |
+| 5 seed community extensions in `registry.nimbus.dev` | Registry host live (§5 in prerequisites runbook) |
+
+### 🔒 Deferred to a later point release (not v0.1.1)
+
+| Item | Trigger |
+|---|---|
+| Signed + notarized macOS `.pkg` | Explicit maintainer decision to fund Apple Developer Program ($99/yr) |
+| Signed Windows installer (EV, SmartScreen-clean) | Explicit maintainer decision to fund Windows EV cert + signing service (~$470–$840/yr) |
+
+---
+
+## 3. v0.1.0 Sequencing
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                      v0.1.0 critical path                         │
+└──────────────────────────────────────────────────────────────────┘
+
+  ┌─ [P1] WS5-D polish (UI drawers)     ─┐
+  │                                      │
+  ├─ [P1] Linux signing + unsigned-install ├──►  [P3] Voice 3-platform
+  │       docs (+ SHA256SUMS.asc)        │         manual verify
+  │                                      │
+  ├─ [P2] WS6 — Rich TUI ────────────────┤
+  │                                      │
+  └─ [P2] WS7 — VS Code extension ───────┘
+                                            │
+                                            ▼
+                               ┌────────────────────────┐
+                               │ Release-gate checklist │
+                               │   (3-OS matrix)        │
+                               └────────────────────────┘
+                                            │
+                                            ▼
+                                       tag v0.1.0
+```
+
+**Parallelism rules:**
+
+- **P1 track** (WS5-D polish + Linux signing + unsigned-install docs) should land first — small scope, unblocks the release pipeline, and lets a `v0.1.0-rc1` dry-run exercise the full artifact + signature + SHA256SUMS flow before the bigger workstreams land.
+- **P2 track** (WS6 + WS7) is the biggest remaining work. Solo dev should run them **sequentially in the order WS6 → WS7**; WS6 validates the streaming IPC surface that WS7 will also consume, and debugging two new surfaces at once against the same Gateway multiplies surface-area churn.
+- **P3 track** (voice verify) runs on the produced installers once WS6 is in, not earlier — voice paths surface through both CLI/TUI and Tauri.
+
+---
+
+## 4. v0.1.0 Workstreams
+
+### 4.1 WS5-D Polish
+
+**Scope.** Three small additions that close the three bullet-points remaining on `docs/roadmap.md:317-319`:
+
+1. **Watcher history drawer** on `Watchers.tsx` — list the last N fires of the selected watcher, paginated, with timestamp + matched item preview. New IPC: `watcher.listHistory({ watcherId, limit })`.
+2. **Workflow run history** on `Workflows.tsx` — row-expand shows last 10 runs with status, duration, dry-run flag, and a "View audit entry" link that deep-links to the matching `audit_log` row (bridges the operational view to the tamper-evident legal record). New IPC: `workflow.listRuns({ workflowName, limit })`.
+3. **Parameter override on run** — `WorkflowRow` "Run" becomes a two-button split: "Run" (existing) and "Run with params…" opening a small dialog that patches `step.params` for one invocation. No new IPC; reuses `workflow.run`.
+4. **Retention policy for `workflow_run`** — pruning at run completion keeps the last **100 runs per workflow** (count-based, per §8 decision). Implemented as `DELETE FROM workflow_run WHERE workflow_id = ? AND id NOT IN (SELECT id FROM workflow_run WHERE workflow_id = ? ORDER BY started_at DESC LIMIT 100)` called from `finishWorkflowRunRow`. Future revisit (post-v0.1.0): consider time-based TTL if count-based proves insufficient.
+5. **V23 migration** — adds `dry_run INTEGER NOT NULL DEFAULT 0` + `params_override_json TEXT` columns to the existing `workflow_run` table (v9 schema already has the table; these are additive). The runner starts writing dry-run rows too (currently dry runs short-circuit before the INSERT).
+6. **Audit logging for workflow runs** — `runWorkflowExecution` writes an `audit_log` entry on completion (status, duration, dry-run, error if any). This gives the "View audit entry" link a real target in the BLAKE3-chained legal record.
+
+**Allowlist delta.** +2 methods → `ALLOWED_METHODS.len()` becomes 56.
+
+**Acceptance criteria.**
+
+- [ ] Watcher history drawer renders last N fires within 1 s of open; pagination works on 1,000-row fixture.
+- [ ] Workflow run row expands inline without navigating; dry-run runs are visually distinguished from real runs.
+- [ ] "Run with params…" dialog successfully overrides `step.params` for one invocation without persisting; audit log shows the override values.
+- [ ] Flip `docs/roadmap.md:317-319` to `[x]` and append "v0.1.0" markers.
+- [ ] Vitest coverage on `Watchers.tsx` + `Workflows.tsx` stays ≥ 80 % lines / ≥ 75 % branches.
+
+### 4.2 Signing Pipeline + Unsigned-Install Documentation
+
+**Scope.** Ship Linux GPG signing fully operational. For macOS and Windows, **do not wire CI signing jobs** (they would be dead code until certs are procured, and fresh keys would need re-wiring then anyway). Instead, deliver clear user-facing docs for the unsigned-install bypass, plus a `SHA256SUMS.asc` file that gives users a cryptographic integrity check independent of platform signing.
+
+**Deliverables.**
+
+1. **`release.yml` job matrix** — `ubuntu-latest`, `macos-14`, `windows-latest`. All three build; only Linux signs.
+2. **Linux signing (live in v0.1.0):**
+   - `gpg --detach-sign --armor` on `nimbus_<ver>_amd64.deb` + `nimbus-<ver>.AppImage`.
+   - `SHA256SUMS` file listing hashes of every release artifact (all three OSes).
+   - `SHA256SUMS.asc` — detached GPG signature of `SHA256SUMS`. **This is the integrity proof for macOS and Windows users too.**
+   - Keys: `GPG_SIGNING_SUBKEY` + `GPG_PASSPHRASE` secrets (procurement runbook §3).
+   - Public key at `docs/release/SIGNING-KEY.asc`, committed; linked from README.
+3. **macOS build (unsigned):** produce `.pkg` via `pkgbuild` without `--sign`. Binary still runs; Gatekeeper blocks first-launch until bypass.
+4. **Windows build (unsigned):** produce installer (NSIS or WiX output) without `signtool` invocation. Binary still runs; SmartScreen warns first-launch until bypass.
+5. **Documentation:**
+   - `docs/install-macos-unsigned.md` — three-line bypass: `xattr -d com.apple.quarantine ~/Downloads/nimbus-<ver>.pkg && open ~/Downloads/nimbus-<ver>.pkg`, plus the right-click-Open alternative with screenshots. Include a **"Why is this unsigned?"** section framing the tradeoff honestly (local-first project, avoiding recurring cost + vendor telemetry until product is stable; integrity proof is via GPG-signed hashes, independent of platform signing).
+   - `docs/install-windows-unsigned.md` — screenshot of the SmartScreen "Windows protected your PC" dialog with "More info → Run anyway" annotated. Same "Why is this unsigned?" section.
+   - `docs/verify-release-integrity.md` — how any user on any platform verifies `SHA256SUMS.asc` with `gpg --verify` against the public key. This is the *real* integrity proof for v0.1.0.
+   - README install section — three OS sub-sections. Each leads with a **"One-liner for Pro Users"** copy-pasteable command (e.g., `curl -L …/nimbus-verify.sh | bash` for macOS/Linux; `iwr …/nimbus-verify.ps1 | iex` for Windows), then links to the full doc for those who want the long-form explanation. Framing is "Power-User Shortcut" not "Security Warning".
+6. **`nimbus-verify.sh` + `nimbus-verify.ps1`** — small standalone scripts in `scripts/release/` that (a) download the release artifact + `SHA256SUMS` + `SHA256SUMS.asc` + public key if not already imported, (b) run `gpg --verify` + `sha256sum -c` automatically, (c) print a clear ✅ / ❌ summary. Published alongside the release artifacts so users can run a single command to verify integrity.
+7. **GPG key distribution** — public key published to:
+   - `docs/release/SIGNING-KEY.asc` in the repo.
+   - Linked from README + GitHub Release notes.
+   - Uploaded to `keys.openpgp.org` **and** `keyserver.ubuntu.com` (two keyservers for redundancy). Users can run `gpg --keyserver keyserver.ubuntu.com --recv-keys <FINGERPRINT>` without touching the repo.
+8. **Release-environment gating** — publish step runs in the `release` GitHub Environment with required reviewers = maintainer (procurement runbook §9.4).
+
+**Updater-transition note.** The Ed25519 auto-updater verifies signatures over the *binary hash manifest* — it is **orthogonal** to platform code-signing (codesign, signtool). A future release that switches from unsigned to platform-signed binaries is **transparent to the updater**: the Ed25519 manifest signature continues to verify; only the downloaded binary's surface metadata (Gatekeeper attributes, Authenticode blob) changes. No updater code change needed at the signing transition.
+
+**Non-deliverables (explicitly out of scope for v0.1.0):**
+
+- No `codesign` / `notarytool` / `stapler` invocations in `release.yml`.
+- No `signtool` / Authenticode logic in `release.yml`.
+- No Apple `.p12` / eSigner / Azure Trusted Signing secrets configured on the repo.
+- No self-hosted Windows runner.
+
+Reason: wiring these without real certs produces dead code; re-wiring when a cert finally arrives is cheap. Don't carry unused infrastructure.
+
+**Acceptance criteria.**
+
+- [ ] `release.yml` runs green end-to-end on a `v0.1.0-rc1` tag with only `GPG_SIGNING_SUBKEY` + `GPG_PASSPHRASE` + `UPDATER_ED25519_PRIVATE_KEY` populated.
+- [ ] Release artifacts include: `nimbus_<ver>_amd64.deb` + `.deb.asc`, `nimbus-<ver>.AppImage` + `.AppImage.asc`, `nimbus-<ver>.pkg` (unsigned), `nimbus-<ver>-setup.exe` (unsigned), `SHA256SUMS`, `SHA256SUMS.asc`.
+- [ ] From a clean machine: `gpg --verify SHA256SUMS.asc SHA256SUMS && sha256sum -c SHA256SUMS` succeeds against the downloaded artifact set (whichever platform).
+- [ ] `docs/install-macos-unsigned.md` bypass verified working on a fresh macOS install (manual smoke).
+- [ ] `docs/install-windows-unsigned.md` bypass verified working on a fresh Windows 11 install (manual smoke).
+- [ ] Release-environment reviewer approval is enforced before artifacts upload to the GitHub Release.
+
+### 4.3 WS6 — Rich TUI (Ink)
+
+**Scope.** Pulled forward unchanged from `phase-4-plan.md` — the original design is authoritative.
+
+**Key new files.**
+
+| File | Purpose |
+|---|---|
+| `packages/cli/src/tui/App.tsx` | 4-pane root — Query Input / Result Stream / Connector Health / Sub-Task Progress |
+| `packages/cli/src/tui/QueryInput.tsx` | Input + last-100 history (`query_history.json`) + inline HITL overlay |
+| `packages/cli/src/tui/ResultStream.tsx` | Token-by-token render over `engine.streamToken` |
+| `packages/cli/src/tui/ConnectorHealth.tsx` | `connector.list` poll (30 s), coloured dot per service |
+| `packages/cli/src/tui/WatcherPane.tsx` | `watcher.list` poll (30 s) |
+| `packages/cli/src/tui/SubTaskPane.tsx` | `agent.subTaskProgress` subscription, bar per sub-task |
+
+**SSH safety.** `TERM=dumb` or `NO_COLOR` → automatic fallback to the existing Phase 3 REPL. No new flag.
+
+**IPC.** No new methods required — all streams already exist (`engine.askStream`, `engine.streamToken`, `engine.streamDone`, `engine.streamError`, `agent.subTaskProgress`).
+
+**Acceptance criteria.**
+
+- [ ] `nimbus tui` launches on Windows (Windows Terminal), macOS (Terminal.app, iTerm2), Linux (gnome-terminal, alacritty).
+- [ ] Token-by-token stream renders continuously without flicker on a 20 s generation.
+- [ ] HITL overlay appears mid-stream; approving resumes the stream without dropping tokens already buffered.
+- [ ] `TERM=dumb nimbus tui` exits cleanly into the Phase 3 REPL; no Ink stack trace.
+- [ ] Coverage on `packages/cli/src/tui/` ≥ 80 % lines / ≥ 75 % branches.
+
+### 4.4 WS7 — VS Code Extension
+
+**Scope.** Pulled forward unchanged from `phase-4-plan.md`.
+
+**New package.** `packages/vscode-extension/`. Depends **only** on `@nimbus-dev/client` (already in `packages/client/src/index.ts`) + stable Gateway IPC. Never imports Gateway source.
+
+**Commands.**
+
+- `Nimbus: Ask` — streaming Markdown result into a new editor tab, tokens rendered via `@nimbus-dev/client.ask()`.
+- `Nimbus: Search` — Quick Pick over local index results.
+- `Nimbus: Run Workflow` — Quick Pick over `workflow.list`, invokes `workflow.run`.
+
+**HITL.** Inline VS Code `window.showInformationMessage(..., { modal: true })` with Approve / Reject; diff preview rendered in a transient Webview panel for multi-action requests.
+
+**Status bar.** Item shows active profile name + health dot; polls every 30 s via `@nimbus-dev/client`.
+
+**Publishing.** `publish-vscode.yml` triggers on `vscode-v*` tags → VS Code Marketplace (via `vsce`) + Open VSX (via `ovsx`). Secrets `VSCE_PAT` + `OVSX_PAT` (procurement runbook §6–§7).
+
+**Node.js compatibility (dedicated task).** `@nimbus-dev/client` was developed against Bun; VS Code's extension host is Node.js. The client must handle the following differences explicitly:
+
+- Unix sockets (macOS/Linux) via `net.createConnection({ path: '/path/to/socket' })` — Node's `net.Socket` semantics are close to Bun's but not identical; confirm no reliance on `Bun.connect` or `Bun.listen` in the client path.
+- Named pipes (Windows) via `\\.\pipe\<name>` — different path convention from Unix sockets; client must detect and dispatch correctly.
+- No reliance on Bun-only globals (`Bun.file`, `Bun.write`, `Bun.env`) — use `node:fs` + `process.env` instead.
+
+A `packages/client/test/node-compat.test.ts` run under `node` (not `bun test`) confirms the client's IPC path works end-to-end against a running Gateway on each OS.
+
+**Theme syncing.** The streaming Webview must use VS Code CSS variables (`--vscode-editor-background`, `--vscode-editor-foreground`, `--vscode-textLink-foreground`, `--vscode-widget-border`, etc.) so the chat surface matches the user's theme across Dark / Light / High Contrast variants without manual switching.
+
+**Acceptance criteria.**
+
+- [ ] `Nimbus: Ask` streams a result from a running Gateway without manual configuration on VS Code 1.90+ and Cursor.
+- [ ] Inline HITL modal approves correctly; rejection cleans up the in-flight request; diff-preview Webview disposes on close.
+- [ ] Status bar health dot changes within 30 s of a connector transitioning to `degraded`.
+- [ ] Extension installs on Open VSX from a published `vscode-v0.1.0` tag.
+- [ ] `@nimbus-dev/client` node-compat test passes on all three OSes under `node`, not just `bun`.
+- [ ] Webview theme matches VS Code theme on Dark, Light, and High Contrast — screenshot smoke test.
+- [ ] Coverage on `packages/vscode-extension/src/` ≥ 80 % lines / ≥ 75 % branches.
+
+### 4.5 Voice 3-Platform Verification
+
+**Scope.** Manual smoke test — WS2 code is merged; platform reality needs to be verified on real hardware.
+
+**Matrix.** For each of Windows / macOS / Linux:
+
+- [ ] `nimbus doctor` reports `voice: ok` with no warnings.
+- [ ] `voice.transcribe` round-trip on a 10 s utterance produces transcript within 5 s.
+- [ ] `voice.speak "hello from nimbus"` uses the platform's native TTS (`say` / PowerShell SAPI / `espeak-ng` or `spd-say`). For Linux, document **Piper** as the recommended higher-quality alternative in `docs/voice.md` (users opt in by setting a config key; not installed by default — keeps the Linux dependency footprint small).
+- [ ] Wake-word loop (`voice.startWakeWord`) activates on "hey nimbus" and deactivates on `voice.stopWakeWord`.
+- [ ] Network inspector (Wireshark / `tcpdump`) recorded during a full round-trip shows zero outbound traffic to non-localhost endpoints.
+
+Document results in `docs/manual-smoke-voice.md` (new file).
+
+### 4.6 Release-Gate Checklist Execution
+
+**Scope.** Every box in the Phase 4 release gate, ticked twice (code + verified) per platform. Results recorded in a new `docs/release/v0.1.0-release-gate.md` committed alongside the release.
+
+**Checklist rows** (from the Phase 4 reference — `nimbus-phase-4`):
+
+| Check | Notes |
+|---|---|
+| `nimbus ask` via Ollama (no API key) | Budget 30 s p95 on mid-range laptop |
+| `nimbus ask` via llama.cpp GGUF | Second provider — Ollama not required |
+| Voice push-to-talk round-trip | See §4.5 above |
+| `nimbus data export` + `import` restores full state | WS3 already has unit coverage; this is the manual 3-OS re-verification |
+| `nimbus audit verify` passes (100+ rows) | Run on a populated, real index |
+| Release integrity proof usable on every platform | Linux: `gpg --verify nimbus_<ver>_amd64.deb.asc` → `Good signature`. macOS + Windows: `gpg --verify SHA256SUMS.asc SHA256SUMS && sha256sum -c SHA256SUMS` succeeds. Platform-native signatures (Gatekeeper, SmartScreen) are **out of scope for v0.1.0** — documented unsigned-install bypass is the acceptance bar. |
+| Tauri UI: Dashboard + HITL dialog | Verified by WS5-B smoke |
+| `nimbus tui` launches + streams | §4.3 acceptance |
+| VS Code extension connects + Ask works | §4.4 acceptance |
+
+---
+
+## 5. v0.1.1 Point Release
+
+Triggered when all WS2/WS3/WS4/WS5 bug fixes from early-adopter reports have stabilized for 2 weeks, *and* at least one deferred engineering item (SQLCipher, Workflow Branching, Meeting Prep) is ready to ship.
+
+Platform code-signing on macOS + Windows is **explicitly not a v0.1.1 gate** — it lands in a separate point release on its own schedule, whenever the maintainer decides to fund procurement.
+
+### 5.1 Contents
+
+1. **SQLCipher at rest.** Opt-in `[db.encrypt] = true` in config; key derived from the OS Vault (same trust boundary as credential storage). New migration `V20` to re-wrap existing index. Documentation: `docs/db-encryption.md`.
+2. **Workflow branching & conditionals.** `if` / `else` / `switch` step types in the workflow DSL; condition expressions may reference step outputs + index queries; independent branches execute in parallel; DSL backwards-compatible with Phase 3 linear pipelines; dry-run + HITL apply to every branch.
+3. **Built-in `nimbus prep` agent.** Resolves a calendar event, surfaces attendees via the people graph, pulls related docs from Drive/OneDrive/Notion, emits a structured brief. On-demand, not scheduled; no new connectors; uses the full Phase 2 index.
+4. **Seed community extensions.** Five first-party connectors re-packaged as community extensions and published to `registry.nimbus.dev` — selected from high-traffic Phase 2 connectors (candidates: Notion, Linear, Jira, Slack, GitHub).
+
+### 5.2 Out of scope for v0.1.1
+
+- Marketplace v2 features (online browse, ratings, verified publisher, auto-update toggle). Phase 5.
+- Federation, multi-user HITL, shared namespaces. Phase 6.
+- Enterprise SCIM / SIEM / compliance tooling. Phase 9.
+
+---
+
+## 6. Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| WS6 streaming token render flickers on Windows Terminal | Medium | Prototype `ResultStream` against Ink 5 on Windows first; fallback to line-buffered render if cursor-based render flickers. |
+| WS7 VS Code extension dual-target (Cursor + Open VSX) fails manifest validation | Low | Use the `@vscode/vsce` + `ovsx` dual-publish flow already documented in prerequisites §6–§7; test on Cursor in a dev container before tagging. |
+| User confusion / support load from unsigned macOS `.pkg` (Gatekeeper block dialog has no clear fix path) | Medium–High | Ship `docs/install-macos-unsigned.md` with the `xattr -d com.apple.quarantine` + right-click-Open bypass. Link from README + GitHub Release notes. Accept that some users will bounce on first install friction. |
+| Windows SmartScreen "publisher not commonly downloaded" warning blocks adoption | Medium | Document the two-click "More info → Run anyway" workflow in `docs/install-windows-unsigned.md`. Friction accepted as v0.1.0 UX tax. |
+| Perception of "unsigned = untrusted" among security-conscious users | Medium | README + release notes explain: "Linux binaries GPG-signed; macOS + Windows binaries unsigned for v0.1.0. Verify integrity via `SHA256SUMS.asc`." Signed hashes + reproducible builds are the *real* integrity story — platform signing is an anti-phishing measure, not a supply-chain guarantee. |
+| SHA256SUMS verification instructions too intimidating for non-technical users to follow | Low–Medium | Target audience (per CLAUDE.md Guiding Principle 7) is professional engineers; GPG verification is reasonable to expect. Provide copy-pasteable commands in `docs/verify-release-integrity.md`. |
+| Voice cross-platform verification finds `espeak-ng` missing on minimal Linux installs | High | Document install requirements in `docs/voice.md`; fallback to `spd-say` detection (already implemented) verified on clean Ubuntu + Fedora minimal installs. |
+| Solo-dev context thrash from running WS6 + WS7 in parallel | High | Sequence TUI before VS Code (see §3). Explicitly *do not* try to parallelise them. |
+| Running out of GitHub Actions minutes on private repo during CI matrix explosion | Low (public repo) | Repo is public → unlimited minutes across all three runners. macOS runners at 10× cost don't matter here; builds are unsigned and cheap. |
+
+---
+
+## 7. Non-Goals (explicit, for Phase 4)
+
+Items that fit "obvious next thing" but are explicitly **not** Phase 4 work:
+
+- Any Phase 5 connector (browser history, web clipper, Pocket, CRM, finance, HR, MLflow, Vertex, etc.).
+- Team features (Team Vault, shared namespaces, multi-user HITL, SSO/OIDC).
+- Mobile or web client.
+- P2P sync, DIDs, hardware vault, Digital Executor.
+- Enterprise compliance (SCIM, SIEM, Helm).
+- Marketplace v2 (community ratings, verified publisher, online browse).
+- Online auto-update of extensions (file-system install only, per current Marketplace panel).
+
+If any of these become pressing before Phase 5 can begin, open a scope-change issue — do not slip them into this plan.
+
+---
+
+## 8. Decisions Recorded During Planning
+
+All four open decisions from the initial draft have been resolved:
+
+1. **WS6 fallback strategy when `TERM=dumb`** — ✅ Reuse the existing Phase 3 REPL verbatim. The Phase 4 reference mandates this; no new Ink fallback UI.
+2. **Workflow run history storage** — ✅ Extend the existing `workflow_run` table (v9 schema already in place) with `dry_run` + `params_override_json` columns via V23 migration, plus audit-log entries on completion. Audit log remains the BLAKE3-chained legal record; `workflow_run` is the operational view with count-based pruning (last 100 per workflow). Earlier plan draft said "new table" — that was pre-recon; the table already exists.
+3. **Platform code signing on macOS + Windows** — ✅ Both **parked** for v0.1.0 and v0.1.1. Ship unsigned binaries with documented bypass + GPG-signed `SHA256SUMS.asc` as integrity proof. Signing lands in a later point release gated on explicit maintainer decision to fund procurement. Rationale: Windows EV cert ($350–700/yr + monthly) is not justified before the product reaches a stable-user milestone; macOS ($99/yr) parked at the same time for consistency and to keep `release.yml` simple.
+4. **VS Code streaming Markdown target** — ✅ Webview. Avoids the unsaved-changes dot on streaming editor tabs and matches how every production VS Code LLM extension (Copilot Chat, Cursor, Continue, Cody) renders streaming. A "Save to Markdown note" button in the Webview covers the real editor-tab use-case as a follow-up.
+
+Remaining implementation-level decisions (small enough to resolve during each workstream's own implementation plan, not here):
+
+- Which `.pkg` builder on macOS (`pkgbuild` alone vs. `productbuild` wrapper)? — §4.2 concern; `pkgbuild` should suffice for v0.1.0.
+- Which Windows installer format — NSIS, WiX, or Tauri-bundled MSI? — §4.2 concern; Tauri's default bundler already chooses, so defer to it.
+- Workflow-run retention policy (last 1,000 per workflow vs. time-based)? — §4.1 concern; implement count-based first, revisit after telemetry.
+
+---
+
+## 9. Handoff to Implementation
+
+When this plan is approved:
+
+1. Create an implementation plan via `superpowers:writing-plans` for whichever workstream is started first (suggested: §4.1 WS5-D polish — smallest, clears three roadmap boxes).
+2. Each subsequent workstream gets its own implementation plan in `docs/superpowers/plans/`.
+3. Cross-reference each implementation plan back to this finish plan in its header.
+4. On completing each workstream, tick the relevant row in the status snapshot (§2) and the release-gate checklist (§4.6).
+5. Tag `v0.1.0` only after every row in §4.6 is ticked on all three platforms.

--- a/docs/release/v0.1.0-finish-review.md
+++ b/docs/release/v0.1.0-finish-review.md
@@ -1,0 +1,38 @@
+# Review: v0.1.0 Finish Plan — Remaining Phase 4 Work
+
+## 1. UX & Documentation Improvements
+
+### A. The "Unsigned" Friction
+- **Observation:** Relying on `xattr -d com.apple.quarantine` (macOS) and "More info -> Run anyway" (Windows) is the right technical bypass, but it may trigger "Malware" scares for less technical users.
+- **Suggestion:** In `docs/install-macos-unsigned.md` and `docs/install-windows-unsigned.md`, include a "Why is this unsigned?" section. Explain that as a local-first, privacy-focused tool, Nimbus avoids the recurring costs and "phone home" requirements of corporate signing authorities for the initial release.
+- **Improvement:** Provide a "One-liner for Pro Users" at the top of the README for each platform to make the bypass feel like a "Power User" shortcut rather than a "Security Risk" workaround.
+
+### B. Verification Tooling
+- **Observation:** `gpg --verify` is a high bar for some users.
+- **Suggestion:** Create a small, standalone `nimbus-verify.sh` (and `.ps1`) script that automates the GPG public key import and checksum verification. This makes "Trust but Verify" accessible to more people.
+
+## 2. VS Code Extension (WS7) Refinements
+
+### A. IPC Transport via Node.js
+- **Observation:** The plan notes that the extension must work in Node.js (VS Code host) rather than Bun.
+- **Question:** Has the `@nimbus-dev/client` been verified to handle the `net.Socket` differences between Bun and Node.js for named pipes (Windows) vs. Unix sockets (macOS/Linux)?
+- **Suggestion:** Add a specific "Node.js Compatibility" test task to WS7 to ensure the client doesn't rely on Bun-specific globals.
+
+### B. Streaming Render (Webview vs. Virtual Doc)
+- **Observation:** Section 8 (Decision 4) confirms using a **Webview** for streaming Markdown to match Copilot/Cursor.
+- **Improvement:** Ensure the Webview supports **Theme Syncing**. Users expect the Nimbus chat window to match their VS Code theme (Dark/Light/High Contrast). Use VS Code's CSS variables (`--vscode-editor-background`, etc.).
+
+## 3. Automation & Workflow History (WS5-D Polish)
+
+### A. Retention & Pruning
+- **Question:** Task 4.1 mentions a new `workflow_runs` table. Does the plan include an automatic pruning strategy? 
+- **Suggestion:** Implement a "Keep last 100 runs" per workflow or a 30-day TTL to prevent the `index.db` from bloating over time, especially for high-frequency watchers.
+
+### B. Run History UI
+- **Suggestion:** In the "Workflow run history" drawer, add a "View Audit Log Entry" link for each run. This bridges the operational view with the cryptographically-signed legal record in the `audit_log` table.
+
+## 4. Technical Open Questions
+
+1. **GPG Key Management:** Where is the GPG public key hosted? The plan mentions `docs/release/SIGNING-KEY.asc`, but it should also be pushed to a major keyserver (e.g., `keyserver.ubuntu.com`) to allow `gpg --recv-keys` commands.
+2. **Updater Loop:** Since `v0.1.0` is the "Update source," how does the Ed25519-verified updater handle the transition to a *signed* binary in the future? (e.g., will the updater care if the binary it downloads changes from unsigned to signed?).
+3. **Voice on Linux:** The plan mentions `espeak-ng` or `spd-say`. On many modern Linux distros, `piper` is a much higher-quality local TTS option. Consider adding it as a "Recommended" fallback in `docs/voice.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -314,9 +314,9 @@ Commercial license also available now for organizations that need to embed Nimbu
 - Tray badge matches pending HITL count.
 - `ALLOWED_METHODS` grew by exactly four read-side methods; no `vault.*` or `db.*` writes.
 - `packages/ui` coverage ≥ 80 % lines / ≥ 75 % branches.
-- [ ] **Extension Marketplace panel** — browse, install, update, disable, remove extensions; verified publisher badge; community ratings; changelog per version; auto-update toggle
-- [ ] **Watcher management UI** — create, pause, delete watchers; condition builder; history of fired events
-- [ ] **Workflow pipeline editor** — visual step list; run history; re-run failed steps; parameter override before run
+- [x] **Extension Marketplace panel** (v0.1.0 MVP) — list, install-from-directory, enable/disable, remove. *Online browse, verified publisher, ratings, changelog, auto-update — deferred to Phase 5 "Marketplace v2".*
+- [x] **Watcher management UI** (v0.1.0) — create, pause, delete; graph-aware condition builder; **history-of-fires drawer** (WS5-D Polish).
+- [x] **Workflow pipeline editor** (v0.1.0) — step list editor, run, dry-run toggle, delete; **run history drawer with audit deep-link** + **"Run with params…" one-shot parameter override** (WS5-D Polish). *Re-run-failed-steps deferred to v0.1.1.*
 - [x] **Settings** — ~~model selection (cloud vs local)~~ ✅ (Plan 3) · ~~sync intervals per connector~~ ✅ (Plan 3) · ~~profile switcher~~ ✅ (Plan 2) · ~~audit log viewer + export~~ ✅ (Plan 4) · ~~data export/import~~ ✅ (Plan 5) · ~~telemetry toggle~~ ✅ (Plan 2) · ~~Updates panel~~ ✅ (Plan 4) · ~~Delete service data~~ ✅ (Plan 5) — Vault key listing deferred to Phase 5
 
 ### Local LLM & Multi-Agent

--- a/docs/superpowers/plans/2026-04-22-ws5d-polish-review.md
+++ b/docs/superpowers/plans/2026-04-22-ws5d-polish-review.md
@@ -1,0 +1,33 @@
+# Review: WS5-D Polish Implementation Plan
+
+## 1. Overall Assessment
+The plan is exceptionally detailed and follows the Research -> Strategy -> Execution lifecycle rigorously. It maintains high standards for testing and architectural consistency with the existing Nimbus codebase.
+
+## 2. Strengths
+- **Layered Testing:** Includes tests at the DB migration, helper, IPC, and UI levels.
+- **Data Integrity:** Correctly implements the BLAKE3-chained audit log entries for workflow completions, bridging operational history with the secure audit trail.
+- **Resource Management:** Proactively includes a pruning strategy for the `workflow_run` table to prevent unbounded database growth.
+- **Security:** Updates the Tauri `ALLOWED_METHODS` allowlist and maintains the alphabetization requirement.
+
+## 3. Suggestions for Improvement
+
+### A. Audit Page Deep-Linking (Task 14)
+- **Observation:** The plan introduces a link to `#/settings/audit?runId=...`.
+- **Suggestion:** Verify if `AuditPanel.tsx` currently supports the `runId` query parameter for filtering/highlighting. If not, a small task should be added to the Audit page to handle this parameter, otherwise the link will only lead to the general audit log.
+
+### B. UI JSON UX (Task 15)
+- **Observation:** `RunWithParamsDialog.tsx` uses a raw `textarea` for JSON overrides.
+- **Improvement:** While sufficient for v0.1.0, adding a "Format JSON" button or auto-formatting on blur using `JSON.stringify(JSON.parse(json), null, 2)` would significantly improve the user experience and help catch syntax errors early.
+
+### C. Watcher History Display (Task 13)
+- **Observation:** The history drawer renders `conditionSnapshot` as a truncated string.
+- **Improvement:** Some snapshots (especially graph predicates) can be large. Suggest adding a "Copy to Clipboard" icon or a "Click to Expand" modal for the snapshot/result JSON strings to avoid layout breaking or data loss in the UI.
+
+### D. Pruning Performance (Task 9)
+- **Observation:** Pruning is triggered on *every* workflow completion.
+- **Question:** For workflows that fire frequently (e.g., every minute via a watcher), is the overhead of a `DELETE ... NOT IN (SELECT ...)` subquery acceptable?
+- **Recommendation:** For v0.1.0 it is likely fine given the 100-row limit, but for Phase 5+, consider debouncing the prune or triggering it only when the count exceeds a "soft limit" (e.g., 120).
+
+## 4. Open Questions
+1. **Multi-Agent Progress:** Does the `WorkflowRunHistoryDrawer` need to surface the `sub_task_results` from the multi-agent coordinator, or is the top-level status enough for this view?
+2. **Audit Link Persistence:** If a `workflow_run` row is pruned after 100 runs, the "View audit entry" link in the *Audit Log* (which is never pruned) will still work, but the run history itself will be gone. This is correct behavior, but worth noting in the docs.

--- a/docs/superpowers/plans/2026-04-22-ws5d-polish.md
+++ b/docs/superpowers/plans/2026-04-22-ws5d-polish.md
@@ -1,0 +1,2410 @@
+# WS5-D Polish Implementation Plan — Watcher History, Workflow Run History, Parameter Override
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three remaining WS5-D roadmap items on `docs/roadmap.md:317-319` — add a Watcher fire-history drawer, a Workflow run-history drawer with audit-log deep-link, and "Run with params…" single-invocation parameter override on Workflows.
+
+**Architecture:** The gateway extensions are additive-only — a V23 migration adds two columns (`dry_run`, `params_override_json`) to the existing `workflow_run` table (v9 schema); the runner learns to write dry-run rows + apply a transient params override + emit audit-log entries + prune to last 100 per workflow; two new IPC methods (`watcher.listHistory`, `workflow.listRuns`) expose read views over the existing `watcher_event` + `workflow_run` tables. UI changes are confined to the two existing pages: collapsible drawers, no new routes.
+
+**Tech Stack:** Bun 1.2 + TypeScript 6 (gateway + UI), bun:sqlite, Biome, React 19 + Vitest (UI), Rust/Tauri 2.0 (bridge), BLAKE3-chained audit log (v18).
+
+**Finish-plan reference:** [`docs/release/v0.1.0-finish-plan.md §4.1`](../../release/v0.1.0-finish-plan.md) — scope, acceptance criteria, retention policy.
+
+---
+
+## File Map
+
+**Create:**
+- `packages/gateway/src/index/workflow-run-columns-v23-sql.ts` — V23 migration SQL constant.
+- `packages/gateway/src/index/migrations/runner-v23.test.ts` — migration runner test.
+- `packages/gateway/src/automation/workflow-run-history.ts` — `listWorkflowRuns` + `pruneWorkflowRuns` helpers.
+- `packages/gateway/src/automation/workflow-run-history.test.ts` — unit tests for the helpers.
+- `packages/gateway/src/automation/watcher-history.ts` — `listWatcherHistory` helper.
+- `packages/gateway/src/automation/watcher-history.test.ts` — unit tests.
+- `packages/ui/src/components/watchers/WatcherHistoryDrawer.tsx` — collapsible history panel.
+- `packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx` — expandable run history row.
+- `packages/ui/src/components/workflows/RunWithParamsDialog.tsx` — single-invocation params override dialog.
+
+**Modify:**
+- `packages/gateway/src/index/migrations/runner.ts` — add V22→V23 migration step.
+- `packages/gateway/src/ipc/automation-rpc.ts` — add `watcher.listHistory` + `workflow.listRuns` cases, thread `paramsOverride` through to runner via existing `workflow.run` handler (handler lives on `server.ts`; params parsing here).
+- `packages/gateway/src/ipc/server.ts` — extend `WorkflowRunHandler` signature + plumbing to accept `paramsOverride`.
+- `packages/gateway/src/automation/workflow-runner.ts` — write dry-run rows, apply `paramsOverride`, call `pruneWorkflowRuns`, emit audit-log entries.
+- `packages/gateway/src/automation/workflow-runner.test.ts` — extend coverage.
+- `packages/gateway/src/automation/workflow-store.ts` — update `insertWorkflowRunRow` to accept `dryRun` + `paramsOverrideJson`.
+- `packages/gateway/src/automation/workflow-store.test.ts` — update fixtures to match new columns.
+- `packages/ui/src/ipc/types.ts` — add `WatcherHistoryEntry`, `WatcherListHistoryResult`, `WorkflowRunHistoryEntry`, `WorkflowListRunsResult`, extend `WorkflowRunParams` with optional `paramsOverride`.
+- `packages/ui/src/ipc/client.ts` — add `watcherListHistory()` + `workflowListRuns()` methods; update `workflowRun()` signature.
+- `packages/ui/src/ipc/__mocks__/client.ts` — add `watcherListHistoryMock` + `workflowListRunsMock`.
+- `packages/ui/src-tauri/src/gateway_bridge.rs` — insert two allowlist entries, bump size assertion 54 → 56, update WS5-D comment.
+- `packages/ui/src/pages/Watchers.tsx` — mount `WatcherHistoryDrawer` per row.
+- `packages/ui/src/pages/Workflows.tsx` — mount `WorkflowRunHistoryDrawer` + `RunWithParamsDialog`.
+- `packages/ui/test/pages/Watchers.test.tsx` — add history drawer coverage.
+- `packages/ui/test/pages/Workflows.test.tsx` — add run history + params dialog coverage.
+- `docs/roadmap.md` — flip lines 317-319 to `[x]` + append "v0.1.0 — Watchers history, Workflow run history, Parameter override" marker.
+
+---
+
+## Task 1: V23 Migration — Add `dry_run` + `params_override_json` Columns
+
+**Why this is Task 1:** Every later gateway task depends on the schema shape. Run it in isolation so downstream tasks don't need to guard column existence.
+
+**Files:**
+- Create: `packages/gateway/src/index/workflow-run-columns-v23-sql.ts`
+- Modify: `packages/gateway/src/index/migrations/runner.ts`
+- Create: `packages/gateway/src/index/migrations/runner-v23.test.ts`
+
+---
+
+- [ ] **Step 1.1: Read the existing V22 migration to mirror the exact pattern**
+
+Run: `cat packages/gateway/src/index/watcher-graph-v22-sql.ts`
+
+You should see a simple pattern: a JSDoc header describing the migration, then `export const <NAME>_SQL = \`ALTER TABLE … ADD COLUMN …;\``. Use the same shape for V23.
+
+- [ ] **Step 1.2: Create the V23 SQL constant**
+
+Create `packages/gateway/src/index/workflow-run-columns-v23-sql.ts`:
+
+```ts
+/**
+ * V23 migration — adds `dry_run` and `params_override_json` columns to the
+ * existing `workflow_run` table (v9 schema). These support the WS5-D Polish
+ * sub-project: the runner writes dry-run rows (previously short-circuited
+ * before INSERT) and records the per-invocation params override so the UI
+ * can surface it in the run-history drawer.
+ *
+ * Purely additive — no backfill required. Existing rows get `dry_run = 0`
+ * and `params_override_json = NULL`.
+ */
+export const WORKFLOW_RUN_COLUMNS_V23_SQL = `
+ALTER TABLE workflow_run ADD COLUMN dry_run INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE workflow_run ADD COLUMN params_override_json TEXT;
+`;
+```
+
+- [ ] **Step 1.3: Locate the existing migration runner's V22→V23 slot**
+
+Run: `grep -nE "user_version = 22|migrateIndexedV22ToV23|PRAGMA user_version" packages/gateway/src/index/migrations/runner.ts`
+
+You should see the V22 migration function and a dispatcher (switch or sequence). Read the V22 function (`migrateIndexedV21ToV22` or similar) to match its structure — transaction wrapper, SQL exec, `PRAGMA user_version = 22` bump at the end.
+
+- [ ] **Step 1.4: Write the failing V23 migration test**
+
+Create `packages/gateway/src/index/migrations/runner-v23.test.ts`:
+
+```ts
+import { afterEach, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { applyIndexedMigrations } from "./runner";
+import { readIndexedUserVersion } from "../user-version";
+
+const dbs: Database[] = [];
+
+afterEach(() => {
+  while (dbs.length > 0) {
+    const d = dbs.pop();
+    if (d) d.close();
+  }
+});
+
+function newDb(): Database {
+  const db = new Database(":memory:");
+  dbs.push(db);
+  return db;
+}
+
+test("V23 adds dry_run and params_override_json to workflow_run", () => {
+  const db = newDb();
+  applyIndexedMigrations(db);
+  expect(readIndexedUserVersion(db)).toBeGreaterThanOrEqual(23);
+
+  const info = db.query(`PRAGMA table_info(workflow_run)`).all() as Array<{
+    name: string;
+    type: string;
+    dflt_value: string | null;
+    notnull: number;
+  }>;
+
+  const dryRun = info.find((c) => c.name === "dry_run");
+  expect(dryRun).toBeDefined();
+  expect(dryRun?.type.toUpperCase()).toBe("INTEGER");
+  expect(dryRun?.notnull).toBe(1);
+  expect(dryRun?.dflt_value).toBe("0");
+
+  const paramsOverride = info.find((c) => c.name === "params_override_json");
+  expect(paramsOverride).toBeDefined();
+  expect(paramsOverride?.type.toUpperCase()).toBe("TEXT");
+});
+
+test("V23 is idempotent on re-apply", () => {
+  const db = newDb();
+  applyIndexedMigrations(db);
+  applyIndexedMigrations(db); // re-apply must not error
+  expect(readIndexedUserVersion(db)).toBeGreaterThanOrEqual(23);
+});
+
+test("V23 backfills existing rows with defaults", () => {
+  const db = newDb();
+  applyIndexedMigrations(db);
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES ('wf1', 'n', NULL, '[]', 0, 0)`,
+  );
+  db.run(
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at)
+     VALUES ('r1', 'wf1', 'user', 'done', 1)`,
+  );
+  const row = db
+    .query(`SELECT dry_run, params_override_json FROM workflow_run WHERE id = 'r1'`)
+    .get() as { dry_run: number; params_override_json: string | null };
+  expect(row.dry_run).toBe(0);
+  expect(row.params_override_json).toBeNull();
+});
+```
+
+- [ ] **Step 1.5: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/index/migrations/runner-v23.test.ts`
+
+Expected: FAIL — "user_version < 23" or "dry_run column does not exist" or runner doesn't reach V23.
+
+- [ ] **Step 1.6: Wire the V23 migration into the runner**
+
+Open `packages/gateway/src/index/migrations/runner.ts`. Immediately after the V22 step, add:
+
+```ts
+// V22 → V23: dry_run + params_override_json columns on workflow_run
+import { WORKFLOW_RUN_COLUMNS_V23_SQL } from "../workflow-run-columns-v23-sql";
+
+function migrateIndexedV22ToV23(db: Database): void {
+  db.transaction(() => {
+    db.exec(WORKFLOW_RUN_COLUMNS_V23_SQL);
+    db.exec(`PRAGMA user_version = 23`);
+  })();
+}
+```
+
+Hook this into the migration dispatcher alongside existing steps. **Mirror the exact pattern used for V22** — don't invent a new shape.
+
+- [ ] **Step 1.7: Run the test to verify it passes**
+
+Run: `bun test packages/gateway/src/index/migrations/runner-v23.test.ts`
+
+Expected: PASS — all three tests green.
+
+- [ ] **Step 1.8: Full migration suite regression**
+
+Run: `bun test packages/gateway/src/index/migrations/`
+
+Expected: PASS — no earlier migration test regresses. `runner-v22.test.ts` still passes.
+
+- [ ] **Step 1.9: Commit**
+
+```bash
+git add packages/gateway/src/index/workflow-run-columns-v23-sql.ts packages/gateway/src/index/migrations/runner.ts packages/gateway/src/index/migrations/runner-v23.test.ts
+git commit -m "feat(gateway): V23 migration — add dry_run + params_override_json to workflow_run"
+```
+
+---
+
+## Task 2: `listWatcherHistory` Helper + Tests
+
+**Files:**
+- Create: `packages/gateway/src/automation/watcher-history.ts`
+- Create: `packages/gateway/src/automation/watcher-history.test.ts`
+
+The helper reads from the existing `watcher_event` table (v8 schema) — no migration needed.
+
+---
+
+- [ ] **Step 2.1: Write the failing test**
+
+Create `packages/gateway/src/automation/watcher-history.test.ts`:
+
+```ts
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { applyIndexedMigrations } from "../index/migrations/runner";
+import { listWatcherHistory } from "./watcher-history";
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  applyIndexedMigrations(db);
+  db.run(
+    `INSERT INTO watcher (id, name, enabled, condition_type, condition_json, action_type, action_json, created_at)
+     VALUES ('w1', 'alpha', 1, 'schedule', '{}', 'notify', '{}', 0)`,
+  );
+});
+
+afterEach(() => db.close());
+
+test("listWatcherHistory returns the last N fires newest-first", () => {
+  for (let i = 0; i < 5; i++) {
+    db.run(
+      `INSERT INTO watcher_event (watcher_id, fired_at, condition_snapshot, action_result)
+       VALUES ('w1', ?, ?, ?)`,
+      [100 + i, `{"i":${i}}`, `{"ok":true}`],
+    );
+  }
+  const out = listWatcherHistory(db, { watcherId: "w1", limit: 3 });
+  expect(out.events.length).toBe(3);
+  expect(out.events[0].firedAt).toBe(104);
+  expect(out.events[2].firedAt).toBe(102);
+  expect(out.events[0].conditionSnapshot).toBe('{"i":4}');
+});
+
+test("listWatcherHistory returns empty for an unknown watcher", () => {
+  const out = listWatcherHistory(db, { watcherId: "nonexistent", limit: 10 });
+  expect(out.events).toEqual([]);
+});
+
+test("listWatcherHistory clamps limit to 1..500", () => {
+  const out0 = listWatcherHistory(db, { watcherId: "w1", limit: 0 });
+  expect(out0.events).toEqual([]);
+  // Insert 501 rows
+  for (let i = 0; i < 501; i++) {
+    db.run(
+      `INSERT INTO watcher_event (watcher_id, fired_at, condition_snapshot, action_result)
+       VALUES ('w1', ?, '{}', '{}')`,
+      [i],
+    );
+  }
+  const outBig = listWatcherHistory(db, { watcherId: "w1", limit: 10000 });
+  expect(outBig.events.length).toBe(500);
+});
+```
+
+- [ ] **Step 2.2: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/automation/watcher-history.test.ts`
+
+Expected: FAIL — `listWatcherHistory is not a function` / module not found.
+
+- [ ] **Step 2.3: Implement the helper**
+
+Create `packages/gateway/src/automation/watcher-history.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+
+export interface WatcherHistoryEvent {
+  readonly firedAt: number;
+  readonly conditionSnapshot: string;
+  readonly actionResult: string;
+}
+
+export interface WatcherHistoryListResult {
+  readonly events: ReadonlyArray<WatcherHistoryEvent>;
+}
+
+export interface ListWatcherHistoryParams {
+  readonly watcherId: string;
+  readonly limit: number;
+}
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 500;
+
+function clamp(n: number): number {
+  if (!Number.isFinite(n) || n < MIN_LIMIT) return 0;
+  if (n > MAX_LIMIT) return MAX_LIMIT;
+  return Math.floor(n);
+}
+
+export function listWatcherHistory(
+  db: Database,
+  params: ListWatcherHistoryParams,
+): WatcherHistoryListResult {
+  const limit = clamp(params.limit);
+  if (limit === 0) return { events: [] };
+  const rows = db
+    .query(
+      `SELECT fired_at, condition_snapshot, action_result
+       FROM watcher_event
+       WHERE watcher_id = ?
+       ORDER BY fired_at DESC
+       LIMIT ?`,
+    )
+    .all(params.watcherId, limit) as Array<{
+    fired_at: number;
+    condition_snapshot: string;
+    action_result: string;
+  }>;
+  return {
+    events: rows.map((r) => ({
+      firedAt: r.fired_at,
+      conditionSnapshot: r.condition_snapshot,
+      actionResult: r.action_result,
+    })),
+  };
+}
+```
+
+- [ ] **Step 2.4: Run the test to verify it passes**
+
+Run: `bun test packages/gateway/src/automation/watcher-history.test.ts`
+
+Expected: PASS — all three tests green.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add packages/gateway/src/automation/watcher-history.ts packages/gateway/src/automation/watcher-history.test.ts
+git commit -m "feat(gateway): add listWatcherHistory helper over watcher_event"
+```
+
+---
+
+## Task 3: `listWorkflowRuns` + `pruneWorkflowRuns` Helpers
+
+**Files:**
+- Create: `packages/gateway/src/automation/workflow-run-history.ts`
+- Create: `packages/gateway/src/automation/workflow-run-history.test.ts`
+
+Reads the existing `workflow_run` table with the V23 `dry_run` column, joins name from `workflow`, and provides a prune helper for Task 9.
+
+---
+
+- [ ] **Step 3.1: Write the failing test**
+
+Create `packages/gateway/src/automation/workflow-run-history.test.ts`:
+
+```ts
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { applyIndexedMigrations } from "../index/migrations/runner";
+import { listWorkflowRuns, pruneWorkflowRuns } from "./workflow-run-history";
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  applyIndexedMigrations(db);
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES ('wf1', 'alpha', NULL, '[]', 0, 0)`,
+  );
+});
+
+afterEach(() => db.close());
+
+function insertRun(id: string, startedAt: number, dryRun = 0, status = "done"): void {
+  db.run(
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg, dry_run, params_override_json)
+     VALUES (?, 'wf1', 'user', ?, ?, ?, NULL, ?, NULL)`,
+    [id, status, startedAt, startedAt + 10, dryRun],
+  );
+}
+
+test("listWorkflowRuns returns last N runs for a workflow newest-first", () => {
+  for (let i = 0; i < 5; i++) insertRun(`r${i}`, 100 + i);
+  const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 3 });
+  expect(out.runs.length).toBe(3);
+  expect(out.runs[0].id).toBe("r4");
+  expect(out.runs[2].id).toBe("r2");
+  expect(out.runs[0].durationMs).toBe(10);
+  expect(out.runs[0].dryRun).toBe(false);
+});
+
+test("listWorkflowRuns surfaces dry_run as boolean", () => {
+  insertRun("d1", 100, 1);
+  const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 10 });
+  expect(out.runs[0].dryRun).toBe(true);
+});
+
+test("listWorkflowRuns returns empty for unknown workflow", () => {
+  const out = listWorkflowRuns(db, { workflowName: "missing", limit: 10 });
+  expect(out.runs).toEqual([]);
+});
+
+test("pruneWorkflowRuns keeps newest 100 per workflow", () => {
+  for (let i = 0; i < 110; i++) insertRun(`r${i}`, i);
+  const deleted = pruneWorkflowRuns(db, "wf1", 100);
+  expect(deleted).toBe(10);
+  const remain = db
+    .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = 'wf1'`)
+    .get() as { c: number };
+  expect(remain.c).toBe(100);
+  const oldest = db
+    .query(`SELECT MIN(started_at) AS m FROM workflow_run WHERE workflow_id = 'wf1'`)
+    .get() as { m: number };
+  expect(oldest.m).toBe(10); // rows 0..9 pruned
+});
+
+test("pruneWorkflowRuns is a no-op when under the cap", () => {
+  for (let i = 0; i < 5; i++) insertRun(`r${i}`, i);
+  const deleted = pruneWorkflowRuns(db, "wf1", 100);
+  expect(deleted).toBe(0);
+});
+```
+
+- [ ] **Step 3.2: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/automation/workflow-run-history.test.ts`
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3.3: Implement the helpers**
+
+Create `packages/gateway/src/automation/workflow-run-history.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+
+export interface WorkflowRunHistoryRow {
+  readonly id: string;
+  readonly startedAt: number;
+  readonly finishedAt: number | null;
+  readonly durationMs: number | null;
+  readonly status: string;
+  readonly errorMsg: string | null;
+  readonly dryRun: boolean;
+  readonly paramsOverrideJson: string | null;
+  readonly triggeredBy: string;
+}
+
+export interface WorkflowRunListResult {
+  readonly runs: ReadonlyArray<WorkflowRunHistoryRow>;
+}
+
+export interface ListWorkflowRunsParams {
+  readonly workflowName: string;
+  readonly limit: number;
+}
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 500;
+
+function clamp(n: number): number {
+  if (!Number.isFinite(n) || n < MIN_LIMIT) return 0;
+  if (n > MAX_LIMIT) return MAX_LIMIT;
+  return Math.floor(n);
+}
+
+export function listWorkflowRuns(
+  db: Database,
+  params: ListWorkflowRunsParams,
+): WorkflowRunListResult {
+  const limit = clamp(params.limit);
+  if (limit === 0) return { runs: [] };
+  const rows = db
+    .query(
+      `SELECT r.id, r.started_at, r.finished_at, r.status, r.error_msg,
+              r.dry_run, r.params_override_json, r.triggered_by
+       FROM workflow_run AS r
+       INNER JOIN workflow AS w ON w.id = r.workflow_id
+       WHERE w.name = ?
+       ORDER BY r.started_at DESC
+       LIMIT ?`,
+    )
+    .all(params.workflowName, limit) as Array<{
+    id: string;
+    started_at: number;
+    finished_at: number | null;
+    status: string;
+    error_msg: string | null;
+    dry_run: number;
+    params_override_json: string | null;
+    triggered_by: string;
+  }>;
+  return {
+    runs: rows.map((r) => ({
+      id: r.id,
+      startedAt: r.started_at,
+      finishedAt: r.finished_at,
+      durationMs: r.finished_at === null ? null : r.finished_at - r.started_at,
+      status: r.status,
+      errorMsg: r.error_msg,
+      dryRun: r.dry_run === 1,
+      paramsOverrideJson: r.params_override_json,
+      triggeredBy: r.triggered_by,
+    })),
+  };
+}
+
+export function pruneWorkflowRuns(db: Database, workflowId: string, keep: number): number {
+  const res = db.run(
+    `DELETE FROM workflow_run
+     WHERE workflow_id = ?
+       AND id NOT IN (
+         SELECT id FROM workflow_run
+         WHERE workflow_id = ?
+         ORDER BY started_at DESC
+         LIMIT ?
+       )`,
+    [workflowId, workflowId, keep],
+  );
+  return res.changes;
+}
+```
+
+- [ ] **Step 3.4: Run the test to verify it passes**
+
+Run: `bun test packages/gateway/src/automation/workflow-run-history.test.ts`
+
+Expected: PASS — all five tests green.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add packages/gateway/src/automation/workflow-run-history.ts packages/gateway/src/automation/workflow-run-history.test.ts
+git commit -m "feat(gateway): add listWorkflowRuns + pruneWorkflowRuns helpers"
+```
+
+---
+
+## Task 4: Wire `watcher.listHistory` + `workflow.listRuns` into IPC Dispatcher
+
+**Files:**
+- Modify: `packages/gateway/src/ipc/automation-rpc.ts`
+- Modify: `packages/gateway/src/ipc/automation-rpc.test.ts` (create if missing — follow the pattern of existing IPC dispatcher tests)
+
+---
+
+- [ ] **Step 4.1: Read the existing automation-rpc.ts to mirror the case pattern**
+
+Run: `sed -n '50,90p' packages/gateway/src/ipc/automation-rpc.ts`
+
+Confirm the `case "watcher.validateCondition":` pattern — `requireString` / `requireNumber` helpers, `throw new AutomationRpcError(-32602, ...)` on bad input, return `{ kind: "hit", value: <result> }`.
+
+- [ ] **Step 4.2: Write the failing IPC dispatcher tests**
+
+Find the existing dispatcher test or mirror an existing watcher-rpc test. Add cases to the relevant test file (likely `packages/gateway/src/ipc/automation-rpc.test.ts`) — if the file doesn't exist, create it matching the style of `packages/gateway/src/ipc/ipc.test.ts`. Add:
+
+```ts
+test("watcher.listHistory returns fires newest-first", async () => {
+  // seed DB with a watcher + 2 events; call dispatcher; assert result shape
+  const db = new Database(":memory:");
+  applyIndexedMigrations(db);
+  db.run(
+    `INSERT INTO watcher (id, name, enabled, condition_type, condition_json, action_type, action_json, created_at)
+     VALUES ('w1', 'x', 1, 'schedule', '{}', 'notify', '{}', 0)`,
+  );
+  db.run(
+    `INSERT INTO watcher_event (watcher_id, fired_at, condition_snapshot, action_result)
+     VALUES ('w1', 10, '{"a":1}', '{"ok":true}'), ('w1', 20, '{"a":2}', '{"ok":true}')`,
+  );
+  const result = await dispatchAutomationRpc({ db }, "watcher.listHistory", {
+    watcherId: "w1",
+    limit: 5,
+  });
+  expect(result.kind).toBe("hit");
+  if (result.kind === "hit") {
+    const value = result.value as { events: Array<{ firedAt: number }> };
+    expect(value.events.length).toBe(2);
+    expect(value.events[0].firedAt).toBe(20);
+  }
+});
+
+test("workflow.listRuns returns last N runs newest-first", async () => {
+  const db = new Database(":memory:");
+  applyIndexedMigrations(db);
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES ('wf1', 'alpha', NULL, '[]', 0, 0)`,
+  );
+  db.run(
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg, dry_run, params_override_json)
+     VALUES ('r1', 'wf1', 'user', 'done', 10, 20, NULL, 0, NULL),
+            ('r2', 'wf1', 'user', 'done', 30, 40, NULL, 0, NULL)`,
+  );
+  const result = await dispatchAutomationRpc({ db }, "workflow.listRuns", {
+    workflowName: "alpha",
+    limit: 5,
+  });
+  expect(result.kind).toBe("hit");
+  if (result.kind === "hit") {
+    const value = result.value as { runs: Array<{ id: string }> };
+    expect(value.runs.length).toBe(2);
+    expect(value.runs[0].id).toBe("r2");
+  }
+});
+
+test("watcher.listHistory rejects missing watcherId", async () => {
+  const db = new Database(":memory:");
+  applyIndexedMigrations(db);
+  await expect(
+    dispatchAutomationRpc({ db }, "watcher.listHistory", { limit: 5 }),
+  ).rejects.toThrow();
+});
+```
+
+Import helpers at the top of the test file (`Database`, `applyIndexedMigrations`, `dispatchAutomationRpc`, `expect`, `test`). **Don't omit imports** — if the dispatcher is named differently, grep for it: `grep -n "export .* dispatch" packages/gateway/src/ipc/automation-rpc.ts`.
+
+- [ ] **Step 4.3: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/ipc/automation-rpc.test.ts`
+
+Expected: FAIL — "Method not found: watcher.listHistory" or similar.
+
+- [ ] **Step 4.4: Add the two cases to the dispatcher**
+
+In `packages/gateway/src/ipc/automation-rpc.ts`, add imports at the top:
+
+```ts
+import { listWatcherHistory } from "../automation/watcher-history";
+import { listWorkflowRuns } from "../automation/workflow-run-history";
+```
+
+Add two `case` branches inside the dispatcher (mirror the positioning of the existing cases):
+
+```ts
+case "watcher.listHistory": {
+  const watcherId = requireString(rec, "watcherId");
+  const limit = requireNumber(rec, "limit");
+  return { kind: "hit", value: listWatcherHistory(db, { watcherId, limit }) };
+}
+
+case "workflow.listRuns": {
+  const workflowName = requireString(rec, "workflowName");
+  const limit = requireNumber(rec, "limit");
+  return { kind: "hit", value: listWorkflowRuns(db, { workflowName, limit }) };
+}
+```
+
+- [ ] **Step 4.5: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/ipc/automation-rpc.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add packages/gateway/src/ipc/automation-rpc.ts packages/gateway/src/ipc/automation-rpc.test.ts
+git commit -m "feat(gateway): expose watcher.listHistory + workflow.listRuns over IPC"
+```
+
+---
+
+## Task 5: Runner Writes Dry-Run Rows
+
+**Files:**
+- Modify: `packages/gateway/src/automation/workflow-store.ts`
+- Modify: `packages/gateway/src/automation/workflow-runner.ts`
+- Modify: `packages/gateway/src/automation/workflow-store.test.ts`
+- Modify: `packages/gateway/src/automation/workflow-runner.test.ts`
+
+Currently `runWorkflowExecution` returns early before `insertWorkflowRunRow` when `p.dryRun === true`. After this task, every run (real or dry) writes a row; dry runs are marked with `dry_run = 1` and `status = "preview"`.
+
+---
+
+- [ ] **Step 5.1: Extend `insertWorkflowRunRow` with `dryRun` + `paramsOverrideJson`**
+
+Open `packages/gateway/src/automation/workflow-store.ts`. Update the signature:
+
+```ts
+export function insertWorkflowRunRow(
+  db: Database,
+  row: {
+    id: string;
+    workflowId: string;
+    triggeredBy: string;
+    status: string;
+    startedAt: number;
+    dryRun?: boolean;
+    paramsOverrideJson?: string | null;
+  },
+): void {
+  db.run(
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg, dry_run, params_override_json)
+     VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?)`,
+    [
+      row.id,
+      row.workflowId,
+      row.triggeredBy,
+      row.status,
+      row.startedAt,
+      row.dryRun === true ? 1 : 0,
+      row.paramsOverrideJson ?? null,
+    ],
+  );
+}
+```
+
+- [ ] **Step 5.2: Update `workflow-store.test.ts` to cover the new fields**
+
+Open the test file. Add:
+
+```ts
+test("insertWorkflowRunRow persists dry_run and params_override_json", () => {
+  applyIndexedMigrations(db);
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES ('wf1', 'x', NULL, '[]', 0, 0)`,
+  );
+  insertWorkflowRunRow(db, {
+    id: "r1",
+    workflowId: "wf1",
+    triggeredBy: "user",
+    status: "preview",
+    startedAt: 1,
+    dryRun: true,
+    paramsOverrideJson: '{"key":"v"}',
+  });
+  const row = db
+    .query(`SELECT dry_run, params_override_json FROM workflow_run WHERE id = 'r1'`)
+    .get() as { dry_run: number; params_override_json: string };
+  expect(row.dry_run).toBe(1);
+  expect(row.params_override_json).toBe('{"key":"v"}');
+});
+```
+
+- [ ] **Step 5.3: Run the store tests**
+
+Run: `bun test packages/gateway/src/automation/workflow-store.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5.4: Write the failing runner test for dry-run persistence**
+
+In `packages/gateway/src/automation/workflow-runner.test.ts`, add:
+
+```ts
+test("runWorkflowExecution writes a dry_run=1 row when dryRun is true", async () => {
+  // Assume test fixture seeds a workflow 'preview-me' with one step.
+  await runWorkflowExecution({ db, workflowName: "preview-me", dryRun: true, triggeredBy: "user" });
+  const row = db
+    .query(`SELECT dry_run, status FROM workflow_run ORDER BY started_at DESC LIMIT 1`)
+    .get() as { dry_run: number; status: string };
+  expect(row.dry_run).toBe(1);
+  expect(row.status).toBe("preview");
+});
+```
+
+*(If the file's existing fixtures differ, match them — the existing tests will show how to seed a workflow.)*
+
+- [ ] **Step 5.5: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: FAIL — no row is inserted (current runner short-circuits before insert).
+
+- [ ] **Step 5.6: Modify `runWorkflowExecution` to insert dry-run rows**
+
+Open `packages/gateway/src/automation/workflow-runner.ts`. Replace the existing `if (p.dryRun) { return { ... } }` early-return block with an insert-then-finish pattern:
+
+```ts
+if (p.dryRun) {
+  insertWorkflowRunRow(p.db, {
+    id: runId,
+    workflowId: wf.id,
+    triggeredBy: p.triggeredBy,
+    status: "preview",
+    startedAt: now,
+    dryRun: true,
+  });
+  finishWorkflowRunRow(p.db, runId, "preview", Date.now(), null);
+  return {
+    runId,
+    dryRun: true,
+    stepResults: steps.map((s, i) => ({
+      label: s.label ?? `step-${String(i + 1)}`,
+      status: "preview",
+      output: s.run,
+      hitlActions: previewHitlActionsForStepText(s.run),
+    })),
+  };
+}
+```
+
+- [ ] **Step 5.7: Run the runner test to verify it passes**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5.8: Commit**
+
+```bash
+git add packages/gateway/src/automation/workflow-store.ts packages/gateway/src/automation/workflow-store.test.ts packages/gateway/src/automation/workflow-runner.ts packages/gateway/src/automation/workflow-runner.test.ts
+git commit -m "feat(gateway): persist dry-run workflow invocations to workflow_run"
+```
+
+---
+
+## Task 6: Thread `paramsOverride` Through the Runner
+
+**Files:**
+- Modify: `packages/gateway/src/automation/workflow-runner.ts`
+- Modify: `packages/gateway/src/automation/workflow-runner.test.ts`
+
+The override is a map of `{ [stepLabel]: Record<string, unknown> }`. The runner applies it transiently during step execution and persists the raw JSON on the run row for audit/UI surfacing.
+
+---
+
+- [ ] **Step 6.1: Write the failing test for paramsOverride persistence**
+
+Add to `workflow-runner.test.ts`:
+
+```ts
+test("runWorkflowExecution persists paramsOverride JSON on the run row", async () => {
+  const override = { "step-1": { greeting: "hi" } };
+  await runWorkflowExecution({
+    db,
+    workflowName: "preview-me",
+    dryRun: false,
+    triggeredBy: "user",
+    paramsOverride: override,
+  });
+  const row = db
+    .query(`SELECT params_override_json FROM workflow_run ORDER BY started_at DESC LIMIT 1`)
+    .get() as { params_override_json: string };
+  expect(JSON.parse(row.params_override_json)).toEqual(override);
+});
+
+test("runWorkflowExecution persists NULL params_override_json when not provided", async () => {
+  await runWorkflowExecution({
+    db,
+    workflowName: "preview-me",
+    dryRun: false,
+    triggeredBy: "user",
+  });
+  const row = db
+    .query(`SELECT params_override_json FROM workflow_run ORDER BY started_at DESC LIMIT 1`)
+    .get() as { params_override_json: string | null };
+  expect(row.params_override_json).toBeNull();
+});
+```
+
+- [ ] **Step 6.2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: FAIL — runner doesn't accept `paramsOverride` yet; column stays NULL.
+
+- [ ] **Step 6.3: Extend `RunWorkflowExecutionParams` + runner**
+
+In `workflow-runner.ts`, find the `RunWorkflowExecutionParams` type. Add:
+
+```ts
+export interface RunWorkflowExecutionParams {
+  readonly db: Database;
+  readonly workflowName: string;
+  readonly dryRun: boolean;
+  readonly triggeredBy: string;
+  readonly paramsOverride?: Readonly<Record<string, Record<string, unknown>>>;
+}
+```
+
+Update `insertWorkflowRunRow` callsites (both the dry-run branch added in Task 5 and the real-run branch on line ~180) to pass `paramsOverrideJson`:
+
+```ts
+const paramsOverrideJson =
+  p.paramsOverride === undefined ? null : JSON.stringify(p.paramsOverride);
+
+insertWorkflowRunRow(p.db, {
+  id: runId,
+  workflowId: wf.id,
+  triggeredBy: p.triggeredBy,
+  status: "running", // or "preview" for dry run
+  startedAt: now,
+  dryRun: p.dryRun,
+  paramsOverrideJson,
+});
+```
+
+- [ ] **Step 6.4: Apply the override transiently in `executeWorkflowStep`**
+
+Find `executeWorkflowStep` (~line 97 of `workflow-runner.ts`). Pass `paramsOverride` through, look up the step's override by label, and merge into the tool params before dispatching. Example:
+
+```ts
+async function executeWorkflowStep(
+  p: RunWorkflowExecutionParams,
+  runId: string,
+  stepIndex: number,
+  step: WorkflowStep,
+  outputs: string[],
+): Promise<StepOutcome> {
+  const label = step.label ?? `step-${String(stepIndex + 1)}`;
+  const override = p.paramsOverride?.[label];
+  // existing code that constructs step params, e.g. `const args = { ...baseArgs, ... }` — merge override last:
+  // const mergedArgs = override === undefined ? baseArgs : { ...baseArgs, ...override };
+  // ... rest unchanged ...
+}
+```
+
+**Read the existing function before editing — the exact merge point depends on where step params are constructed. If the runner uses a templating pass first, the override should be merged after templating.**
+
+- [ ] **Step 6.5: Run the runner tests**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: PASS — both new tests green, existing tests unchanged.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add packages/gateway/src/automation/workflow-runner.ts packages/gateway/src/automation/workflow-runner.test.ts
+git commit -m "feat(gateway): thread paramsOverride through workflow runner"
+```
+
+---
+
+## Task 7: Accept `paramsOverride` on the `workflow.run` IPC
+
+**Files:**
+- Modify: `packages/gateway/src/ipc/server.ts`
+- Modify: `packages/gateway/src/ipc/ipc.test.ts`
+
+The current `WorkflowRunHandler` type takes `{ name, dryRun }`. Add optional `paramsOverride`. Downstream callers pass it into `runWorkflowExecution`.
+
+---
+
+- [ ] **Step 7.1: Read the existing WorkflowRunHandler definition**
+
+Run: `grep -n "WorkflowRunHandler\|workflowRun" packages/gateway/src/ipc/server.ts`
+
+Open the file; read the handler signature + how params are parsed in the `workflow.run` dispatch branch (~line 644).
+
+- [ ] **Step 7.2: Write the failing IPC integration test**
+
+In `packages/gateway/src/ipc/ipc.test.ts`, extend or add alongside the existing `workflow.run uses registered handler` test:
+
+```ts
+test("workflow.run forwards paramsOverride to the handler", async () => {
+  let captured: unknown = null;
+  const line = await rpcCall(listenPath, "workflow.run", {
+    name: "wf1",
+    dryRun: false,
+    paramsOverride: { "step-1": { greeting: "hello" } },
+  });
+  // The test harness registers a fake handler that records its params arg.
+  // Assuming the existing test already wires `recordParams`, extend it; otherwise mirror the existing pattern.
+  expect(captured).toMatchObject({ paramsOverride: { "step-1": { greeting: "hello" } } });
+});
+```
+
+*(Note: adapt to the file's existing harness — the existing `workflow.run` test on line 448 shows how handlers are registered.)*
+
+- [ ] **Step 7.3: Run to verify it fails**
+
+Run: `bun test packages/gateway/src/ipc/ipc.test.ts`
+
+Expected: FAIL — handler signature doesn't include `paramsOverride`.
+
+- [ ] **Step 7.4: Extend the handler type in `server.ts`**
+
+```ts
+export interface WorkflowRunRequest {
+  readonly name: string;
+  readonly dryRun: boolean;
+  readonly paramsOverride?: Readonly<Record<string, Record<string, unknown>>>;
+}
+
+export type WorkflowRunHandler = (req: WorkflowRunRequest) => Promise<unknown>;
+```
+
+Update the dispatch branch (the `if (method === "workflow.run")` block) to parse the optional override:
+
+```ts
+if (method === "workflow.run") {
+  const name = requireString(params, "name");
+  const dryRun = Boolean(params.dryRun);
+  const paramsOverride = params.paramsOverride as
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
+  return await workflowRunHandler({ name, dryRun, paramsOverride });
+}
+```
+
+- [ ] **Step 7.5: Update the runner-wiring code (where `workflowRun` is registered) to forward the override**
+
+In the file that calls `ipcServer.setWorkflowRunHandler(...)` (search: `grep -rn "setWorkflowRunHandler" packages/gateway/src/`):
+
+```ts
+ipcServer.setWorkflowRunHandler(async ({ name, dryRun, paramsOverride }) => {
+  return runWorkflowExecution({
+    db,
+    workflowName: name,
+    dryRun,
+    triggeredBy: "user",
+    paramsOverride,
+  });
+});
+```
+
+- [ ] **Step 7.6: Run the IPC test to verify it passes**
+
+Run: `bun test packages/gateway/src/ipc/ipc.test.ts`
+
+Expected: PASS — new test green, existing `workflow.run` test unchanged.
+
+- [ ] **Step 7.7: Commit**
+
+```bash
+git add packages/gateway/src/ipc/server.ts packages/gateway/src/ipc/ipc.test.ts $(grep -rln "setWorkflowRunHandler" packages/gateway/src/)
+git commit -m "feat(gateway): accept paramsOverride on workflow.run IPC"
+```
+
+---
+
+## Task 8: Audit-Log Entry on Workflow Run Completion
+
+**Files:**
+- Modify: `packages/gateway/src/automation/workflow-runner.ts`
+- Modify: `packages/gateway/src/automation/workflow-runner.test.ts`
+
+Every completed workflow run writes one `audit_log` entry with action `workflow.run.completed` and a details payload carrying `{ runId, workflowName, status, durationMs, dryRun, paramsOverride? }`. The audit log is BLAKE3-chained (v18), so the entry gets a row hash linked to the previous row — providing the legal-record anchor for the UI's "View audit entry" link.
+
+---
+
+- [ ] **Step 8.1: Locate the audit-writer helper**
+
+Run: `grep -rn "writeAuditEntry\|appendAuditLog\|audit_log" packages/gateway/src/db/ packages/gateway/src/audit/ 2>/dev/null | head -20`
+
+Identify the exact symbol + import path (likely `writeAuditEntry` or similar from `packages/gateway/src/audit/`). Read its signature to confirm expected params.
+
+- [ ] **Step 8.2: Write the failing test**
+
+Add to `workflow-runner.test.ts`:
+
+```ts
+test("runWorkflowExecution writes an audit_log entry on completion", async () => {
+  await runWorkflowExecution({
+    db,
+    workflowName: "preview-me",
+    dryRun: false,
+    triggeredBy: "user",
+  });
+  const entry = db
+    .query(`SELECT action_type, target_ref, details_json FROM audit_log ORDER BY id DESC LIMIT 1`)
+    .get() as { action_type: string; target_ref: string; details_json: string };
+  expect(entry.action_type).toBe("workflow.run.completed");
+  const details = JSON.parse(entry.details_json) as {
+    runId: string;
+    workflowName: string;
+    status: string;
+    durationMs: number;
+    dryRun: boolean;
+  };
+  expect(details.workflowName).toBe("preview-me");
+  expect(details.status).toBe("done");
+  expect(details.dryRun).toBe(false);
+  expect(typeof details.durationMs).toBe("number");
+});
+
+test("runWorkflowExecution writes an audit_log entry on error", async () => {
+  // Seed a workflow whose step will fail (use an unknown tool or inject an error).
+  await expect(
+    runWorkflowExecution({
+      db,
+      workflowName: "broken-wf",
+      dryRun: false,
+      triggeredBy: "user",
+    }),
+  ).rejects.toThrow();
+  const entry = db
+    .query(`SELECT action_type, details_json FROM audit_log ORDER BY id DESC LIMIT 1`)
+    .get() as { action_type: string; details_json: string };
+  expect(entry.action_type).toBe("workflow.run.completed");
+  const details = JSON.parse(entry.details_json) as { status: string };
+  expect(details.status).toBe("error");
+});
+```
+
+- [ ] **Step 8.3: Run to verify failure**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: FAIL — no audit entry written.
+
+- [ ] **Step 8.4: Add audit writes in the runner**
+
+In `runWorkflowExecution`, after each `finishWorkflowRunRow(...)` call (there are three: dry-run, step-error-halt, success, uncaught-throw), write an audit entry:
+
+```ts
+import { writeAuditEntry } from "../audit/audit-writer"; // adapt to the actual path
+
+function emitRunCompletedAudit(
+  db: Database,
+  runId: string,
+  workflowName: string,
+  status: string,
+  startedAt: number,
+  dryRun: boolean,
+  paramsOverride: RunWorkflowExecutionParams["paramsOverride"],
+  errorMsg: string | null,
+): void {
+  writeAuditEntry(db, {
+    actionType: "workflow.run.completed",
+    targetRef: runId,
+    details: {
+      runId,
+      workflowName,
+      status,
+      durationMs: Date.now() - startedAt,
+      dryRun,
+      ...(paramsOverride !== undefined && { paramsOverride }),
+      ...(errorMsg !== null && { errorMsg }),
+    },
+  });
+}
+```
+
+Call this helper at each of the three exit points. For the `throw err` branch, call it *before* re-throwing.
+
+- [ ] **Step 8.5: Run to verify passing**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: PASS — both new tests green.
+
+- [ ] **Step 8.6: Verify audit chain integrity after new entries**
+
+Run: `bun test packages/gateway/src/audit/`
+
+Expected: PASS — chain-integrity tests confirm `prev_hash` linkage for workflow.run entries is valid.
+
+- [ ] **Step 8.7: Commit**
+
+```bash
+git add packages/gateway/src/automation/workflow-runner.ts packages/gateway/src/automation/workflow-runner.test.ts
+git commit -m "feat(gateway): emit audit_log entry on workflow.run.completed"
+```
+
+---
+
+## Task 9: Apply 100-Run Retention at Completion
+
+**Files:**
+- Modify: `packages/gateway/src/automation/workflow-runner.ts`
+- Modify: `packages/gateway/src/automation/workflow-runner.test.ts`
+
+---
+
+- [ ] **Step 9.1: Write the failing test**
+
+Add to `workflow-runner.test.ts`:
+
+```ts
+test("workflow run completion prunes to the last 100 runs per workflow", async () => {
+  // Seed 100 historical runs for 'preview-me' directly via insertWorkflowRunRow.
+  for (let i = 0; i < 100; i++) {
+    insertWorkflowRunRow(db, {
+      id: `hist-${i}`,
+      workflowId: "wf-preview-me", // the id from the fixture workflow
+      triggeredBy: "user",
+      status: "done",
+      startedAt: 1_000 + i,
+      dryRun: false,
+    });
+    finishWorkflowRunRow(db, `hist-${i}`, "done", 1_010 + i, null);
+  }
+  // Now run — this should push the count to 101, triggering a prune back to 100.
+  await runWorkflowExecution({ db, workflowName: "preview-me", dryRun: false, triggeredBy: "user" });
+  const count = db
+    .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = 'wf-preview-me'`)
+    .get() as { c: number };
+  expect(count.c).toBe(100);
+  // Oldest row (hist-0) should have been pruned.
+  const oldestExists = db
+    .query(`SELECT id FROM workflow_run WHERE id = 'hist-0'`)
+    .get();
+  expect(oldestExists).toBeNull();
+});
+```
+
+- [ ] **Step 9.2: Run to verify failure**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: FAIL — count stays at 101.
+
+- [ ] **Step 9.3: Call `pruneWorkflowRuns` after each completion**
+
+In `runWorkflowExecution`, after each `finishWorkflowRunRow` call (at all three completion sites: success, step-halt, uncaught-throw), invoke:
+
+```ts
+import { pruneWorkflowRuns } from "./workflow-run-history";
+
+const RUN_RETENTION_PER_WORKFLOW = 100;
+
+// … after finishWorkflowRunRow(...) …
+pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
+```
+
+Place the prune **outside** the audit-log write so a chain failure doesn't block retention and vice versa.
+
+- [ ] **Step 9.4: Run to verify passing**
+
+Run: `bun test packages/gateway/src/automation/workflow-runner.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add packages/gateway/src/automation/workflow-runner.ts packages/gateway/src/automation/workflow-runner.test.ts
+git commit -m "feat(gateway): prune workflow_run to last 100 per workflow on completion"
+```
+
+---
+
+## Task 10: UI IPC Types for Watcher History + Workflow Runs
+
+**Files:**
+- Modify: `packages/ui/src/ipc/types.ts`
+
+---
+
+- [ ] **Step 10.1: Add the new types**
+
+Open `packages/ui/src/ipc/types.ts`. After `WatcherListResult` (~line 443), add:
+
+```ts
+export interface WatcherHistoryEntry {
+  readonly firedAt: number;
+  readonly conditionSnapshot: string;
+  readonly actionResult: string;
+}
+
+export interface WatcherListHistoryResult {
+  readonly events: ReadonlyArray<WatcherHistoryEntry>;
+}
+```
+
+After `WorkflowListResult` (~line 496), add:
+
+```ts
+export interface WorkflowRunHistoryEntry {
+  readonly id: string;
+  readonly startedAt: number;
+  readonly finishedAt: number | null;
+  readonly durationMs: number | null;
+  readonly status: string;
+  readonly errorMsg: string | null;
+  readonly dryRun: boolean;
+  readonly paramsOverrideJson: string | null;
+  readonly triggeredBy: string;
+}
+
+export interface WorkflowListRunsResult {
+  readonly runs: ReadonlyArray<WorkflowRunHistoryEntry>;
+}
+```
+
+Extend the existing `WorkflowRunParams` (or the inline params of `workflowRun`) to accept `paramsOverride?: Readonly<Record<string, Record<string, unknown>>>`. Locate the existing shape:
+
+```ts
+grep -n "workflowRun\|WorkflowRunParams\|dryRun: boolean" packages/ui/src/ipc/types.ts
+```
+
+Add or extend:
+
+```ts
+export interface WorkflowRunParams {
+  readonly name: string;
+  readonly dryRun: boolean;
+  readonly paramsOverride?: Readonly<Record<string, Record<string, unknown>>>;
+}
+```
+
+- [ ] **Step 10.2: Type-check the UI package**
+
+Run: `cd packages/ui && bun run typecheck`
+
+Expected: PASS — no errors. If existing code uses inline `{ name, dryRun }` and you extracted to `WorkflowRunParams`, update callsites to import the type.
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add packages/ui/src/ipc/types.ts
+git commit -m "feat(ui): add WatcherHistoryEntry + WorkflowRunHistoryEntry IPC types"
+```
+
+---
+
+## Task 11: UI IPC Client Methods
+
+**Files:**
+- Modify: `packages/ui/src/ipc/client.ts`
+- Modify: `packages/ui/src/ipc/__mocks__/client.ts`
+
+---
+
+- [ ] **Step 11.1: Add the two methods on the client class**
+
+Open `packages/ui/src/ipc/client.ts`. After `watcherList()` (~line 411), add:
+
+```ts
+async watcherListHistory(watcherId: string, limit: number): Promise<WatcherListHistoryResult> {
+  const res = await this.call<unknown>("watcher.listHistory", { watcherId, limit });
+  if (typeof res !== "object" || res === null || !Array.isArray((res as WatcherListHistoryResult).events)) {
+    throw new Error("watcher.listHistory: expected { events: [] }");
+  }
+  return res as WatcherListHistoryResult;
+}
+```
+
+Near `workflowList()` (~line 430), add:
+
+```ts
+async workflowListRuns(workflowName: string, limit: number): Promise<WorkflowListRunsResult> {
+  const res = await this.call<unknown>("workflow.listRuns", { workflowName, limit });
+  if (typeof res !== "object" || res === null || !Array.isArray((res as WorkflowListRunsResult).runs)) {
+    throw new Error("workflow.listRuns: expected { runs: [] }");
+  }
+  return res as WorkflowListRunsResult;
+}
+```
+
+Update the existing `workflowRun` method to accept `paramsOverride`:
+
+```ts
+async workflowRun(params: WorkflowRunParams): Promise<unknown> {
+  return this.call<unknown>("workflow.run", params);
+}
+```
+
+Ensure the import block at the top includes the new types:
+
+```ts
+import type {
+  WatcherListHistoryResult,
+  WorkflowListRunsResult,
+  WorkflowRunParams,
+  // ...existing imports...
+} from "./types";
+```
+
+- [ ] **Step 11.2: Register the mocks**
+
+Open `packages/ui/src/ipc/__mocks__/client.ts`. Add:
+
+```ts
+export const watcherListHistoryMock = vi.fn();
+export const workflowListRunsMock = vi.fn();
+```
+
+And in the mocked `createIpcClient` returned object, include:
+
+```ts
+watcherListHistory: watcherListHistoryMock,
+workflowListRuns: workflowListRunsMock,
+```
+
+- [ ] **Step 11.3: Typecheck**
+
+Run: `cd packages/ui && bun run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 11.4: Commit**
+
+```bash
+git add packages/ui/src/ipc/client.ts packages/ui/src/ipc/__mocks__/client.ts
+git commit -m "feat(ui): add watcherListHistory + workflowListRuns IPC client methods"
+```
+
+---
+
+## Task 12: Tauri Allowlist — Add 2 Methods, Bump Size to 56
+
+**Files:**
+- Modify: `packages/ui/src-tauri/src/gateway_bridge.rs`
+
+---
+
+- [ ] **Step 12.1: Read the current allowlist layout**
+
+Run: `sed -n '80,120p' packages/ui/src-tauri/src/gateway_bridge.rs`
+
+Confirm the alphabetical grouping — `watcher.create`, `watcher.delete`, `watcher.list`, `watcher.listCandidateRelations`, `watcher.pause`, ... — and the `workflow.delete`, `workflow.list`, `workflow.run`, `workflow.save` block.
+
+- [ ] **Step 12.2: Insert the two methods**
+
+Add `"watcher.listHistory",` between `"watcher.list",` (line 109) and `"watcher.listCandidateRelations",` (line 110).
+
+Add `"workflow.listRuns",` between `"workflow.list",` (line 115) and `"workflow.run",` (line 116).
+
+- [ ] **Step 12.3: Update the size assertion**
+
+Open the `allowlist_exact_size` test (~line 429). Change:
+
+```rust
+// WS5-D polish (Watcher history + Workflow run history) adds watcher.listHistory +
+// workflow.listRuns → 2 new methods → 56 total.
+assert_eq!(ALLOWED_METHODS.len(), 56);
+```
+
+Replace the existing WS5-D comment with the updated comment text.
+
+- [ ] **Step 12.4: Run the Rust tests**
+
+Run: `cd packages/ui/src-tauri && cargo test`
+
+Expected: PASS — `allowlist_exact_size`, `allowlist_is_alphabetized`, and other allowlist tests all green.
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add packages/ui/src-tauri/src/gateway_bridge.rs
+git commit -m "feat(ui/tauri): allow watcher.listHistory + workflow.listRuns (54 → 56)"
+```
+
+---
+
+## Task 13: Watchers Page — History Drawer
+
+**Files:**
+- Create: `packages/ui/src/components/watchers/WatcherHistoryDrawer.tsx`
+- Modify: `packages/ui/src/pages/Watchers.tsx`
+- Modify: `packages/ui/test/pages/Watchers.test.tsx`
+
+---
+
+- [ ] **Step 13.1: Write the failing UI test**
+
+Extend `packages/ui/test/pages/Watchers.test.tsx`:
+
+```tsx
+import { watcherListHistoryMock, watcherListMock } from "../../src/ipc/__mocks__/client";
+
+test("clicking History on a watcher row fetches and renders the last N fires", async () => {
+  watcherListMock.mockResolvedValue({
+    watchers: [
+      {
+        id: "w1",
+        name: "alpha",
+        enabled: 1,
+        condition_type: "schedule",
+        condition_json: "{}",
+        action_type: "notify",
+        action_json: "{}",
+        created_at: 0,
+        last_checked_at: null,
+        last_fired_at: null,
+        graph_predicate_json: null,
+      },
+    ],
+  });
+  watcherListHistoryMock.mockResolvedValue({
+    events: [
+      { firedAt: 2000, conditionSnapshot: '{"a":2}', actionResult: '{"ok":true}' },
+      { firedAt: 1000, conditionSnapshot: '{"a":1}', actionResult: '{"ok":true}' },
+    ],
+  });
+
+  render(<Watchers />);
+  await screen.findByText("alpha");
+  const historyButton = await screen.findByRole("button", { name: /history for alpha/i });
+  fireEvent.click(historyButton);
+  await screen.findByText(/\{"a":2\}/);
+  expect(watcherListHistoryMock).toHaveBeenCalledWith("w1", expect.any(Number));
+});
+
+test("History drawer shows an empty state when no events have fired", async () => {
+  watcherListMock.mockResolvedValue({
+    watchers: [
+      {
+        id: "w1",
+        name: "alpha",
+        enabled: 1,
+        condition_type: "schedule",
+        condition_json: "{}",
+        action_type: "notify",
+        action_json: "{}",
+        created_at: 0,
+        last_checked_at: null,
+        last_fired_at: null,
+        graph_predicate_json: null,
+      },
+    ],
+  });
+  watcherListHistoryMock.mockResolvedValue({ events: [] });
+
+  render(<Watchers />);
+  await screen.findByText("alpha");
+  fireEvent.click(await screen.findByRole("button", { name: /history for alpha/i }));
+  await screen.findByText(/no fires yet/i);
+});
+```
+
+*(Adapt imports — `render`, `screen`, `fireEvent` from `@testing-library/react`; `Watchers` from `../../src/pages/Watchers`. Confirm against existing imports in the test file.)*
+
+- [ ] **Step 13.2: Run the test to verify it fails**
+
+Run: `cd packages/ui && bunx vitest run test/pages/Watchers.test.tsx`
+
+Expected: FAIL — "Unable to find role button with name /history for alpha/i".
+
+- [ ] **Step 13.3: Create `WatcherHistoryDrawer.tsx`**
+
+Create `packages/ui/src/components/watchers/WatcherHistoryDrawer.tsx`:
+
+```tsx
+import { useEffect, useState } from "react";
+import { createIpcClient } from "../../ipc/client";
+import type { WatcherHistoryEntry } from "../../ipc/types";
+
+interface WatcherHistoryDrawerProps {
+  readonly watcherId: string;
+  readonly watcherName: string;
+  readonly onClose: () => void;
+}
+
+const HISTORY_LIMIT = 50;
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toLocaleString();
+}
+
+export function WatcherHistoryDrawer({ watcherId, watcherName, onClose }: WatcherHistoryDrawerProps) {
+  const [events, setEvents] = useState<ReadonlyArray<WatcherHistoryEntry> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    createIpcClient()
+      .watcherListHistory(watcherId, HISTORY_LIMIT)
+      .then((res) => {
+        if (!cancelled) setEvents(res.events);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [watcherId]);
+
+  return (
+    <div
+      role="region"
+      aria-label={`History for ${watcherName}`}
+      className="border rounded p-3 mt-2 bg-neutral-50 dark:bg-neutral-900 flex flex-col gap-2"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold">Fire history — last {HISTORY_LIMIT}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-neutral-500 hover:text-neutral-700"
+        >
+          Close
+        </button>
+      </div>
+      {error && <p className="text-red-600 text-xs">{error}</p>}
+      {events === null && !error && <p className="text-xs text-neutral-500">Loading…</p>}
+      {events !== null && events.length === 0 && (
+        <p className="text-xs text-neutral-500">No fires yet.</p>
+      )}
+      {events !== null && events.length > 0 && (
+        <ul className="flex flex-col gap-1 max-h-64 overflow-y-auto">
+          {events.map((ev) => (
+            <li key={ev.firedAt} className="text-xs border-b border-neutral-200 dark:border-neutral-800 py-1">
+              <div className="font-mono text-neutral-500">{formatTimestamp(ev.firedAt)}</div>
+              {/* whitespace-pre-wrap + break-all: prevents data loss on large graph
+                  predicate snapshots; the drawer's own max-h-64 overflow-y-auto scrolls. */}
+              <div className="font-mono whitespace-pre-wrap break-all">{ev.conditionSnapshot}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 13.4: Mount the drawer in `Watchers.tsx`**
+
+Open `packages/ui/src/pages/Watchers.tsx`. Add state for the open drawer and a per-row history button. Near the existing watcher-row render:
+
+```tsx
+const [openHistoryForId, setOpenHistoryForId] = useState<string | null>(null);
+```
+
+In the row rendering (wherever watchers are mapped to JSX), add a button:
+
+```tsx
+<button
+  type="button"
+  aria-label={`History for ${w.name}`}
+  onClick={() => setOpenHistoryForId(openHistoryForId === w.id ? null : w.id)}
+  className="text-xs border rounded px-2 py-0.5"
+>
+  History
+</button>
+```
+
+And conditionally render the drawer below the row:
+
+```tsx
+{openHistoryForId === w.id && (
+  <WatcherHistoryDrawer
+    watcherId={w.id}
+    watcherName={w.name}
+    onClose={() => setOpenHistoryForId(null)}
+  />
+)}
+```
+
+Add the import at the top: `import { WatcherHistoryDrawer } from "../components/watchers/WatcherHistoryDrawer";`
+
+- [ ] **Step 13.5: Run the test to verify passing**
+
+Run: `cd packages/ui && bunx vitest run test/pages/Watchers.test.tsx`
+
+Expected: PASS — both history tests green.
+
+- [ ] **Step 13.6: Verify coverage holds**
+
+Run: `cd packages/ui && bunx vitest run --coverage test/pages/Watchers.test.tsx`
+
+Expected: Watchers.tsx + WatcherHistoryDrawer.tsx coverage ≥ 80 % lines / ≥ 75 % branches.
+
+- [ ] **Step 13.7: Commit**
+
+```bash
+git add packages/ui/src/components/watchers/ packages/ui/src/pages/Watchers.tsx packages/ui/test/pages/Watchers.test.tsx
+git commit -m "feat(ui): watcher history drawer with last-50 fire preview"
+```
+
+---
+
+## Task 14: Workflows Page — Run-History Drawer with Audit Link
+
+**Files:**
+- Create: `packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx`
+- Modify: `packages/ui/src/pages/Workflows.tsx`
+- Modify: `packages/ui/test/pages/Workflows.test.tsx`
+
+---
+
+- [ ] **Step 14.1: Write the failing UI tests**
+
+Add to `packages/ui/test/pages/Workflows.test.tsx`:
+
+```tsx
+import { workflowListMock, workflowListRunsMock } from "../../src/ipc/__mocks__/client";
+
+test("Expanding a workflow row fetches and renders the last N runs", async () => {
+  workflowListMock.mockResolvedValue({
+    workflows: [
+      { id: "wf1", name: "alpha", description: null, steps_json: "[]", created_at: 0, updated_at: 0 },
+    ],
+  });
+  workflowListRunsMock.mockResolvedValue({
+    runs: [
+      {
+        id: "r1",
+        startedAt: 1000,
+        finishedAt: 1200,
+        durationMs: 200,
+        status: "done",
+        errorMsg: null,
+        dryRun: false,
+        paramsOverrideJson: null,
+        triggeredBy: "user",
+      },
+      {
+        id: "r2",
+        startedAt: 500,
+        finishedAt: 700,
+        durationMs: 200,
+        status: "preview",
+        errorMsg: null,
+        dryRun: true,
+        paramsOverrideJson: null,
+        triggeredBy: "user",
+      },
+    ],
+  });
+
+  render(<Workflows />);
+  await screen.findByText("alpha");
+  fireEvent.click(await screen.findByRole("button", { name: /show history for alpha/i }));
+  await screen.findByText(/200 ms/);
+  expect(screen.getByText(/done/i)).toBeInTheDocument();
+  expect(screen.getByText(/preview/i)).toBeInTheDocument();
+  expect(workflowListRunsMock).toHaveBeenCalledWith("alpha", expect.any(Number));
+});
+
+test("Run history row shows a 'View audit entry' link with the runId", async () => {
+  workflowListMock.mockResolvedValue({
+    workflows: [
+      { id: "wf1", name: "alpha", description: null, steps_json: "[]", created_at: 0, updated_at: 0 },
+    ],
+  });
+  workflowListRunsMock.mockResolvedValue({
+    runs: [
+      {
+        id: "run-abc",
+        startedAt: 1000,
+        finishedAt: 1200,
+        durationMs: 200,
+        status: "done",
+        errorMsg: null,
+        dryRun: false,
+        paramsOverrideJson: null,
+        triggeredBy: "user",
+      },
+    ],
+  });
+  render(<Workflows />);
+  await screen.findByText("alpha");
+  fireEvent.click(await screen.findByRole("button", { name: /show history for alpha/i }));
+  const link = await screen.findByRole("link", { name: /view audit entry/i });
+  expect(link.getAttribute("href")).toContain("run-abc");
+});
+```
+
+- [ ] **Step 14.2: Run to verify failure**
+
+Run: `cd packages/ui && bunx vitest run test/pages/Workflows.test.tsx`
+
+Expected: FAIL — "Unable to find role button with name /show history for alpha/i".
+
+- [ ] **Step 14.3: Create `WorkflowRunHistoryDrawer.tsx`**
+
+Create `packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx`:
+
+```tsx
+import { useEffect, useState } from "react";
+import { createIpcClient } from "../../ipc/client";
+import type { WorkflowRunHistoryEntry } from "../../ipc/types";
+
+interface WorkflowRunHistoryDrawerProps {
+  readonly workflowName: string;
+  readonly onClose: () => void;
+}
+
+const HISTORY_LIMIT = 10;
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toLocaleString();
+}
+
+function statusColor(status: string, dryRun: boolean): string {
+  if (dryRun) return "text-amber-600 italic";
+  if (status === "error") return "text-red-600";
+  if (status === "done") return "text-green-700";
+  return "text-neutral-600";
+}
+
+export function WorkflowRunHistoryDrawer({ workflowName, onClose }: WorkflowRunHistoryDrawerProps) {
+  const [runs, setRuns] = useState<ReadonlyArray<WorkflowRunHistoryEntry> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    createIpcClient()
+      .workflowListRuns(workflowName, HISTORY_LIMIT)
+      .then((res) => {
+        if (!cancelled) setRuns(res.runs);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workflowName]);
+
+  return (
+    <tr>
+      <td colSpan={3} className="py-2 px-3 bg-neutral-50 dark:bg-neutral-900">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-semibold">Last {HISTORY_LIMIT} runs</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-xs text-neutral-500 hover:text-neutral-700"
+          >
+            Close
+          </button>
+        </div>
+        {error && <p className="text-red-600 text-xs">{error}</p>}
+        {runs === null && !error && <p className="text-xs text-neutral-500">Loading…</p>}
+        {runs !== null && runs.length === 0 && (
+          <p className="text-xs text-neutral-500">No runs yet.</p>
+        )}
+        {runs !== null && runs.length > 0 && (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-neutral-500">
+                <th className="text-left px-2 py-1">Started</th>
+                <th className="text-left px-2 py-1">Duration</th>
+                <th className="text-left px-2 py-1">Status</th>
+                <th className="text-left px-2 py-1">Audit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((r) => (
+                <tr key={r.id}>
+                  <td className="px-2 py-1 font-mono">{formatTimestamp(r.startedAt)}</td>
+                  <td className="px-2 py-1 font-mono">
+                    {r.durationMs === null ? "—" : `${r.durationMs} ms`}
+                  </td>
+                  <td className={`px-2 py-1 ${statusColor(r.status, r.dryRun)}`}>
+                    {r.dryRun ? `preview (${r.status})` : r.status}
+                  </td>
+                  <td className="px-2 py-1">
+                    <a
+                      href={`#/settings/audit?runId=${encodeURIComponent(r.id)}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      View audit entry
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </td>
+    </tr>
+  );
+}
+```
+
+- [ ] **Step 14.4: Mount the drawer in `Workflows.tsx`**
+
+Open `packages/ui/src/pages/Workflows.tsx`. Add state:
+
+```tsx
+const [openHistoryForName, setOpenHistoryForName] = useState<string | null>(null);
+```
+
+In `WorkflowRow`, add a button before the existing action buttons:
+
+```tsx
+<button
+  type="button"
+  aria-label={`Show history for ${workflow.name}`}
+  disabled={disabled}
+  onClick={() => onToggleHistory(workflow.name)}
+  className="px-2 py-0.5 rounded border text-xs disabled:opacity-40"
+>
+  History
+</button>
+```
+
+Pass `onToggleHistory` into `WorkflowRow`. In the table body, after each matching row, render the drawer when open:
+
+```tsx
+{data.workflows.map((w) => (
+  <>
+    <WorkflowRow
+      key={w.id}
+      workflow={w}
+      dryRun={dryRun}
+      disabled={offline || actionInFlight !== null}
+      onRun={handleRun}
+      onEdit={(wf) => setShowSave(wf)}
+      onDelete={handleDelete}
+      onToggleHistory={(name) =>
+        setOpenHistoryForName(openHistoryForName === name ? null : name)
+      }
+    />
+    {openHistoryForName === w.name && (
+      <WorkflowRunHistoryDrawer
+        key={`${w.id}-history`}
+        workflowName={w.name}
+        onClose={() => setOpenHistoryForName(null)}
+      />
+    )}
+  </>
+))}
+```
+
+Import: `import { WorkflowRunHistoryDrawer } from "../components/workflows/WorkflowRunHistoryDrawer";`
+
+Extend the `WorkflowRowProps` with `onToggleHistory: (name: string) => void`.
+
+- [ ] **Step 14.5: Run the tests to verify passing**
+
+Run: `cd packages/ui && bunx vitest run test/pages/Workflows.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 14.6: Commit**
+
+```bash
+git add packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx packages/ui/src/pages/Workflows.tsx packages/ui/test/pages/Workflows.test.tsx
+git commit -m "feat(ui): workflow run history drawer with audit entry deep-link"
+```
+
+---
+
+## Task 15: Workflows Page — "Run with params…" Dialog
+
+**Files:**
+- Create: `packages/ui/src/components/workflows/RunWithParamsDialog.tsx`
+- Modify: `packages/ui/src/pages/Workflows.tsx`
+- Modify: `packages/ui/test/pages/Workflows.test.tsx`
+
+---
+
+- [ ] **Step 15.1: Write the failing test**
+
+Add to `Workflows.test.tsx`:
+
+```tsx
+import { workflowRunMock } from "../../src/ipc/__mocks__/client";
+
+test("Run with params... opens a dialog and forwards paramsOverride to workflow.run", async () => {
+  workflowListMock.mockResolvedValue({
+    workflows: [
+      { id: "wf1", name: "alpha", description: null, steps_json: "[]", created_at: 0, updated_at: 0 },
+    ],
+  });
+  workflowRunMock.mockResolvedValue({});
+
+  render(<Workflows />);
+  await screen.findByText("alpha");
+  fireEvent.click(await screen.findByRole("button", { name: /run with params for alpha/i }));
+
+  const textbox = await screen.findByRole("textbox", { name: /params override json/i });
+  fireEvent.change(textbox, {
+    target: { value: '{"step-1":{"greeting":"hello"}}' },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /confirm run/i }));
+
+  await waitFor(() =>
+    expect(workflowRunMock).toHaveBeenCalledWith({
+      name: "alpha",
+      dryRun: false,
+      paramsOverride: { "step-1": { greeting: "hello" } },
+    }),
+  );
+});
+
+test("Run with params... rejects invalid JSON with an inline error", async () => {
+  workflowListMock.mockResolvedValue({
+    workflows: [
+      { id: "wf1", name: "alpha", description: null, steps_json: "[]", created_at: 0, updated_at: 0 },
+    ],
+  });
+
+  render(<Workflows />);
+  await screen.findByText("alpha");
+  fireEvent.click(await screen.findByRole("button", { name: /run with params for alpha/i }));
+  const textbox = await screen.findByRole("textbox", { name: /params override json/i });
+  fireEvent.change(textbox, { target: { value: "not json" } });
+  fireEvent.click(screen.getByRole("button", { name: /confirm run/i }));
+  expect(await screen.findByText(/invalid json/i)).toBeInTheDocument();
+  expect(workflowRunMock).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 15.2: Run to verify failure**
+
+Run: `cd packages/ui && bunx vitest run test/pages/Workflows.test.tsx`
+
+Expected: FAIL — no "Run with params for alpha" button.
+
+- [ ] **Step 15.3: Create `RunWithParamsDialog.tsx`**
+
+Create `packages/ui/src/components/workflows/RunWithParamsDialog.tsx`:
+
+```tsx
+import { useState } from "react";
+import { createIpcClient } from "../../ipc/client";
+
+interface RunWithParamsDialogProps {
+  readonly workflowName: string;
+  readonly dryRun: boolean;
+  readonly onClose: () => void;
+  readonly onRan: () => void;
+}
+
+export function RunWithParamsDialog({
+  workflowName,
+  dryRun,
+  onClose,
+  onRan,
+}: RunWithParamsDialogProps) {
+  const [json, setJson] = useState("{}");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleConfirm() {
+    setError(null);
+    let parsed: Record<string, Record<string, unknown>>;
+    try {
+      const maybe = JSON.parse(json) as unknown;
+      if (typeof maybe !== "object" || maybe === null || Array.isArray(maybe)) {
+        throw new Error("Params override must be a JSON object");
+      }
+      parsed = maybe as Record<string, Record<string, unknown>>;
+    } catch (err) {
+      setError(err instanceof Error ? `Invalid JSON: ${err.message}` : "Invalid JSON");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createIpcClient().workflowRun({
+        name: workflowName,
+        dryRun,
+        paramsOverride: parsed,
+      });
+      onRan();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`Run ${workflowName} with params override`}
+      className="fixed inset-0 flex items-center justify-center bg-black/40 z-50"
+    >
+      <div className="bg-white dark:bg-neutral-900 rounded p-4 w-[520px] flex flex-col gap-3">
+        <h2 className="text-base font-semibold">
+          Run “{workflowName}” with parameter override
+        </h2>
+        <p className="text-xs text-neutral-500">
+          Provide a JSON object keyed by step label. Values replace step parameters for this
+          invocation only. Example: <code>{`{"step-1":{"greeting":"hello"}}`}</code>
+        </p>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="sr-only">Params override JSON</span>
+          <textarea
+            aria-label="Params override JSON"
+            className="font-mono border rounded p-2 text-xs h-32"
+            value={json}
+            onChange={(e) => setJson(e.target.value)}
+          />
+        </label>
+        {error && <p className="text-red-600 text-xs">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 rounded border">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={submitting}
+            className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
+          >
+            {submitting ? "Running…" : "Confirm run"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 15.4: Wire the dialog into `Workflows.tsx`**
+
+Extend `WorkflowRow` with a second run button:
+
+```tsx
+<button
+  type="button"
+  aria-label={`Run with params for ${workflow.name}`}
+  disabled={disabled}
+  onClick={() => onRunWithParams(workflow)}
+  className="px-2 py-0.5 rounded border text-xs disabled:opacity-40"
+>
+  Run with params…
+</button>
+```
+
+Add state + handler in `Workflows`:
+
+```tsx
+const [paramsDialogFor, setParamsDialogFor] = useState<WorkflowSummary | null>(null);
+```
+
+Pass `onRunWithParams={(w) => setParamsDialogFor(w)}` to `WorkflowRow`. Extend `WorkflowRowProps` with `onRunWithParams: (w: WorkflowSummary) => void`. Render the dialog at the page level:
+
+```tsx
+{paramsDialogFor !== null && (
+  <RunWithParamsDialog
+    workflowName={paramsDialogFor.name}
+    dryRun={dryRun}
+    onClose={() => setParamsDialogFor(null)}
+    onRan={() => setParamsDialogFor(null)}
+  />
+)}
+```
+
+Import: `import { RunWithParamsDialog } from "../components/workflows/RunWithParamsDialog";`
+
+- [ ] **Step 15.5: Run tests**
+
+Run: `cd packages/ui && bunx vitest run test/pages/Workflows.test.tsx`
+
+Expected: PASS — both new tests green.
+
+- [ ] **Step 15.6: Run the full UI coverage gate**
+
+Run: `cd packages/ui && bunx vitest run --coverage`
+
+Expected: package-level coverage ≥ 80 % lines / ≥ 75 % branches (CI threshold).
+
+- [ ] **Step 15.7: Commit**
+
+```bash
+git add packages/ui/src/components/workflows/RunWithParamsDialog.tsx packages/ui/src/pages/Workflows.tsx packages/ui/test/pages/Workflows.test.tsx
+git commit -m "feat(ui): 'Run with params...' dialog for one-shot workflow parameter override"
+```
+
+---
+
+## Task 16: Audit Panel — `runId` Deep-link Support
+
+**Files:**
+- Modify: `packages/ui/src/pages/settings/AuditPanel.tsx`
+- Modify: `packages/ui/test/pages/settings/AuditPanel.test.tsx` (create if it doesn't exist yet — mirror an existing settings-panel test)
+
+**Why this task exists:** Task 14 links from the Workflow run-history drawer to `#/settings/audit?runId=<runId>`. Without this task, the link reaches the audit page but the user has to eyeball a potentially long list to find the matching entry. This task adds the tiny integration: `AuditPanel` reads `runId` from the URL, filters the list to entries with `target_ref = <runId>`, and highlights the matching row (mirrors the Dashboard connector-highlight pattern already in use).
+
+---
+
+- [ ] **Step 16.1: Confirm the existing `AuditPanel` shape**
+
+Run: `cat packages/ui/src/pages/settings/AuditPanel.tsx | head -60`
+
+Identify how rows are fetched (likely `audit.list` IPC or similar) and how each row renders. Look for an existing pattern to mirror — the Connectors panel already uses `useSearchParams` + `highlightService` (per `docs/release/v0.1.0-finish-plan.md` + the store slice in `packages/ui/src/store/slices/connectors.ts`).
+
+- [ ] **Step 16.2: Write the failing test**
+
+Create or extend `packages/ui/test/pages/settings/AuditPanel.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { AuditPanel } from "../../../src/pages/settings/AuditPanel";
+import { auditListMock } from "../../../src/ipc/__mocks__/client";
+
+function renderWith(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <AuditPanel />
+    </MemoryRouter>,
+  );
+}
+
+describe("AuditPanel runId deep-link", () => {
+  test("filters rows by target_ref when ?runId=<id> is present", async () => {
+    auditListMock.mockResolvedValue({
+      entries: [
+        { id: 1, actionType: "workflow.run.completed", targetRef: "run-abc", detailsJson: "{}", createdAt: 1 },
+        { id: 2, actionType: "workflow.run.completed", targetRef: "run-xyz", detailsJson: "{}", createdAt: 2 },
+      ],
+    });
+    renderWith("/settings/audit?runId=run-abc");
+    expect(await screen.findByText("run-abc")).toBeInTheDocument();
+    expect(screen.queryByText("run-xyz")).toBeNull();
+  });
+
+  test("highlights the matching row with aria-current", async () => {
+    auditListMock.mockResolvedValue({
+      entries: [
+        { id: 1, actionType: "workflow.run.completed", targetRef: "run-abc", detailsJson: "{}", createdAt: 1 },
+      ],
+    });
+    renderWith("/settings/audit?runId=run-abc");
+    const row = await screen.findByRole("row", { name: /run-abc/i });
+    expect(row.getAttribute("aria-current")).toBe("true");
+  });
+
+  test("shows the full list when no runId is provided", async () => {
+    auditListMock.mockResolvedValue({
+      entries: [
+        { id: 1, actionType: "workflow.run.completed", targetRef: "run-abc", detailsJson: "{}", createdAt: 1 },
+        { id: 2, actionType: "workflow.run.completed", targetRef: "run-xyz", detailsJson: "{}", createdAt: 2 },
+      ],
+    });
+    renderWith("/settings/audit");
+    expect(await screen.findByText("run-abc")).toBeInTheDocument();
+    expect(await screen.findByText("run-xyz")).toBeInTheDocument();
+  });
+});
+```
+
+*(Adapt `auditListMock` import + row shape to the real IPC type. Run `grep -n "audit\." packages/ui/src/ipc/client.ts` first to find the existing method name — it may be `auditList` or `auditExport` or another name.)*
+
+- [ ] **Step 16.3: Run the tests to verify they fail**
+
+Run: `cd packages/ui && bunx vitest run test/pages/settings/AuditPanel.test.tsx`
+
+Expected: FAIL — panel ignores `runId`.
+
+- [ ] **Step 16.4: Wire `useSearchParams` + filter + highlight into `AuditPanel`**
+
+In `AuditPanel.tsx`:
+
+```tsx
+import { useSearchParams } from "react-router-dom";
+
+// inside the component:
+const [searchParams] = useSearchParams();
+const runIdFilter = searchParams.get("runId");
+
+const filteredEntries =
+  runIdFilter === null
+    ? entries
+    : entries.filter((e) => e.targetRef === runIdFilter);
+```
+
+In the row render (JSX):
+
+```tsx
+<tr
+  key={entry.id}
+  aria-current={runIdFilter !== null && entry.targetRef === runIdFilter ? "true" : undefined}
+  className={
+    runIdFilter !== null && entry.targetRef === runIdFilter
+      ? "bg-amber-50 dark:bg-amber-900/20"
+      : ""
+  }
+>
+  {/* existing cells — keep unchanged */}
+</tr>
+```
+
+If `filteredEntries.length === 0 && runIdFilter !== null`, render a short banner: `"No audit entries found for run <runIdFilter>. It may have been pruned from the operational run history; the audit log row survives if it was ever created."` — this surfaces the audit-persistence-vs-run-pruning semantics to the user.
+
+- [ ] **Step 16.5: Run the tests to verify passing**
+
+Run: `cd packages/ui && bunx vitest run test/pages/settings/AuditPanel.test.tsx`
+
+Expected: PASS — all three tests green.
+
+- [ ] **Step 16.6: Manually verify the link from Task 14 drawer**
+
+Run: `cd packages/ui && bun run dev` and:
+1. Trigger a workflow run on the Workflows page.
+2. Expand the run history.
+3. Click "View audit entry" on the new run.
+4. Confirm the Audit panel opens with just that row visible + highlighted (amber background).
+
+- [ ] **Step 16.7: Commit**
+
+```bash
+git add packages/ui/src/pages/settings/AuditPanel.tsx packages/ui/test/pages/settings/AuditPanel.test.tsx
+git commit -m "feat(ui): filter + highlight audit entries by ?runId deep-link param"
+```
+
+---
+
+## Task 17: Flip Roadmap Checkboxes + Append v0.1.0 Marker
+
+**Files:**
+- Modify: `docs/roadmap.md`
+
+---
+
+- [ ] **Step 17.1: Edit lines 317-319**
+
+Open `docs/roadmap.md`. Replace:
+
+```
+- [ ] **Extension Marketplace panel** — browse, install, update, disable, remove extensions; verified publisher badge; community ratings; changelog per version; auto-update toggle
+- [ ] **Watcher management UI** — create, pause, delete watchers; condition builder; history of fired events
+- [ ] **Workflow pipeline editor** — visual step list; run history; re-run failed steps; parameter override before run
+```
+
+with:
+
+```
+- [x] **Extension Marketplace panel** (v0.1.0 MVP) — list, install-from-directory, enable/disable, remove. *Online browse, verified publisher, ratings, changelog, auto-update — deferred to Phase 5 "Marketplace v2".*
+- [x] **Watcher management UI** (v0.1.0) — create, pause, delete; graph-aware condition builder; **history-of-fires drawer** (WS5-D Polish).
+- [x] **Workflow pipeline editor** (v0.1.0) — step list editor, run, dry-run toggle, delete; **run history drawer with audit deep-link** + **"Run with params…" one-shot parameter override** (WS5-D Polish). *Re-run-failed-steps deferred to v0.1.1.*
+```
+
+- [ ] **Step 17.2: Run any docs lints (if they exist)**
+
+Run: `grep -n "markdownlint\|doctoc" package.json`
+
+If there's a docs lint script, run it. Otherwise skip.
+
+- [ ] **Step 17.3: Commit**
+
+```bash
+git add docs/roadmap.md
+git commit -m "docs: mark WS5-D polish complete on roadmap"
+```
+
+---
+
+## Final Verification
+
+- [ ] **V1. Full gateway test suite**
+
+Run: `bun test packages/gateway/src/`
+
+Expected: all tests PASS. No regressions in `audit/`, `automation/`, `ipc/`, `index/migrations/`.
+
+- [ ] **V2. Full UI test + coverage**
+
+Run: `cd packages/ui && bunx vitest run --coverage`
+
+Expected: all tests PASS. Coverage ≥ 80 % lines / ≥ 75 % branches at the package level.
+
+- [ ] **V3. Rust allowlist tests**
+
+Run: `cd packages/ui/src-tauri && cargo test`
+
+Expected: `allowlist_exact_size` asserts 56; `allowlist_is_alphabetized` passes.
+
+- [ ] **V4. Biome + typecheck**
+
+Run: `bun run lint && bun run typecheck`
+
+Expected: clean.
+
+- [ ] **V5. Manual smoke (optional — requires running Gateway + Tauri dev)**
+
+Run: `bun run dev` (or per-package dev scripts) and manually:
+1. Open the Watchers page; verify a "History" button appears on a row with fires; clicking opens the drawer with fires listed newest-first.
+2. Open the Workflows page; verify a "History" button exists; expanding shows last 10 runs with status + duration + "View audit entry" link that navigates to `#/settings/audit?runId=...`.
+3. Click "View audit entry" on a completed run. Confirm the Audit panel opens showing **only** that run's entry, highlighted in amber (Task 16).
+4. Visit `#/settings/audit?runId=does-not-exist`. Confirm the banner explains that the run may have been pruned from operational history.
+5. Click "Run with params…"; enter `{"step-1":{"x":1}}`; confirm. Verify the audit log entry records `paramsOverride`.
+
+- [ ] **V6. Tag readiness**
+
+Verify §4.1 acceptance criteria in `docs/release/v0.1.0-finish-plan.md` are all satisfied. Flip the status line in that doc to mark WS5-D polish ✅.
+
+```bash
+# Example status line update in v0.1.0-finish-plan.md:
+# Change the §2 "Open in v0.1.0" row for WS5-D polish from an open checkbox to ✅.
+```
+
+---
+
+## Review Responses — Deferred Items & Notes
+
+Reviewer feedback from `docs/superpowers/plans/2026-04-22-ws5d-polish-review.md`. Items not addressed as code changes in this plan, with rationale:
+
+### Deferred to post-v0.1.0
+
+- **JSON "Format" button in `RunWithParamsDialog` (review §3B).** A raw textarea plus an explicit `Invalid JSON: <reason>` error message is sufficient for the target user (someone already comfortable with JSON param overrides). Adding auto-format pulls in either a dependency or handwritten whitespace preservation — YAGNI for v0.1.0. Revisit in a future UX polish pass.
+- **Copy-to-clipboard / modal-expand for watcher fire-history JSON (review §3C partial).** This plan addresses the data-loss concern by switching the `conditionSnapshot` rendering from `truncate` to `whitespace-pre-wrap break-all` inside the drawer's `max-h-64 overflow-y-auto` — long snapshots scroll instead of being silently clipped. A dedicated copy button or modal-expand is a nice-to-have that can land in a future pass.
+- **Debounced / soft-limit pruning (review §3D).** The reviewer themselves noted that for v0.1.0 the naive `DELETE ... NOT IN (SELECT ... LIMIT 100)` is "likely fine." Premature optimization — the 100-row limit keeps the DELETE cheap. Revisit in Phase 5 if telemetry shows meaningful latency impact on high-frequency workflows.
+- **Surfacing `sub_task_results` in run-history drawer (review §4 Q1).** Multi-agent sub-task progress is a separate orthogonal axis from linear workflow steps; conflating them in the same drawer bloats both the IPC surface and the UI. If Phase 5 wants to expose sub-task progress, that's a new drawer/pane (likely under the existing `agent.subTaskProgress` subscription), not an extension of this one.
+
+### Documentation-only notes
+
+- **Audit-log link outlives `workflow_run` pruning (review §4 Q2).** This is correct and intended: the BLAKE3-chained `audit_log` is the tamper-evident legal record; `workflow_run` is a 100-row operational view that rotates. After pruning, the "View audit entry" link from an external source (e.g., a bookmarked URL, a Slack paste) still resolves to the audit row, while the operational run-row is gone. Task 16 adds a user-facing banner to surface this when a filtered audit view returns zero rows for a `runId`. Also flag this semantics in `docs/audit-log.md` (separate doc task — not code; track as a follow-up if that file exists, otherwise skip).
+
+### Fixed inline
+
+- **AuditPanel `runId` deep-link support (review §3A)** — added as Task 16 with its own TDD cycle. Without this task, the "View audit entry" link from Task 14 lands on the unfiltered audit page, breaking the UX the review identified.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-22-ws5d-polish.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-04-22-ws5d-polish.md
+++ b/docs/superpowers/plans/2026-04-22-ws5d-polish.md
@@ -2393,6 +2393,10 @@ Reviewer feedback from `docs/superpowers/plans/2026-04-22-ws5d-polish-review.md`
 
 - **Audit-log link outlives `workflow_run` pruning (review §4 Q2).** This is correct and intended: the BLAKE3-chained `audit_log` is the tamper-evident legal record; `workflow_run` is a 100-row operational view that rotates. After pruning, the "View audit entry" link from an external source (e.g., a bookmarked URL, a Slack paste) still resolves to the audit row, while the operational run-row is gone. Task 16 adds a user-facing banner to surface this when a filtered audit view returns zero rows for a `runId`. Also flag this semantics in `docs/audit-log.md` (separate doc task — not code; track as a follow-up if that file exists, otherwise skip).
 
+### Release-gate follow-ups (out of WS5-D scope; track for v0.1.0 tag-time)
+
+- **Create the `release` GitHub Environment with maintainer-reviewer gate.** Surfaced during the repo-settings audit that ran alongside this branch. The `docs/release/v0.1.0-prerequisites.md §9.4` runbook already specifies this: a `release` environment with required reviewer = maintainer, wildcard protected tags `v*` / `client-v*` / `vscode-v*`, deployment branches restricted to `main`. Every release-publishing workflow job (`release.yml`, `publish-vscode.yml`, `publish-client.yml`) should set `environment: release` so a human button-press is required before the job runs, even if a token were stolen. **Not a WS5-D Polish item** — it's a v0.1.0 release-gate prerequisite. Do before tagging `v0.1.0-rc1`. Create via Settings → Environments (UI only; the REST API requires a deployment to exist first) or `gh api --method PUT repos/.../environments/release -f reviewers='[{"type":"User","id":<maintainer-id>}]'`.
+
 ### Fixed inline
 
 - **AuditPanel `runId` deep-link support (review §3A)** — added as Task 16 with its own TDD cycle. Without this task, the "View audit entry" link from Task 14 lands on the unfiltered audit page, breaking the UX the review identified.

--- a/packages/gateway/src/automation/watcher-history.test.ts
+++ b/packages/gateway/src/automation/watcher-history.test.ts
@@ -26,9 +26,9 @@ test("listWatcherHistory returns the last N fires newest-first", () => {
   }
   const out = listWatcherHistory(db, { watcherId: "w1", limit: 3 });
   expect(out.events.length).toBe(3);
-  expect(out.events[0].firedAt).toBe(104);
-  expect(out.events[2].firedAt).toBe(102);
-  expect(out.events[0].conditionSnapshot).toBe('{"i":4}');
+  expect(out.events[0]?.firedAt).toBe(104);
+  expect(out.events[2]?.firedAt).toBe(102);
+  expect(out.events[0]?.conditionSnapshot).toBe('{"i":4}');
 });
 
 test("listWatcherHistory returns empty for an unknown watcher", () => {

--- a/packages/gateway/src/automation/watcher-history.test.ts
+++ b/packages/gateway/src/automation/watcher-history.test.ts
@@ -1,0 +1,51 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { LocalIndex } from "../index/local-index.ts";
+import { listWatcherHistory } from "./watcher-history";
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  db.run(
+    `INSERT INTO watcher (id, name, enabled, condition_type, condition_json, action_type, action_json, created_at)
+     VALUES ('w1', 'alpha', 1, 'schedule', '{}', 'notify', '{}', 0)`,
+  );
+});
+
+afterEach(() => db.close());
+
+test("listWatcherHistory returns the last N fires newest-first", () => {
+  for (let i = 0; i < 5; i++) {
+    db.run(
+      `INSERT INTO watcher_event (watcher_id, fired_at, condition_snapshot, action_result)
+       VALUES ('w1', ?, ?, ?)`,
+      [100 + i, `{"i":${i}}`, `{"ok":true}`],
+    );
+  }
+  const out = listWatcherHistory(db, { watcherId: "w1", limit: 3 });
+  expect(out.events.length).toBe(3);
+  expect(out.events[0].firedAt).toBe(104);
+  expect(out.events[2].firedAt).toBe(102);
+  expect(out.events[0].conditionSnapshot).toBe('{"i":4}');
+});
+
+test("listWatcherHistory returns empty for an unknown watcher", () => {
+  const out = listWatcherHistory(db, { watcherId: "nonexistent", limit: 10 });
+  expect(out.events).toEqual([]);
+});
+
+test("listWatcherHistory clamps limit to 1..500", () => {
+  const out0 = listWatcherHistory(db, { watcherId: "w1", limit: 0 });
+  expect(out0.events).toEqual([]);
+  for (let i = 0; i < 501; i++) {
+    db.run(
+      `INSERT INTO watcher_event (watcher_id, fired_at, condition_snapshot, action_result)
+       VALUES ('w1', ?, '{}', '{}')`,
+      [i],
+    );
+  }
+  const outBig = listWatcherHistory(db, { watcherId: "w1", limit: 10000 });
+  expect(outBig.events.length).toBe(500);
+});

--- a/packages/gateway/src/automation/watcher-history.test.ts
+++ b/packages/gateway/src/automation/watcher-history.test.ts
@@ -36,6 +36,17 @@ test("listWatcherHistory returns empty for an unknown watcher", () => {
   expect(out.events).toEqual([]);
 });
 
+test("listWatcherHistory returns empty on a pre-v8 schema", () => {
+  const fresh = new Database(":memory:");
+  try {
+    // Fresh DB with no migrations applied — user_version = 0.
+    const out = listWatcherHistory(fresh, { watcherId: "w1", limit: 10 });
+    expect(out.events).toEqual([]);
+  } finally {
+    fresh.close();
+  }
+});
+
 test("listWatcherHistory clamps limit to 1..500", () => {
   const out0 = listWatcherHistory(db, { watcherId: "w1", limit: 0 });
   expect(out0.events).toEqual([]);

--- a/packages/gateway/src/automation/watcher-history.ts
+++ b/packages/gateway/src/automation/watcher-history.ts
@@ -1,5 +1,7 @@
 import type { Database } from "bun:sqlite";
 
+import { readIndexedUserVersion } from "../index/migrations/runner.ts";
+
 export interface WatcherHistoryEvent {
   readonly firedAt: number;
   readonly conditionSnapshot: string;
@@ -28,6 +30,9 @@ export function listWatcherHistory(
   db: Database,
   params: ListWatcherHistoryParams,
 ): WatcherHistoryListResult {
+  if (readIndexedUserVersion(db) < 8) {
+    return { events: [] };
+  }
   const limit = clamp(params.limit);
   if (limit === 0) return { events: [] };
   const rows = db

--- a/packages/gateway/src/automation/watcher-history.ts
+++ b/packages/gateway/src/automation/watcher-history.ts
@@ -1,0 +1,53 @@
+import type { Database } from "bun:sqlite";
+
+export interface WatcherHistoryEvent {
+  readonly firedAt: number;
+  readonly conditionSnapshot: string;
+  readonly actionResult: string;
+}
+
+export interface WatcherHistoryListResult {
+  readonly events: ReadonlyArray<WatcherHistoryEvent>;
+}
+
+export interface ListWatcherHistoryParams {
+  readonly watcherId: string;
+  readonly limit: number;
+}
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 500;
+
+function clamp(n: number): number {
+  if (!Number.isFinite(n) || n < MIN_LIMIT) return 0;
+  if (n > MAX_LIMIT) return MAX_LIMIT;
+  return Math.floor(n);
+}
+
+export function listWatcherHistory(
+  db: Database,
+  params: ListWatcherHistoryParams,
+): WatcherHistoryListResult {
+  const limit = clamp(params.limit);
+  if (limit === 0) return { events: [] };
+  const rows = db
+    .query(
+      `SELECT fired_at, condition_snapshot, action_result
+       FROM watcher_event
+       WHERE watcher_id = ?
+       ORDER BY fired_at DESC
+       LIMIT ?`,
+    )
+    .all(params.watcherId, limit) as Array<{
+    fired_at: number;
+    condition_snapshot: string;
+    action_result: string;
+  }>;
+  return {
+    events: rows.map((r) => ({
+      firedAt: r.fired_at,
+      conditionSnapshot: r.condition_snapshot,
+      actionResult: r.action_result,
+    })),
+  };
+}

--- a/packages/gateway/src/automation/workflow-run-history.test.ts
+++ b/packages/gateway/src/automation/workflow-run-history.test.ts
@@ -28,16 +28,16 @@ test("listWorkflowRuns returns the last N runs newest-first", () => {
   for (let i = 0; i < 5; i++) insertRun(`r${i}`, 100 + i);
   const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 3 });
   expect(out.runs.length).toBe(3);
-  expect(out.runs[0].id).toBe("r4");
-  expect(out.runs[2].id).toBe("r2");
-  expect(out.runs[0].durationMs).toBe(10);
-  expect(out.runs[0].dryRun).toBe(false);
+  expect(out.runs[0]?.id).toBe("r4");
+  expect(out.runs[2]?.id).toBe("r2");
+  expect(out.runs[0]?.durationMs).toBe(10);
+  expect(out.runs[0]?.dryRun).toBe(false);
 });
 
 test("listWorkflowRuns surfaces dry_run as boolean", () => {
   insertRun("d1", 100, 1);
   const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 10 });
-  expect(out.runs[0].dryRun).toBe(true);
+  expect(out.runs[0]?.dryRun).toBe(true);
 });
 
 test("listWorkflowRuns returns empty for an unknown workflow", () => {
@@ -69,8 +69,8 @@ test("listWorkflowRuns handles null finished_at (durationMs = null)", () => {
      VALUES ('running1', 'wf1', 'user', 'running', 500, NULL, NULL, 0, NULL)`,
   );
   const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 1 });
-  expect(out.runs[0].durationMs).toBeNull();
-  expect(out.runs[0].finishedAt).toBeNull();
+  expect(out.runs[0]?.durationMs).toBeNull();
+  expect(out.runs[0]?.finishedAt).toBeNull();
 });
 
 test("pruneWorkflowRuns keeps the newest N per workflow", () => {

--- a/packages/gateway/src/automation/workflow-run-history.test.ts
+++ b/packages/gateway/src/automation/workflow-run-history.test.ts
@@ -1,0 +1,104 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { LocalIndex } from "../index/local-index.ts";
+import { listWorkflowRuns, pruneWorkflowRuns } from "./workflow-run-history";
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES ('wf1', 'alpha', NULL, '[]', 0, 0)`,
+  );
+});
+
+afterEach(() => db.close());
+
+function insertRun(id: string, startedAt: number, dryRun = 0, status = "done"): void {
+  db.run(
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg, dry_run, params_override_json)
+     VALUES (?, 'wf1', 'user', ?, ?, ?, NULL, ?, NULL)`,
+    [id, status, startedAt, startedAt + 10, dryRun],
+  );
+}
+
+test("listWorkflowRuns returns the last N runs newest-first", () => {
+  for (let i = 0; i < 5; i++) insertRun(`r${i}`, 100 + i);
+  const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 3 });
+  expect(out.runs.length).toBe(3);
+  expect(out.runs[0].id).toBe("r4");
+  expect(out.runs[2].id).toBe("r2");
+  expect(out.runs[0].durationMs).toBe(10);
+  expect(out.runs[0].dryRun).toBe(false);
+});
+
+test("listWorkflowRuns surfaces dry_run as boolean", () => {
+  insertRun("d1", 100, 1);
+  const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 10 });
+  expect(out.runs[0].dryRun).toBe(true);
+});
+
+test("listWorkflowRuns returns empty for an unknown workflow", () => {
+  const out = listWorkflowRuns(db, { workflowName: "missing", limit: 10 });
+  expect(out.runs).toEqual([]);
+});
+
+test("listWorkflowRuns returns empty on a pre-v9 schema", () => {
+  const fresh = new Database(":memory:");
+  try {
+    const out = listWorkflowRuns(fresh, { workflowName: "alpha", limit: 10 });
+    expect(out.runs).toEqual([]);
+  } finally {
+    fresh.close();
+  }
+});
+
+test("listWorkflowRuns clamps limit to 1..500", () => {
+  for (let i = 0; i < 501; i++) insertRun(`r${i}`, i);
+  const out0 = listWorkflowRuns(db, { workflowName: "alpha", limit: 0 });
+  expect(out0.runs).toEqual([]);
+  const outBig = listWorkflowRuns(db, { workflowName: "alpha", limit: 10000 });
+  expect(outBig.runs.length).toBe(500);
+});
+
+test("listWorkflowRuns handles null finished_at (durationMs = null)", () => {
+  db.run(
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg, dry_run, params_override_json)
+     VALUES ('running1', 'wf1', 'user', 'running', 500, NULL, NULL, 0, NULL)`,
+  );
+  const out = listWorkflowRuns(db, { workflowName: "alpha", limit: 1 });
+  expect(out.runs[0].durationMs).toBeNull();
+  expect(out.runs[0].finishedAt).toBeNull();
+});
+
+test("pruneWorkflowRuns keeps the newest N per workflow", () => {
+  for (let i = 0; i < 110; i++) insertRun(`r${i}`, i);
+  const deleted = pruneWorkflowRuns(db, "wf1", 100);
+  expect(deleted).toBe(10);
+  const remain = db
+    .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = 'wf1'`)
+    .get() as { c: number };
+  expect(remain.c).toBe(100);
+  const oldest = db
+    .query(`SELECT MIN(started_at) AS m FROM workflow_run WHERE workflow_id = 'wf1'`)
+    .get() as { m: number };
+  expect(oldest.m).toBe(10);
+});
+
+test("pruneWorkflowRuns is a no-op when under the cap", () => {
+  for (let i = 0; i < 5; i++) insertRun(`r${i}`, i);
+  const deleted = pruneWorkflowRuns(db, "wf1", 100);
+  expect(deleted).toBe(0);
+});
+
+test("pruneWorkflowRuns returns 0 on a pre-v9 schema", () => {
+  const fresh = new Database(":memory:");
+  try {
+    const deleted = pruneWorkflowRuns(fresh, "wf1", 100);
+    expect(deleted).toBe(0);
+  } finally {
+    fresh.close();
+  }
+});

--- a/packages/gateway/src/automation/workflow-run-history.ts
+++ b/packages/gateway/src/automation/workflow-run-history.ts
@@ -1,0 +1,91 @@
+import type { Database } from "bun:sqlite";
+import { readIndexedUserVersion } from "../index/migrations/runner";
+
+export interface WorkflowRunHistoryRow {
+  readonly id: string;
+  readonly startedAt: number;
+  readonly finishedAt: number | null;
+  readonly durationMs: number | null;
+  readonly status: string;
+  readonly errorMsg: string | null;
+  readonly dryRun: boolean;
+  readonly paramsOverrideJson: string | null;
+  readonly triggeredBy: string;
+}
+
+export interface WorkflowRunListResult {
+  readonly runs: ReadonlyArray<WorkflowRunHistoryRow>;
+}
+
+export interface ListWorkflowRunsParams {
+  readonly workflowName: string;
+  readonly limit: number;
+}
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 500;
+const WORKFLOW_RUN_SCHEMA_VERSION = 9;
+
+function clamp(n: number): number {
+  if (!Number.isFinite(n) || n < MIN_LIMIT) return 0;
+  if (n > MAX_LIMIT) return MAX_LIMIT;
+  return Math.floor(n);
+}
+
+export function listWorkflowRuns(
+  db: Database,
+  params: ListWorkflowRunsParams,
+): WorkflowRunListResult {
+  if (readIndexedUserVersion(db) < WORKFLOW_RUN_SCHEMA_VERSION) return { runs: [] };
+  const limit = clamp(params.limit);
+  if (limit === 0) return { runs: [] };
+  const rows = db
+    .query(
+      `SELECT r.id, r.started_at, r.finished_at, r.status, r.error_msg,
+              r.dry_run, r.params_override_json, r.triggered_by
+       FROM workflow_run AS r
+       INNER JOIN workflow AS w ON w.id = r.workflow_id
+       WHERE w.name = ?
+       ORDER BY r.started_at DESC
+       LIMIT ?`,
+    )
+    .all(params.workflowName, limit) as Array<{
+    id: string;
+    started_at: number;
+    finished_at: number | null;
+    status: string;
+    error_msg: string | null;
+    dry_run: number;
+    params_override_json: string | null;
+    triggered_by: string;
+  }>;
+  return {
+    runs: rows.map((r) => ({
+      id: r.id,
+      startedAt: r.started_at,
+      finishedAt: r.finished_at,
+      durationMs: r.finished_at === null ? null : r.finished_at - r.started_at,
+      status: r.status,
+      errorMsg: r.error_msg,
+      dryRun: r.dry_run === 1,
+      paramsOverrideJson: r.params_override_json,
+      triggeredBy: r.triggered_by,
+    })),
+  };
+}
+
+export function pruneWorkflowRuns(db: Database, workflowId: string, keep: number): number {
+  if (readIndexedUserVersion(db) < WORKFLOW_RUN_SCHEMA_VERSION) return 0;
+  const res = db.run(
+    `DELETE FROM workflow_run
+     WHERE workflow_id = ?
+       AND id NOT IN (
+         SELECT id FROM workflow_run
+         WHERE workflow_id = ?
+         ORDER BY started_at DESC
+         LIMIT ?
+       )`,
+    [workflowId, workflowId, keep],
+  );
+  return res.changes;
+}

--- a/packages/gateway/src/automation/workflow-runner.test.ts
+++ b/packages/gateway/src/automation/workflow-runner.test.ts
@@ -4,7 +4,11 @@ import type { Agent } from "@mastra/core/agent";
 
 import { LocalIndex } from "../index/local-index.ts";
 import { parseWorkflowStepsJson, runWorkflowExecution } from "./workflow-runner.ts";
-import { upsertWorkflowByName } from "./workflow-store.ts";
+import {
+  finishWorkflowRunRow,
+  insertWorkflowRunRow,
+  upsertWorkflowByName,
+} from "./workflow-store.ts";
 
 describe("parseWorkflowStepsJson", () => {
   test("parses run steps", () => {
@@ -366,5 +370,86 @@ describe("runWorkflowExecution (dry run and validation)", () => {
       .get() as { action_json: string };
     const details = JSON.parse(entry.action_json) as { paramsOverride?: Record<string, unknown> };
     expect(details.paramsOverride).toEqual({ "step-1": { x: 1 } });
+  });
+});
+
+describe("runWorkflowExecution — run retention", () => {
+  const noopAgent = {} as Agent;
+
+  test("workflow run completion prunes to the last 100 runs per workflow", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf-ret-1', 'retention-test', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
+    );
+    for (let i = 0; i < 100; i++) {
+      insertWorkflowRunRow(db, {
+        id: `hist-${i}`,
+        workflowId: "wf-ret-1",
+        triggeredBy: "user",
+        status: "done",
+        startedAt: 1_000 + i,
+        dryRun: false,
+      });
+      finishWorkflowRunRow(db, `hist-${i}`, "done", 1_010 + i, null);
+    }
+    // Now run — dry-run path completes without tool calls, still emits row 101.
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "retention-test",
+      dryRun: true,
+      triggeredBy: "user",
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+    });
+    const count = db
+      .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = 'wf-ret-1'`)
+      .get() as { c: number };
+    expect(count.c).toBe(100);
+    // Oldest seeded row must be pruned.
+    const oldestExists = db.query(`SELECT id FROM workflow_run WHERE id = 'hist-0'`).get();
+    expect(oldestExists).toBeNull();
+    // A more-recent seeded row must remain (proves retention kept the newest 100).
+    const hist50 = db.query(`SELECT id FROM workflow_run WHERE id = 'hist-50'`).get();
+    expect(hist50).not.toBeNull();
+  });
+
+  test("workflow run completion is a no-op on retention when under cap", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf-ret-2', 'retention-no-op', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
+    );
+    for (let i = 0; i < 5; i++) {
+      insertWorkflowRunRow(db, {
+        id: `h2-${i}`,
+        workflowId: "wf-ret-2",
+        triggeredBy: "user",
+        status: "done",
+        startedAt: 2_000 + i,
+        dryRun: false,
+      });
+      finishWorkflowRunRow(db, `h2-${i}`, "done", 2_010 + i, null);
+    }
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "retention-no-op",
+      dryRun: true,
+      triggeredBy: "user",
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+    });
+    const count = db
+      .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = 'wf-ret-2'`)
+      .get() as { c: number };
+    expect(count.c).toBe(6); // 5 seeded + 1 new
   });
 });

--- a/packages/gateway/src/automation/workflow-runner.test.ts
+++ b/packages/gateway/src/automation/workflow-runner.test.ts
@@ -77,7 +77,7 @@ describe("runWorkflowExecution (dry run and validation)", () => {
     ).rejects.toThrow(/Unknown workflow/);
   });
 
-  test("dry run returns preview step results without persisting run", async () => {
+  test("dry run returns preview step results and persists a dry_run=1 row", async () => {
     const db = new Database(":memory:");
     LocalIndex.ensureSchema(db);
     const now = Date.now();
@@ -105,7 +105,13 @@ describe("runWorkflowExecution (dry run and validation)", () => {
       { label: "step-2", status: "preview", output: "second", hitlActions: [] },
     ]);
     const runCount = db.query(`SELECT COUNT(*) as c FROM workflow_run`).get() as { c: number };
-    expect(runCount.c).toBe(0);
+    expect(runCount.c).toBe(1);
+    const runRow = db.query(`SELECT dry_run, status FROM workflow_run LIMIT 1`).get() as {
+      dry_run: number;
+      status: string;
+    };
+    expect(runRow.dry_run).toBe(1);
+    expect(runRow.status).toBe("preview");
   });
 
   test("dry run includes heuristic hitlActions for HITL-like step text", async () => {
@@ -131,5 +137,37 @@ describe("runWorkflowExecution (dry run and validation)", () => {
       },
     });
     expect(r.stepResults[0]?.hitlActions).toContain("iac.terraform.apply");
+  });
+
+  test("runWorkflowExecution writes a dry_run=1 row when dryRun is true", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    upsertWorkflowByName(
+      db,
+      "preview-me",
+      null,
+      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
+      Date.now(),
+    );
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "preview-me",
+      triggeredBy: "user",
+      dryRun: true,
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+    });
+    const row = db
+      .query(
+        `SELECT dry_run, status FROM workflow_run
+         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'preview-me')
+         ORDER BY started_at DESC LIMIT 1`,
+      )
+      .get() as { dry_run: number; status: string };
+    expect(row.dry_run).toBe(1);
+    expect(row.status).toBe("preview");
   });
 });

--- a/packages/gateway/src/automation/workflow-runner.test.ts
+++ b/packages/gateway/src/automation/workflow-runner.test.ts
@@ -96,6 +96,30 @@ function lastRunCompletedAudit<T>(db: Database, columns: string): T {
     .get() as T;
 }
 
+/**
+ * Seed `count` historical (already-finished) workflow_run rows for a given
+ * workflow_id. Used by the retention tests to push totals near/past the cap.
+ */
+function seedHistoricalRuns(
+  db: Database,
+  workflowId: string,
+  count: number,
+  startedAtBase: number,
+  idPrefix: string,
+): void {
+  for (let i = 0; i < count; i++) {
+    insertWorkflowRunRow(db, {
+      id: `${idPrefix}-${i}`,
+      workflowId,
+      triggeredBy: "user",
+      status: "done",
+      startedAt: startedAtBase + i,
+      dryRun: false,
+    });
+    finishWorkflowRunRow(db, `${idPrefix}-${i}`, "done", startedAtBase + 10 + i, null);
+  }
+}
+
 describe("parseWorkflowStepsJson", () => {
   test("parses run steps", () => {
     const steps = parseWorkflowStepsJson(
@@ -289,30 +313,6 @@ describe("runWorkflowExecution (dry run and validation)", () => {
 });
 
 describe("runWorkflowExecution — run retention", () => {
-  /**
-   * Seed `count` historical (already-finished) workflow_run rows for a given
-   * workflow_id. Used by the retention tests to push totals near/past the cap.
-   */
-  function seedHistoricalRuns(
-    db: Database,
-    workflowId: string,
-    count: number,
-    startedAtBase: number,
-    idPrefix: string,
-  ): void {
-    for (let i = 0; i < count; i++) {
-      insertWorkflowRunRow(db, {
-        id: `${idPrefix}-${i}`,
-        workflowId,
-        triggeredBy: "user",
-        status: "done",
-        startedAt: startedAtBase + i,
-        dryRun: false,
-      });
-      finishWorkflowRunRow(db, `${idPrefix}-${i}`, "done", startedAtBase + 10 + i, null);
-    }
-  }
-
   test("workflow run completion prunes to the last 100 runs per workflow", async () => {
     const db = freshDb();
     const { id: workflowId } = seedOneStepWorkflow(db, "retention-test", {

--- a/packages/gateway/src/automation/workflow-runner.test.ts
+++ b/packages/gateway/src/automation/workflow-runner.test.ts
@@ -3,12 +3,98 @@ import { describe, expect, test } from "bun:test";
 import type { Agent } from "@mastra/core/agent";
 
 import { LocalIndex } from "../index/local-index.ts";
-import { parseWorkflowStepsJson, runWorkflowExecution } from "./workflow-runner.ts";
+import {
+  parseWorkflowStepsJson,
+  type RunWorkflowExecutionParams,
+  runWorkflowExecution,
+} from "./workflow-runner.ts";
 import {
   finishWorkflowRunRow,
   insertWorkflowRunRow,
   upsertWorkflowByName,
 } from "./workflow-store.ts";
+
+// -----------------------------------------------------------------------------
+// Shared test helpers — collapse the ~44 lines of duplicated DB-setup + seed
+// workflow + runWorkflowExecution-parameter scaffolding across the tests below.
+// -----------------------------------------------------------------------------
+
+const noopAgent = {} as Agent;
+
+/** Fresh in-memory DB with the current schema applied. */
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+/**
+ * Insert a workflow row with a single named step. When `id` is omitted, a
+ * deterministic id of `wf-<name>` is used so tests can scope follow-up queries
+ * without another SELECT.
+ */
+function seedOneStepWorkflow(
+  db: Database,
+  name: string,
+  opts: { id?: string; run?: string; label?: string } = {},
+): { id: string } {
+  const id = opts.id ?? `wf-${name}`;
+  const label = opts.label ?? "step-1";
+  const run = opts.run ?? "echo";
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES (?, ?, NULL, ?, 0, 0)`,
+    [id, name, JSON.stringify([{ label, run }])],
+  );
+  return { id };
+}
+
+/**
+ * Build a `RunWorkflowExecutionParams` with boilerplate defaults (noop agent,
+ * stream off, silent sendChunk). Callers override only what the test needs.
+ */
+function makeRunParams(
+  db: Database,
+  workflowName: string,
+  overrides: Partial<RunWorkflowExecutionParams> = {},
+): RunWorkflowExecutionParams {
+  return {
+    db,
+    agent: noopAgent,
+    workflowName,
+    triggeredBy: "user",
+    dryRun: false,
+    stream: false,
+    sendChunk: () => {
+      /* noop */
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Read the most recently started workflow_run row for a given workflow name —
+ * handy for assertions on the persisted run after runWorkflowExecution returns.
+ */
+function lastRunRow<T>(db: Database, workflowName: string, columns: string): T {
+  return db
+    .query(
+      `SELECT ${columns} FROM workflow_run
+       WHERE workflow_id = (SELECT id FROM workflow WHERE name = ?)
+       ORDER BY started_at DESC LIMIT 1`,
+    )
+    .get(workflowName) as T;
+}
+
+/** Read the most recent workflow.run.completed audit entry. */
+function lastRunCompletedAudit<T>(db: Database, columns: string): T {
+  return db
+    .query(
+      `SELECT ${columns} FROM audit_log
+       WHERE action_type = 'workflow.run.completed' ORDER BY id DESC LIMIT 1`,
+    )
+    .get() as T;
+}
 
 describe("parseWorkflowStepsJson", () => {
   test("parses run steps", () => {
@@ -44,65 +130,32 @@ describe("parseWorkflowStepsJson", () => {
 });
 
 describe("runWorkflowExecution (dry run and validation)", () => {
-  const noopAgent = {} as Agent;
-
   test("throws when workflow schema below v9", async () => {
     const db = new Database(":memory:");
     await expect(
-      runWorkflowExecution({
-        db,
-        agent: noopAgent,
-        workflowName: "w",
-        triggeredBy: "t",
-        dryRun: true,
-        stream: false,
-        sendChunk: () => {
-          /* noop */
-        },
-      }),
+      runWorkflowExecution(makeRunParams(db, "w", { triggeredBy: "t", dryRun: true })),
     ).rejects.toThrow(/v9/);
   });
 
   test("throws for unknown workflow", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
+    const db = freshDb();
     await expect(
-      runWorkflowExecution({
-        db,
-        agent: noopAgent,
-        workflowName: "missing",
-        triggeredBy: "t",
-        dryRun: true,
-        stream: false,
-        sendChunk: () => {
-          /* noop */
-        },
-      }),
+      runWorkflowExecution(makeRunParams(db, "missing", { triggeredBy: "t", dryRun: true })),
     ).rejects.toThrow(/Unknown workflow/);
   });
 
   test("dry run returns preview step results and persists a dry_run=1 row", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const now = Date.now();
+    const db = freshDb();
     upsertWorkflowByName(
       db,
       "demo",
       null,
       JSON.stringify([{ label: "L1", run: "do thing" }, { run: "second" }]),
-      now,
+      Date.now(),
     );
-    const r = await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "demo",
-      triggeredBy: "cli",
-      dryRun: true,
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-    });
+    const r = await runWorkflowExecution(
+      makeRunParams(db, "demo", { triggeredBy: "cli", dryRun: true }),
+    );
     expect(r.dryRun).toBe(true);
     expect(r.stepResults).toEqual([
       { label: "L1", status: "preview", output: "do thing", hitlActions: [] },
@@ -119,186 +172,82 @@ describe("runWorkflowExecution (dry run and validation)", () => {
   });
 
   test("dry run includes heuristic hitlActions for HITL-like step text", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const now = Date.now();
+    const db = freshDb();
     upsertWorkflowByName(
       db,
       "hitl-demo",
       null,
       JSON.stringify([{ run: "Run terraform apply in production" }]),
-      now,
+      Date.now(),
     );
-    const r = await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "hitl-demo",
-      triggeredBy: "t",
-      dryRun: true,
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-    });
+    const r = await runWorkflowExecution(
+      makeRunParams(db, "hitl-demo", { triggeredBy: "t", dryRun: true }),
+    );
     expect(r.stepResults[0]?.hitlActions).toContain("iac.terraform.apply");
   });
 
   test("runWorkflowExecution writes a dry_run=1 row when dryRun is true", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    upsertWorkflowByName(
+    const db = freshDb();
+    seedOneStepWorkflow(db, "preview-me", { run: "echo hi" });
+    await runWorkflowExecution(makeRunParams(db, "preview-me", { dryRun: true }));
+    const row = lastRunRow<{ dry_run: number; status: string }>(
       db,
       "preview-me",
-      null,
-      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
-      Date.now(),
+      "dry_run, status",
     );
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "preview-me",
-      triggeredBy: "user",
-      dryRun: true,
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-    });
-    const row = db
-      .query(
-        `SELECT dry_run, status FROM workflow_run
-         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'preview-me')
-         ORDER BY started_at DESC LIMIT 1`,
-      )
-      .get() as { dry_run: number; status: string };
     expect(row.dry_run).toBe(1);
     expect(row.status).toBe("preview");
   });
 
   test("runWorkflowExecution persists paramsOverride JSON on the real-run row", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    upsertWorkflowByName(
-      db,
-      "po-real",
-      null,
-      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
-      Date.now(),
-    );
+    const db = freshDb();
+    seedOneStepWorkflow(db, "po-real", { run: "echo hi" });
     const override = { "step-1": { greeting: "hi" } };
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "po-real",
-      triggeredBy: "user",
-      dryRun: false,
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-      conversationalRunner: async () => ({ reply: "ok" }),
-      paramsOverride: override,
-    });
-    const row = db
-      .query(
-        `SELECT params_override_json FROM workflow_run
-         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'po-real')
-         ORDER BY started_at DESC LIMIT 1`,
-      )
-      .get() as { params_override_json: string };
+    await runWorkflowExecution(
+      makeRunParams(db, "po-real", {
+        conversationalRunner: async () => ({ reply: "ok" }),
+        paramsOverride: override,
+      }),
+    );
+    const row = lastRunRow<{ params_override_json: string }>(db, "po-real", "params_override_json");
     expect(JSON.parse(row.params_override_json)).toEqual(override);
   });
 
   test("runWorkflowExecution persists paramsOverride JSON on the dry-run row", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    upsertWorkflowByName(
-      db,
-      "po-dry",
-      null,
-      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
-      Date.now(),
-    );
+    const db = freshDb();
+    seedOneStepWorkflow(db, "po-dry", { run: "echo hi" });
     const override = { "step-1": { greeting: "dry" } };
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "po-dry",
-      triggeredBy: "user",
-      dryRun: true,
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-      paramsOverride: override,
-    });
-    const row = db
-      .query(
-        `SELECT params_override_json FROM workflow_run
-         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'po-dry')
-         ORDER BY started_at DESC LIMIT 1`,
-      )
-      .get() as { params_override_json: string };
+    await runWorkflowExecution(
+      makeRunParams(db, "po-dry", { dryRun: true, paramsOverride: override }),
+    );
+    const row = lastRunRow<{ params_override_json: string }>(db, "po-dry", "params_override_json");
     expect(JSON.parse(row.params_override_json)).toEqual(override);
   });
 
   test("runWorkflowExecution persists NULL params_override_json when not provided", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    upsertWorkflowByName(
+    const db = freshDb();
+    seedOneStepWorkflow(db, "po-absent", { run: "echo hi" });
+    await runWorkflowExecution(
+      makeRunParams(db, "po-absent", { conversationalRunner: async () => ({ reply: "ok" }) }),
+    );
+    const row = lastRunRow<{ params_override_json: string | null }>(
       db,
       "po-absent",
-      null,
-      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
-      Date.now(),
+      "params_override_json",
     );
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "po-absent",
-      triggeredBy: "user",
-      dryRun: false,
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-      conversationalRunner: async () => ({ reply: "ok" }),
-    });
-    const row = db
-      .query(
-        `SELECT params_override_json FROM workflow_run
-         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'po-absent')
-         ORDER BY started_at DESC LIMIT 1`,
-      )
-      .get() as { params_override_json: string | null };
     expect(row.params_override_json).toBeNull();
   });
 
   test("runWorkflowExecution writes a workflow.run.completed audit entry on success", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    db.run(
-      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
-       VALUES ('wf-audit-ok', 'audit-ok', NULL, '[{"label":"step-1","run":"echo hi"}]', 0, 0)`,
+    const db = freshDb();
+    seedOneStepWorkflow(db, "audit-ok", { run: "echo hi" });
+    await runWorkflowExecution(
+      makeRunParams(db, "audit-ok", { conversationalRunner: async () => ({ reply: "ok" }) }),
     );
-    await runWorkflowExecution({
+    const entry = lastRunCompletedAudit<{ action_type: string; action_json: string }>(
       db,
-      agent: noopAgent,
-      workflowName: "audit-ok",
-      dryRun: false,
-      triggeredBy: "user",
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-      conversationalRunner: async () => ({ reply: "ok" }),
-    });
-    const entry = db
-      .query(
-        `SELECT action_type, action_json FROM audit_log
-         WHERE action_type = 'workflow.run.completed' ORDER BY id DESC LIMIT 1`,
-      )
-      .get() as { action_type: string; action_json: string };
+      "action_type, action_json",
+    );
     expect(entry.action_type).toBe("workflow.run.completed");
     const details = JSON.parse(entry.action_json) as {
       runId: string;
@@ -315,141 +264,83 @@ describe("runWorkflowExecution (dry run and validation)", () => {
   });
 
   test("runWorkflowExecution writes a workflow.run.completed audit entry on dry-run", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    db.run(
-      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
-       VALUES ('wf-audit-dry', 'audit-dry', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
-    );
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "audit-dry",
-      dryRun: true,
-      triggeredBy: "user",
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-    });
-    const entry = db
-      .query(
-        `SELECT action_json FROM audit_log
-         WHERE action_type = 'workflow.run.completed' ORDER BY id DESC LIMIT 1`,
-      )
-      .get() as { action_json: string };
+    const db = freshDb();
+    seedOneStepWorkflow(db, "audit-dry");
+    await runWorkflowExecution(makeRunParams(db, "audit-dry", { dryRun: true }));
+    const entry = lastRunCompletedAudit<{ action_json: string }>(db, "action_json");
     const details = JSON.parse(entry.action_json) as { status: string; dryRun: boolean };
     expect(details.status).toBe("preview");
     expect(details.dryRun).toBe(true);
   });
 
   test("runWorkflowExecution writes a workflow.run.completed audit entry with paramsOverride payload", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    db.run(
-      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
-       VALUES ('wf-audit-po', 'audit-po', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
+    const db = freshDb();
+    seedOneStepWorkflow(db, "audit-po");
+    await runWorkflowExecution(
+      makeRunParams(db, "audit-po", {
+        dryRun: true,
+        paramsOverride: { "step-1": { x: 1 } },
+      }),
     );
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "audit-po",
-      dryRun: true,
-      triggeredBy: "user",
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
-      paramsOverride: { "step-1": { x: 1 } },
-    });
-    const entry = db
-      .query(
-        `SELECT action_json FROM audit_log
-         WHERE action_type = 'workflow.run.completed' ORDER BY id DESC LIMIT 1`,
-      )
-      .get() as { action_json: string };
+    const entry = lastRunCompletedAudit<{ action_json: string }>(db, "action_json");
     const details = JSON.parse(entry.action_json) as { paramsOverride?: Record<string, unknown> };
     expect(details.paramsOverride).toEqual({ "step-1": { x: 1 } });
   });
 });
 
 describe("runWorkflowExecution — run retention", () => {
-  const noopAgent = {} as Agent;
-
-  test("workflow run completion prunes to the last 100 runs per workflow", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    db.run(
-      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
-       VALUES ('wf-ret-1', 'retention-test', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
-    );
-    for (let i = 0; i < 100; i++) {
+  /**
+   * Seed `count` historical (already-finished) workflow_run rows for a given
+   * workflow_id. Used by the retention tests to push totals near/past the cap.
+   */
+  function seedHistoricalRuns(
+    db: Database,
+    workflowId: string,
+    count: number,
+    startedAtBase: number,
+    idPrefix: string,
+  ): void {
+    for (let i = 0; i < count; i++) {
       insertWorkflowRunRow(db, {
-        id: `hist-${i}`,
-        workflowId: "wf-ret-1",
+        id: `${idPrefix}-${i}`,
+        workflowId,
         triggeredBy: "user",
         status: "done",
-        startedAt: 1_000 + i,
+        startedAt: startedAtBase + i,
         dryRun: false,
       });
-      finishWorkflowRunRow(db, `hist-${i}`, "done", 1_010 + i, null);
+      finishWorkflowRunRow(db, `${idPrefix}-${i}`, "done", startedAtBase + 10 + i, null);
     }
-    // Now run — dry-run path completes without tool calls, still emits row 101.
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "retention-test",
-      dryRun: true,
-      triggeredBy: "user",
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
+  }
+
+  test("workflow run completion prunes to the last 100 runs per workflow", async () => {
+    const db = freshDb();
+    const { id: workflowId } = seedOneStepWorkflow(db, "retention-test", {
+      id: "wf-ret-1",
     });
+    seedHistoricalRuns(db, workflowId, 100, 1_000, "hist");
+    // Now run — dry-run path completes without tool calls, still emits row 101.
+    await runWorkflowExecution(makeRunParams(db, "retention-test", { dryRun: true }));
     const count = db
-      .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = 'wf-ret-1'`)
-      .get() as { c: number };
+      .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = ?`)
+      .get(workflowId) as { c: number };
     expect(count.c).toBe(100);
     // Oldest seeded row must be pruned.
-    const oldestExists = db.query(`SELECT id FROM workflow_run WHERE id = 'hist-0'`).get();
-    expect(oldestExists).toBeNull();
+    expect(db.query(`SELECT id FROM workflow_run WHERE id = 'hist-0'`).get()).toBeNull();
     // A more-recent seeded row must remain (proves retention kept the newest 100).
-    const hist50 = db.query(`SELECT id FROM workflow_run WHERE id = 'hist-50'`).get();
-    expect(hist50).not.toBeNull();
+    expect(db.query(`SELECT id FROM workflow_run WHERE id = 'hist-50'`).get()).not.toBeNull();
   });
 
   test("workflow run completion is a no-op on retention when under cap", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    db.run(
-      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
-       VALUES ('wf-ret-2', 'retention-no-op', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
-    );
-    for (let i = 0; i < 5; i++) {
-      insertWorkflowRunRow(db, {
-        id: `h2-${i}`,
-        workflowId: "wf-ret-2",
-        triggeredBy: "user",
-        status: "done",
-        startedAt: 2_000 + i,
-        dryRun: false,
-      });
-      finishWorkflowRunRow(db, `h2-${i}`, "done", 2_010 + i, null);
-    }
-    await runWorkflowExecution({
-      db,
-      agent: noopAgent,
-      workflowName: "retention-no-op",
-      dryRun: true,
-      triggeredBy: "user",
-      stream: false,
-      sendChunk: () => {
-        /* noop */
-      },
+    const db = freshDb();
+    const { id: workflowId } = seedOneStepWorkflow(db, "retention-no-op", {
+      id: "wf-ret-2",
     });
+    seedHistoricalRuns(db, workflowId, 5, 2_000, "h2");
+    await runWorkflowExecution(makeRunParams(db, "retention-no-op", { dryRun: true }));
     const count = db
-      .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = 'wf-ret-2'`)
-      .get() as { c: number };
+      .query(`SELECT COUNT(*) AS c FROM workflow_run WHERE workflow_id = ?`)
+      .get(workflowId) as { c: number };
     expect(count.c).toBe(6); // 5 seeded + 1 new
   });
 });

--- a/packages/gateway/src/automation/workflow-runner.test.ts
+++ b/packages/gateway/src/automation/workflow-runner.test.ts
@@ -269,4 +269,102 @@ describe("runWorkflowExecution (dry run and validation)", () => {
       .get() as { params_override_json: string | null };
     expect(row.params_override_json).toBeNull();
   });
+
+  test("runWorkflowExecution writes a workflow.run.completed audit entry on success", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf-audit-ok', 'audit-ok', NULL, '[{"label":"step-1","run":"echo hi"}]', 0, 0)`,
+    );
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "audit-ok",
+      dryRun: false,
+      triggeredBy: "user",
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+      conversationalRunner: async () => ({ reply: "ok" }),
+    });
+    const entry = db
+      .query(
+        `SELECT action_type, action_json FROM audit_log
+         WHERE action_type = 'workflow.run.completed' ORDER BY id DESC LIMIT 1`,
+      )
+      .get() as { action_type: string; action_json: string };
+    expect(entry.action_type).toBe("workflow.run.completed");
+    const details = JSON.parse(entry.action_json) as {
+      runId: string;
+      workflowName: string;
+      status: string;
+      durationMs: number;
+      dryRun: boolean;
+    };
+    expect(details.workflowName).toBe("audit-ok");
+    expect(details.status).toBe("done");
+    expect(details.dryRun).toBe(false);
+    expect(typeof details.durationMs).toBe("number");
+    expect(typeof details.runId).toBe("string");
+  });
+
+  test("runWorkflowExecution writes a workflow.run.completed audit entry on dry-run", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf-audit-dry', 'audit-dry', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
+    );
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "audit-dry",
+      dryRun: true,
+      triggeredBy: "user",
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+    });
+    const entry = db
+      .query(
+        `SELECT action_json FROM audit_log
+         WHERE action_type = 'workflow.run.completed' ORDER BY id DESC LIMIT 1`,
+      )
+      .get() as { action_json: string };
+    const details = JSON.parse(entry.action_json) as { status: string; dryRun: boolean };
+    expect(details.status).toBe("preview");
+    expect(details.dryRun).toBe(true);
+  });
+
+  test("runWorkflowExecution writes a workflow.run.completed audit entry with paramsOverride payload", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf-audit-po', 'audit-po', NULL, '[{"label":"step-1","run":"echo"}]', 0, 0)`,
+    );
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "audit-po",
+      dryRun: true,
+      triggeredBy: "user",
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+      paramsOverride: { "step-1": { x: 1 } },
+    });
+    const entry = db
+      .query(
+        `SELECT action_json FROM audit_log
+         WHERE action_type = 'workflow.run.completed' ORDER BY id DESC LIMIT 1`,
+      )
+      .get() as { action_json: string };
+    const details = JSON.parse(entry.action_json) as { paramsOverride?: Record<string, unknown> };
+    expect(details.paramsOverride).toEqual({ "step-1": { x: 1 } });
+  });
 });

--- a/packages/gateway/src/automation/workflow-runner.test.ts
+++ b/packages/gateway/src/automation/workflow-runner.test.ts
@@ -170,4 +170,103 @@ describe("runWorkflowExecution (dry run and validation)", () => {
     expect(row.dry_run).toBe(1);
     expect(row.status).toBe("preview");
   });
+
+  test("runWorkflowExecution persists paramsOverride JSON on the real-run row", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    upsertWorkflowByName(
+      db,
+      "po-real",
+      null,
+      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
+      Date.now(),
+    );
+    const override = { "step-1": { greeting: "hi" } };
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "po-real",
+      triggeredBy: "user",
+      dryRun: false,
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+      conversationalRunner: async () => ({ reply: "ok" }),
+      paramsOverride: override,
+    });
+    const row = db
+      .query(
+        `SELECT params_override_json FROM workflow_run
+         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'po-real')
+         ORDER BY started_at DESC LIMIT 1`,
+      )
+      .get() as { params_override_json: string };
+    expect(JSON.parse(row.params_override_json)).toEqual(override);
+  });
+
+  test("runWorkflowExecution persists paramsOverride JSON on the dry-run row", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    upsertWorkflowByName(
+      db,
+      "po-dry",
+      null,
+      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
+      Date.now(),
+    );
+    const override = { "step-1": { greeting: "dry" } };
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "po-dry",
+      triggeredBy: "user",
+      dryRun: true,
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+      paramsOverride: override,
+    });
+    const row = db
+      .query(
+        `SELECT params_override_json FROM workflow_run
+         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'po-dry')
+         ORDER BY started_at DESC LIMIT 1`,
+      )
+      .get() as { params_override_json: string };
+    expect(JSON.parse(row.params_override_json)).toEqual(override);
+  });
+
+  test("runWorkflowExecution persists NULL params_override_json when not provided", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    upsertWorkflowByName(
+      db,
+      "po-absent",
+      null,
+      JSON.stringify([{ label: "step-1", run: "echo hi" }]),
+      Date.now(),
+    );
+    await runWorkflowExecution({
+      db,
+      agent: noopAgent,
+      workflowName: "po-absent",
+      triggeredBy: "user",
+      dryRun: false,
+      stream: false,
+      sendChunk: () => {
+        /* noop */
+      },
+      conversationalRunner: async () => ({ reply: "ok" }),
+    });
+    const row = db
+      .query(
+        `SELECT params_override_json FROM workflow_run
+         WHERE workflow_id = (SELECT id FROM workflow WHERE name = 'po-absent')
+         ORDER BY started_at DESC LIMIT 1`,
+      )
+      .get() as { params_override_json: string | null };
+    expect(row.params_override_json).toBeNull();
+  });
 });

--- a/packages/gateway/src/automation/workflow-runner.ts
+++ b/packages/gateway/src/automation/workflow-runner.ts
@@ -9,6 +9,7 @@ import {
 } from "../engine/run-conversational-agent.ts";
 import { readIndexedUserVersion } from "../index/migrations/runner.ts";
 import { previewHitlActionsForStepText } from "./workflow-hitl-preview.ts";
+import { pruneWorkflowRuns } from "./workflow-run-history.ts";
 import {
   finishWorkflowRunRow,
   getWorkflowByName,
@@ -16,6 +17,8 @@ import {
   insertWorkflowRunStepRow,
   updateWorkflowRunStepRow,
 } from "./workflow-store.ts";
+
+const RUN_RETENTION_PER_WORKFLOW = 100;
 
 function emitRunCompletedAudit(params: {
   readonly db: Database;
@@ -227,6 +230,7 @@ export async function runWorkflowExecution(
       dryRun: true,
       paramsOverride: p.paramsOverride,
     });
+    pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
     return {
       runId,
       dryRun: true,
@@ -275,6 +279,7 @@ export async function runWorkflowExecution(
           paramsOverride: p.paramsOverride,
           errorMsg: outcome.message,
         });
+        pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
         return { runId, dryRun: false, stepResults };
       }
     }
@@ -289,6 +294,7 @@ export async function runWorkflowExecution(
       dryRun: false,
       paramsOverride: p.paramsOverride,
     });
+    pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
     return { runId, dryRun: false, stepResults };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -303,6 +309,7 @@ export async function runWorkflowExecution(
       paramsOverride: p.paramsOverride,
       errorMsg: msg,
     });
+    pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
     throw err;
   }
 }

--- a/packages/gateway/src/automation/workflow-runner.ts
+++ b/packages/gateway/src/automation/workflow-runner.ts
@@ -1,6 +1,8 @@
 import type { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
 import type { Agent } from "@mastra/core/agent";
+import { formatAuditPayload } from "../audit/format-audit-payload.ts";
+import { computeAuditRowHash, GENESIS_HASH } from "../db/audit-chain.ts";
 import {
   type RunConversationalAgentParams,
   runConversationalAgent,
@@ -14,6 +16,47 @@ import {
   insertWorkflowRunStepRow,
   updateWorkflowRunStepRow,
 } from "./workflow-store.ts";
+
+function emitRunCompletedAudit(params: {
+  readonly db: Database;
+  readonly runId: string;
+  readonly workflowName: string;
+  readonly status: string;
+  readonly startedAt: number;
+  readonly dryRun: boolean;
+  readonly paramsOverride?: Readonly<Record<string, Record<string, unknown>>>;
+  readonly errorMsg?: string | null;
+}): void {
+  const durationMs = Date.now() - params.startedAt;
+  const details: Record<string, unknown> = {
+    runId: params.runId,
+    workflowName: params.workflowName,
+    status: params.status,
+    durationMs,
+    dryRun: params.dryRun,
+  };
+  if (params.paramsOverride !== undefined) {
+    details.paramsOverride = params.paramsOverride;
+  }
+  if (params.errorMsg !== undefined && params.errorMsg !== null) {
+    details.errorMsg = params.errorMsg;
+  }
+  const actionType = "workflow.run.completed";
+  const hitlStatus = "not_required";
+  const actionJson = formatAuditPayload(details);
+  const timestamp = Date.now();
+  const prevHashRow = params.db
+    .query(`SELECT row_hash FROM audit_log ORDER BY id DESC LIMIT 1`)
+    .get() as { row_hash: string | null } | undefined;
+  const rawPrev = prevHashRow?.row_hash;
+  const prevHash = typeof rawPrev === "string" && rawPrev.length === 64 ? rawPrev : GENESIS_HASH;
+  const rowHash = computeAuditRowHash({ prevHash, actionType, hitlStatus, actionJson, timestamp });
+  params.db.run(
+    `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [actionType, hitlStatus, actionJson, timestamp, rowHash, prevHash],
+  );
+}
 
 export type WorkflowStep = {
   label?: string;
@@ -184,6 +227,15 @@ export async function runWorkflowExecution(
       paramsOverrideJson,
     });
     finishWorkflowRunRow(p.db, runId, "preview", Date.now(), null);
+    emitRunCompletedAudit({
+      db: p.db,
+      runId,
+      workflowName: wf.name,
+      status: "preview",
+      startedAt: now,
+      dryRun: true,
+      paramsOverride: p.paramsOverride,
+    });
     return {
       runId,
       dryRun: true,
@@ -222,15 +274,44 @@ export async function runWorkflowExecution(
       stepResults.push({ label: outcome.label, status: "error", error: outcome.message });
       if (outcome.halt) {
         finishWorkflowRunRow(p.db, runId, "error", Date.now(), outcome.message);
+        emitRunCompletedAudit({
+          db: p.db,
+          runId,
+          workflowName: wf.name,
+          status: "error",
+          startedAt: now,
+          dryRun: false,
+          paramsOverride: p.paramsOverride,
+          errorMsg: outcome.message,
+        });
         return { runId, dryRun: false, stepResults };
       }
     }
 
     finishWorkflowRunRow(p.db, runId, "done", Date.now(), null);
+    emitRunCompletedAudit({
+      db: p.db,
+      runId,
+      workflowName: wf.name,
+      status: "done",
+      startedAt: now,
+      dryRun: false,
+      paramsOverride: p.paramsOverride,
+    });
     return { runId, dryRun: false, stepResults };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     finishWorkflowRunRow(p.db, runId, "error", Date.now(), msg);
+    emitRunCompletedAudit({
+      db: p.db,
+      runId,
+      workflowName: wf.name,
+      status: "error",
+      startedAt: now,
+      dryRun: false,
+      paramsOverride: p.paramsOverride,
+      errorMsg: msg,
+    });
     throw err;
   }
 }

--- a/packages/gateway/src/automation/workflow-runner.ts
+++ b/packages/gateway/src/automation/workflow-runner.ts
@@ -39,10 +39,10 @@ function emitRunCompletedAudit(params: {
     dryRun: params.dryRun,
   };
   if (params.paramsOverride !== undefined) {
-    details.paramsOverride = params.paramsOverride;
+    details["paramsOverride"] = params.paramsOverride;
   }
   if (params.errorMsg !== undefined && params.errorMsg !== null) {
-    details.errorMsg = params.errorMsg;
+    details["errorMsg"] = params.errorMsg;
   }
   appendAuditEntry(params.db, {
     actionType: "workflow.run.completed",
@@ -228,7 +228,7 @@ export async function runWorkflowExecution(
       status: "preview",
       startedAt: now,
       dryRun: true,
-      paramsOverride: p.paramsOverride,
+      ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
     });
     pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
     return {
@@ -276,7 +276,7 @@ export async function runWorkflowExecution(
           status: "error",
           startedAt: now,
           dryRun: false,
-          paramsOverride: p.paramsOverride,
+          ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
           errorMsg: outcome.message,
         });
         pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
@@ -292,7 +292,7 @@ export async function runWorkflowExecution(
       status: "done",
       startedAt: now,
       dryRun: false,
-      paramsOverride: p.paramsOverride,
+      ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
     });
     pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
     return { runId, dryRun: false, stepResults };
@@ -306,7 +306,7 @@ export async function runWorkflowExecution(
       status: "error",
       startedAt: now,
       dryRun: false,
-      paramsOverride: p.paramsOverride,
+      ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
       errorMsg: msg,
     });
     pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);

--- a/packages/gateway/src/automation/workflow-runner.ts
+++ b/packages/gateway/src/automation/workflow-runner.ts
@@ -165,6 +165,15 @@ export async function runWorkflowExecution(
   const now = Date.now();
 
   if (p.dryRun) {
+    insertWorkflowRunRow(p.db, {
+      id: runId,
+      workflowId: wf.id,
+      triggeredBy: p.triggeredBy,
+      status: "preview",
+      startedAt: now,
+      dryRun: true,
+    });
+    finishWorkflowRunRow(p.db, runId, "preview", Date.now(), null);
     return {
       runId,
       dryRun: true,

--- a/packages/gateway/src/automation/workflow-runner.ts
+++ b/packages/gateway/src/automation/workflow-runner.ts
@@ -192,6 +192,96 @@ async function executeWorkflowStep(
 }
 
 /**
+ * Close out a completed run: write the finished row, emit the chained audit
+ * entry, and prune the retention window. The three gateway-side effects always
+ * fire together, in that order, at every completion site.
+ */
+function finalizeRun(
+  p: RunWorkflowExecutionParams,
+  wf: { id: string; name: string },
+  runId: string,
+  status: string,
+  startedAt: number,
+  errorMsg: string | null,
+): void {
+  finishWorkflowRunRow(p.db, runId, status, Date.now(), errorMsg);
+  emitRunCompletedAudit({
+    db: p.db,
+    runId,
+    workflowName: wf.name,
+    status,
+    startedAt,
+    dryRun: p.dryRun,
+    ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
+    ...(errorMsg !== null && { errorMsg }),
+  });
+  pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
+}
+
+/** Dry-run branch: persist + finalize the preview row, return the preview results. */
+function executeDryRun(
+  p: RunWorkflowExecutionParams,
+  wf: { id: string; name: string },
+  steps: WorkflowStep[],
+  runId: string,
+  now: number,
+  paramsOverrideJson: string | null,
+): RunWorkflowExecutionResult {
+  insertWorkflowRunRow(p.db, {
+    id: runId,
+    workflowId: wf.id,
+    triggeredBy: p.triggeredBy,
+    status: "preview",
+    startedAt: now,
+    dryRun: true,
+    paramsOverrideJson,
+  });
+  finalizeRun(p, wf, runId, "preview", now, null);
+  return {
+    runId,
+    dryRun: true,
+    stepResults: steps.map((s, i) => ({
+      label: s.label ?? `step-${String(i + 1)}`,
+      status: "preview",
+      output: s.run,
+      hitlActions: previewHitlActionsForStepText(s.run),
+    })),
+  };
+}
+
+/**
+ * Real-run step loop. Returns either a completed result (all steps done, or a
+ * halt-on-error) or a directive to continue — used to keep runWorkflowExecution
+ * flat.
+ */
+async function executeRealRunSteps(
+  p: RunWorkflowExecutionParams,
+  wf: { id: string; name: string },
+  steps: WorkflowStep[],
+  runId: string,
+  now: number,
+): Promise<RunWorkflowExecutionResult> {
+  const outputs: string[] = [];
+  const stepResults: RunWorkflowExecutionResult["stepResults"] = [];
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    if (step === undefined) continue;
+    const outcome = await executeWorkflowStep(p, runId, i, step, outputs);
+    if (outcome.kind === "ok") {
+      stepResults.push({ label: outcome.label, status: "done", output: outcome.reply });
+      continue;
+    }
+    stepResults.push({ label: outcome.label, status: "error", error: outcome.message });
+    if (outcome.halt) {
+      finalizeRun(p, wf, runId, "error", now, outcome.message);
+      return { runId, dryRun: false, stepResults };
+    }
+  }
+  finalizeRun(p, wf, runId, "done", now, null);
+  return { runId, dryRun: false, stepResults };
+}
+
+/**
  * Executes a saved workflow sequentially via the conversational agent (tools allowed per step).
  */
 export async function runWorkflowExecution(
@@ -211,36 +301,7 @@ export async function runWorkflowExecution(
     p.paramsOverride === undefined ? null : JSON.stringify(p.paramsOverride);
 
   if (p.dryRun) {
-    insertWorkflowRunRow(p.db, {
-      id: runId,
-      workflowId: wf.id,
-      triggeredBy: p.triggeredBy,
-      status: "preview",
-      startedAt: now,
-      dryRun: true,
-      paramsOverrideJson,
-    });
-    finishWorkflowRunRow(p.db, runId, "preview", Date.now(), null);
-    emitRunCompletedAudit({
-      db: p.db,
-      runId,
-      workflowName: wf.name,
-      status: "preview",
-      startedAt: now,
-      dryRun: true,
-      ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
-    });
-    pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
-    return {
-      runId,
-      dryRun: true,
-      stepResults: steps.map((s, i) => ({
-        label: s.label ?? `step-${String(i + 1)}`,
-        status: "preview",
-        output: s.run,
-        hitlActions: previewHitlActionsForStepText(s.run),
-      })),
-    };
+    return executeDryRun(p, wf, steps, runId, now, paramsOverrideJson);
   }
 
   insertWorkflowRunRow(p.db, {
@@ -252,64 +313,11 @@ export async function runWorkflowExecution(
     paramsOverrideJson,
   });
 
-  const outputs: string[] = [];
-  const stepResults: RunWorkflowExecutionResult["stepResults"] = [];
-
   try {
-    for (let i = 0; i < steps.length; i++) {
-      const step = steps[i];
-      if (step === undefined) {
-        continue;
-      }
-      const outcome = await executeWorkflowStep(p, runId, i, step, outputs);
-      if (outcome.kind === "ok") {
-        stepResults.push({ label: outcome.label, status: "done", output: outcome.reply });
-        continue;
-      }
-      stepResults.push({ label: outcome.label, status: "error", error: outcome.message });
-      if (outcome.halt) {
-        finishWorkflowRunRow(p.db, runId, "error", Date.now(), outcome.message);
-        emitRunCompletedAudit({
-          db: p.db,
-          runId,
-          workflowName: wf.name,
-          status: "error",
-          startedAt: now,
-          dryRun: false,
-          ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
-          errorMsg: outcome.message,
-        });
-        pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
-        return { runId, dryRun: false, stepResults };
-      }
-    }
-
-    finishWorkflowRunRow(p.db, runId, "done", Date.now(), null);
-    emitRunCompletedAudit({
-      db: p.db,
-      runId,
-      workflowName: wf.name,
-      status: "done",
-      startedAt: now,
-      dryRun: false,
-      ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
-    });
-    pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
-    return { runId, dryRun: false, stepResults };
+    return await executeRealRunSteps(p, wf, steps, runId, now);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    finishWorkflowRunRow(p.db, runId, "error", Date.now(), msg);
-    emitRunCompletedAudit({
-      db: p.db,
-      runId,
-      workflowName: wf.name,
-      status: "error",
-      startedAt: now,
-      dryRun: false,
-      ...(p.paramsOverride !== undefined && { paramsOverride: p.paramsOverride }),
-      errorMsg: msg,
-    });
-    pruneWorkflowRuns(p.db, wf.id, RUN_RETENTION_PER_WORKFLOW);
+    finalizeRun(p, wf, runId, "error", now, msg);
     throw err;
   }
 }

--- a/packages/gateway/src/automation/workflow-runner.ts
+++ b/packages/gateway/src/automation/workflow-runner.ts
@@ -2,7 +2,7 @@ import type { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
 import type { Agent } from "@mastra/core/agent";
 import { formatAuditPayload } from "../audit/format-audit-payload.ts";
-import { computeAuditRowHash, GENESIS_HASH } from "../db/audit-chain.ts";
+import { appendAuditEntry } from "../db/audit-chain.ts";
 import {
   type RunConversationalAgentParams,
   runConversationalAgent,
@@ -41,21 +41,12 @@ function emitRunCompletedAudit(params: {
   if (params.errorMsg !== undefined && params.errorMsg !== null) {
     details.errorMsg = params.errorMsg;
   }
-  const actionType = "workflow.run.completed";
-  const hitlStatus = "not_required";
-  const actionJson = formatAuditPayload(details);
-  const timestamp = Date.now();
-  const prevHashRow = params.db
-    .query(`SELECT row_hash FROM audit_log ORDER BY id DESC LIMIT 1`)
-    .get() as { row_hash: string | null } | undefined;
-  const rawPrev = prevHashRow?.row_hash;
-  const prevHash = typeof rawPrev === "string" && rawPrev.length === 64 ? rawPrev : GENESIS_HASH;
-  const rowHash = computeAuditRowHash({ prevHash, actionType, hitlStatus, actionJson, timestamp });
-  params.db.run(
-    `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [actionType, hitlStatus, actionJson, timestamp, rowHash, prevHash],
-  );
+  appendAuditEntry(params.db, {
+    actionType: "workflow.run.completed",
+    hitlStatus: "not_required",
+    actionJson: formatAuditPayload(details),
+    timestamp: Date.now(),
+  });
 }
 
 export type WorkflowStep = {

--- a/packages/gateway/src/automation/workflow-runner.ts
+++ b/packages/gateway/src/automation/workflow-runner.ts
@@ -75,6 +75,13 @@ export type RunWorkflowExecutionParams = {
   sendChunk: (text: string) => void;
   /** When set (tests), invoked instead of {@link runConversationalAgent}. Production IPC omits this. */
   conversationalRunner?: (p: RunConversationalAgentParams) => Promise<{ reply: string }>;
+  /**
+   * Optional per-step parameter overrides: map of step label → params patch.
+   * Persisted on the workflow_run row as `params_override_json` for audit.
+   * For prompt-based steps, the override is recorded but not applied mid-execution
+   * (steps have no structured params object to merge into).
+   */
+  readonly paramsOverride?: Readonly<Record<string, Record<string, unknown>>>;
 };
 
 export type RunWorkflowExecutionResult = {
@@ -163,6 +170,8 @@ export async function runWorkflowExecution(
   const steps = parseWorkflowStepsJson(wf.steps_json);
   const runId = randomUUID();
   const now = Date.now();
+  const paramsOverrideJson =
+    p.paramsOverride === undefined ? null : JSON.stringify(p.paramsOverride);
 
   if (p.dryRun) {
     insertWorkflowRunRow(p.db, {
@@ -172,6 +181,7 @@ export async function runWorkflowExecution(
       status: "preview",
       startedAt: now,
       dryRun: true,
+      paramsOverrideJson,
     });
     finishWorkflowRunRow(p.db, runId, "preview", Date.now(), null);
     return {
@@ -192,6 +202,7 @@ export async function runWorkflowExecution(
     triggeredBy: p.triggeredBy,
     status: "running",
     startedAt: now,
+    paramsOverrideJson,
   });
 
   const outputs: string[] = [];

--- a/packages/gateway/src/automation/workflow-store.test.ts
+++ b/packages/gateway/src/automation/workflow-store.test.ts
@@ -60,6 +60,50 @@ describe("workflow-store", () => {
     expect(deleteWorkflowByName(db, "report")).toBe(false);
   });
 
+  test("insertWorkflowRunRow persists dry_run and params_override_json", () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf-dry', 'x', NULL, '[]', 0, 0)`,
+    );
+    insertWorkflowRunRow(db, {
+      id: "run-dry-1",
+      workflowId: "wf-dry",
+      triggeredBy: "user",
+      status: "preview",
+      startedAt: 1,
+      dryRun: true,
+      paramsOverrideJson: '{"key":"v"}',
+    });
+    const row = db
+      .query(`SELECT dry_run, params_override_json FROM workflow_run WHERE id = 'run-dry-1'`)
+      .get() as { dry_run: number; params_override_json: string };
+    expect(row.dry_run).toBe(1);
+    expect(row.params_override_json).toBe('{"key":"v"}');
+  });
+
+  test("insertWorkflowRunRow defaults dry_run to 0 and params_override_json to NULL when omitted", () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf-legacy', 'y', NULL, '[]', 0, 0)`,
+    );
+    insertWorkflowRunRow(db, {
+      id: "run-legacy-1",
+      workflowId: "wf-legacy",
+      triggeredBy: "user",
+      status: "running",
+      startedAt: 10,
+    });
+    const row = db
+      .query(`SELECT dry_run, params_override_json FROM workflow_run WHERE id = 'run-legacy-1'`)
+      .get() as { dry_run: number; params_override_json: string | null };
+    expect(row.dry_run).toBe(0);
+    expect(row.params_override_json).toBeNull();
+  });
+
   test("workflow run and step rows", () => {
     const db = new Database(":memory:");
     LocalIndex.ensureSchema(db);

--- a/packages/gateway/src/automation/workflow-store.ts
+++ b/packages/gateway/src/automation/workflow-store.ts
@@ -84,12 +84,22 @@ export function insertWorkflowRunRow(
     triggeredBy: string;
     status: string;
     startedAt: number;
+    dryRun?: boolean;
+    paramsOverrideJson?: string | null;
   },
 ): void {
   db.run(
-    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg)
-     VALUES (?, ?, ?, ?, ?, NULL, NULL)`,
-    [row.id, row.workflowId, row.triggeredBy, row.status, row.startedAt],
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg, dry_run, params_override_json)
+     VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?)`,
+    [
+      row.id,
+      row.workflowId,
+      row.triggeredBy,
+      row.status,
+      row.startedAt,
+      row.dryRun === true ? 1 : 0,
+      row.paramsOverrideJson ?? null,
+    ],
   );
 }
 

--- a/packages/gateway/src/db/audit-chain.test.ts
+++ b/packages/gateway/src/db/audit-chain.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
-import { computeAuditRowHash, GENESIS_HASH } from "./audit-chain.ts";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { LocalIndex } from "../index/local-index.ts";
+import { appendAuditEntry, computeAuditRowHash, GENESIS_HASH } from "./audit-chain.ts";
 
 describe("computeAuditRowHash", () => {
   test("is deterministic for identical inputs", () => {
@@ -45,5 +47,73 @@ describe("computeAuditRowHash", () => {
     const a = computeAuditRowHash({ ...row, prevHash: GENESIS_HASH });
     const b = computeAuditRowHash({ ...row, prevHash: "deadbeef".repeat(8) });
     expect(a).not.toBe(b);
+  });
+});
+
+describe("appendAuditEntry", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+  });
+
+  afterEach(() => db.close());
+
+  test("chains to genesis for the first row", () => {
+    appendAuditEntry(db, {
+      actionType: "test.first",
+      hitlStatus: "not_required",
+      actionJson: JSON.stringify({ a: 1 }),
+      timestamp: 1000,
+    });
+    const row = db
+      .query(`SELECT action_type, prev_hash, row_hash FROM audit_log ORDER BY id DESC LIMIT 1`)
+      .get() as { action_type: string; prev_hash: string; row_hash: string };
+    expect(row.action_type).toBe("test.first");
+    expect(row.prev_hash).toBe(GENESIS_HASH);
+    expect(row.row_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("chains subsequent rows to the previous row_hash", () => {
+    appendAuditEntry(db, {
+      actionType: "a",
+      hitlStatus: "not_required",
+      actionJson: "{}",
+      timestamp: 1,
+    });
+    appendAuditEntry(db, {
+      actionType: "b",
+      hitlStatus: "not_required",
+      actionJson: "{}",
+      timestamp: 2,
+    });
+    const rows = db
+      .query(`SELECT id, row_hash, prev_hash FROM audit_log ORDER BY id ASC`)
+      .all() as Array<{ id: number; row_hash: string; prev_hash: string }>;
+    expect(rows.length).toBe(2);
+    expect(rows[1].prev_hash).toBe(rows[0].row_hash);
+  });
+
+  test("row_hash matches what computeAuditRowHash would produce", () => {
+    const fields = {
+      actionType: "verify.hash",
+      hitlStatus: "approved",
+      actionJson: '{"x":42}',
+      timestamp: 9999,
+    };
+    appendAuditEntry(db, fields);
+    const row = db
+      .query(`SELECT row_hash, prev_hash FROM audit_log ORDER BY id DESC LIMIT 1`)
+      .get() as { row_hash: string; prev_hash: string };
+    const expected = computeAuditRowHash({
+      prevHash: GENESIS_HASH,
+      actionType: fields.actionType,
+      hitlStatus: fields.hitlStatus,
+      actionJson: fields.actionJson,
+      timestamp: fields.timestamp,
+    });
+    expect(row.row_hash).toBe(expected);
+    expect(row.prev_hash).toBe(GENESIS_HASH);
   });
 });

--- a/packages/gateway/src/db/audit-chain.test.ts
+++ b/packages/gateway/src/db/audit-chain.test.ts
@@ -92,7 +92,7 @@ describe("appendAuditEntry", () => {
       .query(`SELECT id, row_hash, prev_hash FROM audit_log ORDER BY id ASC`)
       .all() as Array<{ id: number; row_hash: string; prev_hash: string }>;
     expect(rows.length).toBe(2);
-    expect(rows[1].prev_hash).toBe(rows[0].row_hash);
+    expect(rows[1]?.prev_hash).toBe(rows[0]?.row_hash);
   });
 
   test("row_hash matches what computeAuditRowHash would produce", () => {

--- a/packages/gateway/src/db/audit-chain.ts
+++ b/packages/gateway/src/db/audit-chain.ts
@@ -1,3 +1,4 @@
+import type { Database } from "bun:sqlite";
 import { blake3 } from "@noble/hashes/blake3.js";
 import { bytesToHex } from "@noble/hashes/utils.js";
 
@@ -26,4 +27,37 @@ export function computeAuditRowHash(input: AuditRowHashInput): string {
     `${input.prevHash}|${input.actionType}|${input.hitlStatus}|${input.actionJson}|${String(input.timestamp)}`,
   );
   return bytesToHex(blake3(payload));
+}
+
+export interface AppendAuditEntryFields {
+  readonly actionType: string;
+  readonly hitlStatus: string;
+  readonly actionJson: string;
+  readonly timestamp: number;
+}
+
+/**
+ * Reads the previous row hash, computes the new row hash, and INSERTs a new
+ * audit_log row in one call. Both LocalIndex.recordAudit and the gateway's
+ * out-of-band audit writers (e.g. emitRunCompletedAudit in workflow-runner)
+ * delegate here so the chain-append recipe is single-sourced.
+ */
+export function appendAuditEntry(db: Database, fields: AppendAuditEntryFields): void {
+  const rawPrev = db.query(`SELECT row_hash FROM audit_log ORDER BY id DESC LIMIT 1`).get() as
+    | { row_hash: string | null }
+    | undefined;
+  const h = rawPrev?.row_hash;
+  const prevHash = typeof h === "string" && h.length === 64 ? h : GENESIS_HASH;
+  const rowHash = computeAuditRowHash({
+    prevHash,
+    actionType: fields.actionType,
+    hitlStatus: fields.hitlStatus,
+    actionJson: fields.actionJson,
+    timestamp: fields.timestamp,
+  });
+  db.run(
+    `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [fields.actionType, fields.hitlStatus, fields.actionJson, fields.timestamp, rowHash, prevHash],
+  );
 }

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
       dryRun: ctx.dryRun,
       stream: ctx.stream,
       sendChunk: ctx.sendChunk,
-      paramsOverride: ctx.paramsOverride,
+      ...(ctx.paramsOverride !== undefined && { paramsOverride: ctx.paramsOverride }),
     }),
   );
 

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -58,6 +58,7 @@ async function main(): Promise<void> {
       dryRun: ctx.dryRun,
       stream: ctx.stream,
       sendChunk: ctx.sendChunk,
+      paramsOverride: ctx.paramsOverride,
     }),
   );
 

--- a/packages/gateway/src/index/local-index.ts
+++ b/packages/gateway/src/index/local-index.ts
@@ -264,7 +264,7 @@ export interface LanPeerRow {
 }
 
 /** Current indexed DB schema version — also accessible as `LocalIndex.SCHEMA_VERSION`. */
-export const CURRENT_SCHEMA_VERSION = 22;
+export const CURRENT_SCHEMA_VERSION = 23;
 
 export class LocalIndex {
   static readonly SCHEMA_VERSION = CURRENT_SCHEMA_VERSION;

--- a/packages/gateway/src/index/local-index.ts
+++ b/packages/gateway/src/index/local-index.ts
@@ -2,7 +2,7 @@ import type { Database } from "bun:sqlite";
 import type { NimbusItem } from "@nimbus-dev/sdk";
 import { getConnectorHealth } from "../connectors/health.ts";
 import type { ReindexDepth } from "../connectors/reindex.ts";
-import { computeAuditRowHash, GENESIS_HASH } from "../db/audit-chain.ts";
+import { appendAuditEntry } from "../db/audit-chain.ts";
 import {
   DEFAULT_SLOW_QUERY_THRESHOLD_MS,
   latencyRingBuffer,
@@ -754,31 +754,11 @@ export class LocalIndex {
     actionJson: string;
     timestamp: number;
   }): void {
-    const prevHash = this.getLastAuditRowHash();
-    const rowHash = computeAuditRowHash({
-      prevHash,
-      actionType: entry.actionType,
-      hitlStatus: entry.hitlStatus,
-      actionJson: entry.actionJson,
-      timestamp: entry.timestamp,
-    });
-    this.db.run(
-      `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-      [entry.actionType, entry.hitlStatus, entry.actionJson, entry.timestamp, rowHash, prevHash],
-    );
+    appendAuditEntry(this.db, entry);
   }
 
   get rawDb(): Database {
     return this.db;
-  }
-
-  getLastAuditRowHash(): string {
-    const row = this.db.query(`SELECT row_hash FROM audit_log ORDER BY id DESC LIMIT 1`).get() as
-      | { row_hash: string | null }
-      | undefined;
-    const h = row?.row_hash;
-    return typeof h === "string" && h.length === 64 ? h : GENESIS_HASH;
   }
 
   listAuditWithChain(limit: number): Array<AuditEntry & { rowHash: string; prevHash: string }> {

--- a/packages/gateway/src/index/migrations/runner-v23.test.ts
+++ b/packages/gateway/src/index/migrations/runner-v23.test.ts
@@ -1,0 +1,66 @@
+import { Database } from "bun:sqlite";
+import { afterEach, expect, test } from "bun:test";
+import { readIndexedUserVersion, runIndexedSchemaMigrations } from "./runner.ts";
+
+const dbs: Database[] = [];
+
+afterEach(() => {
+  while (dbs.length > 0) {
+    const d = dbs.pop();
+    if (d) d.close();
+  }
+});
+
+function newDb(): Database {
+  const db = new Database(":memory:");
+  dbs.push(db);
+  return db;
+}
+
+test("V23 adds dry_run and params_override_json to workflow_run", () => {
+  const db = newDb();
+  runIndexedSchemaMigrations(db, 23);
+  expect(readIndexedUserVersion(db)).toBeGreaterThanOrEqual(23);
+
+  const info = db.query(`PRAGMA table_info(workflow_run)`).all() as Array<{
+    name: string;
+    type: string;
+    dflt_value: string | null;
+    notnull: number;
+  }>;
+
+  const dryRun = info.find((c) => c.name === "dry_run");
+  expect(dryRun).toBeDefined();
+  expect(dryRun?.type.toUpperCase()).toBe("INTEGER");
+  expect(dryRun?.notnull).toBe(1);
+  expect(dryRun?.dflt_value).toBe("0");
+
+  const paramsOverride = info.find((c) => c.name === "params_override_json");
+  expect(paramsOverride).toBeDefined();
+  expect(paramsOverride?.type.toUpperCase()).toBe("TEXT");
+});
+
+test("V23 is idempotent on re-apply", () => {
+  const db = newDb();
+  runIndexedSchemaMigrations(db, 23);
+  runIndexedSchemaMigrations(db, 23); // re-apply must not error
+  expect(readIndexedUserVersion(db)).toBeGreaterThanOrEqual(23);
+});
+
+test("V23 backfills existing rows with defaults", () => {
+  const db = newDb();
+  runIndexedSchemaMigrations(db, 23);
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES ('wf1', 'n', NULL, '[]', 0, 0)`,
+  );
+  db.run(
+    `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at)
+     VALUES ('r1', 'wf1', 'user', 'done', 1)`,
+  );
+  const row = db
+    .query(`SELECT dry_run, params_override_json FROM workflow_run WHERE id = 'r1'`)
+    .get() as { dry_run: number; params_override_json: string | null };
+  expect(row.dry_run).toBe(0);
+  expect(row.params_override_json).toBeNull();
+});

--- a/packages/gateway/src/index/migrations/runner.ts
+++ b/packages/gateway/src/index/migrations/runner.ts
@@ -45,6 +45,7 @@ import {
 import { USER_MCP_V11_MIGRATION_SQL } from "../user-mcp-v11-sql.ts";
 import { WATCHER_GRAPH_V22_SQL } from "../watcher-graph-v22-sql.ts";
 import { WATCHER_V8_MIGRATION_SQL } from "../watcher-v8-sql.ts";
+import { WORKFLOW_RUN_COLUMNS_V23_SQL } from "../workflow-run-columns-v23-sql.ts";
 import { WORKFLOW_V9_MIGRATION_SQL } from "../workflow-v9-sql.ts";
 
 const MIGRATIONS_LEDGER_SQL = `
@@ -321,6 +322,19 @@ function migrateIndexedV21ToV22(db: Database, now: number): void {
   })();
 }
 
+function migrateIndexedV22ToV23(db: Database, now: number): void {
+  db.transaction(() => {
+    db.exec(WORKFLOW_RUN_COLUMNS_V23_SQL);
+    db.exec("PRAGMA user_version = 23");
+    recordMigration(
+      db,
+      23,
+      "workflow_run.dry_run + workflow_run.params_override_json (WS5-D Polish)",
+      now,
+    );
+  })();
+}
+
 const INDEXED_SCHEMA_STEPS: readonly IndexedSchemaStep[] = [
   { fromVersion: 0, toVersion: 1, apply: migrateIndexedV0ToV1 },
   { fromVersion: 1, toVersion: 2, apply: migrateIndexedV1ToV2 },
@@ -344,6 +358,7 @@ const INDEXED_SCHEMA_STEPS: readonly IndexedSchemaStep[] = [
   { fromVersion: 19, toVersion: 20, apply: migrateIndexedV19ToV20 },
   { fromVersion: 20, toVersion: 21, apply: migrateIndexedV20ToV21 },
   { fromVersion: 21, toVersion: 22, apply: migrateIndexedV21ToV22 },
+  { fromVersion: 22, toVersion: 23, apply: migrateIndexedV22ToV23 },
 ];
 
 const BACKFILL_LABELS: readonly string[] = [
@@ -369,6 +384,7 @@ const BACKFILL_LABELS: readonly string[] = [
   "llm_task_defaults (per-task-type LLM model defaults) (backfilled)",
   "sync_state.depth (per-connector reindex depth) (backfilled)",
   "watcher.graph_predicate_json (graph-aware conditions) (backfilled)",
+  "workflow_run.dry_run + workflow_run.params_override_json (WS5-D Polish) (backfilled)",
 ];
 
 /**

--- a/packages/gateway/src/index/workflow-run-columns-v23-sql.ts
+++ b/packages/gateway/src/index/workflow-run-columns-v23-sql.ts
@@ -1,0 +1,15 @@
+/**
+ * V23 migration — adds `dry_run` and `params_override_json` columns to the
+ * existing `workflow_run` table (v9 schema). These support the WS5-D Polish
+ * sub-project: the runner writes dry-run rows (previously short-circuited
+ * before INSERT) and records the per-invocation params override so the UI
+ * can surface it in the run-history drawer.
+ *
+ * Purely additive — no backfill required. Existing rows get `dry_run = 0`
+ * and `params_override_json = NULL`.
+ */
+
+export const WORKFLOW_RUN_COLUMNS_V23_SQL = `
+ALTER TABLE workflow_run ADD COLUMN dry_run INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE workflow_run ADD COLUMN params_override_json TEXT;
+`;

--- a/packages/gateway/src/ipc/automation-rpc.test.ts
+++ b/packages/gateway/src/ipc/automation-rpc.test.ts
@@ -156,7 +156,7 @@ describe("watcher.listHistory", () => {
     if (out.kind !== "hit") return;
     const value = out.value as { events: Array<{ firedAt: number }> };
     expect(value.events.length).toBe(2);
-    expect(value.events[0].firedAt).toBe(20);
+    expect(value.events[0]?.firedAt).toBe(20);
   });
 
   test("rejects missing watcherId", () => {
@@ -192,6 +192,6 @@ describe("workflow.listRuns", () => {
     if (out.kind !== "hit") return;
     const value = out.value as { runs: Array<{ id: string }> };
     expect(value.runs.length).toBe(2);
-    expect(value.runs[0].id).toBe("r2");
+    expect(value.runs[0]?.id).toBe("r2");
   });
 });

--- a/packages/gateway/src/ipc/automation-rpc.test.ts
+++ b/packages/gateway/src/ipc/automation-rpc.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { upsertGraphEntity, upsertGraphRelation } from "../graph/relationship-graph.ts";
 import { LocalIndex } from "../index/local-index.ts";
-import { dispatchAutomationRpc } from "./automation-rpc.ts";
+import { AutomationRpcError, dispatchAutomationRpc } from "./automation-rpc.ts";
 
 function seededDb(): Database {
   const db = new Database(":memory:");
@@ -133,5 +133,65 @@ describe("watcher.validateCondition", () => {
     expect(out.kind).toBe("hit");
     const json = JSON.stringify(out.kind === "hit" ? out.value : {});
     expect(json).not.toContain("SECRET_TOKEN_xyz");
+  });
+});
+
+describe("watcher.listHistory", () => {
+  test("returns fires newest-first", () => {
+    const db = seededDb();
+    db.run(
+      `INSERT INTO watcher (id, name, enabled, condition_type, condition_json, action_type, action_json, created_at)
+       VALUES ('w1', 'x', 1, 'schedule', '{}', 'notify', '{}', 0)`,
+    );
+    db.run(
+      `INSERT INTO watcher_event (watcher_id, fired_at, condition_snapshot, action_result)
+       VALUES ('w1', 10, '{"a":1}', '{"ok":true}'), ('w1', 20, '{"a":2}', '{"ok":true}')`,
+    );
+    const out = dispatchAutomationRpc({
+      method: "watcher.listHistory",
+      params: { watcherId: "w1", limit: 5 },
+      db,
+    });
+    expect(out.kind).toBe("hit");
+    if (out.kind !== "hit") return;
+    const value = out.value as { events: Array<{ firedAt: number }> };
+    expect(value.events.length).toBe(2);
+    expect(value.events[0].firedAt).toBe(20);
+  });
+
+  test("rejects missing watcherId", () => {
+    const db = seededDb();
+    expect(() =>
+      dispatchAutomationRpc({
+        method: "watcher.listHistory",
+        params: { limit: 5 },
+        db,
+      }),
+    ).toThrow(AutomationRpcError);
+  });
+});
+
+describe("workflow.listRuns", () => {
+  test("returns last N runs newest-first", () => {
+    const db = seededDb();
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES ('wf1', 'alpha', NULL, '[]', 0, 0)`,
+    );
+    db.run(
+      `INSERT INTO workflow_run (id, workflow_id, triggered_by, status, started_at, finished_at, error_msg, dry_run, params_override_json)
+       VALUES ('r1', 'wf1', 'user', 'done', 10, 20, NULL, 0, NULL),
+              ('r2', 'wf1', 'user', 'done', 30, 40, NULL, 0, NULL)`,
+    );
+    const out = dispatchAutomationRpc({
+      method: "workflow.listRuns",
+      params: { workflowName: "alpha", limit: 5 },
+      db,
+    });
+    expect(out.kind).toBe("hit");
+    if (out.kind !== "hit") return;
+    const value = out.value as { runs: Array<{ id: string }> };
+    expect(value.runs.length).toBe(2);
+    expect(value.runs[0].id).toBe("r2");
   });
 });

--- a/packages/gateway/src/ipc/automation-rpc.ts
+++ b/packages/gateway/src/ipc/automation-rpc.ts
@@ -10,12 +10,14 @@ import {
   listCandidateGraphRelations,
   parseGraphPredicate,
 } from "../automation/graph-predicate.ts";
+import { listWatcherHistory } from "../automation/watcher-history.ts";
 import {
   deleteWatcher,
   insertWatcher,
   listWatchers,
   setWatcherEnabled,
 } from "../automation/watcher-store.ts";
+import { listWorkflowRuns } from "../automation/workflow-run-history.ts";
 import {
   deleteWorkflowByName,
   listWorkflows,
@@ -136,6 +138,12 @@ export function dispatchAutomationRpc(options: {
     case "watcher.validateCondition":
       return handleValidateCondition(rec, db);
 
+    case "watcher.listHistory": {
+      const watcherId = requireString(rec, "watcherId");
+      const limit = requireNumber(rec, "limit");
+      return { kind: "hit", value: listWatcherHistory(db, { watcherId, limit }) };
+    }
+
     case "extension.list":
       return { kind: "hit", value: { extensions: listExtensions(db) } };
 
@@ -212,6 +220,12 @@ export function dispatchAutomationRpc(options: {
       const name = requireString(rec, "name");
       const ok = deleteWorkflowByName(db, name);
       return { kind: "hit", value: { ok } };
+    }
+
+    case "workflow.listRuns": {
+      const workflowName = requireString(rec, "workflowName");
+      const limit = requireNumber(rec, "limit");
+      return { kind: "hit", value: listWorkflowRuns(db, { workflowName, limit }) };
     }
 
     default:

--- a/packages/gateway/src/ipc/ipc.test.ts
+++ b/packages/gateway/src/ipc/ipc.test.ts
@@ -488,7 +488,17 @@ describe("ipc server integration", () => {
     }
   });
 
-  test("workflow.run forwards paramsOverride to the registered handler", async () => {
+  /**
+   * Shared fixture for the paramsOverride tests below: boots an IPC server with an
+   * in-memory LocalIndex seeded with one workflow, registers a handler that records
+   * the received context, and returns everything the caller needs. Collapses ~35 lines
+   * of duplicated setup per test.
+   */
+  async function makeWorkflowRunCapture(workflowName: string): Promise<{
+    readonly server: IPCServer;
+    readonly listenPath: string;
+    readonly getReceived: () => unknown;
+  }> {
     const listenPath = testListenPath();
     const db = new Database(":memory:");
     LocalIndex.ensureSchema(db);
@@ -497,9 +507,8 @@ describe("ipc server integration", () => {
     db.run(
       `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
        VALUES (?, ?, NULL, ?, ?, ?)`,
-      [randomUUID(), "wf1", JSON.stringify([{ run: "a" }]), now, now],
+      [randomUUID(), workflowName, JSON.stringify([{ run: "a" }]), now, now],
     );
-
     const server = createIpcServer({
       listenPath,
       vault: new MockVault(),
@@ -514,6 +523,11 @@ describe("ipc server integration", () => {
       return { runId: "abc", dryRun: ctx.dryRun, stepResults: [] };
     });
     await server.start();
+    return { server, listenPath, getReceived: () => received };
+  }
+
+  test("workflow.run forwards paramsOverride to the registered handler", async () => {
+    const { server, listenPath, getReceived } = await makeWorkflowRunCapture("wf1");
     try {
       const line = await rpcCall(listenPath, "workflow.run", {
         name: "wf1",
@@ -522,7 +536,7 @@ describe("ipc server integration", () => {
       });
       const parsed = JSON.parse(line) as { result: unknown };
       expect(parsed.result).toBeDefined();
-      expect(received).toMatchObject({
+      expect(getReceived()).toMatchObject({
         workflowName: "wf1",
         dryRun: false,
         paramsOverride: { "step-1": { greeting: "hello" } },
@@ -533,34 +547,10 @@ describe("ipc server integration", () => {
   });
 
   test("workflow.run omits paramsOverride when not provided", async () => {
-    const listenPath = testListenPath();
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const localIndex = new LocalIndex(db);
-    const now = Date.now();
-    db.run(
-      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
-       VALUES (?, ?, NULL, ?, ?, ?)`,
-      [randomUUID(), "wf1", JSON.stringify([{ run: "a" }]), now, now],
-    );
-
-    const server = createIpcServer({
-      listenPath,
-      vault: new MockVault(),
-      version: "t",
-      localIndex,
-      dataDir: tmpdir(),
-      configDir: tmpdir(),
-    });
-    let received: unknown = null;
-    server.setWorkflowRunHandler(async (ctx) => {
-      received = ctx;
-      return { runId: "abc", dryRun: ctx.dryRun, stepResults: [] };
-    });
-    await server.start();
+    const { server, listenPath, getReceived } = await makeWorkflowRunCapture("wf1");
     try {
       await rpcCall(listenPath, "workflow.run", { name: "wf1", dryRun: false });
-      expect((received as { paramsOverride?: unknown }).paramsOverride).toBeUndefined();
+      expect((getReceived() as { paramsOverride?: unknown }).paramsOverride).toBeUndefined();
     } finally {
       await server.stop();
     }

--- a/packages/gateway/src/ipc/ipc.test.ts
+++ b/packages/gateway/src/ipc/ipc.test.ts
@@ -172,6 +172,43 @@ async function rpcCall(listenPath: string, method: string, params: unknown): Pro
   return exchangeFirstNdjsonLine(listenPath, jsonRpcNdjsonLine(method, 42, params));
 }
 
+/**
+ * Shared fixture for the workflow.run paramsOverride tests: boots an IPC server
+ * with an in-memory LocalIndex seeded with one workflow, registers a handler
+ * that records the received context, and returns everything the caller needs.
+ */
+async function makeWorkflowRunCapture(workflowName: string): Promise<{
+  readonly server: IPCServer;
+  readonly listenPath: string;
+  readonly getReceived: () => unknown;
+}> {
+  const listenPath = testListenPath();
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  const localIndex = new LocalIndex(db);
+  const now = Date.now();
+  db.run(
+    `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+     VALUES (?, ?, NULL, ?, ?, ?)`,
+    [randomUUID(), workflowName, JSON.stringify([{ run: "a" }]), now, now],
+  );
+  const server = createIpcServer({
+    listenPath,
+    vault: new MockVault(),
+    version: "t",
+    localIndex,
+    dataDir: tmpdir(),
+    configDir: tmpdir(),
+  });
+  let received: unknown = null;
+  server.setWorkflowRunHandler(async (ctx) => {
+    received = ctx;
+    return { runId: "abc", dryRun: ctx.dryRun, stepResults: [] };
+  });
+  await server.start();
+  return { server, listenPath, getReceived: () => received };
+}
+
 async function rpcPing(listenPath: string): Promise<string> {
   return exchangeFirstNdjsonLine(listenPath, jsonRpcNdjsonLine("gateway.ping", 1));
 }
@@ -487,44 +524,6 @@ describe("ipc server integration", () => {
       await server.stop();
     }
   });
-
-  /**
-   * Shared fixture for the paramsOverride tests below: boots an IPC server with an
-   * in-memory LocalIndex seeded with one workflow, registers a handler that records
-   * the received context, and returns everything the caller needs. Collapses ~35 lines
-   * of duplicated setup per test.
-   */
-  async function makeWorkflowRunCapture(workflowName: string): Promise<{
-    readonly server: IPCServer;
-    readonly listenPath: string;
-    readonly getReceived: () => unknown;
-  }> {
-    const listenPath = testListenPath();
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const localIndex = new LocalIndex(db);
-    const now = Date.now();
-    db.run(
-      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
-       VALUES (?, ?, NULL, ?, ?, ?)`,
-      [randomUUID(), workflowName, JSON.stringify([{ run: "a" }]), now, now],
-    );
-    const server = createIpcServer({
-      listenPath,
-      vault: new MockVault(),
-      version: "t",
-      localIndex,
-      dataDir: tmpdir(),
-      configDir: tmpdir(),
-    });
-    let received: unknown = null;
-    server.setWorkflowRunHandler(async (ctx) => {
-      received = ctx;
-      return { runId: "abc", dryRun: ctx.dryRun, stepResults: [] };
-    });
-    await server.start();
-    return { server, listenPath, getReceived: () => received };
-  }
 
   test("workflow.run forwards paramsOverride to the registered handler", async () => {
     const { server, listenPath, getReceived } = await makeWorkflowRunCapture("wf1");

--- a/packages/gateway/src/ipc/ipc.test.ts
+++ b/packages/gateway/src/ipc/ipc.test.ts
@@ -488,6 +488,84 @@ describe("ipc server integration", () => {
     }
   });
 
+  test("workflow.run forwards paramsOverride to the registered handler", async () => {
+    const listenPath = testListenPath();
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    const localIndex = new LocalIndex(db);
+    const now = Date.now();
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES (?, ?, NULL, ?, ?, ?)`,
+      [randomUUID(), "wf1", JSON.stringify([{ run: "a" }]), now, now],
+    );
+
+    const server = createIpcServer({
+      listenPath,
+      vault: new MockVault(),
+      version: "t",
+      localIndex,
+      dataDir: tmpdir(),
+      configDir: tmpdir(),
+    });
+    let received: unknown = null;
+    server.setWorkflowRunHandler(async (ctx) => {
+      received = ctx;
+      return { runId: "abc", dryRun: ctx.dryRun, stepResults: [] };
+    });
+    await server.start();
+    try {
+      const line = await rpcCall(listenPath, "workflow.run", {
+        name: "wf1",
+        dryRun: false,
+        paramsOverride: { "step-1": { greeting: "hello" } },
+      });
+      const parsed = JSON.parse(line) as { result: unknown };
+      expect(parsed.result).toBeDefined();
+      expect(received).toMatchObject({
+        workflowName: "wf1",
+        dryRun: false,
+        paramsOverride: { "step-1": { greeting: "hello" } },
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("workflow.run omits paramsOverride when not provided", async () => {
+    const listenPath = testListenPath();
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    const localIndex = new LocalIndex(db);
+    const now = Date.now();
+    db.run(
+      `INSERT INTO workflow (id, name, description, steps_json, created_at, updated_at)
+       VALUES (?, ?, NULL, ?, ?, ?)`,
+      [randomUUID(), "wf1", JSON.stringify([{ run: "a" }]), now, now],
+    );
+
+    const server = createIpcServer({
+      listenPath,
+      vault: new MockVault(),
+      version: "t",
+      localIndex,
+      dataDir: tmpdir(),
+      configDir: tmpdir(),
+    });
+    let received: unknown = null;
+    server.setWorkflowRunHandler(async (ctx) => {
+      received = ctx;
+      return { runId: "abc", dryRun: ctx.dryRun, stepResults: [] };
+    });
+    await server.start();
+    try {
+      await rpcCall(listenPath, "workflow.run", { name: "wf1", dryRun: false });
+      expect((received as { paramsOverride?: unknown }).paramsOverride).toBeUndefined();
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("pending consent rejects when client disconnects", async () => {
     const listenPath = testListenPath();
     const clientIds: string[] = [];

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -604,6 +604,18 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     const agent =
       typeof agentRaw === "string" && agentRaw.trim() !== "" ? agentRaw.trim() : undefined;
 
+    const rawOverride = rec?.["paramsOverride"];
+    let paramsOverride: Readonly<Record<string, Record<string, unknown>>> | undefined;
+    if (rawOverride !== undefined && rawOverride !== null) {
+      if (typeof rawOverride !== "object" || Array.isArray(rawOverride)) {
+        throw new RpcMethodError(
+          -32602,
+          "workflow.run: paramsOverride must be an object keyed by step label",
+        );
+      }
+      paramsOverride = rawOverride as Readonly<Record<string, Record<string, unknown>>>;
+    }
+
     const ctx: WorkflowRunContext = {
       clientId,
       workflowName,
@@ -619,6 +631,9 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     }
     if (agent !== undefined) {
       ctx.agent = agent;
+    }
+    if (paramsOverride !== undefined) {
+      ctx.paramsOverride = paramsOverride;
     }
 
     try {

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -573,6 +573,59 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     throw new RpcMethodError(-32601, `Method not found: ${method}`);
   }
 
+  function parseOptionalString(
+    rec: Record<string, unknown> | undefined,
+    key: string,
+  ): string | undefined {
+    const raw = rec?.[key];
+    if (typeof raw !== "string" || raw.trim() === "") return undefined;
+    return raw.trim();
+  }
+
+  function parseWorkflowRunParamsOverride(
+    rec: Record<string, unknown> | undefined,
+  ): Readonly<Record<string, Record<string, unknown>>> | undefined {
+    const raw = rec?.["paramsOverride"];
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== "object" || Array.isArray(raw)) {
+      throw new RpcMethodError(
+        -32602,
+        "workflow.run: paramsOverride must be an object keyed by step label",
+      );
+    }
+    return raw as Readonly<Record<string, Record<string, unknown>>>;
+  }
+
+  function buildWorkflowRunContext(
+    clientId: string,
+    session: ClientSession,
+    params: unknown,
+  ): { ctx: WorkflowRunContext; sessionId: string | undefined } {
+    const rec = asRecord(params);
+    const workflowName = requireNonEmptyRpcString(rec, "name");
+    const triggeredBy = parseOptionalString(rec, "triggeredBy") ?? clientId;
+    const dryRun = rec?.["dryRun"] === true;
+    const stream = rec?.["stream"] === true;
+    const sessionId = parseOptionalString(rec, "sessionId");
+    const agent = parseOptionalString(rec, "agent");
+    const paramsOverride = parseWorkflowRunParamsOverride(rec);
+
+    const ctx: WorkflowRunContext = {
+      clientId,
+      workflowName,
+      triggeredBy,
+      dryRun,
+      stream,
+      sendChunk: (text: string) => {
+        sendAgentChunkIfStreaming(session, stream, text);
+      },
+    };
+    if (sessionId !== undefined) ctx.sessionId = sessionId;
+    if (agent !== undefined) ctx.agent = agent;
+    if (paramsOverride !== undefined) ctx.paramsOverride = paramsOverride;
+    return { ctx, sessionId };
+  }
+
   async function dispatchWorkflowRunRpc(
     clientId: string,
     session: ClientSession,
@@ -585,56 +638,7 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     if (handler === undefined) {
       throw new RpcMethodError(-32603, "Workflow runner is not configured");
     }
-    const rec = asRecord(params);
-    const workflowName = requireNonEmptyRpcString(rec, "name");
-    const triggeredBy =
-      rec !== undefined &&
-      typeof rec["triggeredBy"] === "string" &&
-      rec["triggeredBy"].trim() !== ""
-        ? rec["triggeredBy"].trim()
-        : clientId;
-    const dryRun = rec?.["dryRun"] === true;
-    const stream = rec?.["stream"] === true;
-    const sessionIdRaw = rec?.["sessionId"];
-    const sessionId =
-      typeof sessionIdRaw === "string" && sessionIdRaw.trim() !== ""
-        ? sessionIdRaw.trim()
-        : undefined;
-    const agentRaw = rec?.["agent"];
-    const agent =
-      typeof agentRaw === "string" && agentRaw.trim() !== "" ? agentRaw.trim() : undefined;
-
-    const rawOverride = rec?.["paramsOverride"];
-    let paramsOverride: Readonly<Record<string, Record<string, unknown>>> | undefined;
-    if (rawOverride !== undefined && rawOverride !== null) {
-      if (typeof rawOverride !== "object" || Array.isArray(rawOverride)) {
-        throw new RpcMethodError(
-          -32602,
-          "workflow.run: paramsOverride must be an object keyed by step label",
-        );
-      }
-      paramsOverride = rawOverride as Readonly<Record<string, Record<string, unknown>>>;
-    }
-
-    const ctx: WorkflowRunContext = {
-      clientId,
-      workflowName,
-      triggeredBy,
-      dryRun,
-      stream,
-      sendChunk: (text: string) => {
-        sendAgentChunkIfStreaming(session, stream, text);
-      },
-    };
-    if (sessionId !== undefined) {
-      ctx.sessionId = sessionId;
-    }
-    if (agent !== undefined) {
-      ctx.agent = agent;
-    }
-    if (paramsOverride !== undefined) {
-      ctx.paramsOverride = paramsOverride;
-    }
+    const { ctx, sessionId } = buildWorkflowRunContext(clientId, session, params);
 
     try {
       const requestStore: AgentRequestContext = {};

--- a/packages/gateway/src/ipc/workflow-invoke.ts
+++ b/packages/gateway/src/ipc/workflow-invoke.ts
@@ -9,6 +9,8 @@ export type WorkflowRunContext = {
   sessionId?: string;
   /** Engine profile: `nimbus` (default), `devops`, or `research`. */
   agent?: string;
+  /** Optional per-step parameter overrides forwarded from the IPC caller. */
+  paramsOverride?: Readonly<Record<string, Record<string, unknown>>>;
 };
 
 export type WorkflowRunHandler = (ctx: WorkflowRunContext) => Promise<{

--- a/packages/ui/src-tauri/Cargo.lock
+++ b/packages/ui/src-tauri/Cargo.lock
@@ -995,9 +995,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2178,12 +2178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,12 +2273,11 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2554,11 +2547,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap 2.14.0",
 ]
 
@@ -4633,14 +4627,12 @@ dependencies = [
 
 [[package]]
 name = "tree_magic_mini"
-version = "3.1.6"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
- "fnv",
  "memchr",
  "nom",
- "once_cell",
  "petgraph",
 ]
 

--- a/packages/ui/src-tauri/Cargo.lock
+++ b/packages/ui/src-tauri/Cargo.lock
@@ -995,9 +995,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
-version = "0.5.7"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2178,6 +2178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,11 +2279,12 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "8.0.0"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2547,12 +2554,11 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.8.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "hashbrown 0.15.5",
  "indexmap 2.14.0",
 ]
 
@@ -4627,12 +4633,14 @@ dependencies = [
 
 [[package]]
 name = "tree_magic_mini"
-version = "3.2.2"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
 dependencies = [
+ "fnv",
  "memchr",
  "nom",
+ "once_cell",
  "petgraph",
 ]
 

--- a/packages/ui/src-tauri/Cargo.toml
+++ b/packages/ui/src-tauri/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "app"
 version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
-license = ""
-repository = ""
+description = "Nimbus desktop Tauri shell — thin bridge to the headless Bun Gateway over JSON-RPC 2.0 IPC."
+authors = ["Nimbus contributors"]
+license = "AGPL-3.0-or-later"
+repository = "https://github.com/asafgolombek/Nimbus"
 edition = "2021"
-rust-version = "1.77.2"
+rust-version = "1.88.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/ui/src-tauri/deny.toml
+++ b/packages/ui/src-tauri/deny.toml
@@ -1,0 +1,71 @@
+# cargo-deny configuration for the Tauri shell.
+#
+# Nimbus core (Gateway/CLI/MCP connectors) is AGPL-3.0; the SDK is MIT.
+# This Tauri shell is part of the core (AGPL-3.0). Allowed-license list below
+# enforces compatibility with AGPL-3.0 *or-later*: anything inbound must be
+# permissive enough to be redistributed under AGPL-3.0.
+#
+# Run locally:  cargo deny --manifest-path packages/ui/src-tauri/Cargo.toml check all
+# Docs:        https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Match CI target. Add more triples as new platforms ship.
+targets = [
+  { triple = "x86_64-unknown-linux-gnu" },
+  { triple = "x86_64-apple-darwin" },
+  { triple = "aarch64-apple-darwin" },
+  { triple = "x86_64-pc-windows-msvc" },
+]
+
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+# Permissive licenses compatible with AGPL-3.0 redistribution.
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "MIT-0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "ISC",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "CC0-1.0",
+  "Zlib",
+  "MPL-2.0",
+  "OpenSSL",
+]
+confidence-threshold = 0.92
+exceptions = []
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+allow = []
+deny = [
+  # Known-bad / unmaintained crates we never want to pull in transitively.
+  { name = "openssl", reason = "Prefer rustls; OpenSSL bindings add packaging risk." },
+  { name = "openssl-sys", reason = "Prefer rustls." },
+]
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/packages/ui/src-tauri/deny.toml
+++ b/packages/ui/src-tauri/deny.toml
@@ -22,12 +22,35 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = []
+# Transitive unmaintained advisories (can't fix without upstream Tauri bump
+# or library author action) are ignored individually below. Workspace-direct
+# unmaintained would still fail — that's the policy we want.
+ignore = [
+  # --- gtk3-rs bindings: marked unmaintained 2024-10; transitive via Tauri
+  #     2.x on Linux. Tauri is migrating to GTK4; revisit at next Tauri bump.
+  "RUSTSEC-2024-0411", # atk
+  "RUSTSEC-2024-0412", # gdk
+  "RUSTSEC-2024-0413", # gdkwayland-sys
+  "RUSTSEC-2024-0414", # gdkx11-sys
+  "RUSTSEC-2024-0415", # gdkx11
+  "RUSTSEC-2024-0416", # gtk
+  "RUSTSEC-2024-0417", # gtk-sys
+  "RUSTSEC-2024-0418", # atk-sys
+  "RUSTSEC-2024-0419", # gdk-sys
+  "RUSTSEC-2024-0420", # gtk3-macros
+  # --- proc-macro-error: unmaintained. Transitive via borsh-derive. Shallow.
+  "RUSTSEC-2024-0370",
+  # --- fxhash: unmaintained. Transitive.
+  "RUSTSEC-2025-0057",
+  # --- unic-char-property + related unic-*: unmaintained, transitive.
+  "RUSTSEC-2025-0098",
+]
 
 [licenses]
 version = 2
 # Permissive licenses compatible with AGPL-3.0 redistribution.
 allow = [
+  "0BSD",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "MIT",

--- a/packages/ui/src-tauri/deny.toml
+++ b/packages/ui/src-tauri/deny.toml
@@ -42,14 +42,19 @@ ignore = [
   "RUSTSEC-2024-0370",
   # --- fxhash: unmaintained. Transitive.
   "RUSTSEC-2025-0057",
-  # --- unic-char-property + related unic-*: unmaintained, transitive.
-  "RUSTSEC-2025-0098",
+  # --- unic-*: all open-i18n/rust-unic crates are unmaintained (transitive).
+  "RUSTSEC-2025-0075", # unic-char-range
+  "RUSTSEC-2025-0080", # unic-common
+  "RUSTSEC-2025-0081", # unic-char-property (new advisory, DB updated 2026-04)
+  "RUSTSEC-2025-0098", # unic-char-property (original advisory)
+  "RUSTSEC-2025-0100", # unic-ucd-ident
 ]
 
 [licenses]
 version = 2
 # Permissive licenses compatible with AGPL-3.0 redistribution.
 allow = [
+  "AGPL-3.0-or-later",
   "0BSD",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",

--- a/packages/ui/src-tauri/src/gateway_bridge.rs
+++ b/packages/ui/src-tauri/src/gateway_bridge.rs
@@ -108,11 +108,13 @@ pub const ALLOWED_METHODS: &[&str] = &[
     "watcher.delete",
     "watcher.list",
     "watcher.listCandidateRelations",
+    "watcher.listHistory",
     "watcher.pause",
     "watcher.resume",
     "watcher.validateCondition",
     "workflow.delete",
     "workflow.list",
+    "workflow.listRuns",
     "workflow.run",
     "workflow.save",
 ];
@@ -430,7 +432,8 @@ mod tests {
     fn allowlist_exact_size() {
         // WS5-D adds extension.{disable,enable,install,list,remove} + watcher.{create,delete,
         // list,pause,resume} + workflow.{delete,list,run,save} → 14 new methods → 54 total.
-        assert_eq!(ALLOWED_METHODS.len(), 54);
+        // WS5-D polish adds watcher.listHistory + workflow.listRuns → 2 new methods → 56 total.
+        assert_eq!(ALLOWED_METHODS.len(), 56);
     }
 
     #[test]

--- a/packages/ui/src-tauri/src/gateway_bridge.rs
+++ b/packages/ui/src-tauri/src/gateway_bridge.rs
@@ -189,7 +189,7 @@ pub async fn connect_and_run(app: AppHandle, state: BridgeState) {
         let connect_result = {
             let path = std::env::var("NIMBUS_SOCKET").unwrap_or_else(|_| {
                 let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-                format!("{}/.local/share/nimbus/nimbus.sock", home)
+                format!("{home}/.local/share/nimbus/nimbus.sock")
             });
             let fs_name = path
                 .to_fs_name::<GenericFilePath>()
@@ -280,7 +280,7 @@ pub async fn rpc_call(
     params: Value,
 ) -> Result<Value, String> {
     if !is_method_allowed(&method) {
-        return Err(format!("ERR_METHOD_NOT_ALLOWED:{}", method));
+        return Err(format!("ERR_METHOD_NOT_ALLOWED:{method}"));
     }
     let tx = {
         let guard = state.write_tx.lock().await;

--- a/packages/ui/src/components/watchers/WatcherHistoryDrawer.tsx
+++ b/packages/ui/src/components/watchers/WatcherHistoryDrawer.tsx
@@ -38,8 +38,7 @@ export function WatcherHistoryDrawer({
   }, [watcherId]);
 
   return (
-    <div
-      role="region"
+    <section
       aria-label={`History for ${watcherName}`}
       className="border rounded p-3 mt-2 bg-neutral-50 dark:bg-neutral-900 flex flex-col gap-2"
     >
@@ -73,6 +72,6 @@ export function WatcherHistoryDrawer({
           ))}
         </ul>
       )}
-    </div>
+    </section>
   );
 }

--- a/packages/ui/src/components/watchers/WatcherHistoryDrawer.tsx
+++ b/packages/ui/src/components/watchers/WatcherHistoryDrawer.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { createIpcClient } from "../../ipc/client";
+import type { WatcherHistoryEntry } from "../../ipc/types";
+
+interface WatcherHistoryDrawerProps {
+  readonly watcherId: string;
+  readonly watcherName: string;
+  readonly onClose: () => void;
+}
+
+const HISTORY_LIMIT = 50;
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toLocaleString();
+}
+
+export function WatcherHistoryDrawer({
+  watcherId,
+  watcherName,
+  onClose,
+}: WatcherHistoryDrawerProps) {
+  const [events, setEvents] = useState<ReadonlyArray<WatcherHistoryEntry> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    createIpcClient()
+      .watcherListHistory(watcherId, HISTORY_LIMIT)
+      .then((res) => {
+        if (!cancelled) setEvents(res.events);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [watcherId]);
+
+  return (
+    <div
+      role="region"
+      aria-label={`History for ${watcherName}`}
+      className="border rounded p-3 mt-2 bg-neutral-50 dark:bg-neutral-900 flex flex-col gap-2"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold">Fire history — last {HISTORY_LIMIT}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-neutral-500 hover:text-neutral-700"
+        >
+          Close
+        </button>
+      </div>
+      {error && <p className="text-red-600 text-xs">{error}</p>}
+      {events === null && !error && <p className="text-xs text-neutral-500">Loading…</p>}
+      {events !== null && events.length === 0 && (
+        <p className="text-xs text-neutral-500">No fires yet.</p>
+      )}
+      {events !== null && events.length > 0 && (
+        <ul className="flex flex-col gap-1 max-h-64 overflow-y-auto">
+          {events.map((ev) => (
+            <li
+              key={ev.firedAt}
+              className="text-xs border-b border-neutral-200 dark:border-neutral-800 py-1"
+            >
+              <div className="font-mono text-neutral-500">{formatTimestamp(ev.firedAt)}</div>
+              {/* whitespace-pre-wrap + break-all: prevents data loss on large graph
+                  predicate snapshots; the drawer's own max-h-64 overflow-y-auto scrolls. */}
+              <div className="font-mono whitespace-pre-wrap break-all">{ev.conditionSnapshot}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/workflows/RunWithParamsDialog.tsx
+++ b/packages/ui/src/components/workflows/RunWithParamsDialog.tsx
@@ -48,10 +48,10 @@ export function RunWithParamsDialog({
   }
 
   return (
-    <div
-      role="dialog"
+    <dialog
+      open
       aria-label={`Run ${workflowName} with params override`}
-      className="fixed inset-0 flex items-center justify-center bg-black/40 z-50"
+      className="fixed inset-0 flex items-center justify-center bg-black/40 z-50 w-full h-full max-w-none max-h-none"
     >
       <div className="bg-white dark:bg-neutral-900 rounded p-4 w-[520px] flex flex-col gap-3">
         <h2 className="text-base font-semibold">Run "{workflowName}" with parameter override</h2>
@@ -83,6 +83,6 @@ export function RunWithParamsDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/packages/ui/src/components/workflows/RunWithParamsDialog.tsx
+++ b/packages/ui/src/components/workflows/RunWithParamsDialog.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { createIpcClient } from "../../ipc/client";
+
+interface RunWithParamsDialogProps {
+  readonly workflowName: string;
+  readonly dryRun: boolean;
+  readonly onClose: () => void;
+  readonly onRan: () => void;
+}
+
+export function RunWithParamsDialog({
+  workflowName,
+  dryRun,
+  onClose,
+  onRan,
+}: RunWithParamsDialogProps) {
+  const [json, setJson] = useState("{}");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleConfirm() {
+    setError(null);
+    let parsed: Record<string, Record<string, unknown>>;
+    try {
+      const maybe = JSON.parse(json) as unknown;
+      if (typeof maybe !== "object" || maybe === null || Array.isArray(maybe)) {
+        throw new Error("Params override must be a JSON object");
+      }
+      parsed = maybe as Record<string, Record<string, unknown>>;
+    } catch (err) {
+      setError(err instanceof Error ? `Invalid JSON: ${err.message}` : "Invalid JSON");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createIpcClient().workflowRun({
+        name: workflowName,
+        dryRun,
+        paramsOverride: parsed,
+      });
+      onRan();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`Run ${workflowName} with params override`}
+      className="fixed inset-0 flex items-center justify-center bg-black/40 z-50"
+    >
+      <div className="bg-white dark:bg-neutral-900 rounded p-4 w-[520px] flex flex-col gap-3">
+        <h2 className="text-base font-semibold">Run "{workflowName}" with parameter override</h2>
+        <p className="text-xs text-neutral-500">
+          Provide a JSON object keyed by step label. Values replace step parameters for this
+          invocation only. Example: <code>{`{"step-1":{"greeting":"hello"}}`}</code>
+        </p>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="sr-only">Params override JSON</span>
+          <textarea
+            aria-label="Params override JSON"
+            className="font-mono border rounded p-2 text-xs h-32"
+            value={json}
+            onChange={(e) => setJson(e.target.value)}
+          />
+        </label>
+        {error && <p className="text-red-600 text-xs">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 rounded border">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={submitting}
+            className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
+          >
+            {submitting ? "Running…" : "Confirm run"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx
+++ b/packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { createIpcClient } from "../../ipc/client";
 import type { WorkflowRunHistoryEntry } from "../../ipc/types";
 
@@ -87,12 +88,12 @@ export function WorkflowRunHistoryDrawer({
                     {formatStatus(r.status, r.dryRun)}
                   </td>
                   <td className="px-2 py-1">
-                    <a
-                      href={`#/settings/audit?runId=${encodeURIComponent(r.id)}`}
+                    <Link
+                      to={`/settings/audit?runId=${encodeURIComponent(r.id)}`}
                       className="text-blue-600 hover:underline"
                     >
                       View audit entry
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               ))}

--- a/packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx
+++ b/packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { createIpcClient } from "../../ipc/client";
+import type { WorkflowRunHistoryEntry } from "../../ipc/types";
+
+interface WorkflowRunHistoryDrawerProps {
+  readonly workflowName: string;
+  readonly onClose: () => void;
+  readonly colSpan: number;
+}
+
+const HISTORY_LIMIT = 10;
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toLocaleString();
+}
+
+function statusColor(status: string, dryRun: boolean): string {
+  if (dryRun) return "text-amber-600 italic";
+  if (status === "error") return "text-red-600";
+  if (status === "done") return "text-green-700";
+  return "text-neutral-600";
+}
+
+function formatStatus(status: string, dryRun: boolean): string {
+  return dryRun ? `preview (${status})` : status;
+}
+
+export function WorkflowRunHistoryDrawer({
+  workflowName,
+  onClose,
+  colSpan,
+}: WorkflowRunHistoryDrawerProps) {
+  const [runs, setRuns] = useState<ReadonlyArray<WorkflowRunHistoryEntry> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    createIpcClient()
+      .workflowListRuns(workflowName, HISTORY_LIMIT)
+      .then((res) => {
+        if (!cancelled) setRuns(res.runs);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workflowName]);
+
+  return (
+    <tr>
+      <td colSpan={colSpan} className="py-2 px-3 bg-neutral-50 dark:bg-neutral-900">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-semibold">Last {HISTORY_LIMIT} runs</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-xs text-neutral-500 hover:text-neutral-700"
+          >
+            Close
+          </button>
+        </div>
+        {error && <p className="text-red-600 text-xs">{error}</p>}
+        {runs === null && !error && <p className="text-xs text-neutral-500">Loading…</p>}
+        {runs !== null && runs.length === 0 && (
+          <p className="text-xs text-neutral-500">No runs yet.</p>
+        )}
+        {runs !== null && runs.length > 0 && (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-neutral-500">
+                <th className="text-left px-2 py-1">Started</th>
+                <th className="text-left px-2 py-1">Duration</th>
+                <th className="text-left px-2 py-1">Status</th>
+                <th className="text-left px-2 py-1">Audit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((r) => (
+                <tr key={r.id}>
+                  <td className="px-2 py-1 font-mono">{formatTimestamp(r.startedAt)}</td>
+                  <td className="px-2 py-1 font-mono">
+                    {r.durationMs === null ? "—" : `${r.durationMs} ms`}
+                  </td>
+                  <td className={`px-2 py-1 ${statusColor(r.status, r.dryRun)}`}>
+                    {formatStatus(r.status, r.dryRun)}
+                  </td>
+                  <td className="px-2 py-1">
+                    <a
+                      href={`#/settings/audit?runId=${encodeURIComponent(r.id)}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      View audit entry
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/packages/ui/src/ipc/__mocks__/client.ts
+++ b/packages/ui/src/ipc/__mocks__/client.ts
@@ -72,17 +72,27 @@ export const watcherResumeMock = vi.fn<(id: string) => Promise<unknown>>();
 export const watcherListCandidateRelationsMock = vi.fn<() => Promise<unknown>>();
 export const watcherValidateConditionMock =
   vi.fn<(graphPredicateJson: string, sinceMs: number) => Promise<unknown>>();
+export const watcherListHistoryMock =
+  vi.fn<(watcherId: string, limit: number) => Promise<unknown>>();
 export const extensionListMock = vi.fn<() => Promise<unknown>>();
 export const extensionInstallMock = vi.fn<(sourcePath: string) => Promise<unknown>>();
 export const extensionEnableMock = vi.fn<(id: string) => Promise<unknown>>();
 export const extensionDisableMock = vi.fn<(id: string) => Promise<unknown>>();
 export const extensionRemoveMock = vi.fn<(id: string) => Promise<unknown>>();
 export const workflowListMock = vi.fn<() => Promise<unknown>>();
+export const workflowListRunsMock =
+  vi.fn<(workflowName: string, limit: number) => Promise<unknown>>();
 export const workflowSaveMock =
   vi.fn<(params: { name: string; description?: string; stepsJson: string }) => Promise<unknown>>();
 export const workflowDeleteMock = vi.fn<(name: string) => Promise<unknown>>();
 export const workflowRunMock =
-  vi.fn<(params: { name: string; dryRun: boolean }) => Promise<unknown>>();
+  vi.fn<
+    (params: {
+      name: string;
+      dryRun: boolean;
+      paramsOverride?: Record<string, Record<string, unknown>>;
+    }) => Promise<unknown>
+  >();
 
 export const createIpcClient = () => ({
   call: callMock,
@@ -127,12 +137,14 @@ export const createIpcClient = () => ({
   watcherResume: watcherResumeMock,
   watcherListCandidateRelations: watcherListCandidateRelationsMock,
   watcherValidateCondition: watcherValidateConditionMock,
+  watcherListHistory: watcherListHistoryMock,
   extensionList: extensionListMock,
   extensionInstall: extensionInstallMock,
   extensionEnable: extensionEnableMock,
   extensionDisable: extensionDisableMock,
   extensionRemove: extensionRemoveMock,
   workflowList: workflowListMock,
+  workflowListRuns: workflowListRunsMock,
   workflowSave: workflowSaveMock,
   workflowDelete: workflowDeleteMock,
   workflowRun: workflowRunMock,

--- a/packages/ui/src/ipc/client.ts
+++ b/packages/ui/src/ipc/client.ts
@@ -36,9 +36,12 @@ import {
   type WatcherCandidateRelationsResult,
   type WatcherCreateParams,
   type WatcherCreateResult,
+  type WatcherListHistoryResult,
   type WatcherListResult,
   type WatcherValidateConditionResult,
   type WorkflowListResult,
+  type WorkflowListRunsResult,
+  type WorkflowRunParams,
   type WorkflowRunResult,
   type WorkflowSaveResult,
 } from "./types";
@@ -114,19 +117,21 @@ export interface NimbusIpcClient {
     graphPredicateJson: string,
     sinceMs: number,
   ): Promise<WatcherValidateConditionResult>;
+  watcherListHistory(watcherId: string, limit: number): Promise<WatcherListHistoryResult>;
   extensionList(): Promise<ExtensionListResult>;
   extensionInstall(sourcePath: string): Promise<ExtensionInstallResult>;
   extensionEnable(id: string): Promise<{ ok: boolean }>;
   extensionDisable(id: string): Promise<{ ok: boolean }>;
   extensionRemove(id: string): Promise<{ ok: boolean }>;
   workflowList(): Promise<WorkflowListResult>;
+  workflowListRuns(workflowName: string, limit: number): Promise<WorkflowListRunsResult>;
   workflowSave(params: {
     name: string;
     description?: string;
     stepsJson: string;
   }): Promise<WorkflowSaveResult>;
   workflowDelete(name: string): Promise<{ ok: boolean }>;
-  workflowRun(params: { name: string; dryRun: boolean }): Promise<WorkflowRunResult>;
+  workflowRun(params: WorkflowRunParams): Promise<WorkflowRunResult>;
 }
 
 const FORBIDDEN_VALUE_KEYS: readonly string[] = [
@@ -443,6 +448,17 @@ export function createIpcClient(): NimbusIpcClient {
         throw new Error("watcher.validateCondition: expected object");
       return res as WatcherValidateConditionResult;
     },
+    async watcherListHistory(watcherId: string, limit: number): Promise<WatcherListHistoryResult> {
+      const res = await this.call<unknown>("watcher.listHistory", { watcherId, limit });
+      if (
+        typeof res !== "object" ||
+        res === null ||
+        !Array.isArray((res as WatcherListHistoryResult).events)
+      ) {
+        throw new Error("watcher.listHistory: expected { events: [] }");
+      }
+      return res as WatcherListHistoryResult;
+    },
     async extensionList(): Promise<ExtensionListResult> {
       const res = await this.call<unknown>("extension.list", {});
       if (typeof res !== "object" || res === null)
@@ -467,6 +483,17 @@ export function createIpcClient(): NimbusIpcClient {
         throw new Error("workflow.list: expected object");
       return res as WorkflowListResult;
     },
+    async workflowListRuns(workflowName: string, limit: number): Promise<WorkflowListRunsResult> {
+      const res = await this.call<unknown>("workflow.listRuns", { workflowName, limit });
+      if (
+        typeof res !== "object" ||
+        res === null ||
+        !Array.isArray((res as WorkflowListRunsResult).runs)
+      ) {
+        throw new Error("workflow.listRuns: expected { runs: [] }");
+      }
+      return res as WorkflowListRunsResult;
+    },
     async workflowSave(params: {
       name: string;
       description?: string;
@@ -481,7 +508,7 @@ export function createIpcClient(): NimbusIpcClient {
     async workflowDelete(name: string): Promise<{ ok: boolean }> {
       return await this.call<{ ok: boolean }>("workflow.delete", { name });
     },
-    async workflowRun(params: { name: string; dryRun: boolean }): Promise<WorkflowRunResult> {
+    async workflowRun(params: WorkflowRunParams): Promise<WorkflowRunResult> {
       return await this.call<WorkflowRunResult>("workflow.run", params);
     },
   };

--- a/packages/ui/src/ipc/types.ts
+++ b/packages/ui/src/ipc/types.ts
@@ -446,6 +446,17 @@ export interface WatcherListResult {
   readonly watchers: ReadonlyArray<WatcherSummary>;
 }
 
+/** One entry from `watcher.listHistory`. */
+export interface WatcherHistoryEntry {
+  readonly firedAt: number;
+  readonly conditionSnapshot: string;
+  readonly actionResult: string;
+}
+
+export interface WatcherListHistoryResult {
+  readonly events: ReadonlyArray<WatcherHistoryEntry>;
+}
+
 export interface WatcherCreateParams {
   readonly name: string;
   readonly conditionType: string;
@@ -493,6 +504,29 @@ export interface WorkflowSummary {
 
 export interface WorkflowListResult {
   readonly workflows: ReadonlyArray<WorkflowSummary>;
+}
+
+/** One entry from `workflow.listRuns`. */
+export interface WorkflowRunHistoryEntry {
+  readonly id: string;
+  readonly startedAt: number;
+  readonly finishedAt: number | null;
+  readonly durationMs: number | null;
+  readonly status: string;
+  readonly errorMsg: string | null;
+  readonly dryRun: boolean;
+  readonly paramsOverrideJson: string | null;
+  readonly triggeredBy: string;
+}
+
+export interface WorkflowListRunsResult {
+  readonly runs: ReadonlyArray<WorkflowRunHistoryEntry>;
+}
+
+export interface WorkflowRunParams {
+  readonly name: string;
+  readonly dryRun: boolean;
+  readonly paramsOverride?: Readonly<Record<string, Record<string, unknown>>>;
 }
 
 export interface WorkflowSaveResult {

--- a/packages/ui/src/pages/Watchers.tsx
+++ b/packages/ui/src/pages/Watchers.tsx
@@ -73,7 +73,7 @@ function GraphConditionBuilder({
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [value.relation, value.targetType, value.targetId]);
+  }, [value]);
 
   return (
     <div className="flex flex-col gap-3">

--- a/packages/ui/src/pages/Watchers.tsx
+++ b/packages/ui/src/pages/Watchers.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { WatcherHistoryDrawer } from "../components/watchers/WatcherHistoryDrawer";
 import { useIpcQuery } from "../hooks/useIpcQuery";
 import { createIpcClient } from "../ipc/client";
 import type {
@@ -333,39 +334,69 @@ function CreateWatcherDialog({ onClose, onCreated }: CreateDialogProps) {
 interface WatcherRowProps {
   watcher: WatcherSummary;
   disabled: boolean;
+  historyOpen: boolean;
   onToggle: (w: WatcherSummary) => void;
   onDelete: (w: WatcherSummary) => void;
+  onToggleHistory: (id: string) => void;
 }
 
-function WatcherRow({ watcher, disabled, onToggle, onDelete }: WatcherRowProps) {
+function WatcherRow({
+  watcher,
+  disabled,
+  historyOpen,
+  onToggle,
+  onDelete,
+  onToggleHistory,
+}: WatcherRowProps) {
   return (
-    <tr>
-      <td className="py-2 px-3 font-medium">{watcher.name}</td>
-      <td className="py-2 px-3 text-sm text-neutral-500">{watcher.condition_type}</td>
-      <td className="py-2 px-3 text-sm" data-testid={`last-fired-${watcher.id}`}>
-        {formatTimestamp(watcher.last_fired_at)}
-      </td>
-      <td className="py-2 px-3">
-        <input
-          type="checkbox"
-          aria-label={`${watcher.name} enabled`}
-          checked={watcher.enabled === 1}
-          disabled={disabled}
-          onChange={() => onToggle(watcher)}
-        />
-      </td>
-      <td className="py-2 px-3">
-        <button
-          type="button"
-          aria-label={`Delete watcher ${watcher.name}`}
-          disabled={disabled}
-          onClick={() => onDelete(watcher)}
-          className="text-red-600 text-sm disabled:opacity-40"
-        >
-          Delete
-        </button>
-      </td>
-    </tr>
+    <>
+      <tr>
+        <td className="py-2 px-3 font-medium">{watcher.name}</td>
+        <td className="py-2 px-3 text-sm text-neutral-500">{watcher.condition_type}</td>
+        <td className="py-2 px-3 text-sm" data-testid={`last-fired-${watcher.id}`}>
+          {formatTimestamp(watcher.last_fired_at)}
+        </td>
+        <td className="py-2 px-3">
+          <input
+            type="checkbox"
+            aria-label={`${watcher.name} enabled`}
+            checked={watcher.enabled === 1}
+            disabled={disabled}
+            onChange={() => onToggle(watcher)}
+          />
+        </td>
+        <td className="py-2 px-3 flex gap-2">
+          <button
+            type="button"
+            aria-label={`History for ${watcher.name}`}
+            onClick={() => onToggleHistory(watcher.id)}
+            className="text-xs border rounded px-2 py-0.5"
+          >
+            History
+          </button>
+          <button
+            type="button"
+            aria-label={`Delete watcher ${watcher.name}`}
+            disabled={disabled}
+            onClick={() => onDelete(watcher)}
+            className="text-red-600 text-sm disabled:opacity-40"
+          >
+            Delete
+          </button>
+        </td>
+      </tr>
+      {historyOpen && (
+        <tr>
+          <td colSpan={5} className="px-3 pb-3">
+            <WatcherHistoryDrawer
+              watcherId={watcher.id}
+              watcherName={watcher.name}
+              onClose={() => onToggleHistory(watcher.id)}
+            />
+          </td>
+        </tr>
+      )}
+    </>
   );
 }
 
@@ -384,6 +415,11 @@ export function Watchers() {
 
   const [showCreate, setShowCreate] = useState(false);
   const [actionInFlight, setActionInFlight] = useState<string | null>(null);
+  const [openHistoryForId, setOpenHistoryForId] = useState<string | null>(null);
+
+  function handleToggleHistory(id: string) {
+    setOpenHistoryForId((prev) => (prev === id ? null : id));
+  }
 
   async function handleToggle(w: WatcherSummary) {
     if (actionInFlight) return;
@@ -445,8 +481,10 @@ export function Watchers() {
                 key={w.id}
                 watcher={w}
                 disabled={offline || actionInFlight !== null}
+                historyOpen={openHistoryForId === w.id}
                 onToggle={handleToggle}
                 onDelete={handleDelete}
+                onToggleHistory={handleToggleHistory}
               />
             ))}
           </tbody>

--- a/packages/ui/src/pages/Watchers.tsx
+++ b/packages/ui/src/pages/Watchers.tsx
@@ -39,9 +39,9 @@ function buildGraphPredicateJson(fields: GraphPredicateFields): string {
 }
 
 interface GraphConditionBuilderProps {
-  value: GraphPredicateFields;
-  onChange: (v: GraphPredicateFields) => void;
-  candidateRelations: readonly CandidateRelation[];
+  readonly value: GraphPredicateFields;
+  readonly onChange: (v: GraphPredicateFields) => void;
+  readonly candidateRelations: readonly CandidateRelation[];
 }
 
 function GraphConditionBuilder({
@@ -332,12 +332,12 @@ function CreateWatcherDialog({ onClose, onCreated }: CreateDialogProps) {
 // ---------------------------------------------------------------------------
 
 interface WatcherRowProps {
-  watcher: WatcherSummary;
-  disabled: boolean;
-  historyOpen: boolean;
-  onToggle: (w: WatcherSummary) => void;
-  onDelete: (w: WatcherSummary) => void;
-  onToggleHistory: (id: string) => void;
+  readonly watcher: WatcherSummary;
+  readonly disabled: boolean;
+  readonly historyOpen: boolean;
+  readonly onToggle: (w: WatcherSummary) => void;
+  readonly onDelete: (w: WatcherSummary) => void;
+  readonly onToggleHistory: (id: string) => void;
 }
 
 function WatcherRow({

--- a/packages/ui/src/pages/Workflows.tsx
+++ b/packages/ui/src/pages/Workflows.tsx
@@ -17,10 +17,14 @@ interface StepDraft {
   paramsJson: string;
 }
 
+// Monotonic counter for StepDraft ids — uniqueness is only required within a
+// single workflow editor instance's lifetime (these ids never persist and are
+// not exposed to any network/security boundary). crypto.randomUUID() would be
+// overkill; a counter is simpler and doesn't trip linters for pseudorandom use.
+let stepIdCounter = 0;
 function newStepId(): string {
-  return typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-    ? crypto.randomUUID()
-    : `step-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+  stepIdCounter += 1;
+  return `step-${String(stepIdCounter)}`;
 }
 
 function emptyStep(): StepDraft {
@@ -60,8 +64,8 @@ function stepsToJson(steps: StepDraft[]): string {
 }
 
 interface StepListEditorProps {
-  steps: StepDraft[];
-  onChange: (steps: StepDraft[]) => void;
+  readonly steps: StepDraft[];
+  readonly onChange: (steps: StepDraft[]) => void;
 }
 
 function StepListEditor({ steps, onChange }: StepListEditorProps) {
@@ -228,15 +232,14 @@ function SaveWorkflowDialog({ initial, onClose, onSaved }: SaveDialogProps) {
 // ---------------------------------------------------------------------------
 
 interface WorkflowRowProps {
-  workflow: WorkflowSummary;
-  dryRun: boolean;
-  disabled: boolean;
-  historyOpen: boolean;
-  onRun: (w: WorkflowSummary) => void;
-  onEdit: (w: WorkflowSummary) => void;
-  onDelete: (w: WorkflowSummary) => void;
-  onToggleHistory: (name: string) => void;
-  onRunWithParams: (w: WorkflowSummary) => void;
+  readonly workflow: WorkflowSummary;
+  readonly dryRun: boolean;
+  readonly disabled: boolean;
+  readonly onRun: (w: WorkflowSummary) => void;
+  readonly onEdit: (w: WorkflowSummary) => void;
+  readonly onDelete: (w: WorkflowSummary) => void;
+  readonly onToggleHistory: (name: string) => void;
+  readonly onRunWithParams: (w: WorkflowSummary) => void;
 }
 
 function WorkflowRow({
@@ -388,7 +391,6 @@ export function Workflows() {
                   workflow={w}
                   dryRun={dryRun}
                   disabled={offline || actionInFlight !== null}
-                  historyOpen={openHistoryForName === w.name}
                   onRun={handleRun}
                   onEdit={(wf) => setShowSave(wf)}
                   onDelete={handleDelete}

--- a/packages/ui/src/pages/Workflows.tsx
+++ b/packages/ui/src/pages/Workflows.tsx
@@ -11,12 +11,20 @@ import { useNimbusStore } from "../store";
 // ---------------------------------------------------------------------------
 
 interface StepDraft {
+  /** Synthetic stable key — assigned at creation, used only for React list rendering. */
+  id: string;
   tool: string;
   paramsJson: string;
 }
 
+function newStepId(): string {
+  return typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `step-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
 function emptyStep(): StepDraft {
-  return { tool: "", paramsJson: "{}" };
+  return { id: newStepId(), tool: "", paramsJson: "{}" };
 }
 
 function stepsFromJson(json: string): StepDraft[] {
@@ -27,6 +35,7 @@ function stepsFromJson(json: string): StepDraft[] {
       if (typeof s !== "object" || s === null) return emptyStep();
       const step = s as { tool?: unknown; params?: unknown };
       return {
+        id: newStepId(),
         tool: typeof step.tool === "string" ? step.tool : "",
         paramsJson: step.params !== undefined ? JSON.stringify(step.params, null, 2) : "{}",
       };
@@ -72,9 +81,8 @@ function StepListEditor({ steps, onChange }: StepListEditorProps) {
   return (
     <div className="flex flex-col gap-3">
       {steps.map((step, index) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: stable draft list keyed by position
         <div
-          key={index}
+          key={step.id}
           className="border rounded p-3 flex flex-col gap-2 bg-neutral-50 dark:bg-neutral-900"
         >
           <div className="flex items-center justify-between">

--- a/packages/ui/src/pages/Workflows.tsx
+++ b/packages/ui/src/pages/Workflows.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useState } from "react";
+import { RunWithParamsDialog } from "../components/workflows/RunWithParamsDialog";
 import { WorkflowRunHistoryDrawer } from "../components/workflows/WorkflowRunHistoryDrawer";
 import { useIpcQuery } from "../hooks/useIpcQuery";
 import { createIpcClient } from "../ipc/client";
@@ -227,6 +228,7 @@ interface WorkflowRowProps {
   onEdit: (w: WorkflowSummary) => void;
   onDelete: (w: WorkflowSummary) => void;
   onToggleHistory: (name: string) => void;
+  onRunWithParams: (w: WorkflowSummary) => void;
 }
 
 function WorkflowRow({
@@ -237,6 +239,7 @@ function WorkflowRow({
   onEdit,
   onDelete,
   onToggleHistory,
+  onRunWithParams,
 }: WorkflowRowProps) {
   return (
     <tr>
@@ -279,6 +282,15 @@ function WorkflowRow({
         >
           History
         </button>
+        <button
+          type="button"
+          aria-label={`Run with params for ${workflow.name}`}
+          disabled={disabled}
+          onClick={() => onRunWithParams(workflow)}
+          className="px-2 py-0.5 rounded border text-xs disabled:opacity-40"
+        >
+          Run with params…
+        </button>
       </td>
     </tr>
   );
@@ -301,6 +313,7 @@ export function Workflows() {
   const [dryRun, setDryRun] = useState(false);
   const [actionInFlight, setActionInFlight] = useState<string | null>(null);
   const [openHistoryForName, setOpenHistoryForName] = useState<string | null>(null);
+  const [paramsDialogFor, setParamsDialogFor] = useState<WorkflowSummary | null>(null);
 
   async function handleRun(w: WorkflowSummary) {
     if (actionInFlight) return;
@@ -374,6 +387,7 @@ export function Workflows() {
                   onToggleHistory={(name) =>
                     setOpenHistoryForName(openHistoryForName === name ? null : name)
                   }
+                  onRunWithParams={(wf) => setParamsDialogFor(wf)}
                 />
                 {openHistoryForName === w.name && (
                   <WorkflowRunHistoryDrawer
@@ -396,6 +410,15 @@ export function Workflows() {
             setShowSave(null);
             refetch();
           }}
+        />
+      )}
+
+      {paramsDialogFor !== null && (
+        <RunWithParamsDialog
+          workflowName={paramsDialogFor.name}
+          dryRun={dryRun}
+          onClose={() => setParamsDialogFor(null)}
+          onRan={() => setParamsDialogFor(null)}
         />
       )}
     </div>

--- a/packages/ui/src/pages/Workflows.tsx
+++ b/packages/ui/src/pages/Workflows.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
+import { WorkflowRunHistoryDrawer } from "../components/workflows/WorkflowRunHistoryDrawer";
 import { useIpcQuery } from "../hooks/useIpcQuery";
 import { createIpcClient } from "../ipc/client";
 import type { WorkflowListResult, WorkflowSummary } from "../ipc/types";
@@ -221,12 +222,22 @@ interface WorkflowRowProps {
   workflow: WorkflowSummary;
   dryRun: boolean;
   disabled: boolean;
+  historyOpen: boolean;
   onRun: (w: WorkflowSummary) => void;
   onEdit: (w: WorkflowSummary) => void;
   onDelete: (w: WorkflowSummary) => void;
+  onToggleHistory: (name: string) => void;
 }
 
-function WorkflowRow({ workflow, dryRun, disabled, onRun, onEdit, onDelete }: WorkflowRowProps) {
+function WorkflowRow({
+  workflow,
+  dryRun,
+  disabled,
+  onRun,
+  onEdit,
+  onDelete,
+  onToggleHistory,
+}: WorkflowRowProps) {
   return (
     <tr>
       <td className="py-2 px-3 font-medium">{workflow.name}</td>
@@ -259,6 +270,15 @@ function WorkflowRow({ workflow, dryRun, disabled, onRun, onEdit, onDelete }: Wo
         >
           Delete
         </button>
+        <button
+          type="button"
+          aria-label={`Show history for ${workflow.name}`}
+          disabled={disabled}
+          onClick={() => onToggleHistory(workflow.name)}
+          className="px-2 py-0.5 rounded border text-xs disabled:opacity-40"
+        >
+          History
+        </button>
       </td>
     </tr>
   );
@@ -280,6 +300,7 @@ export function Workflows() {
   const [showSave, setShowSave] = useState<WorkflowSummary | "new" | null>(null);
   const [dryRun, setDryRun] = useState(false);
   const [actionInFlight, setActionInFlight] = useState<string | null>(null);
+  const [openHistoryForName, setOpenHistoryForName] = useState<string | null>(null);
 
   async function handleRun(w: WorkflowSummary) {
     if (actionInFlight) return;
@@ -341,15 +362,27 @@ export function Workflows() {
           </thead>
           <tbody>
             {data.workflows.map((w) => (
-              <WorkflowRow
-                key={w.id}
-                workflow={w}
-                dryRun={dryRun}
-                disabled={offline || actionInFlight !== null}
-                onRun={handleRun}
-                onEdit={(wf) => setShowSave(wf)}
-                onDelete={handleDelete}
-              />
+              <Fragment key={w.id}>
+                <WorkflowRow
+                  workflow={w}
+                  dryRun={dryRun}
+                  disabled={offline || actionInFlight !== null}
+                  historyOpen={openHistoryForName === w.name}
+                  onRun={handleRun}
+                  onEdit={(wf) => setShowSave(wf)}
+                  onDelete={handleDelete}
+                  onToggleHistory={(name) =>
+                    setOpenHistoryForName(openHistoryForName === name ? null : name)
+                  }
+                />
+                {openHistoryForName === w.name && (
+                  <WorkflowRunHistoryDrawer
+                    workflowName={w.name}
+                    onClose={() => setOpenHistoryForName(null)}
+                    colSpan={3}
+                  />
+                )}
+              </Fragment>
             ))}
           </tbody>
         </table>

--- a/packages/ui/src/pages/settings/AuditPanel.tsx
+++ b/packages/ui/src/pages/settings/AuditPanel.tsx
@@ -1,6 +1,7 @@
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import { AuditFilterChips } from "../../components/settings/audit/AuditFilterChips";
 import { PanelError } from "../../components/settings/PanelError";
@@ -17,6 +18,21 @@ const ROW_HEIGHT = 32;
 const LIST_HEIGHT = 480;
 const POLL_MS = 60_000;
 const MAX_ROWS = 1_000;
+
+/** Best-effort extraction of `runId` from `action_json` for `workflow.run.completed` rows. */
+function extractRunId(actionType: string, actionJson: string): string | null {
+  if (actionType !== "workflow.run.completed") return null;
+  try {
+    const parsed = JSON.parse(actionJson) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      const rec = parsed as Record<string, unknown>;
+      return typeof rec["runId"] === "string" ? rec["runId"] : null;
+    }
+  } catch {
+    // Malformed JSON — treat as no runId.
+  }
+  return null;
+}
 
 interface ToastState {
   readonly kind: "success" | "error" | "info";
@@ -58,6 +74,9 @@ function outcomeClass(outcome: string): string {
 }
 
 export function AuditPanel() {
+  const [searchParams] = useSearchParams();
+  const runIdFilter = searchParams.get("runId");
+
   const connectionState = useNimbusStore((s) => s.connectionState);
   const filter = useNimbusStore((s) => s.auditFilter);
   const summary = useNimbusStore((s) => s.auditSummary);
@@ -126,6 +145,7 @@ export function AuditPanel() {
         outcome: r.hitlStatus,
         rowHash: "", // not present in `audit.list`; populated only in the export pipeline
         actor: "",
+        runId: extractRunId(r.actionType, r.actionJson),
       };
     });
   }, [rawRows]);
@@ -146,6 +166,13 @@ export function AuditPanel() {
     for (const r of displayRows) set.add(r.service);
     return Array.from(set).sort((a, b) => a.localeCompare(b));
   }, [displayRows]);
+
+  // runId is a URL-param-driven transient filter layered on top of the store-state filter.
+  // Does NOT mutate the store — intentionally separate from the service/outcome/since/until chips.
+  const runIdFilteredRows = useMemo(() => {
+    if (runIdFilter === null) return filteredRows;
+    return filteredRows.filter((row) => row.runId === runIdFilter);
+  }, [filteredRows, runIdFilter]);
 
   const onVerify = useCallback(async () => {
     setInFlight(true);
@@ -198,13 +225,15 @@ export function AuditPanel() {
 
   const Row = useCallback(
     ({ index, style }: ListChildComponentProps) => {
-      const row = filteredRows[index];
+      const row = runIdFilteredRows[index];
       if (!row) return null;
+      const isMatch = runIdFilter !== null && row.runId === runIdFilter;
       return (
         <div
           style={style}
-          className="grid grid-cols-[180px_120px_1fr_100px] items-center px-3 text-xs border-b border-[var(--color-border)]"
+          className={`grid grid-cols-[180px_120px_1fr_100px] items-center px-3 text-xs border-b border-[var(--color-border)]${isMatch ? " bg-amber-50 dark:bg-amber-900/20" : ""}`}
           data-testid="audit-row"
+          aria-current={isMatch ? "true" : undefined}
         >
           <span className="font-mono text-[var(--color-text-muted)]">{row.tsIso}</span>
           <span className="font-medium">{row.service}</span>
@@ -213,7 +242,7 @@ export function AuditPanel() {
         </div>
       );
     },
-    [filteredRows],
+    [runIdFilteredRows, runIdFilter],
   );
 
   return (
@@ -257,7 +286,7 @@ export function AuditPanel() {
           Export…
         </button>
         <span className="text-xs text-[var(--color-text-muted)]">
-          {filteredRows.length} of {displayRows.length} rows
+          {runIdFilteredRows.length} of {displayRows.length} rows
         </span>
       </div>
 
@@ -275,6 +304,16 @@ export function AuditPanel() {
       )}
       {toast !== null && <VerifyToast toast={toast} onDismiss={() => setToast(null)} />}
 
+      {runIdFilter !== null && runIdFilteredRows.length === 0 && (
+        <p
+          data-testid="audit-runid-banner"
+          className="text-sm text-amber-600 bg-amber-50 dark:bg-amber-900/20 rounded p-3 my-2"
+        >
+          No audit entries found for run <code>{runIdFilter}</code>. It may have been pruned from
+          the operational run history; the audit log row survives if it was ever created.
+        </p>
+      )}
+
       <div className="border border-[var(--color-border)] rounded">
         <div className="grid grid-cols-[180px_120px_1fr_100px] px-3 py-1.5 text-xs font-semibold border-b border-[var(--color-border)] bg-[var(--color-bg-subtle)]">
           <span>Timestamp</span>
@@ -284,7 +323,7 @@ export function AuditPanel() {
         </div>
         <FixedSizeList
           height={LIST_HEIGHT}
-          itemCount={filteredRows.length}
+          itemCount={runIdFilteredRows.length}
           itemSize={ROW_HEIGHT}
           width="100%"
         >

--- a/packages/ui/test/pages/Watchers.test.tsx
+++ b/packages/ui/test/pages/Watchers.test.tsx
@@ -10,6 +10,7 @@ import {
   watcherCreateMock,
   watcherDeleteMock,
   watcherListCandidateRelationsMock,
+  watcherListHistoryMock,
   watcherPauseMock,
   watcherResumeMock,
   watcherValidateConditionMock,
@@ -87,6 +88,7 @@ beforeEach(() => {
   watcherResumeMock.mockReset();
   watcherListCandidateRelationsMock.mockReset();
   watcherValidateConditionMock.mockReset();
+  watcherListHistoryMock.mockReset();
   watcherListCandidateRelationsMock.mockResolvedValue({ relations: CANDIDATE_RELATIONS });
   useNimbusStore.setState({ connectionState: "connected" } as never);
 });
@@ -284,5 +286,53 @@ describe("Watchers page — graph condition builder", () => {
     await userEvent.type(screen.getByLabelText("Watcher name"), "Incomplete");
     // targetType and targetId left empty
     expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// History drawer
+// ---------------------------------------------------------------------------
+describe("Watchers page — history drawer", () => {
+  it("clicking History on a watcher row fetches and renders the last N fires", async () => {
+    stubWatcherList([WATCHER_1]);
+    watcherListHistoryMock.mockResolvedValue({
+      events: [
+        { firedAt: 2000, conditionSnapshot: '{"a":2}', actionResult: '{"ok":true}' },
+        { firedAt: 1000, conditionSnapshot: '{"a":1}', actionResult: '{"ok":true}' },
+      ],
+    });
+
+    renderPage();
+    await screen.findByText("PR opened");
+    const historyButton = await screen.findByRole("button", { name: /history for PR opened/i });
+    await userEvent.click(historyButton);
+    await screen.findByText('{"a":2}');
+    expect(watcherListHistoryMock).toHaveBeenCalledWith("w1", expect.any(Number));
+  });
+
+  it("History drawer shows an empty state when no events have fired", async () => {
+    stubWatcherList([WATCHER_1]);
+    watcherListHistoryMock.mockResolvedValue({ events: [] });
+
+    renderPage();
+    await screen.findByText("PR opened");
+    await userEvent.click(await screen.findByRole("button", { name: /history for PR opened/i }));
+    await screen.findByText(/no fires yet/i);
+  });
+
+  it("clicking History again collapses the drawer", async () => {
+    stubWatcherList([WATCHER_1]);
+    watcherListHistoryMock.mockResolvedValue({
+      events: [{ firedAt: 3000, conditionSnapshot: '{"x":3}', actionResult: '{"ok":true}' }],
+    });
+
+    renderPage();
+    await screen.findByText("PR opened");
+    const historyButton = await screen.findByRole("button", { name: /history for PR opened/i });
+    await userEvent.click(historyButton);
+    await screen.findByText('{"x":3}');
+    // Click again to close
+    await userEvent.click(historyButton);
+    await waitFor(() => expect(screen.queryByText('{"x":3}')).not.toBeInTheDocument());
   });
 });

--- a/packages/ui/test/pages/Workflows.test.tsx
+++ b/packages/ui/test/pages/Workflows.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,7 @@ vi.mock("../../src/ipc/client");
 import {
   callMock,
   workflowDeleteMock,
+  workflowListRunsMock,
   workflowRunMock,
   workflowSaveMock,
 } from "../../src/ipc/__mocks__/client";
@@ -52,6 +53,7 @@ beforeEach(() => {
   workflowRunMock.mockReset();
   workflowSaveMock.mockReset();
   workflowDeleteMock.mockReset();
+  workflowListRunsMock.mockReset();
   useNimbusStore.setState({ connectionState: "connected" } as never);
 });
 
@@ -225,5 +227,108 @@ describe("Workflows page — step-list editor", () => {
     expect(parsed).toHaveLength(2);
     expect((parsed[0] as { tool: string }).tool).toBe("step-a");
     expect((parsed[1] as { tool: string }).tool).toBe("step-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Run-history drawer
+// ---------------------------------------------------------------------------
+describe("Workflows page — run-history drawer", () => {
+  it("expanding a workflow row fetches and renders the last N runs", async () => {
+    stubWorkflowList([
+      {
+        id: "wf1",
+        name: "alpha",
+        description: null,
+        steps_json: "[]",
+        created_at: 0,
+        updated_at: 0,
+      },
+    ]);
+    workflowListRunsMock.mockResolvedValue({
+      runs: [
+        {
+          id: "r1",
+          startedAt: 1000,
+          finishedAt: 1200,
+          durationMs: 200,
+          status: "done",
+          errorMsg: null,
+          dryRun: false,
+          paramsOverrideJson: null,
+          triggeredBy: "user",
+        },
+        {
+          id: "r2",
+          startedAt: 500,
+          finishedAt: 700,
+          durationMs: 200,
+          status: "preview",
+          errorMsg: null,
+          dryRun: true,
+          paramsOverrideJson: null,
+          triggeredBy: "user",
+        },
+      ],
+    });
+
+    renderPage();
+    await screen.findByText("alpha");
+    fireEvent.click(screen.getByRole("button", { name: /show history for alpha/i }));
+    await screen.findAllByText(/200 ms/);
+    expect(screen.getByText("done")).toBeInTheDocument();
+    expect(screen.getByText(/preview/i)).toBeInTheDocument();
+    expect(workflowListRunsMock).toHaveBeenCalledWith("alpha", expect.any(Number));
+  });
+
+  it("run history row shows a 'View audit entry' link with the runId", async () => {
+    stubWorkflowList([
+      {
+        id: "wf1",
+        name: "alpha",
+        description: null,
+        steps_json: "[]",
+        created_at: 0,
+        updated_at: 0,
+      },
+    ]);
+    workflowListRunsMock.mockResolvedValue({
+      runs: [
+        {
+          id: "run-abc",
+          startedAt: 1000,
+          finishedAt: 1200,
+          durationMs: 200,
+          status: "done",
+          errorMsg: null,
+          dryRun: false,
+          paramsOverrideJson: null,
+          triggeredBy: "user",
+        },
+      ],
+    });
+    renderPage();
+    await screen.findByText("alpha");
+    fireEvent.click(screen.getByRole("button", { name: /show history for alpha/i }));
+    const link = await screen.findByRole("link", { name: /view audit entry/i });
+    expect(link.getAttribute("href")).toContain("run-abc");
+  });
+
+  it("run history drawer shows an empty state when no runs exist", async () => {
+    stubWorkflowList([
+      {
+        id: "wf1",
+        name: "alpha",
+        description: null,
+        steps_json: "[]",
+        created_at: 0,
+        updated_at: 0,
+      },
+    ]);
+    workflowListRunsMock.mockResolvedValue({ runs: [] });
+    renderPage();
+    await screen.findByText("alpha");
+    fireEvent.click(screen.getByRole("button", { name: /show history for alpha/i }));
+    await screen.findByText(/no runs yet/i);
   });
 });

--- a/packages/ui/test/pages/Workflows.test.tsx
+++ b/packages/ui/test/pages/Workflows.test.tsx
@@ -332,3 +332,66 @@ describe("Workflows page — run-history drawer", () => {
     await screen.findByText(/no runs yet/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Run with params dialog
+// ---------------------------------------------------------------------------
+const ALPHA_WORKFLOW = {
+  id: "wf1",
+  name: "alpha",
+  description: null,
+  steps_json: "[]",
+  created_at: 0,
+  updated_at: 0,
+};
+
+describe("Workflows page — run with params dialog", () => {
+  it("Run with params... opens a dialog and forwards paramsOverride to workflow.run", async () => {
+    stubWorkflowList([ALPHA_WORKFLOW]);
+    workflowRunMock.mockResolvedValue({});
+
+    renderPage();
+    await screen.findByText("alpha");
+    fireEvent.click(await screen.findByRole("button", { name: /run with params for alpha/i }));
+
+    const textbox = await screen.findByRole("textbox", { name: /params override json/i });
+    fireEvent.change(textbox, {
+      target: { value: '{"step-1":{"greeting":"hello"}}' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /confirm run/i }));
+
+    await waitFor(() =>
+      expect(workflowRunMock).toHaveBeenCalledWith({
+        name: "alpha",
+        dryRun: false,
+        paramsOverride: { "step-1": { greeting: "hello" } },
+      }),
+    );
+  });
+
+  it("Run with params... rejects invalid JSON with an inline error", async () => {
+    stubWorkflowList([ALPHA_WORKFLOW]);
+
+    renderPage();
+    await screen.findByText("alpha");
+    fireEvent.click(await screen.findByRole("button", { name: /run with params for alpha/i }));
+    const textbox = await screen.findByRole("textbox", { name: /params override json/i });
+    fireEvent.change(textbox, { target: { value: "not json" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm run/i }));
+    expect(await screen.findByText(/invalid json/i)).toBeInTheDocument();
+    expect(workflowRunMock).not.toHaveBeenCalled();
+  });
+
+  it("Run with params... rejects a top-level array as invalid (must be an object)", async () => {
+    stubWorkflowList([ALPHA_WORKFLOW]);
+
+    renderPage();
+    await screen.findByText("alpha");
+    fireEvent.click(await screen.findByRole("button", { name: /run with params for alpha/i }));
+    const textbox = await screen.findByRole("textbox", { name: /params override json/i });
+    fireEvent.change(textbox, { target: { value: "[1,2,3]" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm run/i }));
+    expect(await screen.findByText(/invalid json|must be a json object/i)).toBeInTheDocument();
+    expect(workflowRunMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/test/pages/settings/AuditPanel.test.tsx
+++ b/packages/ui/test/pages/settings/AuditPanel.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 
 vi.mock("../../../src/ipc/client");
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -47,6 +48,14 @@ const SAMPLE_ROWS = [
   },
 ];
 
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <AuditPanel />
+    </MemoryRouter>,
+  );
+}
+
 beforeEach(() => {
   callMock.mockReset();
   auditGetSummaryMock.mockReset();
@@ -80,13 +89,13 @@ afterEach(() => {
 });
 
 async function renderAndWaitForRows(): Promise<void> {
-  render(<AuditPanel />);
+  renderAt("/settings/audit");
   await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBe(3));
 }
 
 describe("AuditPanel", () => {
   it("renders summary and one row per fetched entry", async () => {
-    render(<AuditPanel />);
+    renderAt("/settings/audit");
     await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBeGreaterThan(0));
     await waitFor(() => expect(screen.getByText(/Total rows: 3/)).toBeTruthy());
     expect(screen.getByText("3 of 3 rows")).toBeTruthy();
@@ -184,12 +193,102 @@ describe("AuditPanel", () => {
 
   it("disconnected state disables write buttons", async () => {
     useNimbusStore.setState({ connectionState: "disconnected" } as never);
-    render(<AuditPanel />);
+    renderAt("/settings/audit");
     expect(
       (screen.getByRole("button", { name: "Verify chain" }) as HTMLButtonElement).disabled,
     ).toBe(true);
     expect((screen.getByRole("button", { name: "Export…" }) as HTMLButtonElement).disabled).toBe(
       true,
     );
+  });
+});
+
+// ── runId deep-link tests ──────────────────────────────────────────────────────
+
+const WORKFLOW_ROWS = [
+  {
+    id: 10,
+    actionType: "workflow.run.completed",
+    hitlStatus: "not_required" as const,
+    actionJson: JSON.stringify({
+      runId: "run-abc",
+      workflowName: "alpha",
+      status: "done",
+      durationMs: 100,
+      dryRun: false,
+    }),
+    timestamp: 1745126400000,
+  },
+  {
+    id: 11,
+    actionType: "workflow.run.completed",
+    hitlStatus: "not_required" as const,
+    actionJson: JSON.stringify({
+      runId: "run-xyz",
+      workflowName: "beta",
+      status: "done",
+      durationMs: 200,
+      dryRun: false,
+    }),
+    timestamp: 1745126500000,
+  },
+];
+
+describe("AuditPanel runId deep-link", () => {
+  beforeEach(() => {
+    callMock.mockImplementation(async (method: string) => {
+      if (method === "audit.list") return WORKFLOW_ROWS;
+      return [];
+    });
+    auditGetSummaryMock.mockResolvedValue({
+      byOutcome: { not_required: 2 },
+      byService: { workflow: 2 },
+      total: 2,
+    });
+  });
+
+  test("filters rows by runId extracted from actionJson when ?runId=<id> is present", async () => {
+    renderAt("/settings/audit?runId=run-abc");
+    // Only the run-abc row should be visible; run-xyz row should be filtered out.
+    await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBe(1));
+    // The "1 of 2" counter confirms the runId filter is on top of the full list.
+    expect(screen.getByText("1 of 2 rows")).toBeTruthy();
+  });
+
+  test("highlights the matched row with aria-current", async () => {
+    renderAt("/settings/audit?runId=run-abc");
+    await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBe(1));
+    const rows = screen.getAllByTestId("audit-row");
+    expect(rows[0]?.getAttribute("aria-current")).toBe("true");
+  });
+
+  test("shows the full list when no runId is provided", async () => {
+    renderAt("/settings/audit");
+    await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBe(2));
+    expect(screen.getByText("2 of 2 rows")).toBeTruthy();
+  });
+
+  test("shows a pruning-semantics banner when runId matches no entries", async () => {
+    renderAt("/settings/audit?runId=run-missing");
+    // The banner text spans a <p> with an inner <code>; query the container by testid.
+    await waitFor(() => expect(screen.getByTestId("audit-runid-banner")).toBeInTheDocument());
+    expect(screen.getByTestId("audit-runid-banner").textContent).toMatch(
+      /no audit entries found for run run-missing/i,
+    );
+  });
+
+  test("does not show the pruning banner when runId is absent", async () => {
+    renderAt("/settings/audit");
+    await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBe(2));
+    expect(screen.queryByText(/no audit entries found/i)).toBeNull();
+  });
+
+  test("does not highlight rows when no runId is in the URL", async () => {
+    renderAt("/settings/audit");
+    await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBe(2));
+    const rows = screen.getAllByTestId("audit-row");
+    for (const row of rows) {
+      expect(row.getAttribute("aria-current")).toBeNull();
+    }
   });
 });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+[toolchain]
+# Nimbus uses Rust edition 2024 features indirectly through Tauri's dependency
+# graph (wl-clipboard-rs -> tree_magic_mini, toml_edit -> toml_datetime,
+# proc-macro-crate -> toml_edit, time-core, time-macros, etc.). Edition 2024 is
+# stabilized in Rust 1.85+. We pin 1.88 because time-core@0.1.8 and
+# time-macros@0.2.27 require rustc 1.88+.
+#
+# When bumping this, also update the `toolchain:` input in:
+#   .github/workflows/codeql.yml
+#   .github/workflows/security.yml
+channel = "1.88.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Closes the three remaining WS5-D roadmap items on \`docs/roadmap.md:317-319\`: Watcher fire-history drawer, Workflow run-history drawer with audit-log deep-link, and one-shot \"Run with params…\" parameter override. Also promotes \`appendAuditEntry\` to a shared helper so the BLAKE3-chained audit-log recipe is single-sourced.

Implementation plan: [\`docs/superpowers/plans/2026-04-22-ws5d-polish.md\`](https://github.com/asafgolombek/Nimbus/blob/dev/asafgolombek/ws5d-polish/docs/superpowers/plans/2026-04-22-ws5d-polish.md).
Finish plan: [\`docs/release/v0.1.0-finish-plan.md\`](https://github.com/asafgolombek/Nimbus/blob/dev/asafgolombek/ws5d-polish/docs/release/v0.1.0-finish-plan.md).

## What landed

| Layer | Changes |
|---|---|
| **Schema** | V23 migration adds \`dry_run\` + \`params_override_json\` columns to existing \`workflow_run\` (v9 table). Additive; no backfill. |
| **Gateway** | New helpers: \`listWatcherHistory\`, \`listWorkflowRuns\`, \`pruneWorkflowRuns\`, \`appendAuditEntry\` (+ \`LocalIndex.recordAudit\` refactored to delegate). Runner persists dry-run rows, threads \`paramsOverride\`, emits \`workflow.run.completed\` audit entries at all 4 exit points (dry-run, success, step-halt, uncaught throw), prunes to 100 runs/workflow at completion. |
| **IPC** | \`watcher.listHistory\` + \`workflow.listRuns\` methods. \`workflow.run\` accepts optional \`paramsOverride\`. |
| **Tauri** | \`ALLOWED_METHODS\` 54 → 56, alphabetically ordered. |
| **UI** | Watcher history drawer (semantic \`<section>\`, \`whitespace-pre-wrap break-all\` on \`conditionSnapshot\`). Workflow run-history drawer with \`<Link>\`-based deep-link to audit. \"Run with params…\" dialog with JSON validation. AuditPanel \`?runId\` filter + amber highlight + pruning-semantics banner for deep-links to pruned runs. |
| **Docs** | \`docs/roadmap.md:317-319\` flipped to \`[x]\` with deferral notes (Marketplace-v2 → Phase 5, workflow re-run-failed-steps → v0.1.1). |

## Commit history

23 focused commits, each TDD'd + reviewed by a subagent pair (spec compliance then code quality). History preserved — please merge without squash so \`git bisect\` and the audit trail remain intact.

## Review-caught regressions (fixed before opening this PR)

1. **Audit-chain drift risk.** Task 8 originally duplicated the read-last-hash + compute-row-hash + INSERT recipe between \`LocalIndex.recordAudit\` and the new runner-side audit writer. Reviewer flagged the drift surface; fix extracted \`appendAuditEntry\` to \`packages/gateway/src/db/audit-chain.ts\`, both callers now delegate. Verified behavior-preserving (audit chain integrity tests green).
2. **Broken audit deep-link.** Final branch review caught that \`<a href=\"#/settings/audit?runId=...\">\` is a fragment identifier under \`createBrowserRouter\` — the link rendered but didn't navigate, and \`useSearchParams\` in AuditPanel never saw \`?runId=\`. Swapped to \`<Link to=\"/settings/audit?runId=...\">\`.

## Verification

- \`bun test packages/gateway/src/\` — 780 pass / 2 fail (the 2 failures are pre-existing Windows-specific tempdir-cleanup flake in \`Platform Abstraction Layer\` tests; they pass cleanly in isolation 3/3 and also fail 1x on \`main\`).
- \`bun test packages/gateway/src/automation/\` — 102/102.
- UI Vitest (\`cd packages/ui && bunx vitest run\`) — 474/474 pass, 1 pre-existing skip.
- Rust allowlist (\`cd packages/ui/src-tauri && cargo test\`) — 25/25 pass, including \`allowlist_exact_size\` = 56 + \`allowlist_is_alphabetized\`.
- \`bun run typecheck\` — 0 errors across all packages.
- \`bun run lint\` — 4 findings, all pre-existing on \`main\` (\`Watchers.tsx:58\` useEffect dep, \`Workflows.tsx:75/77\` stale suppression + underlying rule). New code is clean.

## Non-goals / Non-negotiables preserved

- HITL gate structural (audit entry is observational, not a bypass).
- No plaintext credentials in logs / IPC / config.
- MCP-as-connector standard untouched.
- No \`any\` types in new code.
- Migrations append-only; V≤22 code not modified.
- BLAKE3 audit-chain integrity verified end-to-end.

## Followups (non-blocking, recommend as separate issues)

1. Add new canonical files to the \`CLAUDE.md\` Key File Locations table: \`audit-chain.ts\`, \`workflow-run-columns-v23-sql.ts\`, \`watcher-history.ts\`, \`workflow-run-history.ts\`.
2. Remove dead \`historyOpen\` prop from \`WorkflowRowProps\` (drawer render is conditional in parent Fragment; the prop is declared but not read).

## Test plan

- [ ] CI green on all 3 platforms (Ubuntu gates PRs; Windows + macOS run on push to \`main\`).
- [ ] Manual smoke on macOS or Linux: open Watchers → History button, confirm drawer fetches + renders (empty state if no fires).
- [ ] Manual smoke: trigger a workflow (dry-run is enough), open its run-history row, click \"View audit entry\", confirm AuditPanel highlights the matching row in amber.
- [ ] Manual smoke: deep-link to \`#/settings/audit?runId=does-not-exist\`, confirm the pruning-semantics banner renders.
- [ ] Manual smoke: click \"Run with params…\", enter \`{\"step-1\":{\"x\":1}}\`, confirm; verify the audit entry records \`paramsOverride\` in \`action_json\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)