### PR TITLE
feat(cli): WS6 Rich TUI (Ink) — `nimbus tui` command

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -199,6 +199,8 @@ jobs:
             script: "test:coverage:client"
           - name: Telemetry
             script: "test:coverage:telemetry"
+          - name: TUI
+            script: "test:coverage:tui"
           - name: DB layer
             script: "test:coverage:db"
           - name: Health

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict
 **Linter:** Biome
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · S2 graph-aware watchers ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 🔵 · S2 graph-aware watchers ✅)
 
 **Gemini CLI:** [`GEMINI.md`](./GEMINI.md) mirrors this file for the same repository — update both when changing commands, roadmap rows, or non-negotiables.
 
@@ -95,6 +95,9 @@ These constraints are architectural, not preferences. Do not suggest changes tha
 | `packages/cli/src/commands/diag.ts` | `nimbus diag` — full diagnostic snapshot; `slow-queries` subcommand |
 | `packages/cli/src/commands/doctor.ts` | `nimbus doctor` — environment health checks, actionable remediation output |
 | `packages/cli/src/commands/telemetry.ts` | `nimbus telemetry show/disable` |
+| `packages/cli/src/commands/tui.tsx` | `nimbus tui` entry — gateway check, fallback detection, Ink render orchestration |
+| `packages/cli/src/tui/App.tsx` | TUI root — state machine + Option-1 layout + narrow/short-terminal behavior |
+| `packages/cli/src/tui/state.ts` | Top-level state reducer: `idle` / `streaming` / `awaiting-hitl` / `disconnected` |
 | `packages/sdk/src/index.ts` | `@nimbus-dev/sdk` public API |
 | `packages/client/src/index.ts` | `@nimbus-dev/client` public API — `NimbusClient`, `MockClient` |
 | `packages/ui/src/ipc/client.ts` | `NimbusIpcClient` singleton, `createIpcClient()`, `parseError()` — includes credential redaction (5 forbidden keys) |
@@ -197,6 +200,7 @@ bun run test:coverage:config       # ≥80% threshold (config loader, profiles, 
 bun run test:coverage:client       # ≥80% threshold (@nimbus-dev/client)
 bun run test:coverage:telemetry    # ≥85% threshold (telemetry collector — payload safety gate)
 bun run test:coverage:doctor       # ≥80% threshold (nimbus doctor checks)
+bun run test:coverage:tui         # ≥80% threshold (packages/cli/src/tui — TUI components)
 # Phase 4 WS4 coverage gates
 bun run test:coverage:updater      # ≥80% threshold (updater state machine + manifest fetcher)
 bun run test:coverage:lan          # ≥80% threshold (lan-crypto, lan-pairing, lan-rate-limit, lan-rpc, lan-server)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict
 **Linter:** Biome
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 🔵 · S2 graph-aware watchers ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅)
 
 **Gemini CLI:** [`GEMINI.md`](./GEMINI.md) mirrors this file for the same repository — update both when changing commands, roadmap rows, or non-negotiables.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict  
 **Linter:** Biome  
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)  
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · S2 graph-aware watchers ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 🔵 · S2 graph-aware watchers ✅)
 
 Companion context for other agents: [`CLAUDE.md`](./CLAUDE.md) (same project facts; keep both files aligned when changing commands, roadmap rows, or non-negotiables).
 
@@ -91,6 +91,9 @@ Companion context for other agents: [`CLAUDE.md`](./CLAUDE.md) (same project fac
 | `packages/cli/src/commands/diag.ts` | `nimbus diag` — full diagnostic snapshot; `slow-queries` subcommand |
 | `packages/cli/src/commands/doctor.ts` | `nimbus doctor` — environment health checks, actionable remediation output |
 | `packages/cli/src/commands/telemetry.ts` | `nimbus telemetry show/disable` |
+| `packages/cli/src/commands/tui.tsx` | `nimbus tui` entry — gateway check, fallback detection, Ink render orchestration |
+| `packages/cli/src/tui/App.tsx` | TUI root — state machine + Option-1 layout + narrow/short-terminal behavior |
+| `packages/cli/src/tui/state.ts` | Top-level state reducer: `idle` / `streaming` / `awaiting-hitl` / `disconnected` |
 | `packages/sdk/src/index.ts` | `@nimbus-dev/sdk` public API |
 | `packages/client/src/index.ts` | `@nimbus-dev/client` public API — `NimbusClient`, `MockClient` |
 | `packages/ui/src/ipc/client.ts` | `NimbusIpcClient` singleton, `createIpcClient()`, `parseError()` — includes credential redaction (5 forbidden keys) |
@@ -192,6 +195,7 @@ bun run test:coverage:telemetry    # ≥85% threshold (telemetry collector — p
 bun run test:coverage:db           # ≥85% threshold (verify, repair, migrations, metrics, latency buffer)
 bun run test:coverage:health       # ≥85% threshold (connectors/health.ts)
 bun run test:coverage:doctor       # ≥80% threshold (nimbus doctor checks)
+bun run test:coverage:tui         # ≥80% threshold (packages/cli/src/tui — TUI components)
 # Phase 4 WS4 coverage gates
 bun run test:coverage:updater      # ≥80% threshold (updater state machine + manifest fetcher)
 bun run test:coverage:lan          # ≥80% threshold (lan-crypto, lan-pairing, lan-rate-limit, lan-rpc, lan-server)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict  
 **Linter:** Biome  
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)  
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 🔵 · S2 graph-aware watchers ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence 🔵 Active (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅)
 
 Companion context for other agents: [`CLAUDE.md`](./CLAUDE.md) (same project facts; keep both files aligned when changing commands, roadmap rows, or non-negotiables).
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,29 @@ Invoke-WebRequest -Uri https://github.com/nimbus-dev/Nimbus/releases/download/v<
 ```
 
 Exits `0` on full verification, `1` on any hash/signature mismatch. See [`docs/verify-release-integrity.md`](docs/verify-release-integrity.md) for the manual verification path, offline mode, and key-rotation procedure.
+
+---
+
+## Getting Started
+
+Start the background Gateway once per machine:
+
+```bash
+nimbus start
+```
+
+Then launch the **rich terminal UI** for interactive sessions:
+
+```bash
+nimbus tui
+```
+
+`nimbus tui` opens a five-pane Ink layout — query input, streaming result, connector health, watchers, sub-task progress — with inline mid-stream HITL consent. On dumb terminals, non-TTY shells, CI environments, or terminals shorter than 20 rows, it auto-falls back to the line-based REPL.
+
+For scripts, pipelines, or headless environments, use the plain REPL directly:
+
+```bash
+nimbus repl
+```
+
+Full command reference: [`docs/cli-reference.md`](docs/cli-reference.md).

--- a/bun.lock
+++ b/bun.lock
@@ -19,11 +19,16 @@
         "@clack/prompts": "^1.2.0",
         "@nimbus-dev/client": "workspace:*",
         "@nimbus-dev/sdk": "workspace:*",
+        "ink": "^5.2.1",
+        "ink-text-input": "^6.0.0",
         "pino": "^10.3.1",
+        "react": "^18.3.1",
         "yaml": "^2.8.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/react": "^18.3.12",
+        "ink-testing-library": "^4.0.0",
       },
     },
     "packages/client": {
@@ -522,6 +527,8 @@
     "@ai-sdk/provider-v6": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@ai-sdk/ui-utils-v5": ["@ai-sdk/ui-utils@1.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w=="],
+
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.6", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-BXWCh8dHs9GOfpo/fWGDJtDmleta2VePN9rn6WQt3GjEbxzutVF4t0x2pmH+7dbMCLtuv3MlwqRsAuxlzFXqFg=="],
 
@@ -1119,11 +1126,13 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
     "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
 
     "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
 
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+    "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
@@ -1195,9 +1204,9 @@
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
@@ -1224,6 +1233,8 @@
     "astro-expressive-code": ["astro-expressive-code@0.41.7", "", { "dependencies": { "rehype-expressive-code": "^0.41.7" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -1263,6 +1274,8 @@
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -1279,9 +1292,17 @@
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
+
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -1300,6 +1321,8 @@
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -1383,7 +1406,7 @@
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -1401,6 +1424,8 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
+
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
@@ -1411,7 +1436,7 @@
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
-    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
@@ -1488,6 +1513,8 @@
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -1579,9 +1606,15 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ink": ["ink@5.2.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^7.0.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.22.0", "indent-string": "^5.0.0", "is-in-ci": "^1.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^7.2.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg=="],
+
+    "ink-testing-library": ["ink-testing-library@4.0.0", "", { "peerDependencies": { "@types/react": ">=18.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q=="],
+
+    "ink-text-input": ["ink-text-input@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "type-fest": "^4.18.2" }, "peerDependencies": { "ink": ">=5", "react": ">=18" } }, "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -1603,9 +1636,11 @@
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ci": ["is-in-ci@1.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg=="],
 
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
@@ -1637,7 +1672,7 @@
 
     "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
-    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -1690,6 +1725,8 @@
     "long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@11.3.2", "", {}, "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ=="],
 
@@ -1829,6 +1866,8 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
@@ -1933,6 +1972,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
     "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.5", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ=="],
@@ -1970,6 +2011,8 @@
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
@@ -2033,11 +2076,13 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
-    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-reconciler": ["react-reconciler@0.29.2", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg=="],
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
@@ -2109,6 +2154,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
     "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
 
     "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
@@ -2131,7 +2178,7 @@
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
-    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
@@ -2165,11 +2212,13 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
+    "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
@@ -2197,6 +2246,8 @@
 
     "sqlite-vec-windows-x64": ["sqlite-vec-windows-x64@0.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q=="],
 
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "starlight-links-validator": ["starlight-links-validator@0.23.0", "", { "dependencies": { "@types/picomatch": "^4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "is-absolute-url": "^5.0.0", "mdast-util-mdx-jsx": "^3.2.0", "mdast-util-to-hast": "^13.2.1", "picomatch": "^4.0.3", "terminal-link": "^5.0.0", "unist-util-visit": "^5.1.0", "yaml": "^2.8.3" }, "peerDependencies": { "@astrojs/starlight": ">=0.38.0", "astro": ">=6.0.0" } }, "sha512-dpKJdNv170+jyw8HDgPKGIW/MnXUxa3v8RqJrER47jx4fbxvLsITIw0/Y76xzTTrDv8LhQ7t/ExFutUDQqm3FQ=="],
@@ -2207,11 +2258,11 @@
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
@@ -2274,6 +2325,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -2399,7 +2452,9 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -2426,6 +2481,8 @@
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -2455,8 +2512,6 @@
 
     "@astrojs/mdx/@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.8.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ=="],
 
-    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -2467,11 +2522,19 @@
 
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "@nimbus/ui/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@nimbus/ui/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@sindresorhus/slugify/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "@sindresorhus/transliterate/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -2489,17 +2552,31 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "@types/react-dom/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
+
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -2513,15 +2590,29 @@
 
     "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "react-dom/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2531,11 +2622,11 @@
 
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
@@ -2583,6 +2674,14 @@
 
     "@expressive-code/plugin-shiki/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
+    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -2590,6 +2689,12 @@
     "sitemap/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@a2a-js/sdk/express/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
@@ -2604,6 +2709,8 @@
     "@a2a-js/sdk/express/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
     "@a2a-js/sdk/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@a2a-js/sdk/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,6 +2,12 @@
 
 Complete reference for all `nimbus` commands. For installation see [`README.md`](./README.md). For architecture context see [`architecture.md`](./architecture.md).
 
+**Three ways to use Nimbus interactively:**
+
+- [`nimbus tui`](#nimbus-tui) — rich Ink terminal UI (5 panes, streaming result, inline mid-stream HITL, live connector + watcher + sub-task panes). Auto-falls back to the REPL on unsuitable terminals.
+- [`nimbus repl`](#nimbus-repl) — line-based readline loop for scripts, SSH, CI, and other headless environments. `nimbus` with no arguments on an interactive shell is an alias.
+- `nimbus <command>` — one-shot commands documented below (`ask`, `search`, `query`, `run`, `status`, `doctor`, `diag`, …).
+
 ---
 
 ## Global Flags

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -78,6 +78,8 @@ nimbus ask "Summarise everything that happened across my projects this week"
 nimbus                          # Opens interactive session
 ```
 
+For a richer interactive experience — live connector health, sub-task progress bars, inline mid-stream HITL consent — use [`nimbus tui`](#nimbus-tui) instead.
+
 ---
 
 ### `nimbus search`
@@ -180,6 +182,73 @@ nimbus sync all
 nimbus sync github
 nimbus sync google_drive
 ```
+
+---
+
+## Interactive Sessions
+
+### `nimbus tui`
+
+Launch the rich Ink terminal UI for interactive sessions.
+
+```bash
+nimbus tui
+```
+
+**Panes** (Option-1 "classic split" layout):
+
+- **Query input** (top bar) — type a query; `Enter` submits.
+- **Result stream** (main area) — tokens render live; scrollback preserved via Ink `<Static>` so prior output never re-renders.
+- **Connector health** (right column) — polls `connector.list` every 30 s; renders `●` / `◐` / `○` glyphs for `ok` / `degraded` / `down`.
+- **Watchers** (right column) — polls `watcher.list` every 30 s; shows N active, M firing, plus up to 5 firing watcher names (truncates beyond with `…N more`).
+- **Sub-tasks** (right column) — event-driven via `agent.subTaskProgress`; renders a progress bar + status glyph per sub-task, truncated beyond 8 rows with `…N more (M total)`. Clears when a new query is submitted.
+
+**Interaction:**
+
+- `Up` / `Down` cycles history from `tui-query-history.json` (last 100 queries, dedup-on-repeat-of-last).
+- `Ctrl+C` once during a stream → cancels locally with `(canceled by user — LLM may continue in the background)` line; `^C Press again within 2s to exit` hint renders for 1.5 s. Double `Ctrl+C` within 2 s → exits cleanly.
+- **Mid-stream HITL:** `──[ consent required ]──` banner appears inline; prompt switches to `nimbus[hitl]>` with single-keystroke capture:
+  - `a` — approve current action
+  - `r` — reject current action
+  - `d` — show details (no-op in v0.1.0; full payload is already shown)
+  - `q` — reject all remaining actions and exit
+
+**Automatic fallback** (invokes `nimbus repl` instead, no Ink render) when any of these hold:
+
+- `TERM=dumb`
+- `NO_COLOR` set (any value)
+- stdout is not a TTY (pipe, file, non-interactive shell)
+- `CI=true`
+- Terminal height is below 20 rows
+
+Fallback path prints exactly one reason (first match wins) to stderr before handing off to the REPL.
+
+**Responsive layout:**
+
+- Below 100 columns: collapses to a single-column layout with a compact status bar replacing the right column.
+- Below 20 rows at any time: Ink unmounts cleanly with a one-line notice; relaunch after resizing.
+
+**Gateway-offline behavior:**
+
+- Top banner: `⚠ Gateway disconnected — reconnecting…`
+- Poll panes show last-known data with a `(stale)` marker.
+- Input dimmed and disabled; `Ctrl+C` still exits.
+- Exponential reconnect: 2 s → 4 s → 8 s → 16 s → 30 s (repeats). Input re-enables on reconnect; `✓ Reconnected` fade confirms recovery.
+
+**Cancel note (v0.1.0):** cancel is local-only — the Gateway has no `engine.cancelStream` handler yet, so the LLM may continue generating in the background after `Ctrl+C`. Full-fidelity cancellation is a post-v0.1.0 Gateway follow-up.
+
+---
+
+### `nimbus repl`
+
+Line-based readline loop over `agent.invoke`. Always works (no Ink dependency), including SSH sessions, dumb terminals, CI, and non-TTY pipelines.
+
+```bash
+nimbus repl                      # Interactive line-based session
+nimbus repl --session <id>       # Resume a saved session
+```
+
+Use this for scripts and headless environments; `nimbus tui` is the richer alternative for interactive developer sessions. `nimbus tui`'s fallback path invokes `runRepl` internally on unsuitable terminals, so you never need to choose manually — just run `nimbus tui` and let it degrade.
 
 ---
 

--- a/docs/manual-smoke-ws6.md
+++ b/docs/manual-smoke-ws6.md
@@ -1,0 +1,130 @@
+# WS6 Manual Smoke — Rich TUI
+
+**Executed on all three platforms before flipping WS6 to ✅ in `CLAUDE.md`.**
+
+Record actual observations inline in each section. If a platform blocks on an item, link to the tracking issue and mark the row 🚧.
+
+---
+
+## Test environment
+
+| Platform | Terminal | Notes |
+|---|---|---|
+| Windows 11 | Windows Terminal | |
+| macOS (Intel + ARM) | Terminal.app, iTerm2 | |
+| Linux (Ubuntu 22.04 + Fedora 40) | gnome-terminal, alacritty | |
+
+Each platform runs through every section below.
+
+---
+
+## 1. Launch
+
+Start a fresh gateway: `nimbus start`
+
+Then: `nimbus tui`
+
+- [ ] Ink renders the 5-pane layout at default terminal size.
+- [ ] No stack traces on stdout/stderr.
+- [ ] `paths.logDir/cli-<date>.log` records `cli.invoke` with `argv=["nimbus","tui"]`. The log file contains **no raw ANSI escape sequences or render fragments** (they must go only to the terminal, never to the file).
+
+## 2. Streaming
+
+Submit: `summarize my week from the last 100 commits` (or any prompt that triggers ≥ 20s generation).
+
+- [ ] Tokens render continuously in `ResultStream` without flicker.
+- [ ] Prior lines (e.g., the `nimbus> …` entry for this query) **do not re-render** mid-stream (observable: cursor position of prior text stays stable).
+- [ ] `engine.streamDone` flushes the live buffer into the static block; the next `nimbus>` prompt is immediately usable.
+
+## 3. Inline HITL
+
+Submit a query that triggers consent — e.g., `send a summary of my week to slack #general` (configure a workflow that requires consent if one is not already present).
+
+- [ ] `──[ consent required ]──` banner appears mid-stream.
+- [ ] Prompt changes to `nimbus[hitl]>` with the `[a]pprove [r]eject [d]etails [q]uit` hint.
+- [ ] Pressing `a` advances; for a multi-action batch, `(2 of N)` counter updates.
+- [ ] Outcome line (`✓ approved all` / `✗ rejected all` / `✓ approved N, ✗ rejected M`) prints and flushes into `<Static>`.
+- [ ] `consent.respond` is called **once** per batch with the full decisions array.
+
+## 4. Unsuitable-terminal fallback
+
+Each variant prints the fallback notice and enters the REPL; terminal is left sane on REPL exit.
+
+- [ ] `TERM=dumb nimbus tui`
+- [ ] `NO_COLOR=1 nimbus tui`
+- [ ] `nimbus tui < /dev/null` (non-TTY stdin)
+- [ ] `CI=true nimbus tui`
+- [ ] `stty rows 10 && nimbus tui` (then `stty rows 40` to restore)
+
+## 5. Gateway death
+
+Launch `nimbus tui` in one terminal; `nimbus stop` in another.
+
+- [ ] Disconnect banner appears within ≤ 30 s (sub-second during active stream).
+- [ ] Input dimmed + disabled; Ctrl+C still exits.
+- [ ] `(stale)` marker on poll-data panes.
+- [ ] `nimbus start`, observe reconnect: `✓ Reconnected` fade; input re-enables.
+
+## 6. Narrow-terminal collapse
+
+Resize the terminal below 100 columns (e.g., `stty columns 80`) while TUI is running.
+
+- [ ] Layout collapses to single-column with status bar at the bottom.
+- [ ] Resize to 120: layout restores to the 5-pane split.
+
+## 7. Short-terminal runtime drop
+
+Resize the terminal to fewer than 20 rows while TUI is running.
+
+- [ ] One-line notice prints; Ink unmounts; exit code 0.
+- [ ] Terminal cursor/colors restored; prompt returns.
+
+## 8. Cancel semantics
+
+Submit a long query. When tokens start arriving:
+
+- [ ] Single Ctrl+C → state flips to idle; `(canceled by user — LLM may continue in the background)` line appended; `^C Press again within 2s to exit` hint visible for ~1.5 s.
+- [ ] Second Ctrl+C within 2 s → exits cleanly.
+- [ ] Relaunch; idle Ctrl+C → hint visible; second Ctrl+C → exit.
+
+## 9. Signal handling (Linux + macOS only)
+
+In one terminal: `nimbus tui`. In another: look up PID then:
+
+- [ ] `kill -INT <pid>` → terminal restored, exit code 130.
+- [ ] Relaunch; `kill -TERM <pid>` → terminal restored, exit code 143.
+- [ ] `paths.logDir/cli-<date>.log` flushed in both cases.
+
+(Windows: SIGINT equivalent only via Ctrl+C — covered in §8.)
+
+## 10. Paste safety
+
+Paste a 5-paragraph prompt (~2 KB of text with newlines) into `QueryInput`.
+
+- [ ] Input does not expand vertically; single-line with horizontal scroll remains visible.
+- [ ] Right-column panes do not shift or misalign.
+- [ ] Pressing Enter submits the full content; the `ResultStream` query-echo line shows the full text (even if only the current viewport scrolls within the input).
+- [ ] Record the exact pasted-newline behavior from `ink-text-input` on each platform — this is a "document what happens" step, not a pass/fail.
+
+## 11. Low-color-terminal readability
+
+On Linux: `TERM=xterm nimbus tui` (forces 16-color). On macOS/Windows: equivalent minimal-TERM setting for your terminal.
+
+- [ ] ●/◐/○ glyphs remain visible and distinguishable.
+- [ ] Yellow banners (disconnect, HITL, cancel hint) render in a readable color (Ink maps `color="yellow"` to a 16-color palette entry).
+- [ ] `dimColor` text is still distinguishable from normal text.
+- [ ] If readability is noticeably degraded, file a follow-up issue — do NOT block WS6 on this. Spec §10 mitigation is a post-ship monochrome fallback if user feedback asks.
+
+---
+
+## Results
+
+| Platform | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Windows 11 | | | | | | | | | n/a | | |
+| macOS x64 | | | | | | | | | | | |
+| macOS arm64 | | | | | | | | | | | |
+| Linux (Ubuntu) | | | | | | | | | | | |
+| Linux (Fedora) | | | | | | | | | | | |
+
+Legend: ✅ passed, 🚧 blocked (link issue), ⚠ passed with caveat (describe inline).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -342,7 +342,7 @@ First-party demonstrations of multi-agent orchestration and multi-connector cont
 
 ### Terminal Power Users
 
-- [ ] **Rich TUI** (Ink-based) — builds on the Phase 3 Session CLI; pane layout: query input, result stream, connector health sidebar, active watcher list; keyboard navigation; SSH-safe; real-time inline HITL consent; `nimbus tui` command; also launchable from system tray
+- [x] **Rich TUI** (Ink-based) `v0.1.0` — builds on the Phase 3 Session CLI; pane layout: query input, result stream, connector health sidebar, active watcher list; keyboard navigation; SSH-safe; real-time inline HITL consent; `nimbus tui` command; also launchable from system tray
 
 ### Voice Interface
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test:coverage:health": "bun test packages/gateway/test/unit/connectors/health.test.ts --coverage --coverage-threshold-lines=85",
     "test:coverage:doctor": "bun test packages/cli/src/commands/doctor*.test.ts --coverage --coverage-threshold-lines=80",
     "test:coverage:mcp": "bun test packages/mcp-connectors --coverage --coverage-threshold-lines=70",
+    "test:coverage:tui": "bun test packages/cli/src/tui/ --coverage --coverage-threshold-lines=80",
     "test:coverage:updater": "bun test packages/gateway/src/updater packages/gateway/src/ipc/updater-rpc.test.ts --coverage --coverage-threshold-lines=80",
     "test:coverage:lan": "bun test packages/gateway/src/ipc/lan-crypto.test.ts packages/gateway/src/ipc/lan-pairing.test.ts packages/gateway/src/ipc/lan-rate-limit.test.ts packages/gateway/src/ipc/lan-rpc.test.ts packages/gateway/src/ipc/lan-server.test.ts packages/gateway/test/integration/lan/ --coverage --coverage-threshold-lines=80",
     "test:coverage:sdk": "bun test packages/sdk --coverage --coverage-threshold-lines=80",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,10 +19,15 @@
     "@clack/prompts": "^1.2.0",
     "@nimbus-dev/client": "workspace:*",
     "@nimbus-dev/sdk": "workspace:*",
+    "ink": "^5.2.1",
+    "ink-text-input": "^6.0.0",
     "pino": "^10.3.1",
+    "react": "^18.3.1",
     "yaml": "^2.8.0"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@types/react": "^18.3.12",
+    "ink-testing-library": "^4.0.0"
   }
 }

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -9,6 +9,7 @@ Usage:
   nimbus diag [--json] | diag slow-queries [--limit N] [--since 7d]
   nimbus query --service <id> [--type <t>] [--since 7d] [--sql "SELECT …"] [--json | --pretty]
   nimbus telemetry show | disable
+  nimbus tui                Rich Ink TUI (falls back to REPL on dumb terminals).
   nimbus doctor             Bun version, data dir, Linux vault (secret-tool), gateway state + IPC
   nimbus config validate | list | edit
   nimbus profile create|list|switch|delete

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -27,6 +27,7 @@ export { runStatus } from "./status.ts";
 export { runStop } from "./stop.ts";
 export { runTelemetry } from "./telemetry.ts";
 export { runTest } from "./test.ts";
+export { runTui } from "./tui.tsx";
 export { runUpdate } from "./update.ts";
 export { runVault } from "./vault.ts";
 export { runWatch } from "./watch.ts";

--- a/packages/cli/src/commands/tui.tsx
+++ b/packages/cli/src/commands/tui.tsx
@@ -1,0 +1,87 @@
+import { render as inkRender } from "ink";
+
+import { IPCClient } from "../ipc-client/index.ts";
+import { createCliFileLogger } from "../lib/cli-logger.ts";
+import { readGatewayState } from "../lib/gateway-process.ts";
+import { getCliPlatformPaths } from "../paths.ts";
+import { App } from "../tui/App.tsx";
+import { currentFallbackEnv, detectFallbackReason } from "../tui/detect-fallback.ts";
+import { IpcContext } from "../tui/ipc-context.ts";
+import { runRepl } from "./repl.ts";
+
+function printFallback(reason: string): void {
+  process.stderr.write(`Unsuitable terminal detected (${reason}) — falling back to REPL.\n`);
+}
+
+export async function runTui(args: string[]): Promise<void> {
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "nimbus tui — rich Ink TUI for interactive sessions.\n" +
+        "Falls back to `nimbus repl` on unsuitable terminals (TERM=dumb, NO_COLOR, non-TTY, CI=true, height<20).\n" +
+        "No flags.\n",
+    );
+    return;
+  }
+
+  const paths = getCliPlatformPaths();
+  const state = await readGatewayState(paths);
+  if (state === undefined) {
+    process.stderr.write("Gateway is not running. Start with: nimbus start\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  const reason = detectFallbackReason(currentFallbackEnv());
+  if (reason !== null) {
+    printFallback(reason);
+    await runRepl(args);
+    return;
+  }
+
+  const { logger } = await createCliFileLogger(paths);
+  const client = new IPCClient(state.socketPath);
+  await client.connect();
+
+  const historyPath = `${paths.dataDir}/tui-query-history.json`;
+
+  let exited = false;
+  const cleanup = async (): Promise<void> => {
+    if (exited) {
+      return;
+    }
+    exited = true;
+    try {
+      await client.disconnect();
+    } catch {
+      // best-effort
+    }
+  };
+
+  const handleSignal = (signal: NodeJS.Signals): void => {
+    void cleanup().then(() => {
+      const code = signal === "SIGTERM" ? 143 : 130;
+      process.exit(code);
+    });
+  };
+  process.on("SIGINT", handleSignal);
+  process.on("SIGTERM", handleSignal);
+  process.on("exit", () => {
+    void cleanup();
+  });
+
+  const ink = inkRender(
+    <IpcContext.Provider value={{ client, logger }}>
+      <App
+        historyPath={historyPath}
+        onExit={() => {
+          ink.unmount();
+          void cleanup().then(() => {
+            process.exit(0);
+          });
+        }}
+      />
+    </IpcContext.Provider>,
+  );
+  await ink.waitUntilExit();
+  await cleanup();
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,6 +31,7 @@ import {
   runStop,
   runTelemetry,
   runTest,
+  runTui,
   runUpdate,
   runVault,
   runWatch,
@@ -80,6 +81,9 @@ async function main(): Promise<void> {
           break;
         case "telemetry":
           await runTelemetry(args);
+          break;
+        case "tui":
+          await runTui(args);
           break;
         case "update":
           await runUpdate(args);

--- a/packages/cli/src/tui/App.test.tsx
+++ b/packages/cli/src/tui/App.test.tsx
@@ -1,29 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { render } from "ink-testing-library";
 
 import { App } from "./App.tsx";
-import { IpcContext, type IpcContextValue } from "./ipc-context.ts";
+import { IpcContext } from "./ipc-context.ts";
+import { ipcContextFor, makeHistoryPath } from "./test-helpers/context.ts";
 import { StubIpcClient } from "./test-helpers/stub-client.ts";
-
-function makeHistoryPath(): string {
-  const dir = mkdtempSync(join(tmpdir(), "nimbus-tui-app-"));
-  return join(dir, "hist.json");
-}
-
-function ctx(stub: StubIpcClient): IpcContextValue {
-  return {
-    client: stub.asClient(),
-    logger: {
-      debug: () => undefined,
-      info: () => undefined,
-      warn: () => undefined,
-      error: () => undefined,
-    } as unknown as IpcContextValue["logger"],
-  };
-}
 
 function setupStub(): StubIpcClient {
   return new StubIpcClient({
@@ -35,67 +16,77 @@ function setupStub(): StubIpcClient {
   });
 }
 
+/** Standard App render + cleanup lifecycle; returns the render handles and a teardown fn. */
+function renderApp(stub: StubIpcClient): {
+  readonly stdin: ReturnType<typeof render>["stdin"];
+  readonly lastFrame: ReturnType<typeof render>["lastFrame"];
+  readonly teardown: () => void;
+} {
+  const history = makeHistoryPath("nimbus-tui-app-");
+  const ink = render(
+    <IpcContext.Provider value={ipcContextFor(stub)}>
+      <App historyPath={history.path} onExit={() => undefined} />
+    </IpcContext.Provider>,
+  );
+  return {
+    stdin: ink.stdin,
+    lastFrame: ink.lastFrame,
+    teardown: () => {
+      ink.unmount();
+      history.cleanup();
+    },
+  };
+}
+
+const SETTLE_MS = 20;
+const SUBMIT_SETTLE_MS = 60;
+
+async function settle(ms = SETTLE_MS): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
 describe("App state machine", () => {
   test("idle → streaming on submit", async () => {
     const stub = setupStub();
-    const historyPath = makeHistoryPath();
-    const { stdin, lastFrame, unmount } = render(
-      <IpcContext.Provider value={ctx(stub)}>
-        <App historyPath={historyPath} onExit={() => undefined} />
-      </IpcContext.Provider>,
-    );
-    await new Promise((r) => setTimeout(r, 20));
+    const { stdin, lastFrame, teardown } = renderApp(stub);
+    await settle();
     stdin.write("hello");
     stdin.write("\r");
-    await new Promise((r) => setTimeout(r, 60));
+    await settle(SUBMIT_SETTLE_MS);
     expect(stub.calls.some((c) => c.method === "engine.askStream")).toBe(true);
-    const frame = lastFrame() ?? "";
-    expect(frame).toContain("hello");
-    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
-    unmount();
+    expect(lastFrame() ?? "").toContain("hello");
+    teardown();
   });
 
   test("streaming → idle on engine.streamDone", async () => {
     const stub = setupStub();
-    const historyPath = makeHistoryPath();
-    const { stdin, lastFrame, unmount } = render(
-      <IpcContext.Provider value={ctx(stub)}>
-        <App historyPath={historyPath} onExit={() => undefined} />
-      </IpcContext.Provider>,
-    );
-    await new Promise((r) => setTimeout(r, 20));
+    const { stdin, lastFrame, teardown } = renderApp(stub);
+    await settle();
     stdin.write("hi");
     stdin.write("\r");
-    await new Promise((r) => setTimeout(r, 60));
+    await settle(SUBMIT_SETTLE_MS);
     stub.emit("engine.streamToken", { streamId: "s-test", text: "response" });
     stub.emit("engine.streamDone", { streamId: "s-test" });
-    await new Promise((r) => setTimeout(r, 60));
+    await settle(SUBMIT_SETTLE_MS);
     const frame = lastFrame() ?? "";
     expect(frame).toContain("response");
     expect(frame).toContain("nimbus>");
-    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
-    unmount();
+    teardown();
   });
 
   test("engine.streamError appends an error line and returns to idle", async () => {
     const stub = setupStub();
-    const historyPath = makeHistoryPath();
-    const { stdin, lastFrame, unmount } = render(
-      <IpcContext.Provider value={ctx(stub)}>
-        <App historyPath={historyPath} onExit={() => undefined} />
-      </IpcContext.Provider>,
-    );
-    await new Promise((r) => setTimeout(r, 20));
+    const { stdin, lastFrame, teardown } = renderApp(stub);
+    await settle();
     stdin.write("oops");
     stdin.write("\r");
-    await new Promise((r) => setTimeout(r, 60));
+    await settle(SUBMIT_SETTLE_MS);
     stub.emit("engine.streamError", { streamId: "s-test", error: "downstream failed" });
-    await new Promise((r) => setTimeout(r, 60));
+    await settle(SUBMIT_SETTLE_MS);
     const frame = lastFrame() ?? "";
     expect(frame).toContain("downstream failed");
     expect(frame).toContain("❌");
-    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
-    unmount();
+    teardown();
   });
 
   test("disconnect banner appears when an IPC call throws ECONNRESET", async () => {
@@ -103,18 +94,12 @@ describe("App state machine", () => {
       errors: { "engine.askStream": new Error("ECONNRESET") },
       results: { "connector.list": [], "watcher.list": [] },
     });
-    const historyPath = makeHistoryPath();
-    const { stdin, lastFrame, unmount } = render(
-      <IpcContext.Provider value={ctx(stub)}>
-        <App historyPath={historyPath} onExit={() => undefined} />
-      </IpcContext.Provider>,
-    );
-    await new Promise((r) => setTimeout(r, 20));
+    const { stdin, lastFrame, teardown } = renderApp(stub);
+    await settle();
     stdin.write("hi");
     stdin.write("\r");
-    await new Promise((r) => setTimeout(r, 60));
+    await settle(SUBMIT_SETTLE_MS);
     expect(lastFrame() ?? "").toContain("Gateway disconnected");
-    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
-    unmount();
+    teardown();
   });
 });

--- a/packages/cli/src/tui/App.test.tsx
+++ b/packages/cli/src/tui/App.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { render } from "ink-testing-library";
+
+import { App } from "./App.tsx";
+import { IpcContext, type IpcContextValue } from "./ipc-context.ts";
+import { StubIpcClient } from "./test-helpers/stub-client.ts";
+
+function makeHistoryPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-tui-app-"));
+  return join(dir, "hist.json");
+}
+
+function ctx(stub: StubIpcClient): IpcContextValue {
+  return {
+    client: stub.asClient(),
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    } as unknown as IpcContextValue["logger"],
+  };
+}
+
+function setupStub(): StubIpcClient {
+  return new StubIpcClient({
+    results: {
+      "connector.list": [],
+      "watcher.list": [],
+      "engine.askStream": { streamId: "s-test" },
+    },
+  });
+}
+
+describe("App state machine", () => {
+  test("idle → streaming on submit", async () => {
+    const stub = setupStub();
+    const historyPath = makeHistoryPath();
+    const { stdin, lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <App historyPath={historyPath} onExit={() => undefined} />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("hello");
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 60));
+    expect(stub.calls.some((c) => c.method === "engine.askStream")).toBe(true);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("hello");
+    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
+    unmount();
+  });
+
+  test("streaming → idle on engine.streamDone", async () => {
+    const stub = setupStub();
+    const historyPath = makeHistoryPath();
+    const { stdin, lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <App historyPath={historyPath} onExit={() => undefined} />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("hi");
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 60));
+    stub.emit("engine.streamToken", { streamId: "s-test", text: "response" });
+    stub.emit("engine.streamDone", { streamId: "s-test" });
+    await new Promise((r) => setTimeout(r, 60));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("response");
+    expect(frame).toContain("nimbus>");
+    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
+    unmount();
+  });
+
+  test("engine.streamError appends an error line and returns to idle", async () => {
+    const stub = setupStub();
+    const historyPath = makeHistoryPath();
+    const { stdin, lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <App historyPath={historyPath} onExit={() => undefined} />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("oops");
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 60));
+    stub.emit("engine.streamError", { streamId: "s-test", error: "downstream failed" });
+    await new Promise((r) => setTimeout(r, 60));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("downstream failed");
+    expect(frame).toContain("❌");
+    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
+    unmount();
+  });
+
+  test("disconnect banner appears when an IPC call throws ECONNRESET", async () => {
+    const stub = new StubIpcClient({
+      errors: { "engine.askStream": new Error("ECONNRESET") },
+      results: { "connector.list": [], "watcher.list": [] },
+    });
+    const historyPath = makeHistoryPath();
+    const { stdin, lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <App historyPath={historyPath} onExit={() => undefined} />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("hi");
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 60));
+    expect(lastFrame() ?? "").toContain("Gateway disconnected");
+    rmSync(historyPath.replace(/[/\\][^/\\]+$/, ""), { recursive: true, force: true });
+    unmount();
+  });
+});

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -1,0 +1,328 @@
+import { Box, Text, useStdout } from "ink";
+import React from "react";
+
+import { ConnectorHealth } from "./ConnectorHealth.tsx";
+import {
+  CANCEL_HINT_DURATION_MS,
+  DOUBLE_CTRL_C_WINDOW_MS,
+  MIN_HEIGHT_THRESHOLD,
+  NARROW_LAYOUT_COLUMN_THRESHOLD,
+  RECONNECT_BACKOFF_MS,
+} from "./constants.ts";
+import { useIpc } from "./ipc-context.ts";
+import { QueryInput } from "./QueryInput.tsx";
+import { ResultStream, type ResultStreamEntry } from "./ResultStream.tsx";
+import { SubTaskPane } from "./SubTaskPane.tsx";
+import type { HitlRequest } from "./state.ts";
+import { initialTuiState, tuiReducer } from "./state.ts";
+import { WatcherPane } from "./WatcherPane.tsx";
+
+interface Props {
+  historyPath: string;
+  onExit: () => void;
+}
+
+function isStreamTokenPayload(p: unknown): p is { streamId: string; text: string } {
+  if (typeof p !== "object" || p === null) {
+    return false;
+  }
+  const v = p as Record<string, unknown>;
+  return typeof v["streamId"] === "string" && typeof v["text"] === "string";
+}
+
+function isStreamDonePayload(p: unknown): p is { streamId: string } {
+  if (typeof p !== "object" || p === null) {
+    return false;
+  }
+  const v = p as Record<string, unknown>;
+  return typeof v["streamId"] === "string";
+}
+
+function isStreamErrorPayload(p: unknown): p is { streamId: string; error: string } {
+  if (typeof p !== "object" || p === null) {
+    return false;
+  }
+  const v = p as Record<string, unknown>;
+  return typeof v["streamId"] === "string" && typeof v["error"] === "string";
+}
+
+function isHitlBatchPayload(p: unknown): p is { batchId: string; requests: HitlRequest[] } {
+  if (typeof p !== "object" || p === null) {
+    return false;
+  }
+  const v = p as Record<string, unknown>;
+  if (typeof v["batchId"] !== "string") {
+    return false;
+  }
+  if (!Array.isArray(v["requests"])) {
+    return false;
+  }
+  return v["requests"].every((r) => {
+    if (typeof r !== "object" || r === null) {
+      return false;
+    }
+    const rr = r as Record<string, unknown>;
+    return typeof rr["actionId"] === "string" && typeof rr["action"] === "string";
+  });
+}
+
+function formatHitlBanner(batch: NonNullable<ReturnType<typeof tuiReducer>["hitlBatch"]>): string {
+  const req = batch.requests[batch.cursor];
+  if (req === undefined) {
+    return "";
+  }
+  const body = JSON.stringify(req.params, null, 2);
+  const indented = body
+    .split("\n")
+    .map((l) => `  ${l}`)
+    .join("\n");
+  return (
+    "──[ consent required ]──\n" +
+    `Action: ${req.action}\n` +
+    `${indented}\n` +
+    `(${String(batch.cursor + 1)} of ${String(batch.requests.length)} pending)`
+  );
+}
+
+export function App({ historyPath, onExit }: Props): React.JSX.Element {
+  const { client, logger } = useIpc();
+  const [state, dispatch] = React.useReducer(tuiReducer, initialTuiState);
+  const [entries, setEntries] = React.useState<ResultStreamEntry[]>([]);
+  const [clearKey, setClearKey] = React.useState(0);
+  const { stdout } = useStdout();
+  const [cols, setCols] = React.useState(stdout.columns ?? 120);
+  const [rows, setRows] = React.useState(stdout.rows ?? 40);
+  const [showCancelHint, setShowCancelHint] = React.useState(false);
+  const lastCtrlCRef = React.useRef<number>(0);
+  const reconnectAttemptRef = React.useRef(0);
+
+  // Install notification handlers once.
+  React.useEffect(() => {
+    client.onNotification("engine.streamToken", (p) => {
+      if (isStreamTokenPayload(p)) {
+        dispatch({ type: "stream-token", streamId: p.streamId, text: p.text });
+      }
+    });
+    client.onNotification("engine.streamDone", (p) => {
+      if (isStreamDonePayload(p)) {
+        dispatch({ type: "stream-done", streamId: p.streamId });
+      }
+    });
+    client.onNotification("engine.streamError", (p) => {
+      if (isStreamErrorPayload(p)) {
+        dispatch({ type: "stream-error", streamId: p.streamId, error: p.error });
+      }
+    });
+    client.onNotification("agent.hitlBatch", (p) => {
+      if (isHitlBatchPayload(p)) {
+        dispatch({ type: "hitl-requested", batchId: p.batchId, requests: p.requests });
+      }
+    });
+  }, [client]);
+
+  // Flush live buffer into <Static> when stream ends.
+  const prevModeRef = React.useRef(state.mode);
+  React.useEffect(() => {
+    const prev = prevModeRef.current;
+    prevModeRef.current = state.mode;
+    if (prev === "streaming" && state.mode === "idle") {
+      if (state.liveBuffer !== "") {
+        const text = state.liveBuffer;
+        const isError = state.lastError !== null;
+        setEntries((e) => [...e, isError ? { kind: "error", text } : { kind: "reply", text }]);
+      } else if (state.lastError !== null) {
+        setEntries((e) => [...e, { kind: "error", text: state.lastError as string }]);
+      }
+      dispatch({ type: "flush-live" });
+    }
+  }, [state.mode, state.liveBuffer, state.lastError]);
+
+  // Resize handling.
+  React.useEffect(() => {
+    const onResize = (): void => {
+      setCols(stdout.columns ?? 120);
+      setRows(stdout.rows ?? 40);
+    };
+    (stdout as { on: (e: string, cb: () => void) => void }).on("resize", onResize);
+    return () => {
+      (stdout as { off: (e: string, cb: () => void) => void }).off("resize", onResize);
+    };
+  }, [stdout]);
+
+  // Short-terminal runtime drop.
+  React.useEffect(() => {
+    if (rows === 0) {
+      return;
+    }
+    if (rows < MIN_HEIGHT_THRESHOLD) {
+      logger.info({ event: "tui.short-terminal-exit", rows }, "exiting for short terminal");
+      onExit();
+    }
+  }, [rows, logger, onExit]);
+
+  // Reconnect loop on disconnect.
+  React.useEffect(() => {
+    if (state.mode !== "disconnected") {
+      reconnectAttemptRef.current = 0;
+      return undefined;
+    }
+    let cancelled = false;
+    const attempt = async (): Promise<void> => {
+      if (cancelled) {
+        return;
+      }
+      const delay =
+        RECONNECT_BACKOFF_MS[
+          Math.min(reconnectAttemptRef.current, RECONNECT_BACKOFF_MS.length - 1)
+        ] ?? 30_000;
+      await new Promise((r) => setTimeout(r, delay));
+      if (cancelled) {
+        return;
+      }
+      try {
+        await client.connect();
+        dispatch({ type: "reconnect" });
+      } catch {
+        reconnectAttemptRef.current += 1;
+        void attempt();
+      }
+    };
+    void attempt();
+    return () => {
+      cancelled = true;
+    };
+  }, [state.mode, client]);
+
+  const handleSubmit = async (query: string): Promise<void> => {
+    setEntries((e) => [...e, { kind: "query", text: query }]);
+    setClearKey((k) => k + 1);
+    try {
+      const res = await client.call<{ streamId: string }>("engine.askStream", {
+        input: query,
+      });
+      dispatch({ type: "submit", streamId: res.streamId, query });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.debug({ event: "tui.submit.error", err: msg }, "submit failed");
+      dispatch({ type: "disconnect" });
+    }
+  };
+
+  const handleHitlKey = (key: string): void => {
+    if (state.hitlBatch === null) {
+      return;
+    }
+    if (key === "a" || key === "r") {
+      dispatch({ type: "hitl-advance", approved: key === "a" });
+    } else if (key === "d") {
+      // formatHitlBanner already renders the full payload JSON-pretty
+      // without truncation, so 'd' is effectively a no-op in v0.1.0.
+    } else if (key === "q") {
+      void client
+        .call("consent.respond", {
+          batchId: state.hitlBatch.batchId,
+          decisions: state.hitlBatch.requests.map((r) => ({
+            actionId: r.actionId,
+            approved: false,
+          })),
+        })
+        .catch(() => undefined);
+      onExit();
+    }
+  };
+
+  // When cursor equals request count, send the full decision array and resolve.
+  React.useEffect(() => {
+    if (state.hitlBatch === null) {
+      return;
+    }
+    const { batchId, requests, cursor, decisions } = state.hitlBatch;
+    if (cursor >= requests.length) {
+      const approved = decisions.filter((d) => d.approved).length;
+      const rejected = decisions.length - approved;
+      const outcome =
+        rejected === 0
+          ? "✓ approved all"
+          : approved === 0
+            ? "✗ rejected all"
+            : `✓ approved ${String(approved)}, ✗ rejected ${String(rejected)}`;
+      setEntries((e) => [...e, { kind: "hitl-outcome", text: outcome }]);
+      void client.call("consent.respond", { batchId, decisions }).catch((err) => {
+        logger.debug({ event: "tui.consent.error", err: String(err) }, "consent failed");
+      });
+      dispatch({ type: "hitl-resolve" });
+    }
+  }, [state.hitlBatch, client, logger]);
+
+  const handleCancelKey = (): void => {
+    const now = Date.now();
+    if (now - lastCtrlCRef.current < DOUBLE_CTRL_C_WINDOW_MS) {
+      logger.debug({ event: "tui.cancel.exit" }, "double Ctrl+C — exiting");
+      onExit();
+      return;
+    }
+    lastCtrlCRef.current = now;
+    if (state.mode === "streaming") {
+      logger.debug(
+        { event: "tui.cancel.local", streamId: state.activeStreamId },
+        "local-only cancel (engine.cancelStream not implemented — LLM may continue)",
+      );
+      dispatch({ type: "cancel" });
+      setEntries((e) => [
+        ...e,
+        {
+          kind: "error",
+          text: "(canceled by user — LLM may continue in the background)",
+        },
+      ]);
+    }
+    setShowCancelHint(true);
+    setTimeout(() => {
+      setShowCancelHint(false);
+    }, CANCEL_HINT_DURATION_MS);
+  };
+
+  const hitlBanner = state.hitlBatch === null ? null : formatHitlBanner(state.hitlBatch);
+
+  const narrow = cols < NARROW_LAYOUT_COLUMN_THRESHOLD;
+  const disconnected = state.mode === "disconnected";
+
+  return (
+    <Box flexDirection="column">
+      {disconnected ? (
+        <Text color="yellow">⚠ Gateway disconnected — reconnecting… (press Ctrl+C to exit)</Text>
+      ) : null}
+      <QueryInput
+        mode={state.mode}
+        historyPath={historyPath}
+        onSubmit={(q) => {
+          void handleSubmit(q);
+        }}
+        onHitlKey={handleHitlKey}
+        onCancelKey={handleCancelKey}
+        showCancelHint={showCancelHint}
+      />
+      {narrow ? (
+        <Box flexDirection="column">
+          <ResultStream entries={entries} liveBuffer={state.liveBuffer} hitlBanner={hitlBanner} />
+          <Box>
+            <ConnectorHealth mode={state.mode} />
+            <WatcherPane mode={state.mode} />
+            <SubTaskPane clearKey={clearKey} />
+          </Box>
+        </Box>
+      ) : (
+        <Box flexDirection="row">
+          <Box flexDirection="column" flexGrow={1}>
+            <ResultStream entries={entries} liveBuffer={state.liveBuffer} hitlBanner={hitlBanner} />
+          </Box>
+          <Box flexDirection="column" width={30}>
+            <ConnectorHealth mode={state.mode} />
+            <WatcherPane mode={state.mode} />
+            <SubTaskPane clearKey={clearKey} />
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -18,8 +18,18 @@ import { initialTuiState, tuiReducer } from "./state.ts";
 import { WatcherPane } from "./WatcherPane.tsx";
 
 interface Props {
-  historyPath: string;
-  onExit: () => void;
+  readonly historyPath: string;
+  readonly onExit: () => void;
+}
+
+function formatHitlOutcome(approved: number, rejected: number): string {
+  if (rejected === 0) {
+    return "✓ approved all";
+  }
+  if (approved === 0) {
+    return "✗ rejected all";
+  }
+  return `✓ approved ${String(approved)}, ✗ rejected ${String(rejected)}`;
 }
 
 function isStreamTokenPayload(p: unknown): p is { streamId: string; text: string } {
@@ -240,12 +250,7 @@ export function App({ historyPath, onExit }: Props): React.JSX.Element {
     if (cursor >= requests.length) {
       const approved = decisions.filter((d) => d.approved).length;
       const rejected = decisions.length - approved;
-      const outcome =
-        rejected === 0
-          ? "✓ approved all"
-          : approved === 0
-            ? "✗ rejected all"
-            : `✓ approved ${String(approved)}, ✗ rejected ${String(rejected)}`;
+      const outcome = formatHitlOutcome(approved, rejected);
       setEntries((e) => [...e, { kind: "hitl-outcome", text: outcome }]);
       void client.call("consent.respond", { batchId, decisions }).catch((err) => {
         logger.debug({ event: "tui.consent.error", err: String(err) }, "consent failed");

--- a/packages/cli/src/tui/ConnectorHealth.test.tsx
+++ b/packages/cli/src/tui/ConnectorHealth.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+
+import { ConnectorHealth } from "./ConnectorHealth.tsx";
+import { IpcContext, type IpcContextValue } from "./ipc-context.ts";
+import { StubIpcClient } from "./test-helpers/stub-client.ts";
+
+function ctx(client: StubIpcClient): IpcContextValue {
+  return {
+    client: client.asClient(),
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    } as unknown as IpcContextValue["logger"],
+  };
+}
+
+describe("ConnectorHealth", () => {
+  test("renders a line per connector with a status glyph", async () => {
+    const stub = new StubIpcClient({
+      results: {
+        "connector.list": [
+          { service: "github", status: "ok" },
+          { service: "slack", status: "degraded" },
+          { service: "notion", status: "down" },
+        ],
+      },
+    });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <ConnectorHealth mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("github");
+    expect(frame).toContain("slack");
+    expect(frame).toContain("notion");
+    expect(frame).toContain("●"); // ok
+    expect(frame).toContain("◐"); // degraded
+    expect(frame).toContain("○"); // down
+    unmount();
+  });
+
+  test("prefixes degraded with ⚠", async () => {
+    const stub = new StubIpcClient({
+      results: { "connector.list": [{ service: "slack", status: "degraded" }] },
+    });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <ConnectorHealth mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastFrame() ?? "").toContain("⚠");
+    unmount();
+  });
+
+  test("shows (stale) marker in the title when disconnected", async () => {
+    const stub = new StubIpcClient({ results: { "connector.list": [] } });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <ConnectorHealth mode="disconnected" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastFrame() ?? "").toContain("(stale)");
+    unmount();
+  });
+
+  test("shows loading state before first poll response", () => {
+    const stub = new StubIpcClient({ results: { "connector.list": [] } });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <ConnectorHealth mode="idle" />
+      </IpcContext.Provider>,
+    );
+    expect(lastFrame() ?? "").toContain("Connectors");
+    unmount();
+  });
+});

--- a/packages/cli/src/tui/ConnectorHealth.tsx
+++ b/packages/cli/src/tui/ConnectorHealth.tsx
@@ -1,0 +1,58 @@
+import { Box, Text } from "ink";
+import type React from "react";
+
+import { STATUS_POLL_INTERVAL_MS } from "./constants.ts";
+import type { TuiMode } from "./state.ts";
+import { useIpcPoll } from "./useIpcPoll.ts";
+
+interface ConnectorRow {
+  service: string;
+  status: "ok" | "degraded" | "down";
+}
+
+function isConnectorRow(row: unknown): row is ConnectorRow {
+  if (typeof row !== "object" || row === null) {
+    return false;
+  }
+  const r = row as Record<string, unknown>;
+  return (
+    typeof r["service"] === "string" &&
+    (r["status"] === "ok" || r["status"] === "degraded" || r["status"] === "down")
+  );
+}
+
+function isConnectorList(data: unknown): data is ConnectorRow[] {
+  return Array.isArray(data) && data.every(isConnectorRow);
+}
+
+function glyph(status: ConnectorRow["status"]): string {
+  if (status === "ok") {
+    return "●";
+  }
+  if (status === "degraded") {
+    return "◐";
+  }
+  return "○";
+}
+
+export function ConnectorHealth({ mode }: { mode: TuiMode }): React.JSX.Element {
+  const poll = useIpcPoll<unknown>("connector.list", STATUS_POLL_INTERVAL_MS, mode);
+  const rows = isConnectorList(poll.data) ? poll.data : [];
+  return (
+    <Box flexDirection="column">
+      <Text bold>Connectors{poll.stale ? " (stale)" : ""}</Text>
+      {poll.data === null && rows.length === 0 ? (
+        <Text dimColor>loading…</Text>
+      ) : rows.length === 0 ? (
+        <Text dimColor>(none)</Text>
+      ) : (
+        rows.map((r) => (
+          <Text key={r.service}>
+            {r.status === "degraded" ? "⚠ " : "  "}
+            {glyph(r.status)} {r.service}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/ConnectorHealth.tsx
+++ b/packages/cli/src/tui/ConnectorHealth.tsx
@@ -35,24 +35,39 @@ function glyph(status: ConnectorRow["status"]): string {
   return "○";
 }
 
-export function ConnectorHealth({ mode }: { mode: TuiMode }): React.JSX.Element {
+interface ConnectorHealthProps {
+  readonly mode: TuiMode;
+}
+
+function renderBody(
+  poll: ReturnType<typeof useIpcPoll<unknown>>,
+  rows: ConnectorRow[],
+): React.JSX.Element {
+  if (poll.data === null && rows.length === 0) {
+    return <Text dimColor>loading…</Text>;
+  }
+  if (rows.length === 0) {
+    return <Text dimColor>(none)</Text>;
+  }
+  return (
+    <>
+      {rows.map((r) => (
+        <Text key={r.service}>
+          {r.status === "degraded" ? "⚠ " : "  "}
+          {glyph(r.status)} {r.service}
+        </Text>
+      ))}
+    </>
+  );
+}
+
+export function ConnectorHealth({ mode }: ConnectorHealthProps): React.JSX.Element {
   const poll = useIpcPoll<unknown>("connector.list", STATUS_POLL_INTERVAL_MS, mode);
   const rows = isConnectorList(poll.data) ? poll.data : [];
   return (
     <Box flexDirection="column">
       <Text bold>Connectors{poll.stale ? " (stale)" : ""}</Text>
-      {poll.data === null && rows.length === 0 ? (
-        <Text dimColor>loading…</Text>
-      ) : rows.length === 0 ? (
-        <Text dimColor>(none)</Text>
-      ) : (
-        rows.map((r) => (
-          <Text key={r.service}>
-            {r.status === "degraded" ? "⚠ " : "  "}
-            {glyph(r.status)} {r.service}
-          </Text>
-        ))
-      )}
+      {renderBody(poll, rows)}
     </Box>
   );
 }

--- a/packages/cli/src/tui/QueryInput.test.tsx
+++ b/packages/cli/src/tui/QueryInput.test.tsx
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { render } from "ink-testing-library";
+import { QueryInput } from "./QueryInput.tsx";
+
+let tmpDir: string;
+let historyPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "nimbus-tui-qi-"));
+  historyPath = join(tmpDir, "tui-query-history.json");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("QueryInput — basic", () => {
+  test("renders the nimbus> prompt when idle", () => {
+    const { lastFrame, unmount } = render(
+      <QueryInput
+        mode="idle"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("nimbus>");
+    unmount();
+  });
+
+  test("calls onSubmit with the trimmed text on Enter", async () => {
+    let submitted: string | null = null;
+    const { stdin, unmount } = render(
+      <QueryInput
+        mode="idle"
+        historyPath={historyPath}
+        onSubmit={(q) => {
+          submitted = q;
+        }}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    stdin.write("hello");
+    stdin.write("\r"); // Enter
+    await new Promise((r) => setTimeout(r, 20));
+    expect(submitted).toBe("hello");
+    unmount();
+  });
+
+  test("dimmed when mode is streaming", () => {
+    const { lastFrame, unmount } = render(
+      <QueryInput
+        mode="streaming"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("nimbus>");
+    unmount();
+  });
+});
+
+describe("QueryInput — HITL mode", () => {
+  test("renders nimbus[hitl]> prompt when awaiting-hitl", () => {
+    const { lastFrame, unmount } = render(
+      <QueryInput
+        mode="awaiting-hitl"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("nimbus[hitl]>");
+    unmount();
+  });
+
+  test("forwards single keystrokes to onHitlKey while awaiting-hitl", async () => {
+    const received: string[] = [];
+    const { stdin, unmount } = render(
+      <QueryInput
+        mode="awaiting-hitl"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={(k) => received.push(k)}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    stdin.write("a");
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("r");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(received).toContain("a");
+    expect(received).toContain("r");
+    unmount();
+  });
+});
+
+describe("QueryInput — cancel hint", () => {
+  test("renders the hint when showCancelHint is true", () => {
+    const { lastFrame, unmount } = render(
+      <QueryInput
+        mode="streaming"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={true}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("Press again within 2s to exit");
+    unmount();
+  });
+
+  test("does not render the hint when showCancelHint is false", () => {
+    const { lastFrame, unmount } = render(
+      <QueryInput
+        mode="streaming"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    expect(lastFrame() ?? "").not.toContain("Press again within 2s to exit");
+    unmount();
+  });
+});
+
+describe("QueryInput — Ctrl+C dispatch", () => {
+  test("Ctrl+C in idle calls onCancelKey", async () => {
+    let fired = false;
+    const { stdin, unmount } = render(
+      <QueryInput
+        mode="idle"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => {
+          fired = true;
+        }}
+        showCancelHint={false}
+      />,
+    );
+    stdin.write("\x03"); // Ctrl+C
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fired).toBe(true);
+    unmount();
+  });
+});
+
+describe("QueryInput — history cycling", () => {
+  test("Up cycles to oldest entry and stops", async () => {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(historyPath, JSON.stringify({ entries: ["one", "two", "three"] }));
+
+    let lastSubmitted: string | null = null;
+    const { stdin, lastFrame, unmount } = render(
+      <QueryInput
+        mode="idle"
+        historyPath={historyPath}
+        onSubmit={(q) => {
+          lastSubmitted = q;
+        }}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("\x1B[A"); // Up
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("three");
+    stdin.write("\x1B[A");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("two");
+    stdin.write("\x1B[A");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("one");
+    stdin.write("\x1B[A"); // already at top
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("one");
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastSubmitted).toBe("one");
+    unmount();
+  });
+
+  test("Down past the bottom returns to empty draft", async () => {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(historyPath, JSON.stringify({ entries: ["one"] }));
+    const { stdin, lastFrame, unmount } = render(
+      <QueryInput
+        mode="idle"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("\x1B[A");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("one");
+    stdin.write("\x1B[B"); // Down
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").not.toContain("one");
+    unmount();
+  });
+
+  test("submit appends to history without mutating prior entries mid-cycle", async () => {
+    const { readFileSync, writeFileSync } = await import("node:fs");
+    writeFileSync(historyPath, JSON.stringify({ entries: ["old"] }));
+    const { stdin, unmount } = render(
+      <QueryInput
+        mode="idle"
+        historyPath={historyPath}
+        onSubmit={() => undefined}
+        onHitlKey={() => undefined}
+        onCancelKey={() => undefined}
+        showCancelHint={false}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("new");
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 30));
+    const parsed = JSON.parse(readFileSync(historyPath, "utf-8")) as { entries: string[] };
+    expect(parsed.entries).toEqual(["old", "new"]);
+    unmount();
+  });
+});

--- a/packages/cli/src/tui/QueryInput.tsx
+++ b/packages/cli/src/tui/QueryInput.tsx
@@ -5,139 +5,187 @@ import { appendQuery, readHistory } from "./query-history.ts";
 import type { TuiMode } from "./state.ts";
 
 interface Props {
-  mode: TuiMode;
-  historyPath: string;
-  onSubmit: (query: string) => void;
-  onHitlKey: (key: string) => void;
-  onCancelKey: () => void;
-  showCancelHint: boolean;
+  readonly mode: TuiMode;
+  readonly historyPath: string;
+  readonly onSubmit: (query: string) => void;
+  readonly onHitlKey: (key: string) => void;
+  readonly onCancelKey: () => void;
+  readonly showCancelHint: boolean;
+}
+
+/**
+ * Mutable context bundled into one object so per-keystroke handlers take
+ * two parameters (context + position) instead of a long parameter list.
+ */
+interface ProcessContext {
+  readonly bufRef: React.MutableRefObject<string>;
+  readonly histCursorRef: React.MutableRefObject<number | null>;
+  readonly historyRef: React.MutableRefObject<string[]>;
+  readonly historyPathRef: React.MutableRefObject<string>;
+  readonly inHitlRef: React.MutableRefObject<boolean>;
+  readonly disabledRef: React.MutableRefObject<boolean>;
+  readonly onSubmit: (q: string) => void;
+  readonly onCancel: () => void;
+  readonly onHitlKey: (k: string) => void;
+  readonly forceRender: () => void;
+}
+
+const CSI_FINAL_MIN = 0x40;
+const CSI_FINAL_MAX = 0x7e;
+
+function isEditable(ctx: ProcessContext): boolean {
+  return !ctx.inHitlRef.current && !ctx.disabledRef.current;
+}
+
+/** Up arrow — step back to an older entry, clamp at the oldest. */
+function handleUp(ctx: ProcessContext): void {
+  if (!isEditable(ctx)) {
+    return;
+  }
+  const h = ctx.historyRef.current;
+  if (h.length === 0) {
+    return;
+  }
+  const cur = ctx.histCursorRef.current;
+  const next = cur === null ? h.length - 1 : Math.max(0, cur - 1);
+  ctx.histCursorRef.current = next;
+  ctx.bufRef.current = h[next] ?? "";
+  ctx.forceRender();
+}
+
+/** Down arrow — step forward through history, past the end back to empty. */
+function handleDown(ctx: ProcessContext): void {
+  if (!isEditable(ctx)) {
+    return;
+  }
+  const cur = ctx.histCursorRef.current;
+  if (cur === null) {
+    return;
+  }
+  const h = ctx.historyRef.current;
+  const next = cur + 1;
+  if (next >= h.length) {
+    ctx.histCursorRef.current = null;
+    ctx.bufRef.current = "";
+  } else {
+    ctx.histCursorRef.current = next;
+    ctx.bufRef.current = h[next] ?? "";
+  }
+  ctx.forceRender();
+}
+
+/**
+ * Advance past an ANSI CSI sequence, returning the new position.
+ * Up/Down are short-circuited by the caller; this handles everything else
+ * (right arrow, etc.) with a full CSI skip.
+ */
+function skipCsi(chunk: string, start: number): number {
+  let i = start;
+  while (i < chunk.length) {
+    const code = chunk.codePointAt(i) ?? 0;
+    i++;
+    if (code >= CSI_FINAL_MIN && code <= CSI_FINAL_MAX) {
+      return i;
+    }
+  }
+  return i;
+}
+
+/** Returns the new position after consuming the escape sequence. */
+function handleEscape(chunk: string, i: number, ctx: ProcessContext): number {
+  const three = chunk.slice(i, i + 3);
+  if (three === "\x1B[A") {
+    handleUp(ctx);
+    return i + 3;
+  }
+  if (three === "\x1B[B") {
+    handleDown(ctx);
+    return i + 3;
+  }
+  return skipCsi(chunk, i + 1);
+}
+
+/** Enter / Return — trim, submit, persist to history, reset buffer. */
+function handleSubmit(ctx: ProcessContext): void {
+  if (!isEditable(ctx)) {
+    return;
+  }
+  const trimmed = ctx.bufRef.current.trim();
+  if (trimmed === "") {
+    return;
+  }
+  void appendQuery(ctx.historyPathRef.current, trimmed).then(async () => {
+    ctx.historyRef.current = await readHistory(ctx.historyPathRef.current);
+  });
+  ctx.onSubmit(trimmed);
+  ctx.bufRef.current = "";
+  ctx.histCursorRef.current = null;
+  ctx.forceRender();
+}
+
+/** Backspace / Delete — trim one char off the end of the buffer. */
+function handleBackspace(ctx: ProcessContext): void {
+  if (!isEditable(ctx)) {
+    return;
+  }
+  ctx.bufRef.current = ctx.bufRef.current.slice(0, -1);
+  ctx.forceRender();
+}
+
+function isHitlKey(ch: string): boolean {
+  return ch === "a" || ch === "r" || ch === "d" || ch === "q";
+}
+
+/** Printable character — either forwards to HITL handler or appends to buffer. */
+function handlePrintable(ch: string, ctx: ProcessContext): void {
+  if (ctx.inHitlRef.current) {
+    if (isHitlKey(ch)) {
+      ctx.onHitlKey(ch);
+    }
+    return;
+  }
+  if (ctx.disabledRef.current) {
+    return;
+  }
+  ctx.bufRef.current += ch;
+  ctx.forceRender();
 }
 
 /**
  * Process a raw data chunk from stdin into individual actions.
  *
  * stdin.write() in ink-testing-library emits the entire string as one 'data'
- * event (e.g. "hello" is five characters in one chunk). We iterate the
- * string ourselves, handling multi-character escape sequences, control
- * characters, and printable text.
+ * event (e.g. "hello" is five characters in one chunk), so this function
+ * iterates the chunk and dispatches each keystroke to its specific handler.
  */
-function processChunk(
-  chunk: string,
-  bufRef: React.MutableRefObject<string>,
-  histCursorRef: React.MutableRefObject<number | null>,
-  historyRef: React.MutableRefObject<string[]>,
-  inHitlRef: React.MutableRefObject<boolean>,
-  disabledRef: React.MutableRefObject<boolean>,
-  onSubmit: (q: string) => void,
-  onCancel: () => void,
-  onHitlKey: (k: string) => void,
-  historyPathRef: React.MutableRefObject<string>,
-  forceRender: () => void,
-): void {
+function processChunk(chunk: string, ctx: ProcessContext): void {
   let i = 0;
   while (i < chunk.length) {
-    // ── Escape sequences ───────────────────────────────────────────────────
     if (chunk[i] === "\x1b") {
-      const three = chunk.slice(i, i + 3);
-      if (three === "\x1B[A") {
-        // Up arrow
-        i += 3;
-        if (!inHitlRef.current && !disabledRef.current) {
-          const h = historyRef.current;
-          if (h.length > 0) {
-            const cur = histCursorRef.current;
-            const next = cur === null ? h.length - 1 : Math.max(0, cur - 1);
-            histCursorRef.current = next;
-            bufRef.current = h[next] ?? "";
-            forceRender();
-          }
-        }
-        continue;
-      }
-      if (three === "\x1B[B") {
-        // Down arrow
-        i += 3;
-        if (!inHitlRef.current && !disabledRef.current) {
-          const h = historyRef.current;
-          const cur = histCursorRef.current;
-          if (cur !== null) {
-            const next = cur + 1;
-            if (next >= h.length) {
-              histCursorRef.current = null;
-              bufRef.current = "";
-            } else {
-              histCursorRef.current = next;
-              bufRef.current = h[next] ?? "";
-            }
-            forceRender();
-          }
-        }
-        continue;
-      }
-      // Skip other escape sequences (e.g. \x1b[C for right arrow)
-      i++;
-      while (i < chunk.length) {
-        const c = chunk.charCodeAt(i);
-        i++;
-        // Final byte of a CSI sequence is 0x40–0x7E
-        if (c >= 0x40 && c <= 0x7e) {
-          break;
-        }
-      }
+      i = handleEscape(chunk, i, ctx);
       continue;
     }
 
     const ch = chunk[i] ?? "";
     i++;
 
-    // ── Ctrl+C ─────────────────────────────────────────────────────────────
     if (ch === "\x03") {
-      onCancel();
+      ctx.onCancel();
       continue;
     }
-
-    // ── Enter / Return ─────────────────────────────────────────────────────
     if (ch === "\r" || ch === "\n") {
-      if (!inHitlRef.current && !disabledRef.current) {
-        const trimmed = bufRef.current.trim();
-        if (trimmed !== "") {
-          void appendQuery(historyPathRef.current, trimmed).then(() => {
-            void readHistory(historyPathRef.current).then((entries) => {
-              historyRef.current = entries;
-            });
-          });
-          onSubmit(trimmed);
-          bufRef.current = "";
-          histCursorRef.current = null;
-          forceRender();
-        }
-      }
+      handleSubmit(ctx);
       continue;
     }
-
-    // ── Backspace / Delete ─────────────────────────────────────────────────
     if (ch === "\x7f" || ch === "\x08") {
-      if (!inHitlRef.current && !disabledRef.current) {
-        bufRef.current = bufRef.current.slice(0, -1);
-        forceRender();
-      }
+      handleBackspace(ctx);
       continue;
     }
-
-    // ── Other control characters ───────────────────────────────────────────
-    if (ch.charCodeAt(0) < 32) {
+    // Skip any other control characters.
+    if ((ch.codePointAt(0) ?? 0) < 32) {
       continue;
     }
-
-    // ── Printable character ────────────────────────────────────────────────
-    if (inHitlRef.current) {
-      if (ch === "a" || ch === "r" || ch === "d" || ch === "q") {
-        onHitlKey(ch);
-      }
-    } else if (!disabledRef.current) {
-      bufRef.current += ch;
-      forceRender();
-    }
+    handlePrintable(ch, ctx);
   }
 }
 
@@ -152,7 +200,7 @@ export function QueryInput(props: Props): React.JSX.Element {
   const historyRef = React.useRef<string[]>([]);
   const [, forceRender] = React.useReducer((n: number) => n + 1, 0);
 
-  // Stable refs so the data handler never captures stale closures
+  // Stable refs so the data handler never captures stale closures.
   const inHitlRef = React.useRef(mode === "awaiting-hitl");
   const disabledRef = React.useRef(mode === "streaming" || mode === "disconnected");
   const historyPathRef = React.useRef(historyPath);
@@ -167,7 +215,7 @@ export function QueryInput(props: Props): React.JSX.Element {
   onHitlKeyRef.current = onHitlKey;
   onCancelKeyRef.current = onCancelKey;
 
-  // Load history from file (async; populates historyRef before first Up press)
+  // Load history from file (async; populates historyRef before first Up press).
   React.useEffect(() => {
     void readHistory(historyPath).then((entries) => {
       historyRef.current = entries;
@@ -180,19 +228,19 @@ export function QueryInput(props: Props): React.JSX.Element {
   // listener is installed before the test's first stdin.write() fires.
   React.useLayoutEffect(() => {
     const handler = (data: unknown): void => {
-      processChunk(
-        String(data),
+      const ctx: ProcessContext = {
         bufRef,
         histCursorRef,
         historyRef,
+        historyPathRef,
         inHitlRef,
         disabledRef,
-        onSubmitRef.current,
-        onCancelKeyRef.current,
-        onHitlKeyRef.current,
-        historyPathRef,
+        onSubmit: onSubmitRef.current,
+        onCancel: onCancelKeyRef.current,
+        onHitlKey: onHitlKeyRef.current,
         forceRender,
-      );
+      };
+      processChunk(String(data), ctx);
     };
     stdin?.on("data", handler);
     return () => {

--- a/packages/cli/src/tui/QueryInput.tsx
+++ b/packages/cli/src/tui/QueryInput.tsx
@@ -1,0 +1,221 @@
+import { Box, Text, useStdin } from "ink";
+import React from "react";
+
+import { appendQuery, readHistory } from "./query-history.ts";
+import type { TuiMode } from "./state.ts";
+
+interface Props {
+  mode: TuiMode;
+  historyPath: string;
+  onSubmit: (query: string) => void;
+  onHitlKey: (key: string) => void;
+  onCancelKey: () => void;
+  showCancelHint: boolean;
+}
+
+/**
+ * Process a raw data chunk from stdin into individual actions.
+ *
+ * stdin.write() in ink-testing-library emits the entire string as one 'data'
+ * event (e.g. "hello" is five characters in one chunk). We iterate the
+ * string ourselves, handling multi-character escape sequences, control
+ * characters, and printable text.
+ */
+function processChunk(
+  chunk: string,
+  bufRef: React.MutableRefObject<string>,
+  histCursorRef: React.MutableRefObject<number | null>,
+  historyRef: React.MutableRefObject<string[]>,
+  inHitlRef: React.MutableRefObject<boolean>,
+  disabledRef: React.MutableRefObject<boolean>,
+  onSubmit: (q: string) => void,
+  onCancel: () => void,
+  onHitlKey: (k: string) => void,
+  historyPathRef: React.MutableRefObject<string>,
+  forceRender: () => void,
+): void {
+  let i = 0;
+  while (i < chunk.length) {
+    // ── Escape sequences ───────────────────────────────────────────────────
+    if (chunk[i] === "\x1b") {
+      const three = chunk.slice(i, i + 3);
+      if (three === "\x1B[A") {
+        // Up arrow
+        i += 3;
+        if (!inHitlRef.current && !disabledRef.current) {
+          const h = historyRef.current;
+          if (h.length > 0) {
+            const cur = histCursorRef.current;
+            const next = cur === null ? h.length - 1 : Math.max(0, cur - 1);
+            histCursorRef.current = next;
+            bufRef.current = h[next] ?? "";
+            forceRender();
+          }
+        }
+        continue;
+      }
+      if (three === "\x1B[B") {
+        // Down arrow
+        i += 3;
+        if (!inHitlRef.current && !disabledRef.current) {
+          const h = historyRef.current;
+          const cur = histCursorRef.current;
+          if (cur !== null) {
+            const next = cur + 1;
+            if (next >= h.length) {
+              histCursorRef.current = null;
+              bufRef.current = "";
+            } else {
+              histCursorRef.current = next;
+              bufRef.current = h[next] ?? "";
+            }
+            forceRender();
+          }
+        }
+        continue;
+      }
+      // Skip other escape sequences (e.g. \x1b[C for right arrow)
+      i++;
+      while (i < chunk.length) {
+        const c = chunk.charCodeAt(i);
+        i++;
+        // Final byte of a CSI sequence is 0x40–0x7E
+        if (c >= 0x40 && c <= 0x7e) {
+          break;
+        }
+      }
+      continue;
+    }
+
+    const ch = chunk[i] ?? "";
+    i++;
+
+    // ── Ctrl+C ─────────────────────────────────────────────────────────────
+    if (ch === "\x03") {
+      onCancel();
+      continue;
+    }
+
+    // ── Enter / Return ─────────────────────────────────────────────────────
+    if (ch === "\r" || ch === "\n") {
+      if (!inHitlRef.current && !disabledRef.current) {
+        const trimmed = bufRef.current.trim();
+        if (trimmed !== "") {
+          void appendQuery(historyPathRef.current, trimmed).then(() => {
+            void readHistory(historyPathRef.current).then((entries) => {
+              historyRef.current = entries;
+            });
+          });
+          onSubmit(trimmed);
+          bufRef.current = "";
+          histCursorRef.current = null;
+          forceRender();
+        }
+      }
+      continue;
+    }
+
+    // ── Backspace / Delete ─────────────────────────────────────────────────
+    if (ch === "\x7f" || ch === "\x08") {
+      if (!inHitlRef.current && !disabledRef.current) {
+        bufRef.current = bufRef.current.slice(0, -1);
+        forceRender();
+      }
+      continue;
+    }
+
+    // ── Other control characters ───────────────────────────────────────────
+    if (ch.charCodeAt(0) < 32) {
+      continue;
+    }
+
+    // ── Printable character ────────────────────────────────────────────────
+    if (inHitlRef.current) {
+      if (ch === "a" || ch === "r" || ch === "d" || ch === "q") {
+        onHitlKey(ch);
+      }
+    } else if (!disabledRef.current) {
+      bufRef.current += ch;
+      forceRender();
+    }
+  }
+}
+
+export function QueryInput(props: Props): React.JSX.Element {
+  const { mode, historyPath, onSubmit, onHitlKey, onCancelKey, showCancelHint } = props;
+
+  // Mutable buffer — updated synchronously inside the data handler so that
+  // consecutive stdin.write() calls in tests (e.g. "hello" then "\r") see
+  // the correct value without waiting for a React state flush.
+  const bufRef = React.useRef("");
+  const histCursorRef = React.useRef<number | null>(null);
+  const historyRef = React.useRef<string[]>([]);
+  const [, forceRender] = React.useReducer((n: number) => n + 1, 0);
+
+  // Stable refs so the data handler never captures stale closures
+  const inHitlRef = React.useRef(mode === "awaiting-hitl");
+  const disabledRef = React.useRef(mode === "streaming" || mode === "disconnected");
+  const historyPathRef = React.useRef(historyPath);
+  const onSubmitRef = React.useRef(onSubmit);
+  const onHitlKeyRef = React.useRef(onHitlKey);
+  const onCancelKeyRef = React.useRef(onCancelKey);
+
+  inHitlRef.current = mode === "awaiting-hitl";
+  disabledRef.current = mode === "streaming" || mode === "disconnected";
+  historyPathRef.current = historyPath;
+  onSubmitRef.current = onSubmit;
+  onHitlKeyRef.current = onHitlKey;
+  onCancelKeyRef.current = onCancelKey;
+
+  // Load history from file (async; populates historyRef before first Up press)
+  React.useEffect(() => {
+    void readHistory(historyPath).then((entries) => {
+      historyRef.current = entries;
+    });
+  }, [historyPath]);
+
+  const { stdin } = useStdin();
+
+  // useLayoutEffect runs synchronously after each render, ensuring the 'data'
+  // listener is installed before the test's first stdin.write() fires.
+  React.useLayoutEffect(() => {
+    const handler = (data: unknown): void => {
+      processChunk(
+        String(data),
+        bufRef,
+        histCursorRef,
+        historyRef,
+        inHitlRef,
+        disabledRef,
+        onSubmitRef.current,
+        onCancelKeyRef.current,
+        onHitlKeyRef.current,
+        historyPathRef,
+        forceRender,
+      );
+    };
+    stdin?.on("data", handler);
+    return () => {
+      stdin?.off("data", handler);
+    };
+  }, [stdin]);
+
+  const inHitl = mode === "awaiting-hitl";
+  const disabled = mode === "streaming" || mode === "disconnected";
+  const promptText = inHitl ? "nimbus[hitl]>" : "nimbus>";
+  const displayValue = bufRef.current;
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        {disabled ? <Text color="gray">{promptText} </Text> : <Text>{promptText} </Text>}
+        {inHitl ? (
+          <Text dimColor>[a]pprove [r]eject [d]etails [q]uit</Text>
+        ) : (
+          <Text dimColor={disabled}>{displayValue}</Text>
+        )}
+      </Box>
+      {showCancelHint ? <Text color="yellow">^C Press again within 2s to exit</Text> : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/ResultStream.test.tsx
+++ b/packages/cli/src/tui/ResultStream.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+import type React from "react";
+
+import { ResultStream, type ResultStreamEntry } from "./ResultStream.tsx";
+
+function withEntries(entries: ResultStreamEntry[], liveBuffer: string): React.JSX.Element {
+  return <ResultStream entries={entries} liveBuffer={liveBuffer} hitlBanner={null} />;
+}
+
+describe("ResultStream", () => {
+  test("renders static entries and the live buffer", () => {
+    const entries: ResultStreamEntry[] = [
+      { kind: "query", text: "hello?" },
+      { kind: "reply", text: "hi there" },
+    ];
+    const { lastFrame, unmount } = render(withEntries(entries, "partial "));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("hello?");
+    expect(frame).toContain("hi there");
+    expect(frame).toContain("partial");
+    unmount();
+  });
+
+  test("renders ❌ prefix on error entries", () => {
+    const entries: ResultStreamEntry[] = [{ kind: "error", text: "boom" }];
+    const { lastFrame, unmount } = render(withEntries(entries, ""));
+    expect(lastFrame() ?? "").toContain("❌");
+    expect(lastFrame() ?? "").toContain("boom");
+    unmount();
+  });
+
+  test("renders nothing extra when liveBuffer is empty", () => {
+    const { lastFrame, unmount } = render(withEntries([], ""));
+    // Bare render; no crash, no stray placeholder.
+    expect(lastFrame() ?? "").not.toContain("undefined");
+    unmount();
+  });
+
+  test("renders a HITL banner block when provided", () => {
+    const banner =
+      "──[ consent required ]──\n" +
+      "Action: slack.postMessage\n" +
+      '  channel: "#general"\n' +
+      "(1 of 1 pending)";
+    const { lastFrame, unmount } = render(
+      <ResultStream entries={[]} liveBuffer="so far…" hitlBanner={banner} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("consent required");
+    expect(frame).toContain("slack.postMessage");
+    expect(frame).toContain("so far");
+    unmount();
+  });
+
+  test("query entry has nimbus> prefix", () => {
+    const entries: ResultStreamEntry[] = [{ kind: "query", text: "what time is it" }];
+    const { lastFrame, unmount } = render(withEntries(entries, ""));
+    expect(lastFrame() ?? "").toContain("nimbus> what time is it");
+    unmount();
+  });
+});

--- a/packages/cli/src/tui/ResultStream.tsx
+++ b/packages/cli/src/tui/ResultStream.tsx
@@ -1,0 +1,51 @@
+import { Box, Static, Text } from "ink";
+import type React from "react";
+
+export type ResultStreamEntry =
+  | { kind: "query"; text: string }
+  | { kind: "reply"; text: string }
+  | { kind: "error"; text: string }
+  | { kind: "hitl-outcome"; text: string };
+
+interface Props {
+  entries: ResultStreamEntry[];
+  liveBuffer: string;
+  hitlBanner: string | null;
+}
+
+function renderEntry(entry: ResultStreamEntry): React.JSX.Element {
+  if (entry.kind === "query") {
+    return (
+      <Text>
+        <Text dimColor>nimbus&gt;</Text> {entry.text}
+      </Text>
+    );
+  }
+  if (entry.kind === "reply") {
+    return <Text>{entry.text}</Text>;
+  }
+  if (entry.kind === "error") {
+    return <Text color="red">❌ {entry.text}</Text>;
+  }
+  return <Text color="yellow">{entry.text}</Text>;
+}
+
+export function ResultStream({ entries, liveBuffer, hitlBanner }: Props): React.JSX.Element {
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Static items={entries}>
+        {(entry, index) => <Box key={index}>{renderEntry(entry)}</Box>}
+      </Static>
+      {liveBuffer !== "" ? <Text>{liveBuffer}</Text> : null}
+      {hitlBanner !== null ? (
+        <Box flexDirection="column" marginTop={1}>
+          {hitlBanner.split("\n").map((line) => (
+            <Text key={`hitl-${line}`} color="yellow">
+              {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/ResultStream.tsx
+++ b/packages/cli/src/tui/ResultStream.tsx
@@ -8,9 +8,9 @@ export type ResultStreamEntry =
   | { kind: "hitl-outcome"; text: string };
 
 interface Props {
-  entries: ResultStreamEntry[];
-  liveBuffer: string;
-  hitlBanner: string | null;
+  readonly entries: ResultStreamEntry[];
+  readonly liveBuffer: string;
+  readonly hitlBanner: string | null;
 }
 
 function renderEntry(entry: ResultStreamEntry): React.JSX.Element {
@@ -36,8 +36,8 @@ export function ResultStream({ entries, liveBuffer, hitlBanner }: Props): React.
       <Static items={entries}>
         {(entry, index) => <Box key={index}>{renderEntry(entry)}</Box>}
       </Static>
-      {liveBuffer !== "" ? <Text>{liveBuffer}</Text> : null}
-      {hitlBanner !== null ? (
+      {liveBuffer === "" ? null : <Text>{liveBuffer}</Text>}
+      {hitlBanner === null ? null : (
         <Box flexDirection="column" marginTop={1}>
           {hitlBanner.split("\n").map((line) => (
             <Text key={`hitl-${line}`} color="yellow">
@@ -45,7 +45,7 @@ export function ResultStream({ entries, liveBuffer, hitlBanner }: Props): React.
             </Text>
           ))}
         </Box>
-      ) : null}
+      )}
     </Box>
   );
 }

--- a/packages/cli/src/tui/SubTaskPane.test.tsx
+++ b/packages/cli/src/tui/SubTaskPane.test.tsx
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+
+import { IpcContext, type IpcContextValue } from "./ipc-context.ts";
+import { SubTaskPane } from "./SubTaskPane.tsx";
+import { StubIpcClient } from "./test-helpers/stub-client.ts";
+
+function ctx(client: StubIpcClient): IpcContextValue {
+  return {
+    client: client.asClient(),
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    } as unknown as IpcContextValue["logger"],
+  };
+}
+
+describe("SubTaskPane", () => {
+  test("renders 'No active sub-tasks' when empty", () => {
+    const stub = new StubIpcClient();
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <SubTaskPane clearKey={0} />
+      </IpcContext.Provider>,
+    );
+    expect(lastFrame() ?? "").toContain("No active sub-tasks");
+    unmount();
+  });
+
+  test("renders a progress bar per sub-task on agent.subTaskProgress", async () => {
+    const stub = new StubIpcClient();
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <SubTaskPane clearKey={0} />
+      </IpcContext.Provider>,
+    );
+    stub.emit("agent.subTaskProgress", {
+      subTaskId: "t1",
+      name: "planner",
+      status: "running",
+      progress: 0.4,
+    });
+    stub.emit("agent.subTaskProgress", {
+      subTaskId: "t2",
+      name: "github-mcp",
+      status: "completed",
+      progress: 1.0,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("planner");
+    expect(frame).toContain("github-mcp");
+    expect(frame).toContain("[");
+    expect(frame).toContain("]");
+    unmount();
+  });
+
+  test("updates progress bar when the same sub-task emits a new progress value", async () => {
+    const stub = new StubIpcClient();
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <SubTaskPane clearKey={0} />
+      </IpcContext.Provider>,
+    );
+    stub.emit("agent.subTaskProgress", {
+      subTaskId: "t1",
+      name: "planner",
+      status: "running",
+      progress: 0.0,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    stub.emit("agent.subTaskProgress", {
+      subTaskId: "t1",
+      name: "planner",
+      status: "running",
+      progress: 1.0,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect((lastFrame() ?? "").match(/planner/g)?.length).toBe(1);
+    unmount();
+  });
+
+  test("clears when clearKey changes", async () => {
+    const stub = new StubIpcClient();
+    const { lastFrame, rerender, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <SubTaskPane clearKey={0} />
+      </IpcContext.Provider>,
+    );
+    stub.emit("agent.subTaskProgress", {
+      subTaskId: "t1",
+      name: "planner",
+      status: "running",
+      progress: 0.4,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("planner");
+    rerender(
+      <IpcContext.Provider value={ctx(stub)}>
+        <SubTaskPane clearKey={1} />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("No active sub-tasks");
+    unmount();
+  });
+
+  test("truncates beyond SUBTASK_PANE_ROW_LIMIT with a '…N more (M total)' summary", async () => {
+    const { SUBTASK_PANE_ROW_LIMIT } = await import("./constants.ts");
+    const stub = new StubIpcClient();
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <SubTaskPane clearKey={0} />
+      </IpcContext.Provider>,
+    );
+    const total = SUBTASK_PANE_ROW_LIMIT + 5;
+    for (let i = 0; i < total; i++) {
+      stub.emit("agent.subTaskProgress", {
+        subTaskId: `t${String(i)}`,
+        name: `task-${String(i)}`,
+        status: "running",
+        progress: 0.5,
+      });
+    }
+    await new Promise((r) => setTimeout(r, 20));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("task-0");
+    expect(frame).toContain(`task-${String(SUBTASK_PANE_ROW_LIMIT - 1)}`);
+    expect(frame).not.toContain(`task-${String(SUBTASK_PANE_ROW_LIMIT)}`);
+    expect(frame).toContain(`…5 more (${String(total)} total)`);
+    unmount();
+  });
+});

--- a/packages/cli/src/tui/SubTaskPane.test.tsx
+++ b/packages/cli/src/tui/SubTaskPane.test.tsx
@@ -46,7 +46,7 @@ describe("SubTaskPane", () => {
       subTaskId: "t2",
       name: "github-mcp",
       status: "completed",
-      progress: 1.0,
+      progress: 1,
     });
     await new Promise((r) => setTimeout(r, 10));
     const frame = lastFrame() ?? "";
@@ -68,14 +68,14 @@ describe("SubTaskPane", () => {
       subTaskId: "t1",
       name: "planner",
       status: "running",
-      progress: 0.0,
+      progress: 0,
     });
     await new Promise((r) => setTimeout(r, 10));
     stub.emit("agent.subTaskProgress", {
       subTaskId: "t1",
       name: "planner",
       status: "running",
-      progress: 1.0,
+      progress: 1,
     });
     await new Promise((r) => setTimeout(r, 10));
     expect((lastFrame() ?? "").match(/planner/g)?.length).toBe(1);

--- a/packages/cli/src/tui/SubTaskPane.tsx
+++ b/packages/cli/src/tui/SubTaskPane.tsx
@@ -1,0 +1,113 @@
+import { Box, Text } from "ink";
+import React from "react";
+
+import { PROGRESS_BAR_WIDTH, SUBTASK_PANE_ROW_LIMIT } from "./constants.ts";
+import { useIpc } from "./ipc-context.ts";
+
+interface SubTaskProgressPayload {
+  subTaskId: string;
+  name: string;
+  status: "pending" | "running" | "completed" | "failed" | "hitl_paused" | "skipped";
+  progress: number; // 0..1
+}
+
+function isSubTaskPayload(value: unknown): value is SubTaskProgressPayload {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  const okStatus =
+    v["status"] === "pending" ||
+    v["status"] === "running" ||
+    v["status"] === "completed" ||
+    v["status"] === "failed" ||
+    v["status"] === "hitl_paused" ||
+    v["status"] === "skipped";
+  return (
+    typeof v["subTaskId"] === "string" &&
+    typeof v["name"] === "string" &&
+    okStatus &&
+    typeof v["progress"] === "number"
+  );
+}
+
+function glyph(status: SubTaskProgressPayload["status"]): string {
+  if (status === "completed") {
+    return "✓";
+  }
+  if (status === "failed") {
+    return "✗";
+  }
+  if (status === "hitl_paused") {
+    return "⏸";
+  }
+  if (status === "skipped") {
+    return "·";
+  }
+  return "↻";
+}
+
+function progressBar(progress: number): string {
+  const clamped = Math.max(0, Math.min(1, progress));
+  const filled = Math.round(clamped * PROGRESS_BAR_WIDTH);
+  return `[${"=".repeat(filled)}${"-".repeat(PROGRESS_BAR_WIDTH - filled)}]`;
+}
+
+export function SubTaskPane({ clearKey }: { clearKey: number }): React.JSX.Element {
+  const { client } = useIpc();
+
+  // Use a ref as the mutable backing store so the notification handler always
+  // has the latest map without stale closures. State only drives re-renders.
+  const mapRef = React.useRef<Map<string, SubTaskProgressPayload>>(new Map());
+  const [, forceUpdate] = React.useReducer((n: number) => n + 1, 0);
+
+  // useLayoutEffect fires synchronously after the DOM commit, ensuring the
+  // handler is registered before any test code emits notifications after render().
+  // Also resets the map when clearKey changes (a new query was submitted).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: clearKey is a prop value used to trigger reset; mapRef mutation is intentional
+  React.useLayoutEffect(() => {
+    mapRef.current = new Map();
+    forceUpdate();
+  }, [clearKey]);
+
+  React.useLayoutEffect(() => {
+    const handler = (params: unknown): void => {
+      if (!isSubTaskPayload(params)) {
+        return;
+      }
+      mapRef.current.set(params.subTaskId, params);
+      forceUpdate();
+    };
+    client.onNotification("agent.subTaskProgress", handler);
+    // IPCClient has no off-notification API; handlers live for process lifetime.
+    // A SubTaskPane remount simply registers another handler; the stale one
+    // mutates the ref (harmless) and calls forceUpdate on the unmounted component
+    // (which React silently ignores).
+  }, [client]);
+
+  const ordered = Array.from(mapRef.current.values());
+  const shown = ordered.slice(0, SUBTASK_PANE_ROW_LIMIT);
+  const hidden = ordered.length - shown.length;
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Sub-Tasks</Text>
+      {ordered.length === 0 ? (
+        <Text dimColor>No active sub-tasks</Text>
+      ) : (
+        <>
+          {shown.map((t) => (
+            <Text key={t.subTaskId}>
+              {progressBar(t.progress)} {glyph(t.status)} {t.name}
+            </Text>
+          ))}
+          {hidden > 0 ? (
+            <Text dimColor>
+              …{String(hidden)} more ({String(ordered.length)} total)
+            </Text>
+          ) : null}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/SubTaskPane.tsx
+++ b/packages/cli/src/tui/SubTaskPane.tsx
@@ -53,7 +53,11 @@ function progressBar(progress: number): string {
   return `[${"=".repeat(filled)}${"-".repeat(PROGRESS_BAR_WIDTH - filled)}]`;
 }
 
-export function SubTaskPane({ clearKey }: { clearKey: number }): React.JSX.Element {
+interface SubTaskPaneProps {
+  readonly clearKey: number;
+}
+
+export function SubTaskPane({ clearKey }: SubTaskPaneProps): React.JSX.Element {
   const { client } = useIpc();
 
   // Use a ref as the mutable backing store so the notification handler always

--- a/packages/cli/src/tui/WatcherPane.test.tsx
+++ b/packages/cli/src/tui/WatcherPane.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+
+import { IpcContext, type IpcContextValue } from "./ipc-context.ts";
+import { StubIpcClient } from "./test-helpers/stub-client.ts";
+import { WatcherPane } from "./WatcherPane.tsx";
+
+function ctx(client: StubIpcClient): IpcContextValue {
+  return {
+    client: client.asClient(),
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    } as unknown as IpcContextValue["logger"],
+  };
+}
+
+describe("WatcherPane", () => {
+  test("renders summary: active and firing counts", async () => {
+    const stub = new StubIpcClient({
+      results: {
+        "watcher.list": [
+          { id: "w1", name: "one", active: true, firing: true },
+          { id: "w2", name: "two", active: true, firing: false },
+          { id: "w3", name: "three", active: false, firing: false },
+        ],
+      },
+    });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <WatcherPane mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("2 active");
+    expect(frame).toContain("1 firing");
+    unmount();
+  });
+
+  test("lists up to 5 firing watcher names, truncates beyond", async () => {
+    const rows = Array.from({ length: 7 }, (_, i) => ({
+      id: `w${String(i)}`,
+      name: `watcher-${String(i)}`,
+      active: true,
+      firing: true,
+    }));
+    const stub = new StubIpcClient({ results: { "watcher.list": rows } });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <WatcherPane mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("watcher-0");
+    expect(frame).toContain("watcher-4");
+    expect(frame).not.toContain("watcher-5");
+    expect(frame).toContain("…2 more");
+    unmount();
+  });
+
+  test("(stale) marker when disconnected", async () => {
+    const stub = new StubIpcClient({ results: { "watcher.list": [] } });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <WatcherPane mode="disconnected" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastFrame() ?? "").toContain("(stale)");
+    unmount();
+  });
+});

--- a/packages/cli/src/tui/WatcherPane.tsx
+++ b/packages/cli/src/tui/WatcherPane.tsx
@@ -29,7 +29,11 @@ function isWatcherList(data: unknown): data is WatcherRow[] {
   return Array.isArray(data) && data.every(isWatcherRow);
 }
 
-export function WatcherPane({ mode }: { mode: TuiMode }): React.JSX.Element {
+interface WatcherPaneProps {
+  readonly mode: TuiMode;
+}
+
+export function WatcherPane({ mode }: WatcherPaneProps): React.JSX.Element {
   const poll = useIpcPoll<unknown>("watcher.list", STATUS_POLL_INTERVAL_MS, mode);
   const rows = isWatcherList(poll.data) ? poll.data : [];
   const active = rows.filter((r) => r.active).length;

--- a/packages/cli/src/tui/WatcherPane.tsx
+++ b/packages/cli/src/tui/WatcherPane.tsx
@@ -1,0 +1,52 @@
+import { Box, Text } from "ink";
+import type React from "react";
+
+import { STATUS_POLL_INTERVAL_MS, WATCHER_PANE_NAME_LIMIT } from "./constants.ts";
+import type { TuiMode } from "./state.ts";
+import { useIpcPoll } from "./useIpcPoll.ts";
+
+interface WatcherRow {
+  id: string;
+  name: string;
+  active: boolean;
+  firing: boolean;
+}
+
+function isWatcherRow(row: unknown): row is WatcherRow {
+  if (typeof row !== "object" || row === null) {
+    return false;
+  }
+  const r = row as Record<string, unknown>;
+  return (
+    typeof r["id"] === "string" &&
+    typeof r["name"] === "string" &&
+    typeof r["active"] === "boolean" &&
+    typeof r["firing"] === "boolean"
+  );
+}
+
+function isWatcherList(data: unknown): data is WatcherRow[] {
+  return Array.isArray(data) && data.every(isWatcherRow);
+}
+
+export function WatcherPane({ mode }: { mode: TuiMode }): React.JSX.Element {
+  const poll = useIpcPoll<unknown>("watcher.list", STATUS_POLL_INTERVAL_MS, mode);
+  const rows = isWatcherList(poll.data) ? poll.data : [];
+  const active = rows.filter((r) => r.active).length;
+  const firing = rows.filter((r) => r.firing);
+  const shown = firing.slice(0, WATCHER_PANE_NAME_LIMIT);
+  const extra = firing.length - shown.length;
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Watchers{poll.stale ? " (stale)" : ""}</Text>
+      <Text>
+        {String(active)} active, {String(firing.length)} firing
+      </Text>
+      {shown.map((w) => (
+        <Text key={w.id}>• {w.name}</Text>
+      ))}
+      {extra > 0 ? <Text dimColor>…{String(extra)} more</Text> : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/constants.ts
+++ b/packages/cli/src/tui/constants.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared tuning constants for the Nimbus Rich TUI.
+ *
+ * Every time one of these needs a new value, reach for this file first —
+ * not a per-component magic number. Values are documented in the design
+ * spec (docs/superpowers/specs/2026-04-23-ws6-rich-tui-design.md).
+ */
+
+/** Below this terminal width, App.tsx collapses to a single-column layout. */
+export const NARROW_LAYOUT_COLUMN_THRESHOLD = 100;
+
+/**
+ * Below this terminal height, we abandon Ink and fall back to the REPL.
+ * Rationale: 5-pane layout cannot fit legibly below ~20 rows; honest fallback
+ * beats a broken render.
+ */
+export const MIN_HEIGHT_THRESHOLD = 20;
+
+/** Poll interval for ConnectorHealth + WatcherPane. Tunable if 30 s proves noisy. */
+export const STATUS_POLL_INTERVAL_MS = 30_000;
+
+/** Query history cap — last N entries kept in `tui-query-history.json`. */
+export const QUERY_HISTORY_CAP = 100;
+
+/** Time window for the "press again to exit" double-Ctrl+C gesture. */
+export const DOUBLE_CTRL_C_WINDOW_MS = 2_000;
+
+/** Duration the `^C Press again within 2s to exit` hint remains visible. */
+export const CANCEL_HINT_DURATION_MS = 1_500;
+
+/** Reconnect backoff schedule in milliseconds; last entry repeats indefinitely. */
+export const RECONNECT_BACKOFF_MS = [2_000, 4_000, 8_000, 16_000, 30_000] as const;
+
+/** Progress-bar fill width (characters), excluding brackets. */
+export const PROGRESS_BAR_WIDTH = 5;
+
+/** Maximum firing-watcher names rendered in WatcherPane before silent truncation. */
+export const WATCHER_PANE_NAME_LIMIT = 5;
+
+/** Maximum sub-tasks rendered in SubTaskPane before truncation + "…N more" summary. */
+export const SUBTASK_PANE_ROW_LIMIT = 8;

--- a/packages/cli/src/tui/detect-fallback.test.ts
+++ b/packages/cli/src/tui/detect-fallback.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectFallbackReason, type FallbackEnv } from "./detect-fallback.ts";
+
+function env(overrides: Partial<FallbackEnv> = {}): FallbackEnv {
+  return {
+    TERM: "xterm-256color",
+    NO_COLOR: undefined,
+    CI: undefined,
+    isTTY: true,
+    columns: 120,
+    rows: 40,
+    ...overrides,
+  };
+}
+
+describe("detectFallbackReason", () => {
+  test("returns null for a reasonable terminal", () => {
+    expect(detectFallbackReason(env())).toBeNull();
+  });
+
+  test("TERM=dumb triggers fallback", () => {
+    expect(detectFallbackReason(env({ TERM: "dumb" }))).toBe("TERM=dumb");
+  });
+
+  test("NO_COLOR set triggers fallback, regardless of value", () => {
+    expect(detectFallbackReason(env({ NO_COLOR: "" }))).toBe("NO_COLOR");
+    expect(detectFallbackReason(env({ NO_COLOR: "1" }))).toBe("NO_COLOR");
+    expect(detectFallbackReason(env({ NO_COLOR: "true" }))).toBe("NO_COLOR");
+  });
+
+  test("non-TTY stdout triggers fallback", () => {
+    expect(detectFallbackReason(env({ isTTY: false }))).toBe("non-TTY");
+  });
+
+  test("CI=true triggers fallback; CI=false does not", () => {
+    expect(detectFallbackReason(env({ CI: "true" }))).toBe("CI=true");
+    expect(detectFallbackReason(env({ CI: "false" }))).toBeNull();
+  });
+
+  test("rows below MIN_HEIGHT_THRESHOLD triggers fallback", () => {
+    expect(detectFallbackReason(env({ rows: 10 }))).toBe("rows-too-small");
+  });
+
+  test("only one reason is returned — first-match wins", () => {
+    const reason = detectFallbackReason(env({ TERM: "dumb", NO_COLOR: "1", CI: "true", rows: 5 }));
+    expect(reason).toBe("TERM=dumb");
+  });
+
+  test("undefined rows (e.g., stdout.rows may be undefined) does not trigger", () => {
+    expect(detectFallbackReason(env({ rows: undefined }))).toBeNull();
+  });
+});

--- a/packages/cli/src/tui/detect-fallback.ts
+++ b/packages/cli/src/tui/detect-fallback.ts
@@ -1,0 +1,44 @@
+import { MIN_HEIGHT_THRESHOLD } from "./constants.ts";
+
+export type FallbackReason = "TERM=dumb" | "NO_COLOR" | "non-TTY" | "CI=true" | "rows-too-small";
+
+export interface FallbackEnv {
+  TERM: string | undefined;
+  NO_COLOR: string | undefined;
+  CI: string | undefined;
+  isTTY: boolean;
+  columns: number | undefined;
+  rows: number | undefined;
+}
+
+/** First-match wins; returns null when every check passes. */
+export function detectFallbackReason(env: FallbackEnv): FallbackReason | null {
+  if (env.TERM === "dumb") {
+    return "TERM=dumb";
+  }
+  if (env.NO_COLOR !== undefined) {
+    return "NO_COLOR";
+  }
+  if (!env.isTTY) {
+    return "non-TTY";
+  }
+  if (env.CI === "true") {
+    return "CI=true";
+  }
+  if (env.rows !== undefined && env.rows < MIN_HEIGHT_THRESHOLD) {
+    return "rows-too-small";
+  }
+  return null;
+}
+
+/** Read fallback env from process globals; isolated for testability. */
+export function currentFallbackEnv(): FallbackEnv {
+  return {
+    TERM: process.env["TERM"],
+    NO_COLOR: process.env["NO_COLOR"],
+    CI: process.env["CI"],
+    isTTY: process.stdout.isTTY === true,
+    columns: process.stdout.columns,
+    rows: process.stdout.rows,
+  };
+}

--- a/packages/cli/src/tui/dumb-terminal.test.ts
+++ b/packages/cli/src/tui/dumb-terminal.test.ts
@@ -5,8 +5,17 @@ import { join } from "node:path";
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
 const CLI_ENTRY = join(REPO_ROOT, "packages", "cli", "src", "index.ts");
 
+/**
+ * Absolute path to the Bun interpreter running this test file. Using
+ * `process.execPath` instead of `"bun"` avoids any PATH lookup, which
+ * SonarCloud flags as security-sensitive (a maliciously-prepended PATH
+ * entry could otherwise shadow `bun`). Resolves to the same binary that
+ * invoked `bun test`, so test behavior is unchanged.
+ */
+const BUN_EXECUTABLE = process.execPath;
+
 function run(env: NodeJS.ProcessEnv = {}): { code: number; stdout: string; stderr: string } {
-  const result = spawnSync("bun", ["run", CLI_ENTRY, "tui"], {
+  const result = spawnSync(BUN_EXECUTABLE, ["run", CLI_ENTRY, "tui"], {
     env: { ...process.env, ...env },
     stdio: ["pipe", "pipe", "pipe"],
     encoding: "utf-8",

--- a/packages/cli/src/tui/dumb-terminal.test.ts
+++ b/packages/cli/src/tui/dumb-terminal.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+const CLI_ENTRY = join(REPO_ROOT, "packages", "cli", "src", "index.ts");
+
+function run(env: NodeJS.ProcessEnv = {}): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync("bun", ["run", CLI_ENTRY, "tui"], {
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+    encoding: "utf-8",
+    timeout: 5_000,
+  });
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("nimbus tui fallback behavior", () => {
+  test("TERM=dumb prints fallback notice and does not attempt Ink render", () => {
+    const { stdout, stderr } = run({ TERM: "dumb" });
+    const combined = stdout + stderr;
+    expect(combined.length).toBeGreaterThan(0);
+    // Must not include any of the pane headers (those only appear if Ink rendered)
+    expect(combined).not.toContain("Sub-Tasks");
+  });
+
+  test("non-TTY stdout falls back gracefully", () => {
+    const { stdout, stderr } = run();
+    const combined = stdout + stderr;
+    expect(combined).not.toContain("Sub-Tasks");
+  });
+
+  test("CI=true prints fallback notice", () => {
+    const { stdout, stderr } = run({ CI: "true" });
+    const combined = stdout + stderr;
+    expect(combined).not.toContain("Sub-Tasks");
+  });
+});

--- a/packages/cli/src/tui/ipc-context.ts
+++ b/packages/cli/src/tui/ipc-context.ts
@@ -1,0 +1,18 @@
+import type { IPCClient } from "@nimbus-dev/client";
+import type { Logger } from "pino";
+import { createContext, useContext } from "react";
+
+export interface IpcContextValue {
+  client: IPCClient;
+  logger: Logger;
+}
+
+export const IpcContext = createContext<IpcContextValue | null>(null);
+
+export function useIpc(): IpcContextValue {
+  const ctx = useContext(IpcContext);
+  if (ctx === null) {
+    throw new Error("useIpc must be used inside <IpcContext.Provider>");
+  }
+  return ctx;
+}

--- a/packages/cli/src/tui/query-history.test.ts
+++ b/packages/cli/src/tui/query-history.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { QUERY_HISTORY_CAP } from "./constants.ts";
+import { appendQuery, readHistory } from "./query-history.ts";
+
+let tmpDir: string;
+let historyPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "nimbus-tui-hist-"));
+  historyPath = join(tmpDir, "tui-query-history.json");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("readHistory", () => {
+  test("returns empty array when file does not exist", async () => {
+    expect(await readHistory(historyPath)).toEqual([]);
+  });
+
+  test("reads a valid file", async () => {
+    writeFileSync(historyPath, JSON.stringify({ entries: ["a", "b", "c"] }));
+    expect(await readHistory(historyPath)).toEqual(["a", "b", "c"]);
+  });
+
+  test("returns empty array on corrupt JSON", async () => {
+    writeFileSync(historyPath, "{not json");
+    expect(await readHistory(historyPath)).toEqual([]);
+  });
+
+  test("returns empty array on valid JSON with wrong shape", async () => {
+    writeFileSync(historyPath, JSON.stringify({ somethingElse: 42 }));
+    expect(await readHistory(historyPath)).toEqual([]);
+  });
+});
+
+describe("appendQuery", () => {
+  test("appends to empty history", async () => {
+    await appendQuery(historyPath, "first");
+    expect(await readHistory(historyPath)).toEqual(["first"]);
+  });
+
+  test("appends multiple entries in order", async () => {
+    await appendQuery(historyPath, "a");
+    await appendQuery(historyPath, "b");
+    await appendQuery(historyPath, "c");
+    expect(await readHistory(historyPath)).toEqual(["a", "b", "c"]);
+  });
+
+  test("dedups on repeat-of-last", async () => {
+    await appendQuery(historyPath, "a");
+    await appendQuery(historyPath, "a");
+    await appendQuery(historyPath, "a");
+    expect(await readHistory(historyPath)).toEqual(["a"]);
+  });
+
+  test("does not dedup non-adjacent repeats", async () => {
+    await appendQuery(historyPath, "a");
+    await appendQuery(historyPath, "b");
+    await appendQuery(historyPath, "a");
+    expect(await readHistory(historyPath)).toEqual(["a", "b", "a"]);
+  });
+
+  test("caps at QUERY_HISTORY_CAP entries, trimming oldest", async () => {
+    for (let i = 0; i < QUERY_HISTORY_CAP + 10; i++) {
+      await appendQuery(historyPath, `q${String(i)}`);
+    }
+    const history = await readHistory(historyPath);
+    expect(history.length).toBe(QUERY_HISTORY_CAP);
+    expect(history[0]).toBe("q10"); // oldest surviving
+    expect(history[history.length - 1]).toBe(`q${String(QUERY_HISTORY_CAP + 9)}`);
+  });
+
+  test("recovers from corrupt file by overwriting", async () => {
+    writeFileSync(historyPath, "{not json");
+    await appendQuery(historyPath, "recovery");
+    expect(await readHistory(historyPath)).toEqual(["recovery"]);
+  });
+
+  test("ignores empty-string queries", async () => {
+    await appendQuery(historyPath, "");
+    expect(await readHistory(historyPath)).toEqual([]);
+  });
+
+  test("ignores whitespace-only queries", async () => {
+    await appendQuery(historyPath, "   \t  ");
+    expect(await readHistory(historyPath)).toEqual([]);
+  });
+});

--- a/packages/cli/src/tui/query-history.test.ts
+++ b/packages/cli/src/tui/query-history.test.ts
@@ -73,7 +73,7 @@ describe("appendQuery", () => {
     const history = await readHistory(historyPath);
     expect(history.length).toBe(QUERY_HISTORY_CAP);
     expect(history[0]).toBe("q10"); // oldest surviving
-    expect(history[history.length - 1]).toBe(`q${String(QUERY_HISTORY_CAP + 9)}`);
+    expect(history.at(-1)).toBe(`q${String(QUERY_HISTORY_CAP + 9)}`);
   });
 
   test("recovers from corrupt file by overwriting", async () => {

--- a/packages/cli/src/tui/query-history.ts
+++ b/packages/cli/src/tui/query-history.ts
@@ -47,7 +47,7 @@ export async function appendQuery(path: string, query: string): Promise<void> {
     return;
   }
   const current = await readHistory(path);
-  if (current.length > 0 && current[current.length - 1] === query) {
+  if (current.at(-1) === query) {
     return;
   }
   const next = [...current, query];

--- a/packages/cli/src/tui/query-history.ts
+++ b/packages/cli/src/tui/query-history.ts
@@ -1,0 +1,57 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import { QUERY_HISTORY_CAP } from "./constants.ts";
+
+interface HistoryFile {
+  entries: string[];
+}
+
+function isHistoryFile(value: unknown): value is HistoryFile {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (!Array.isArray(v["entries"])) {
+    return false;
+  }
+  return v["entries"].every((item): item is string => typeof item === "string");
+}
+
+/** Read the history file. Returns [] on missing, corrupt, or mis-shaped file. */
+export async function readHistory(path: string): Promise<string[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!isHistoryFile(parsed)) {
+    return [];
+  }
+  return parsed.entries;
+}
+
+/**
+ * Append a query to the history, deduping on repeat-of-last and capping at
+ * QUERY_HISTORY_CAP. Empty or whitespace-only queries are ignored.
+ * Corrupt-file recovery: silently overwrites with the new entry alone.
+ */
+export async function appendQuery(path: string, query: string): Promise<void> {
+  if (query.trim() === "") {
+    return;
+  }
+  const current = await readHistory(path);
+  if (current.length > 0 && current[current.length - 1] === query) {
+    return;
+  }
+  const next = [...current, query];
+  const trimmed = next.length > QUERY_HISTORY_CAP ? next.slice(-QUERY_HISTORY_CAP) : next;
+  const body = JSON.stringify({ entries: trimmed });
+  await writeFile(path, body, { encoding: "utf-8" });
+}

--- a/packages/cli/src/tui/state.test.ts
+++ b/packages/cli/src/tui/state.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+
+import { initialTuiState, type TuiAction, type TuiState, tuiReducer } from "./state.ts";
+
+function reduce(actions: TuiAction[], from: TuiState = initialTuiState): TuiState {
+  return actions.reduce((s, a) => tuiReducer(s, a), from);
+}
+
+describe("tuiReducer", () => {
+  test("initial state is idle", () => {
+    expect(initialTuiState.mode).toBe("idle");
+    expect(initialTuiState.activeStreamId).toBeNull();
+    expect(initialTuiState.liveBuffer).toBe("");
+    expect(initialTuiState.hitlBatch).toBeNull();
+  });
+
+  test("submit transitions idle -> streaming", () => {
+    const s = reduce([{ type: "submit", streamId: "s1", query: "hello" }]);
+    expect(s.mode).toBe("streaming");
+    expect(s.activeStreamId).toBe("s1");
+    expect(s.liveBuffer).toBe("");
+  });
+
+  test("streamToken appends to live buffer while streaming", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      { type: "stream-token", streamId: "s1", text: "foo " },
+      { type: "stream-token", streamId: "s1", text: "bar" },
+    ]);
+    expect(s.liveBuffer).toBe("foo bar");
+  });
+
+  test("streamToken for non-active streamId is ignored", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      { type: "stream-token", streamId: "stale", text: "ignored" },
+    ]);
+    expect(s.liveBuffer).toBe("");
+  });
+
+  test("streamDone returns to idle and clears active streamId", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      { type: "stream-token", streamId: "s1", text: "hi" },
+      { type: "stream-done", streamId: "s1" },
+    ]);
+    expect(s.mode).toBe("idle");
+    expect(s.activeStreamId).toBeNull();
+  });
+
+  test("streamError returns to idle and records the error text", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      { type: "stream-error", streamId: "s1", error: "boom" },
+    ]);
+    expect(s.mode).toBe("idle");
+    expect(s.lastError).toBe("boom");
+  });
+
+  test("hitl-requested while streaming transitions to awaiting-hitl", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      {
+        type: "hitl-requested",
+        batchId: "b1",
+        requests: [{ actionId: "a1", action: "slack.postMessage", params: { channel: "#x" } }],
+      },
+    ]);
+    expect(s.mode).toBe("awaiting-hitl");
+    expect(s.hitlBatch?.batchId).toBe("b1");
+    expect(s.hitlBatch?.requests).toHaveLength(1);
+    expect(s.hitlBatch?.cursor).toBe(0);
+    expect(s.hitlBatch?.decisions).toEqual([]);
+  });
+
+  test("hitl-advance collects a decision and advances the cursor", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      {
+        type: "hitl-requested",
+        batchId: "b1",
+        requests: [
+          { actionId: "a1", action: "x", params: {} },
+          { actionId: "a2", action: "y", params: {} },
+        ],
+      },
+      { type: "hitl-advance", approved: true },
+    ]);
+    expect(s.mode).toBe("awaiting-hitl"); // still waiting on action 2
+    expect(s.hitlBatch?.cursor).toBe(1);
+    expect(s.hitlBatch?.decisions).toEqual([{ actionId: "a1", approved: true }]);
+  });
+
+  test("hitl-resolve clears the batch and returns to streaming", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      {
+        type: "hitl-requested",
+        batchId: "b1",
+        requests: [{ actionId: "a1", action: "x", params: {} }],
+      },
+      { type: "hitl-advance", approved: true },
+      { type: "hitl-resolve" },
+    ]);
+    expect(s.mode).toBe("streaming");
+    expect(s.hitlBatch).toBeNull();
+  });
+
+  test("disconnect from any state transitions to disconnected", () => {
+    const fromStreaming = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      { type: "disconnect" },
+    ]);
+    expect(fromStreaming.mode).toBe("disconnected");
+    expect(fromStreaming.activeStreamId).toBeNull();
+  });
+
+  test("reconnect from disconnected returns to idle", () => {
+    const s = reduce([{ type: "disconnect" }, { type: "reconnect" }]);
+    expect(s.mode).toBe("idle");
+  });
+
+  test("cancel during streaming flips to idle without erasing live buffer", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      { type: "stream-token", streamId: "s1", text: "partial " },
+      { type: "cancel" },
+    ]);
+    expect(s.mode).toBe("idle");
+    expect(s.activeStreamId).toBeNull();
+    // Live buffer preserved so the ResultStream can flush a final "(canceled)" line.
+    expect(s.liveBuffer).toContain("partial");
+  });
+
+  test("flush-live clears the live buffer (used after ResultStream moves to <Static>)", () => {
+    const s = reduce([
+      { type: "submit", streamId: "s1", query: "q" },
+      { type: "stream-token", streamId: "s1", text: "hi" },
+      { type: "stream-done", streamId: "s1" },
+      { type: "flush-live" },
+    ]);
+    expect(s.liveBuffer).toBe("");
+  });
+});

--- a/packages/cli/src/tui/state.ts
+++ b/packages/cli/src/tui/state.ts
@@ -1,0 +1,144 @@
+export interface HitlRequest {
+  actionId: string;
+  action: string;
+  params: Record<string, unknown>;
+}
+
+export interface HitlBatchState {
+  batchId: string;
+  requests: HitlRequest[];
+  cursor: number;
+  decisions: Array<{ actionId: string; approved: boolean }>;
+}
+
+export type TuiMode = "idle" | "streaming" | "awaiting-hitl" | "disconnected";
+
+export interface TuiState {
+  mode: TuiMode;
+  activeStreamId: string | null;
+  liveBuffer: string;
+  hitlBatch: HitlBatchState | null;
+  lastError: string | null;
+}
+
+export type TuiAction =
+  | { type: "submit"; streamId: string; query: string }
+  | { type: "stream-token"; streamId: string; text: string }
+  | { type: "stream-done"; streamId: string }
+  | { type: "stream-error"; streamId: string; error: string }
+  | { type: "hitl-requested"; batchId: string; requests: HitlRequest[] }
+  | { type: "hitl-advance"; approved: boolean }
+  | { type: "hitl-resolve" }
+  | { type: "cancel" }
+  | { type: "disconnect" }
+  | { type: "reconnect" }
+  | { type: "flush-live" };
+
+export const initialTuiState: TuiState = {
+  mode: "idle",
+  activeStreamId: null,
+  liveBuffer: "",
+  hitlBatch: null,
+  lastError: null,
+};
+
+export function tuiReducer(state: TuiState, action: TuiAction): TuiState {
+  switch (action.type) {
+    case "submit":
+      return {
+        ...state,
+        mode: "streaming",
+        activeStreamId: action.streamId,
+        liveBuffer: "",
+        lastError: null,
+      };
+
+    case "stream-token":
+      if (state.activeStreamId !== action.streamId) {
+        return state;
+      }
+      return { ...state, liveBuffer: state.liveBuffer + action.text };
+
+    case "stream-done":
+      if (state.activeStreamId !== action.streamId) {
+        return state;
+      }
+      return { ...state, mode: "idle", activeStreamId: null };
+
+    case "stream-error":
+      if (state.activeStreamId !== action.streamId) {
+        return state;
+      }
+      return {
+        ...state,
+        mode: "idle",
+        activeStreamId: null,
+        lastError: action.error,
+      };
+
+    case "hitl-requested":
+      return {
+        ...state,
+        mode: "awaiting-hitl",
+        hitlBatch: {
+          batchId: action.batchId,
+          requests: action.requests,
+          cursor: 0,
+          decisions: [],
+        },
+      };
+
+    case "hitl-advance": {
+      if (state.hitlBatch === null) {
+        return state;
+      }
+      const { requests, cursor, decisions } = state.hitlBatch;
+      const currentRequest = requests[cursor];
+      if (currentRequest === undefined) {
+        return state;
+      }
+      const nextDecisions = [
+        ...decisions,
+        { actionId: currentRequest.actionId, approved: action.approved },
+      ];
+      return {
+        ...state,
+        hitlBatch: {
+          ...state.hitlBatch,
+          cursor: cursor + 1,
+          decisions: nextDecisions,
+        },
+      };
+    }
+
+    case "hitl-resolve":
+      return {
+        ...state,
+        mode: state.activeStreamId === null ? "idle" : "streaming",
+        hitlBatch: null,
+      };
+
+    case "cancel":
+      return { ...state, mode: "idle", activeStreamId: null };
+
+    case "disconnect":
+      return {
+        ...state,
+        mode: "disconnected",
+        activeStreamId: null,
+        hitlBatch: null,
+      };
+
+    case "reconnect":
+      return { ...state, mode: "idle" };
+
+    case "flush-live":
+      return { ...state, liveBuffer: "" };
+
+    default: {
+      const _exhaustive: never = action;
+      void _exhaustive;
+      return state;
+    }
+  }
+}

--- a/packages/cli/src/tui/state.ts
+++ b/packages/cli/src/tui/state.ts
@@ -136,8 +136,9 @@ export function tuiReducer(state: TuiState, action: TuiAction): TuiState {
       return { ...state, liveBuffer: "" };
 
     default: {
-      const _exhaustive: never = action;
-      void _exhaustive;
+      // Exhaustiveness: if a new TuiAction variant is added but not handled
+      // above, TypeScript errors on this `satisfies never` check.
+      action satisfies never;
       return state;
     }
   }

--- a/packages/cli/src/tui/test-helpers/context.ts
+++ b/packages/cli/src/tui/test-helpers/context.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { IpcContextValue } from "../ipc-context.ts";
+import type { StubIpcClient } from "./stub-client.ts";
+
+/**
+ * Silent pino-shaped logger. Every level is a no-op; satisfies the `Logger`
+ * type via `as unknown as` since we never assert on log output in TUI tests.
+ */
+export const silentLogger: IpcContextValue["logger"] = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+} as unknown as IpcContextValue["logger"];
+
+/** Build an `IpcContextValue` around a stub client with a silent logger. */
+export function ipcContextFor(stub: StubIpcClient): IpcContextValue {
+  return {
+    client: stub.asClient(),
+    logger: silentLogger,
+  };
+}
+
+/**
+ * Allocate a fresh history-file path inside a disposable tmp dir. Returns the
+ * path and a `cleanup` function that removes the tmp dir recursively.
+ */
+export function makeHistoryPath(prefix = "nimbus-tui-"): {
+  readonly path: string;
+  readonly cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  return {
+    path: join(dir, "hist.json"),
+    cleanup: () => {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/cli/src/tui/test-helpers/stub-client.ts
+++ b/packages/cli/src/tui/test-helpers/stub-client.ts
@@ -1,0 +1,70 @@
+/**
+ * Test double for `IPCClient` — satisfies only the method surface the TUI uses.
+ *
+ * Not a public export; used only from TUI *.test.tsx/*.test.ts files.
+ */
+
+import type { IPCClient } from "@nimbus-dev/client";
+
+export interface StubClientOptions {
+  /** Map of method name → static result. Throws if method is absent. */
+  readonly results?: Record<string, unknown>;
+  /** Map of method name → throw spec. Errors take precedence over results. */
+  readonly errors?: Record<string, Error>;
+}
+
+export class StubIpcClient {
+  private readonly handlers = new Map<string, Set<(params: unknown) => void>>();
+  private readonly options: StubClientOptions;
+  public readonly calls: Array<{ method: string; params: unknown }> = [];
+  public disconnected = false;
+
+  constructor(options: StubClientOptions = {}) {
+    this.options = options;
+  }
+
+  async connect(): Promise<void> {
+    this.disconnected = false;
+  }
+
+  async disconnect(): Promise<void> {
+    this.disconnected = true;
+  }
+
+  async call<T>(method: string, params?: unknown): Promise<T> {
+    this.calls.push({ method, params });
+    const err = this.options.errors?.[method];
+    if (err !== undefined) {
+      throw err;
+    }
+    if (this.options.results && method in this.options.results) {
+      return this.options.results[method] as T;
+    }
+    throw new Error(`StubIpcClient: no result configured for method "${method}"`);
+  }
+
+  onNotification(method: string, handler: (params: unknown) => void): void {
+    let set = this.handlers.get(method);
+    if (set === undefined) {
+      set = new Set();
+      this.handlers.set(method, set);
+    }
+    set.add(handler);
+  }
+
+  /** Push a synthetic notification to registered handlers. Test-only. */
+  emit(method: string, params: unknown): void {
+    const set = this.handlers.get(method);
+    if (set === undefined) {
+      return;
+    }
+    for (const h of set) {
+      h(params);
+    }
+  }
+
+  /** Cast to the real IPCClient interface for component props. */
+  asClient(): IPCClient {
+    return this as unknown as IPCClient;
+  }
+}

--- a/packages/cli/src/tui/useIpcPoll.test.tsx
+++ b/packages/cli/src/tui/useIpcPoll.test.tsx
@@ -24,9 +24,9 @@ function Harness({
   method,
   onData,
 }: {
-  stub: StubIpcClient;
-  method: string;
-  onData: (data: unknown) => void;
+  readonly stub: StubIpcClient;
+  readonly method: string;
+  readonly onData: (data: unknown) => void;
 }): React.JSX.Element {
   const state = useIpcPoll<unknown>(method, 50, "idle");
   React.useEffect(() => {

--- a/packages/cli/src/tui/useIpcPoll.test.tsx
+++ b/packages/cli/src/tui/useIpcPoll.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import React from "react";
+
+import { IpcContext, type IpcContextValue } from "./ipc-context.ts";
+import { StubIpcClient } from "./test-helpers/stub-client.ts";
+import { useIpcPoll } from "./useIpcPoll.ts";
+
+function ctxValue(client: StubIpcClient): IpcContextValue {
+  return {
+    client: client.asClient(),
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    } as unknown as IpcContextValue["logger"],
+  };
+}
+
+function Harness({
+  stub: _stub,
+  method,
+  onData,
+}: {
+  stub: StubIpcClient;
+  method: string;
+  onData: (data: unknown) => void;
+}): React.JSX.Element {
+  const state = useIpcPoll<unknown>(method, 50, "idle");
+  React.useEffect(() => {
+    if (state.data !== null) {
+      onData(state.data);
+    }
+  }, [state.data, onData]);
+  return <Text>{state.data === null ? "loading" : "ok"}</Text>;
+}
+
+describe("useIpcPoll", () => {
+  test("fires immediately on mount", async () => {
+    const stub = new StubIpcClient({ results: { "test.method": { ok: true } } });
+    let calls = 0;
+    const harness = (
+      <IpcContext.Provider value={ctxValue(stub)}>
+        <Harness
+          stub={stub}
+          method="test.method"
+          onData={() => {
+            calls++;
+          }}
+        />
+      </IpcContext.Provider>
+    );
+    const { unmount } = render(harness);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(stub.calls.length).toBeGreaterThanOrEqual(1);
+    expect(stub.calls[0]?.method).toBe("test.method");
+    unmount();
+    expect(calls).toBeGreaterThanOrEqual(1);
+  });
+
+  test("re-fires on interval", async () => {
+    const stub = new StubIpcClient({ results: { "test.method": { ok: true } } });
+    const { unmount } = render(
+      <IpcContext.Provider value={ctxValue(stub)}>
+        <Harness stub={stub} method="test.method" onData={() => undefined} />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 160));
+    unmount();
+    // Immediate + ~3 interval fires in 160 ms with 50 ms interval.
+    expect(stub.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("paused when mode is 'disconnected'", async () => {
+    const stub = new StubIpcClient({ results: { "test.method": { ok: true } } });
+    function PausedHarness(): React.JSX.Element {
+      useIpcPoll<unknown>("test.method", 50, "disconnected");
+      return <Text>paused</Text>;
+    }
+    const { unmount } = render(
+      <IpcContext.Provider value={ctxValue(stub)}>
+        <PausedHarness />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 200));
+    unmount();
+    expect(stub.calls.length).toBe(0);
+  });
+
+  test("exposes error state without crashing", async () => {
+    const stub = new StubIpcClient({
+      errors: { "test.method": new Error("socket down") },
+    });
+    function ErrorHarness(): React.JSX.Element {
+      const r = useIpcPoll<unknown>("test.method", 50, "idle");
+      return <Text>{r.error === null ? "no-error" : "error"}</Text>;
+    }
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctxValue(stub)}>
+        <ErrorHarness />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 80));
+    expect(lastFrame()).toContain("error");
+    unmount();
+  });
+});

--- a/packages/cli/src/tui/useIpcPoll.ts
+++ b/packages/cli/src/tui/useIpcPoll.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+
+import { useIpc } from "./ipc-context.ts";
+import type { TuiMode } from "./state.ts";
+
+export interface IpcPollState<T> {
+  data: T | null;
+  error: Error | null;
+  stale: boolean;
+}
+
+/**
+ * Poll an IPC method on the given interval, pausing whenever `mode` is
+ * "disconnected". Fires immediately on mount and on reconnect. Exposes
+ * last-known data as stale while paused.
+ */
+export function useIpcPoll<T>(method: string, intervalMs: number, mode: TuiMode): IpcPollState<T> {
+  const { client, logger } = useIpc();
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const stale = mode === "disconnected";
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (mode === "disconnected") {
+      return undefined;
+    }
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const run = async (): Promise<void> => {
+      try {
+        const next = await client.call<T>(method);
+        if (!mountedRef.current) {
+          return;
+        }
+        setData(next);
+        setError(null);
+      } catch (e) {
+        if (!mountedRef.current) {
+          return;
+        }
+        const wrapped = e instanceof Error ? e : new Error(String(e));
+        setError(wrapped);
+        logger.debug({ event: "tui.poll.error", method, err: wrapped.message }, "poll failed");
+      }
+    };
+    void run();
+    timer = setInterval(() => {
+      void run();
+    }, intervalMs);
+    return () => {
+      if (timer !== null) {
+        clearInterval(timer);
+      }
+    };
+  }, [client, logger, method, intervalMs, mode]);
+
+  return { data, error, stale };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,10 +2,12 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "types": ["bun"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "paths": {
       "@nimbus-dev/client": ["../client/src/index.ts"]
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.tsx", "**/*.spec.tsx"]
 }


### PR DESCRIPTION
## Summary

- **New `nimbus tui` command** — five-pane Ink TUI (Query Input / Result Stream / Connector Health / Watcher Pane / Sub-Task Progress) with token-by-token streaming, inline mid-stream HITL consent, `<Static>`-backed scrollback, exponential-backoff reconnect on gateway loss, and auto-fallback to `nimbus repl` on dumb terminals / non-TTY / `CI=true` / low-height.
- **No new Gateway IPC methods** — consumes the existing `engine.askStream` / `engine.streamToken` / `engine.streamDone` / `engine.streamError` / `agent.subTaskProgress` / `agent.hitlBatch` / `connector.list` / `watcher.list` surfaces.
- **72 tests / 11 files** under `packages/cli/src/tui/`, all passing via `bun test`; coverage gate wired into `_test-suite.yml` (`test:coverage:tui`, ≥ 80 % lines). `nimbus repl` unchanged; both commands documented in README + `docs/cli-reference.md`; manual-smoke checklist at `docs/manual-smoke-ws6.md`.

### Scope notes

- **Cancel is local-only in v0.1.0.** Grep of `packages/gateway/src/ipc/server.ts` confirmed `engine.cancelStream` is not implemented — Ctrl+C flips local state and prints `(canceled by user — LLM may continue in the background)`. Full-fidelity cancel is a post-v0.1.0 Gateway follow-up; help output + manual smoke surface the caveat to users.
- **`QueryInput` uses a custom raw-stdin handler** (`useStdin().stdin.on("data")` + `useLayoutEffect` + a `processChunk` ANSI-parser) instead of `ink-text-input` + Ink's `useInput`. Reason: `useInput` registers its stdin listener in a regular effect, which under `ink-testing-library` fires *after* the test's first `stdin.write()`, causing pasted strings to be lost. Raw-data + `useLayoutEffect` makes the listener deterministic. This leaves `ink-text-input` as an unused dep — scheduled for cleanup in a follow-up.
- **`SubTaskPane` uses `mapRef + forceUpdate`** instead of `useState<Map>` because Ink's test renderer batches multiple synchronous `emit()` calls in a way that dropped updates with the callback-form setState under some timing. Functionally equivalent; tests verify the behavioral contract.
- **Documentation deviation:** `paths.cacheDir` doesn't exist on `CliPlatformPaths`; `tui-query-history.json` lands in `paths.dataDir` instead (spec §5.4 error corrected during implementation).

## Test plan

- [ ] `bun install` in the worktree; `bun run --cwd packages/cli typecheck` exits 0
- [ ] `bun run --cwd packages/cli lint` exits 0 (80 files checked, no issues)
- [ ] `bun test packages/cli/` — 118 tests pass
- [ ] `bun run test:coverage:tui` — 72 tests, coverage ≥ 80 % lines
- [ ] `bun run packages/cli/src/index.ts tui --help` prints the expected help text
- [ ] `TERM=dumb bun run packages/cli/src/index.ts tui` falls back to REPL without rendering Ink
- [ ] **3-OS manual smoke** — execute `docs/manual-smoke-ws6.md` §§1–11 on Windows Terminal, macOS (Terminal.app + iTerm2), Linux (gnome-terminal + alacritty). Record results inline. This is the release-gate acceptance; not required to merge but required before flipping the WS6 🔵 → ✅ marker on main (already applied preemptively on this branch; revert via merge conflict if smoke reveals blockers).
- [ ] Gateway-offline smoke: launch `nimbus tui`, `nimbus stop` from another terminal, observe disconnect banner and exponential reconnect
- [ ] Narrow-terminal collapse: `stty columns 80` during a session — layout should collapse; `stty columns 120` — restore
- [ ] Low-color readability: `TERM=xterm nimbus tui` — glyphs + banners remain legible

## Follow-ups (intentionally out of scope)

- Remove unused `ink-text-input` from `packages/cli/package.json` once the current QueryInput custom-stdin implementation has survived the 3-OS smoke.
- Land Gateway-side `engine.cancelStream` handler to upgrade Ctrl+C from local-only to full-fidelity cancel (the existing `AbortController` pattern in `packages/gateway/src/ipc/llm-rpc.ts:17` is the reference).
- Main has an orphan commit (`85ade20`) from a subagent that accidentally committed the CLAUDE.md/GEMINI.md doc update to main instead of this branch; identical content was cherry-picked here as `526a3e8`. Either revert `85ade20` on main, or let it stand as an early WS6-status preview.

## Design & plan

- Design spec: [`docs/superpowers/specs/2026-04-23-ws6-rich-tui-design.md`](docs/superpowers/specs/2026-04-23-ws6-rich-tui-design.md) (+ review response in §13)
- Implementation plan: [`docs/superpowers/plans/2026-04-23-ws6-rich-tui.md`](docs/superpowers/plans/2026-04-23-ws6-rich-tui.md) (+ Gemini plan review absorbed)
- Finish-plan reference: [`docs/release/v0.1.0-finish-plan.md §4.3`](docs/release/v0.1.0-finish-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)