### PR TITLE
fix: unblock main preflight (react-window v2 + ink/react-devtools-core)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@types/bun": "latest",
         "@types/react": "^18.3.12",
         "ink-testing-library": "^4.0.0",
+        "react-devtools-core": "^6.1.5",
       },
     },
     "packages/client": {
@@ -2078,6 +2079,8 @@
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
+    "react-devtools-core": ["react-devtools-core@6.1.5", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA=="],
+
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -2199,6 +2202,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
@@ -2458,7 +2463,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -2519,6 +2524,8 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@expressive-code/plugin-shiki/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "@mastra/core/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -2585,6 +2592,8 @@
     "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "ink/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/react": "^18.3.12",
-    "ink-testing-library": "^4.0.0"
+    "ink-testing-library": "^4.0.0",
+    "react-devtools-core": "^6.1.5"
   }
 }

--- a/packages/ui/src/pages/settings/AuditPanel.tsx
+++ b/packages/ui/src/pages/settings/AuditPanel.tsx
@@ -2,7 +2,7 @@ import { save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { FixedSizeList, type ListChildComponentProps } from "react-window";
+import { List, type RowComponentProps } from "react-window";
 import { AuditFilterChips } from "../../components/settings/audit/AuditFilterChips";
 import { PanelError } from "../../components/settings/PanelError";
 import { PanelHeader } from "../../components/settings/PanelHeader";
@@ -224,12 +224,13 @@ export function AuditPanel() {
   }, [setInFlight]);
 
   const Row = useCallback(
-    ({ index, style }: ListChildComponentProps) => {
+    ({ index, style, ariaAttributes }: RowComponentProps) => {
       const row = runIdFilteredRows[index];
       if (!row) return null;
       const isMatch = runIdFilter !== null && row.runId === runIdFilter;
       return (
         <div
+          {...ariaAttributes}
           style={style}
           className={`grid grid-cols-[180px_120px_1fr_100px] items-center px-3 text-xs border-b border-[var(--color-border)]${isMatch ? " bg-amber-50 dark:bg-amber-900/20" : ""}`}
           data-testid="audit-row"
@@ -321,14 +322,13 @@ export function AuditPanel() {
           <span>Action</span>
           <span>Outcome</span>
         </div>
-        <FixedSizeList
-          height={LIST_HEIGHT}
-          itemCount={runIdFilteredRows.length}
-          itemSize={ROW_HEIGHT}
-          width="100%"
-        >
-          {Row}
-        </FixedSizeList>
+        <List
+          style={{ height: LIST_HEIGHT, width: "100%" }}
+          rowCount={runIdFilteredRows.length}
+          rowHeight={ROW_HEIGHT}
+          rowComponent={Row}
+          rowProps={{}}
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Two pre-existing breakages on `main` from past Dependabot major-version bumps that didn't update consumer code. Both block local `bun run test:ci` / `bun run build` so they need fixing before any other PR can verify cleanly.

### 1. `react-window` v1 → v2 API migration (commit 4ca685f)

Commit `9b15ea9` on main bumped `react-window` from 1.x to 2.x. The v2 release renamed exports:

- `FixedSizeList` → `List`
- `ListChildComponentProps` → `RowComponentProps`
- prop `itemCount` → `rowCount`, `itemSize` → `rowHeight`, children-fn → `rowComponent` prop
- `height`/`width` props moved into `style`
- new required `ariaAttributes` field on the row component (a11y improvement)

`packages/ui/src/pages/settings/AuditPanel.tsx` was using the v1 API and broke `bun run typecheck` for the UI package. This PR migrates it to v2.

### 2. `ink` / `react-devtools-core` (commit ddf0be3)

`ink@5.2.1` (already on main) loads `react-devtools-core` from its `reconciler.js` when `process.env.DEV === 'true'`. Even though the load is gated, Bun's `--compile` bundler walks the import graph eagerly and fails to resolve the package, breaking `bun run --filter '@nimbus/cli' build` on main.

Adding `react-devtools-core` as a CLI devDep makes it bundleable. Bun's dead-code elimination keeps the actual `devtools.connectToDevTools()` call out of reachable code, so the impact on the compiled binary is minimal — bundle module count went from 285 to 286.

## Why a separate PR

Discovered while preparing a larger toolchain-refresh PR (`dev/asafgolombek/upgrade_packages`). Kept separate so each fix is atomic and the toolchain PR's diff stays scoped to runner OS / Node / Rust / Tauri.

## Test plan

- [x] `bun run typecheck` green across all packages (was red on main due to `react-window` issue).
- [x] `bun run build` green across all packages (was red on main due to `react-devtools-core` issue).
- [x] `packages/ui` AuditPanel vitest: 14/14 passing.
- [x] CLI binary smoke test: `./packages/cli/dist/nimbus.exe` starts up and parses arguments (previously crashed with `Cannot find package react-devtools-core`).
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)