### PR TITLE
fix(security): Low-tier security findings (PR 3 of 3)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,11 @@
+# Gitleaks suppressions for synthetic secret-redaction unit-test fixtures.
+# These are NOT real secrets — they are deliberately constructed strings used
+# to verify that scrubRedactedValuePatterns() in gateway-log-file.ts correctly
+# strips Slack xoxb tokens and JWT fixtures from log output. The values match
+# the shape of the corresponding redaction regexes by design.
+#
+# Adding the inline `// gitleaks:allow` comment in HEAD does not retroactively
+# clear the historical commit, so we pin the fingerprints here.
+
+b37e8d4b0abf44f8cd60b187499acea7f21914a7:packages/gateway/src/platform/gateway-log-redact.test.ts:generic-api-key:41
+b37e8d4b0abf44f8cd60b187499acea7f21914a7:packages/gateway/src/platform/gateway-log-redact.test.ts:jwt:49

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -109,6 +109,10 @@ Third-party extensions run as child processes. They:
 
 **Extension isolation.** Extensions run as child processes spawned by the gateway. They share the gateway's user UID and have full filesystem and network access at that UID's permissions — there is no `seccomp` / `bwrap` / `sandbox-exec` / AppContainer sandbox in this release. The only structural barriers are: (a) `extensionProcessEnv()` filters parent-process environment variables, blocking propagation of OAuth client secrets and LLM provider API keys; (b) startup SHA-256 verification detects post-install drift and disables affected rows; (c) the same SHA-256 is re-checked immediately before each spawn (S7-F3 fix). OS-level sandboxing is on the Phase 7 roadmap. Until then, extensions must be considered code that runs at full user-UID equivalence — do not install extensions from untrusted sources.
 
+#### Extension disable does not orphan-kill subprocesses
+
+When an extension's hash check fails (`verifyExtensionsBestEffort` at startup) or the user invokes `extension.disable`, the gateway terminates the extension's immediate MCP child process via `LazyConnectorMesh.stopExtensionClient`. Any further subprocesses that the extension itself spawned (helper daemons, background watchers) are NOT killed — they continue running until they exit on their own. This is a known limitation of `child_process.spawn` (no process-group kill on POSIX, no Job Object wrapping on Windows) and aligns with the broader same-uid sandbox model documented above. Phase 7 sandbox work (`bwrap` / `sandbox-exec` / `AppContainer`) will close this gap by binding the extension's full descendant tree to a sandbox lifetime.
+
 ---
 
 ### IPC Surface

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -119,6 +119,10 @@ The Gateway listens only on a local domain socket (Unix) or named pipe (Windows)
 
 > **⚠️ Auto-updater (Phase 4 WS4) — pre-flight security audit in progress:** The auto-update pipeline (`nimbus update`) is implemented but not yet wired into the production gateway entrypoint. A security audit has identified that the `NIMBUS_DEV_UPDATER_PUBLIC_KEY` environment override is honoured in production builds (no build-time gate), and that the download does not re-verify the version order before proceeding. These gaps must be fixed before the updater is enabled. Tracked in branch `dev/asafgolombek/security-audit`.
 
+#### Updater temp directory cleanup
+
+`Updater.applyUpdate` writes the verified installer to a fresh temp directory created by `mkdtempSync(join(tmpdir(), "nimbus-update-"))`. The directory and its contents are deleted in a `finally` block after the platform installer returns (success or failure). The installer binary is written with mode `0o600` and is never readable by other users on a shared machine. The `lastError` field exposed via `updater.getStatus` is scrubbed of URL userinfo (`user:pass@`) before storage so a misconfigured `manifestUrl` cannot leak credentials through the diagnostic surface.
+
 ---
 
 ### Prompt Injection

--- a/packages/gateway/src/commands/data-import.test.ts
+++ b/packages/gateway/src/commands/data-import.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { memVault, newIndex } from "../../test/fixtures/data-test-helpers.ts";
+import { _addTestKdfProfile } from "../db/data-vault-crypto.ts";
 import { packBundle, unpackBundle } from "../db/tar-bundle.ts";
 import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
 import { runDataExport } from "./data-export.ts";
 import { DataImportVersionError, runDataImport } from "./data-import.ts";
+
+// S2-F10 — register the FAST_KDF profile used by these round-trip tests so
+// decryptVaultManifest accepts the bundles produced with kdfParams: { t:1, m:1024, p:1 }.
+let _restoreTestKdf: () => void;
+beforeAll(() => {
+  _restoreTestKdf = _addTestKdfProfile({ t: 1, m: 1024, p: 1 });
+});
+afterAll(() => {
+  _restoreTestKdf();
+});
 
 describe("data import", () => {
   const kdfParams = { t: 1, m: 1024, p: 1 } as const;

--- a/packages/gateway/src/connectors/lazy-mesh-args-json.test.ts
+++ b/packages/gateway/src/connectors/lazy-mesh-args-json.test.ts
@@ -1,0 +1,130 @@
+/**
+ * S8-F8 — verify MCPClient ids use crypto.randomUUID() (not Date.now()).
+ * S8-F9 — verify malformed args_json transitions connector health to
+ * persistent_error and emits a warn log line.
+ */
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "../index/local-index.ts";
+import type { PlatformPaths } from "../platform/paths.ts";
+import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import { getConnectorHealth } from "./health.ts";
+import { LazyConnectorMesh, type MeshLogger } from "./lazy-mesh.ts";
+
+function makePaths(): PlatformPaths {
+  const root = mkdtempSync(join(tmpdir(), "nimbus-lazy-mesh-test-"));
+  return {
+    configDir: root,
+    dataDir: join(root, "data"),
+    logDir: join(root, "logs"),
+    socketPath: join(root, "sock"),
+    extensionsDir: join(root, "ext"),
+    tempDir: join(root, "tmp"),
+  };
+}
+
+const stubVault: NimbusVault = {
+  async get(): Promise<string | null> {
+    return null;
+  },
+  async set(): Promise<void> {},
+  async delete(): Promise<void> {},
+  async listKeys(): Promise<string[]> {
+    return [];
+  },
+};
+
+describe("LazyConnectorMesh — args_json failure (S8-F9)", () => {
+  test("malformed args_json (parse error) logs warn and transitions health to persistent_error", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+
+    const warns: Array<{ bindings: Record<string, unknown>; msg: string | undefined }> = [];
+    const logger: MeshLogger = {
+      warn: (b, m) => warns.push({ bindings: b, msg: m }),
+    };
+
+    const mesh = new LazyConnectorMesh(makePaths(), stubVault, {
+      listUserMcpConnectors: () => [
+        {
+          service_id: "broken-svc",
+          command: "/bin/echo",
+          args_json: "not-json",
+          created_at: 0,
+        },
+      ],
+      healthDb: db,
+      logger,
+    });
+
+    await mesh.ensureUserMcpRunning("broken-svc");
+    await mesh.disconnect();
+
+    expect(warns.length).toBeGreaterThan(0);
+    expect(warns[0]?.bindings["serviceId"]).toBe("broken-svc");
+
+    const snap = getConnectorHealth(db, "broken-svc");
+    expect(snap.state).toBe("error");
+    expect(snap.lastError ?? "").toMatch(/args_json/);
+  });
+
+  test("malformed args_json (non-string-array) logs warn and transitions health", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+
+    const warns: Array<{ bindings: Record<string, unknown>; msg: string | undefined }> = [];
+    const logger: MeshLogger = {
+      warn: (b, m) => warns.push({ bindings: b, msg: m }),
+    };
+
+    const mesh = new LazyConnectorMesh(makePaths(), stubVault, {
+      listUserMcpConnectors: () => [
+        {
+          service_id: "non-array-svc",
+          command: "/bin/echo",
+          args_json: '{"not":"an array"}',
+          created_at: 0,
+        },
+      ],
+      healthDb: db,
+      logger,
+    });
+
+    await mesh.ensureUserMcpRunning("non-array-svc");
+    await mesh.disconnect();
+
+    expect(warns.length).toBeGreaterThan(0);
+    const snap = getConnectorHealth(db, "non-array-svc");
+    expect(snap.state).toBe("error");
+    expect(snap.lastError ?? "").toMatch(/args_json/);
+  });
+
+  test("S8-F9 — silent path when no logger / healthDb is wired (legacy callers)", async () => {
+    const mesh = new LazyConnectorMesh(makePaths(), stubVault, {
+      listUserMcpConnectors: () => [
+        {
+          service_id: "broken-svc",
+          command: "/bin/echo",
+          args_json: "not-json",
+          created_at: 0,
+        },
+      ],
+    });
+    // Should not throw, even without db / logger.
+    await mesh.ensureUserMcpRunning("broken-svc");
+    await mesh.disconnect();
+  });
+});
+
+describe("LazyConnectorMesh — UUID ids (S8-F8)", () => {
+  test("source has no Date.now() in MCPClient id literals", () => {
+    const src = readFileSync(join(import.meta.dir, "lazy-mesh.ts"), "utf8");
+    // Every `id:` template literal that previously used Date.now() should now use randomUUID().
+    expect(src.includes("Date.now()")).toBe(false);
+    // randomUUID is imported and used.
+    expect(src.includes("randomUUID")).toBe(true);
+  });
+});

--- a/packages/gateway/src/connectors/lazy-mesh-args-json.test.ts
+++ b/packages/gateway/src/connectors/lazy-mesh-args-json.test.ts
@@ -37,69 +37,49 @@ const stubVault: NimbusVault = {
   },
 };
 
+type LoggedWarn = { bindings: Record<string, unknown>; msg: string | undefined };
+
+function makeArgsJsonFixture(serviceId: string, argsJson: string) {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  const warns: LoggedWarn[] = [];
+  const logger: MeshLogger = {
+    warn: (b, m) => warns.push({ bindings: b, msg: m }),
+  };
+  const mesh = new LazyConnectorMesh(makePaths(), stubVault, {
+    listUserMcpConnectors: () => [
+      {
+        service_id: serviceId,
+        command: "/bin/echo",
+        args_json: argsJson,
+        created_at: 0,
+      },
+    ],
+    healthDb: db,
+    logger,
+  });
+  return { db, warns, mesh };
+}
+
+async function expectArgsJsonHealthFailure(serviceId: string, argsJson: string): Promise<void> {
+  const { db, warns, mesh } = makeArgsJsonFixture(serviceId, argsJson);
+  await mesh.ensureUserMcpRunning(serviceId);
+  await mesh.disconnect();
+
+  expect(warns.length).toBeGreaterThan(0);
+  expect(warns[0]?.bindings["serviceId"]).toBe(serviceId);
+  const snap = getConnectorHealth(db, serviceId);
+  expect(snap.state).toBe("error");
+  expect(snap.lastError ?? "").toMatch(/args_json/);
+}
+
 describe("LazyConnectorMesh — args_json failure (S8-F9)", () => {
   test("malformed args_json (parse error) logs warn and transitions health to persistent_error", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-
-    const warns: Array<{ bindings: Record<string, unknown>; msg: string | undefined }> = [];
-    const logger: MeshLogger = {
-      warn: (b, m) => warns.push({ bindings: b, msg: m }),
-    };
-
-    const mesh = new LazyConnectorMesh(makePaths(), stubVault, {
-      listUserMcpConnectors: () => [
-        {
-          service_id: "broken-svc",
-          command: "/bin/echo",
-          args_json: "not-json",
-          created_at: 0,
-        },
-      ],
-      healthDb: db,
-      logger,
-    });
-
-    await mesh.ensureUserMcpRunning("broken-svc");
-    await mesh.disconnect();
-
-    expect(warns.length).toBeGreaterThan(0);
-    expect(warns[0]?.bindings["serviceId"]).toBe("broken-svc");
-
-    const snap = getConnectorHealth(db, "broken-svc");
-    expect(snap.state).toBe("error");
-    expect(snap.lastError ?? "").toMatch(/args_json/);
+    await expectArgsJsonHealthFailure("broken-svc", "not-json");
   });
 
   test("malformed args_json (non-string-array) logs warn and transitions health", async () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-
-    const warns: Array<{ bindings: Record<string, unknown>; msg: string | undefined }> = [];
-    const logger: MeshLogger = {
-      warn: (b, m) => warns.push({ bindings: b, msg: m }),
-    };
-
-    const mesh = new LazyConnectorMesh(makePaths(), stubVault, {
-      listUserMcpConnectors: () => [
-        {
-          service_id: "non-array-svc",
-          command: "/bin/echo",
-          args_json: '{"not":"an array"}',
-          created_at: 0,
-        },
-      ],
-      healthDb: db,
-      logger,
-    });
-
-    await mesh.ensureUserMcpRunning("non-array-svc");
-    await mesh.disconnect();
-
-    expect(warns.length).toBeGreaterThan(0);
-    const snap = getConnectorHealth(db, "non-array-svc");
-    expect(snap.state).toBe("error");
-    expect(snap.lastError ?? "").toMatch(/args_json/);
+    await expectArgsJsonHealthFailure("non-array-svc", '{"not":"an array"}');
   });
 
   test("S8-F9 — silent path when no logger / healthDb is wired (legacy callers)", async () => {

--- a/packages/gateway/src/connectors/lazy-mesh.ts
+++ b/packages/gateway/src/connectors/lazy-mesh.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -18,6 +19,7 @@ import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import type { PlatformPaths } from "../platform/paths.ts";
 import { stripTrailingSlashes } from "../string/strip-trailing-slashes.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import { transitionHealth } from "./health.ts";
 import type { UserMcpConnectorRow } from "./user-mcp-store.ts";
 
 const _LAZY_MESH_DIR = dirname(fileURLToPath(import.meta.url));
@@ -133,12 +135,20 @@ async function listLazyMeshClientTools(client: MCPClient | undefined): Promise<L
 /**
  * Eager filesystem MCP + lazily spawned Google MCP bundle (Drive + Gmail + Photos) + Microsoft bundle (OneDrive + Outlook + Teams) + GitHub (includes GitHub Actions MCP child) / GitLab / Bitbucket / Slack / Linear / Jira / Notion / Confluence / Jenkins / CircleCI / PagerDuty / Kubernetes credential MCP when vault keys exist; Phase 3 bundle (AWS, Azure, GCP, IaC, Grafana, Sentry, New Relic, Datadog) when matching vault keys exist; Discord MCP when **`discord.enabled`** + **`discord.bot_token`** are set (Q2 §1.6 / Phase 2–5 + §4.3).
  */
+/** Minimal logger shape — accepts the pino `(bindings, msg)` form. */
+export interface MeshLogger {
+  warn(bindings: Record<string, unknown>, msg?: string): void;
+}
+
 export class LazyConnectorMesh {
   private readonly filesystem: MCPClient;
   /** Lazy MCP stdio children: built-in bundles use `LAZY_MESH.*`; user MCP uses `mesh:user:<serviceId>`. */
   private readonly lazySlots = new Map<string, LazyMcpSlot>();
   private readonly listUserMcpConnectors: () => readonly UserMcpConnectorRow[];
   private readonly inactivityMs: number;
+  /** S8-F9 — optional db + logger so args_json failures can transition health and log. */
+  private readonly healthDb: import("bun:sqlite").Database | undefined;
+  private readonly logger: MeshLogger | undefined;
   private toolsEpoch = 0;
 
   constructor(
@@ -147,10 +157,16 @@ export class LazyConnectorMesh {
     options?: {
       inactivityMs?: number;
       listUserMcpConnectors?: () => readonly UserMcpConnectorRow[];
+      /** S8-F9 — when supplied, args_json parse failures call transitionHealth. */
+      healthDb?: import("bun:sqlite").Database;
+      /** S8-F9 — when supplied, args_json parse failures emit a warn line. */
+      logger?: MeshLogger;
     },
   ) {
     this.inactivityMs = options?.inactivityMs ?? 300_000;
     this.listUserMcpConnectors = options?.listUserMcpConnectors ?? (() => []);
+    this.healthDb = options?.healthDb;
+    this.logger = options?.logger;
     this.filesystem = new MCPClient({
       servers: {
         filesystem: {
@@ -257,6 +273,28 @@ export class LazyConnectorMesh {
     await this.stopLazyClient(extensionId);
   }
 
+  /**
+   * S8-F9 — central failure handler for malformed user_mcp_connector.args_json.
+   * Logs a warn line (when a logger was supplied) and transitions connector
+   * health to `persistent_error` (when a healthDb was supplied) so the
+   * failure is observable via `nimbus connector status` instead of silently
+   * leaving the slot unconfigured.
+   */
+  private recordArgsJsonFailure(serviceId: string, reason: string): void {
+    if (this.logger !== undefined) {
+      this.logger.warn(
+        { serviceId, reason },
+        "user MCP args_json failed to parse — slot left unconfigured",
+      );
+    }
+    if (this.healthDb !== undefined) {
+      transitionHealth(this.healthDb, serviceId, {
+        type: "persistent_error",
+        error: `malformed args_json (${reason})`,
+      });
+    }
+  }
+
   private mcpServerKeyForUserConnector(serviceId: string): string {
     return serviceId.replaceAll(/[^a-zA-Z0-9_-]/g, "_");
   }
@@ -272,15 +310,20 @@ export class LazyConnectorMesh {
     try {
       const parsed: unknown = JSON.parse(row.args_json);
       if (!Array.isArray(parsed) || !parsed.every((x) => typeof x === "string")) {
+        // S8-F9 — surface the failure instead of silently leaving the slot
+        // unconfigured. Health transition makes it visible in
+        // `nimbus connector status`.
+        this.recordArgsJsonFailure(row.service_id, "expected string array");
         return;
       }
       args = parsed;
     } catch {
+      this.recordArgsJsonFailure(row.service_id, "JSON parse failed");
       return;
     }
     const key = this.mcpServerKeyForUserConnector(row.service_id);
     const client = new MCPClient({
-      id: `nimbus-user-mcp-${row.service_id}-${String(Date.now())}`,
+      id: `nimbus-user-mcp-${row.service_id}-${randomUUID()}`,
       servers: {
         [key]: {
           command: row.command,
@@ -511,7 +554,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-phase3-${String(Date.now())}`,
+        id: `nimbus-phase3-${randomUUID()}`,
         servers,
       }),
     );
@@ -567,7 +610,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-google-${String(Date.now())}`,
+        id: `nimbus-google-${randomUUID()}`,
         servers: googleServers,
       }),
     );
@@ -594,7 +637,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-ms-${String(Date.now())}`,
+        id: `nimbus-ms-${randomUUID()}`,
         servers: {
           onedrive: {
             command: "bun",
@@ -635,7 +678,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-github-${String(Date.now())}`,
+        id: `nimbus-github-${randomUUID()}`,
         servers: {
           github: {
             command: "bun",
@@ -679,7 +722,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-gitlab-${String(Date.now())}`,
+        id: `nimbus-gitlab-${randomUUID()}`,
         servers: {
           gitlab: {
             command: "bun",
@@ -711,7 +754,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-bitbucket-${String(Date.now())}`,
+        id: `nimbus-bitbucket-${randomUUID()}`,
         servers: {
           bitbucket: {
             command: "bun",
@@ -750,7 +793,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-slack-${String(Date.now())}`,
+        id: `nimbus-slack-${randomUUID()}`,
         servers: {
           slack: {
             command: "bun",
@@ -781,7 +824,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-linear-${String(Date.now())}`,
+        id: `nimbus-linear-${randomUUID()}`,
         servers: {
           linear: {
             command: "bun",
@@ -821,7 +864,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-jira-${String(Date.now())}`,
+        id: `nimbus-jira-${randomUUID()}`,
         servers: {
           jira: {
             command: "bun",
@@ -865,7 +908,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-notion-${String(Date.now())}`,
+        id: `nimbus-notion-${randomUUID()}`,
         servers: {
           notion: {
             command: "bun",
@@ -905,7 +948,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-confluence-${String(Date.now())}`,
+        id: `nimbus-confluence-${randomUUID()}`,
         servers: {
           confluence: {
             command: "bun",
@@ -941,7 +984,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-discord-${String(Date.now())}`,
+        id: `nimbus-discord-${randomUUID()}`,
         servers: {
           discord: {
             command: "bun",
@@ -982,7 +1025,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-jenkins-${String(Date.now())}`,
+        id: `nimbus-jenkins-${randomUUID()}`,
         servers: {
           jenkins: {
             command: "bun",
@@ -1017,7 +1060,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-circleci-${String(Date.now())}`,
+        id: `nimbus-circleci-${randomUUID()}`,
         servers: {
           circleci: {
             command: "bun",
@@ -1048,7 +1091,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-pagerduty-${String(Date.now())}`,
+        id: `nimbus-pagerduty-${randomUUID()}`,
         servers: {
           pagerduty: {
             command: "bun",
@@ -1084,7 +1127,7 @@ export class LazyConnectorMesh {
     this.setLazyClient(
       slotKey,
       new MCPClient({
-        id: `nimbus-kubernetes-${String(Date.now())}`,
+        id: `nimbus-kubernetes-${randomUUID()}`,
         servers: {
           kubernetes: {
             command: "bun",
@@ -1347,7 +1390,12 @@ export class LazyConnectorMesh {
 export async function createLazyConnectorMesh(
   paths: PlatformPaths,
   vault: NimbusVault,
-  options?: { inactivityMs?: number; listUserMcpConnectors?: () => readonly UserMcpConnectorRow[] },
+  options?: {
+    inactivityMs?: number;
+    listUserMcpConnectors?: () => readonly UserMcpConnectorRow[];
+    healthDb?: import("bun:sqlite").Database;
+    logger?: MeshLogger;
+  },
 ): Promise<LazyConnectorMesh> {
   return new LazyConnectorMesh(paths, vault, options);
 }

--- a/packages/gateway/src/connectors/lazy-mesh.ts
+++ b/packages/gateway/src/connectors/lazy-mesh.ts
@@ -238,6 +238,25 @@ export class LazyConnectorMesh {
     await this.stopLazyClient(userMcpMeshKey(serviceId));
   }
 
+  /**
+   * S7-F10 — terminate the running MCP child process for an extension.
+   * Called by `extension.disable` IPC and by `verifyExtensionsBestEffort`
+   * when a hash mismatch is detected. Extension MCPs are stored under the
+   * same `mesh:user:<id>` slot pattern as user MCPs, so we route through
+   * the existing user-mesh teardown. We also attempt the bare extension-id
+   * slot in case a future code path registers extensions there directly.
+   *
+   * Limitation: this only kills the immediate MCP child. Subprocesses
+   * spawned BY the extension (helper daemons, background watchers) keep
+   * running until they exit on their own. Closing that gap requires
+   * platform-specific machinery (POSIX process groups, Windows Job
+   * Objects) and is tracked under Phase 7 sandbox work.
+   */
+  public async stopExtensionClient(extensionId: string): Promise<void> {
+    await this.stopUserMcpClient(extensionId);
+    await this.stopLazyClient(extensionId);
+  }
+
   private mcpServerKeyForUserConnector(serviceId: string): string {
     return serviceId.replaceAll(/[^a-zA-Z0-9_-]/g, "_");
   }

--- a/packages/gateway/src/db/data-vault-crypto.test.ts
+++ b/packages/gateway/src/db/data-vault-crypto.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { decryptVaultManifest, encryptVaultManifest } from "./data-vault-crypto.ts";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  _addTestKdfProfile,
+  decryptVaultManifest,
+  encryptVaultManifest,
+} from "./data-vault-crypto.ts";
 
 const PLAINTEXT = '[{"key":"github.pat","value":"secret_value_xyz"}]';
 const PASSPHRASE = "correct horse battery staple";
@@ -10,6 +14,18 @@ const SEED =
 const FAST_KDF = { t: 1, m: 1024, p: 1 } as const;
 
 describe("envelope encryption", () => {
+  // The KDF allowlist (S2-F10) only accepts production parameters by default.
+  // Tests in this file use FAST_KDF for speed — register it once for the
+  // duration of the suite so decryptVaultManifest accepts the round-tripped
+  // blobs.
+  let restoreKdf: () => void;
+  beforeAll(() => {
+    restoreKdf = _addTestKdfProfile({ ...FAST_KDF });
+  });
+  afterAll(() => {
+    restoreKdf();
+  });
+
   test("round-trips plaintext via passphrase", async () => {
     const blob = await encryptVaultManifest({
       plaintext: PLAINTEXT,
@@ -55,4 +71,52 @@ describe("envelope encryption", () => {
     };
     await expect(decryptVaultManifest(tampered, { passphrase: PASSPHRASE })).rejects.toThrow();
   });
+});
+
+describe("decryptVaultManifest — KDF allowlist (S2-F10)", () => {
+  let restoreKdf: () => void;
+  beforeAll(() => {
+    restoreKdf = _addTestKdfProfile({ ...FAST_KDF });
+  });
+  afterAll(() => {
+    restoreKdf();
+  });
+
+  test("rejects bundles with attacker-substituted weak KDF parameters", async () => {
+    const blob = await encryptVaultManifest({
+      plaintext: PLAINTEXT,
+      passphrase: PASSPHRASE,
+      seed: SEED,
+      kdfParams: FAST_KDF,
+    });
+    // Substitute params not in the allowlist (different m / t).
+    const tampered = { ...blob, kdf: { t: 1, m: 8, p: 1 } };
+    await expect(decryptVaultManifest(tampered, { passphrase: PASSPHRASE })).rejects.toThrow(
+      /kdf params not in allowlist/i,
+    );
+  });
+
+  test("rejects bundles with deeply weak KDF parameters", async () => {
+    const blob = await encryptVaultManifest({
+      plaintext: PLAINTEXT,
+      passphrase: PASSPHRASE,
+      seed: SEED,
+      kdfParams: FAST_KDF,
+    });
+    const tampered = { ...blob, kdf: { t: 1, m: 1, p: 1 } };
+    await expect(decryptVaultManifest(tampered, { passphrase: PASSPHRASE })).rejects.toThrow(
+      /kdf params not in allowlist/i,
+    );
+  });
+
+  test("accepts the DEFAULT_KDF profile (production)", async () => {
+    // No kdfParams override → uses DEFAULT_KDF { t: 3, m: 64*1024, p: 1 }.
+    const blob = await encryptVaultManifest({
+      plaintext: "x",
+      passphrase: PASSPHRASE,
+      seed: SEED,
+    });
+    const out = await decryptVaultManifest(blob, { passphrase: PASSPHRASE });
+    expect(out).toBe("x");
+  }, 30_000);
 });

--- a/packages/gateway/src/db/data-vault-crypto.ts
+++ b/packages/gateway/src/db/data-vault-crypto.ts
@@ -86,10 +86,55 @@ export async function encryptVaultManifest(input: {
   };
 }
 
+/**
+ * KDF parameter allowlist (S2-F10).
+ *
+ * Bundles whose `kdf` field deviates from this list are rejected on import,
+ * defending against attacker-substituted weak Argon2id parameters during
+ * forensic-image attacks.
+ *
+ * Migration ordering rule: when raising Argon2id costs in a future release,
+ * the NEW profile MUST be added to this list at least one release cycle
+ * BEFORE any client begins emitting bundles with the new params. Otherwise
+ * older Nimbus installs cannot import bundles produced by newer ones — and
+ * passphrase-based recovery from a current export becomes impossible without
+ * manually downgrading the user's install. Order:
+ *   (1) ship a release that *accepts* the new profile;
+ *   (2) wait for the install base to converge;
+ *   (3) ship a release that *emits* the new profile.
+ */
+const ACCEPTED_KDF_PROFILES_BACKING: KdfParams[] = [{ t: 3, m: 64 * 1024, p: 1 }];
+
+function isAcceptedKdf(p: KdfParams): boolean {
+  return ACCEPTED_KDF_PROFILES_BACKING.some(
+    (profile) => profile.t === p.t && profile.m === p.m && profile.p === p.p,
+  );
+}
+
+/**
+ * Test-only — temporarily add a KDF profile to the allowlist so existing
+ * round-trip tests can keep using fast Argon2id parameters. Returns a
+ * restore function. Production code must never call this.
+ */
+export function _addTestKdfProfile(profile: KdfParams): () => void {
+  ACCEPTED_KDF_PROFILES_BACKING.push(profile);
+  return () => {
+    const idx = ACCEPTED_KDF_PROFILES_BACKING.findIndex(
+      (p) => p.t === profile.t && p.m === profile.m && p.p === profile.p,
+    );
+    if (idx > 0) ACCEPTED_KDF_PROFILES_BACKING.splice(idx, 1);
+  };
+}
+
 export async function decryptVaultManifest(
   blob: VaultManifestBlob,
   key: { passphrase?: string; seed?: string },
 ): Promise<string> {
+  if (!isAcceptedKdf(blob.kdf)) {
+    throw new Error(
+      `decryptVaultManifest: kdf params not in allowlist (got t=${String(blob.kdf.t)} m=${String(blob.kdf.m)} p=${String(blob.kdf.p)})`,
+    );
+  }
   const { passphrase, seed } = key;
   let dek: Uint8Array;
   if (passphrase !== undefined) {

--- a/packages/gateway/src/db/repair.ts
+++ b/packages/gateway/src/db/repair.ts
@@ -149,6 +149,13 @@ function repairForeignKeys(db: Database): RepairOutcome {
     let totalDeleted = 0;
     db.transaction(() => {
       for (const [table, rowids] of byTable) {
+        // S5-F6 — defense-in-depth: SQLite never produces empty-string or
+        // null-byte-bearing identifiers from PRAGMA foreign_key_check, but
+        // skip them anyway so a future code path that injects synthetic
+        // violations cannot smuggle a malformed identifier past escapeIdentifier.
+        if (table.length === 0 || /\x00/.test(table)) {
+          continue;
+        }
         const BATCH = 999;
         for (let i = 0; i < rowids.length; i += BATCH) {
           const slice = rowids.slice(i, i + BATCH);

--- a/packages/gateway/src/db/repair.ts
+++ b/packages/gateway/src/db/repair.ts
@@ -121,6 +121,15 @@ function repairOrphanedSyncTokens(db: Database): RepairOutcome {
   }
 }
 
+// S5-F6 — defense-in-depth helper. SQLite never produces empty-string or
+// null-byte-bearing identifiers from PRAGMA foreign_key_check, but skip them
+// anyway so a future code path that injects synthetic violations cannot
+// smuggle a malformed identifier past escapeIdentifier.
+const NUL_CHAR = String.fromCharCode(0);
+function isUnsafeSqlIdentifier(id: string): boolean {
+  return id.length === 0 || id.includes(NUL_CHAR);
+}
+
 function repairForeignKeys(db: Database): RepairOutcome {
   const action: RepairAction = "foreign_key_cascade_delete";
   try {
@@ -149,11 +158,7 @@ function repairForeignKeys(db: Database): RepairOutcome {
     let totalDeleted = 0;
     db.transaction(() => {
       for (const [table, rowids] of byTable) {
-        // S5-F6 — defense-in-depth: SQLite never produces empty-string or
-        // null-byte-bearing identifiers from PRAGMA foreign_key_check, but
-        // skip them anyway so a future code path that injects synthetic
-        // violations cannot smuggle a malformed identifier past escapeIdentifier.
-        if (table.length === 0 || table.indexOf("\u0000") !== -1) {
+        if (isUnsafeSqlIdentifier(table)) {
           continue;
         }
         const BATCH = 999;

--- a/packages/gateway/src/db/repair.ts
+++ b/packages/gateway/src/db/repair.ts
@@ -153,7 +153,7 @@ function repairForeignKeys(db: Database): RepairOutcome {
         // null-byte-bearing identifiers from PRAGMA foreign_key_check, but
         // skip them anyway so a future code path that injects synthetic
         // violations cannot smuggle a malformed identifier past escapeIdentifier.
-        if (table.length === 0 || /\x00/.test(table)) {
+        if (table.length === 0 || table.indexOf("\u0000") !== -1) {
           continue;
         }
         const BATCH = 999;

--- a/packages/gateway/src/db/repair.ts
+++ b/packages/gateway/src/db/repair.ts
@@ -125,7 +125,7 @@ function repairOrphanedSyncTokens(db: Database): RepairOutcome {
 // null-byte-bearing identifiers from PRAGMA foreign_key_check, but skip them
 // anyway so a future code path that injects synthetic violations cannot
 // smuggle a malformed identifier past escapeIdentifier.
-const NUL_CHAR = String.fromCharCode(0);
+const NUL_CHAR = String.fromCodePoint(0);
 function isUnsafeSqlIdentifier(id: string): boolean {
   return id.length === 0 || id.includes(NUL_CHAR);
 }

--- a/packages/gateway/src/db/verify.ts
+++ b/packages/gateway/src/db/verify.ts
@@ -61,6 +61,16 @@ function tableExists(db: Database, name: string): boolean {
   return row !== null;
 }
 
+/**
+ * FTS5 integrity check (S5-F1).
+ *
+ * The `INSERT INTO item_fts(item_fts) VALUES('integrity-check')` form is the
+ * SQLite-FTS5 magic command that runs an integrity check against the FTS
+ * shadow tables; it is structurally a write but operates as a read on the
+ * content table. Therefore this function REQUIRES a read-write `db` handle.
+ * Callers passing a `readonly: true` Database will receive
+ * `SQLiteError: attempt to write a readonly database` here.
+ */
 function checkFts5Consistency(db: Database): VerifyFinding {
   const label = "fts5_consistency";
   if (!tableExists(db, "item_fts")) {
@@ -68,7 +78,7 @@ function checkFts5Consistency(db: Database): VerifyFinding {
     return { label, status: "ok", detail: "item_fts not present, skipped" };
   }
   try {
-    // This throws if the FTS5 shadow tables are inconsistent with the content table.
+    // S5-F1 — magic SQL: structurally a write, semantically a read on item_fts.
     db.run("INSERT INTO item_fts(item_fts) VALUES('integrity-check')");
     return { label, status: "ok" };
   } catch (err) {

--- a/packages/gateway/src/embedding/create-embedding-runtime.ts
+++ b/packages/gateway/src/embedding/create-embedding-runtime.ts
@@ -45,7 +45,18 @@ async function tryCreateOpenAIEmbeddingRuntime(
     const embedder = await createOpenAIEmbedder({ apiKey, model: openaiModel, dimensions: 384 });
     return createLazyEmbeddingRuntime(db, paths.dataDir, logger, slice, embedder);
   } catch (err) {
-    logger.warn({ err }, "OpenAI embedder init failed");
+    // S2-F9 — never pass the raw err object to pino. The OpenAI SDK's
+    // verbose error format may embed apiKey hints in nested fields the
+    // pino redact paths do not enumerate. Wrap in { errName, errMessage }
+    // so the redacted-pino value scrubber is the only path credentials can
+    // reach the log line.
+    logger.warn(
+      {
+        errName: err instanceof Error ? err.name : "Error",
+        errMessage: err instanceof Error ? err.message : String(err),
+      },
+      "OpenAI embedder init failed",
+    );
     return null;
   }
 }

--- a/packages/gateway/src/engine/engine.test.ts
+++ b/packages/gateway/src/engine/engine.test.ts
@@ -39,6 +39,17 @@ describe("HITL_REQUIRED", () => {
     expect(HITL_REQUIRED.has("evil.action")).toBe(false);
   });
 
+  test("S1-F8 — facade add() throws TypeError with a clear message", () => {
+    const mutable = HITL_REQUIRED as unknown as Set<string>;
+    expect(() => mutable.add("attacker.action")).toThrow(TypeError);
+    expect(() => mutable.add("attacker.action")).toThrow(/immutable/i);
+    expect(HITL_REQUIRED.has("attacker.action")).toBe(false);
+  });
+
+  test("S1-F7 — connector.reindex is gated for full-depth reindex consent", () => {
+    expect(HITL_REQUIRED.has("connector.reindex")).toBe(true);
+  });
+
   test("includes core destructive / outbound action types", () => {
     for (const t of [
       "file.delete",

--- a/packages/gateway/src/engine/executor.ts
+++ b/packages/gateway/src/engine/executor.ts
@@ -108,6 +108,7 @@ const HITL_REQUIRED_BACKING = new Set<string>([
   "extension.install",
   "connector.addMcp",
   "data.export",
+  "connector.reindex",
 ]);
 
 /** Runtime value is an immutable facade; typed as `ReadonlySet` for call sites (`.has`, iteration). */
@@ -138,7 +139,16 @@ export const HITL_REQUIRED = Object.freeze({
       callbackfn.call(thisArg, v, v, HITL_REQUIRED);
     }
   },
-}) as ReadonlySet<string>;
+  // S1-F8 — surface accidental mutation attempts at runtime with a
+  // meaningful TypeError instead of "is not a function". The cast goes
+  // through `unknown` because `ReadonlySet` does not declare an `add`
+  // member, but the runtime guard is the whole point of this method.
+  add(_value: string): never {
+    throw new TypeError(
+      "HITL_REQUIRED is immutable; edit HITL_REQUIRED_BACKING in executor.ts instead",
+    );
+  },
+}) as unknown as ReadonlySet<string>;
 
 const SENSITIVE_PAYLOAD_KEY = /(token|key|secret|password|credential|bearer|auth)/i;
 

--- a/packages/gateway/src/engine/executor.ts
+++ b/packages/gateway/src/engine/executor.ts
@@ -109,6 +109,11 @@ const HITL_REQUIRED_BACKING = new Set<string>([
   "connector.addMcp",
   "data.export",
   "connector.reindex",
+  // Vault writes — any IPC client planting / overwriting / deleting a
+  // secret requires a consent prompt. Internal callers holding a typed
+  // NimbusVault reference bypass the gate by design (S2-F8).
+  "vault.set",
+  "vault.delete",
 ]);
 
 /** Runtime value is an immutable facade; typed as `ReadonlySet` for call sites (`.has`, iteration). */

--- a/packages/gateway/src/extensions/install-from-local.test.ts
+++ b/packages/gateway/src/extensions/install-from-local.test.ts
@@ -42,7 +42,7 @@ describe("install-from-local", () => {
   test("assertSafeExtensionId rejects ids longer than 128 characters", () => {
     expect(() => assertSafeExtensionId("a".repeat(128))).not.toThrow();
     expect(() => assertSafeExtensionId("a".repeat(129))).toThrow(/too long/i);
-    expect(() => assertSafeExtensionId("@scope/" + "a".repeat(200))).toThrow(/too long/i);
+    expect(() => assertSafeExtensionId(`@scope/${"a".repeat(200)}`)).toThrow(/too long/i);
   });
 
   test("extensionInstallDirectory joins scoped id safely", () => {

--- a/packages/gateway/src/extensions/install-from-local.test.ts
+++ b/packages/gateway/src/extensions/install-from-local.test.ts
@@ -38,6 +38,13 @@ describe("install-from-local", () => {
     expect(() => assertSafeExtensionId("@scope/pkg")).not.toThrow();
   });
 
+  // S7-F9
+  test("assertSafeExtensionId rejects ids longer than 128 characters", () => {
+    expect(() => assertSafeExtensionId("a".repeat(128))).not.toThrow();
+    expect(() => assertSafeExtensionId("a".repeat(129))).toThrow(/too long/i);
+    expect(() => assertSafeExtensionId("@scope/" + "a".repeat(200))).toThrow(/too long/i);
+  });
+
   test("extensionInstallDirectory joins scoped id safely", () => {
     const root = join(tmpdir(), "nimbus-ext-test");
     expect(extensionInstallDirectory(root, "@acme/demo")).toBe(join(root, "@acme", "demo"));

--- a/packages/gateway/src/extensions/install-from-local.ts
+++ b/packages/gateway/src/extensions/install-from-local.ts
@@ -39,10 +39,23 @@ function sha256HexOfBytes(buf: Buffer): string {
   return createHash("sha256").update(buf).digest("hex");
 }
 
+/**
+ * S7-F9 — extension IDs are reflected into filesystem paths under the
+ * platform-specific extensions dir. Windows MAX_PATH is 260 chars; this cap
+ * leaves enough headroom for the install dir prefix (`<configDir>/extensions/`)
+ * and the longest entry filename without overflowing.
+ */
+const MAX_EXTENSION_ID_LENGTH = 128;
+
 /** Reject ids that could escape the extensions directory when joined. */
 export function assertSafeExtensionId(extensionId: string): void {
   if (extensionId.trim() === "" || extensionId.includes("\0")) {
     throw new Error("invalid extension id");
+  }
+  if (extensionId.length > MAX_EXTENSION_ID_LENGTH) {
+    throw new Error(
+      `extension id too long (max ${String(MAX_EXTENSION_ID_LENGTH)} chars, got ${String(extensionId.length)})`,
+    );
   }
   const normalized = extensionId.replaceAll("\\", "/");
   const parts = normalized.split("/").filter((p) => p !== "" && p !== ".");

--- a/packages/gateway/src/extensions/verify-extensions.test.ts
+++ b/packages/gateway/src/extensions/verify-extensions.test.ts
@@ -40,14 +40,14 @@ function makeExtensionDir(
 }
 
 describe("verifyExtensionsBestEffort", () => {
-  test("no-op below schema v10", () => {
+  test("no-op below schema v10", async () => {
     const db = new Database(":memory:");
     const { logger, warns } = memoryLogger();
-    verifyExtensionsBestEffort(db, logger);
+    await verifyExtensionsBestEffort(db, logger);
     expect(warns.length).toBe(0);
   });
 
-  test("manifest hash mismatch logs error and disables extension", () => {
+  test("manifest hash mismatch logs error and disables extension", async () => {
     const db = new Database(":memory:");
     LocalIndex.ensureSchema(db);
     const { dir } = makeExtensionDir("nimbus-ext-vfy-", "bad", "console.log(1)\n");
@@ -64,7 +64,7 @@ describe("verifyExtensionsBestEffort", () => {
     });
 
     const { logger, warns, errors } = memoryLogger();
-    verifyExtensionsBestEffort(db, logger);
+    await verifyExtensionsBestEffort(db, logger);
     expect(errors.some((w) => JSON.stringify(w).includes("manifest hash mismatch"))).toBe(true);
     expect(warns.length).toBe(0);
     const row = db.query("SELECT enabled FROM extension WHERE id = ?").get("bad") as {
@@ -73,7 +73,7 @@ describe("verifyExtensionsBestEffort", () => {
     expect(row.enabled).toBe(0);
   });
 
-  test("entry hash mismatch logs error and disables extension", () => {
+  test("entry hash mismatch logs error and disables extension", async () => {
     const db = new Database(":memory:");
     LocalIndex.ensureSchema(db);
     const { dir, manifestHex } = makeExtensionDir("nimbus-ext-vfy-entry-", "ent", "export {}\n");
@@ -90,9 +90,39 @@ describe("verifyExtensionsBestEffort", () => {
     });
 
     const { logger, errors } = memoryLogger();
-    verifyExtensionsBestEffort(db, logger);
+    await verifyExtensionsBestEffort(db, logger);
     expect(errors.some((w) => JSON.stringify(w).includes("entry hash mismatch"))).toBe(true);
     const row = db.query("SELECT enabled FROM extension WHERE id = ?").get("ent") as {
+      enabled: number;
+    };
+    expect(row.enabled).toBe(0);
+  });
+
+  // S7-F10
+  test("manifest hash mismatch calls mesh.stopExtensionClient when mesh is supplied", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    const { dir } = makeExtensionDir("nimbus-ext-mesh-stop-", "tampered", "console.log(1)\n");
+    const t = Date.now();
+    insertExtensionRow(db, {
+      id: "tampered",
+      version: "1.0.0",
+      install_path: dir,
+      manifest_hash: "0".repeat(64),
+      entry_hash: "0".repeat(64),
+      installed_at: t,
+      last_verified_at: t,
+    });
+    const stopped: string[] = [];
+    const mesh = {
+      stopExtensionClient: async (id: string) => {
+        stopped.push(id);
+      },
+    };
+    const { logger } = memoryLogger();
+    await verifyExtensionsBestEffort(db, logger, mesh);
+    expect(stopped).toEqual(["tampered"]);
+    const row = db.query("SELECT enabled FROM extension WHERE id = ?").get("tampered") as {
       enabled: number;
     };
     expect(row.enabled).toBe(0);

--- a/packages/gateway/src/extensions/verify-extensions.ts
+++ b/packages/gateway/src/extensions/verify-extensions.ts
@@ -11,13 +11,30 @@ import {
   touchExtensionVerifiedAt,
 } from "../automation/extension-store.ts";
 import { readIndexedUserVersion } from "../index/migrations/runner.ts";
+import { sha256HexEqualConstantTime } from "../util/hex-compare.ts";
 import { parseExtensionManifestJson, resolveExtensionManifestPath } from "./manifest.ts";
 
 function sha256HexOfBytes(buf: Buffer): string {
   return createHash("sha256").update(buf).digest("hex");
 }
 
-function verifyOneExtension(db: Database, logger: Logger, row: ExtensionRow, now: number): void {
+/**
+ * Optional mesh handle so the verifier can terminate a running extension
+ * child process when its on-disk hash no longer matches the registry row
+ * (S7-F10). Without this, a tampered extension would continue executing
+ * until the next idle-disconnect.
+ */
+export interface ExtensionMeshHandle {
+  stopExtensionClient(extensionId: string): Promise<void>;
+}
+
+async function verifyOneExtension(
+  db: Database,
+  logger: Logger,
+  row: ExtensionRow,
+  now: number,
+  mesh?: ExtensionMeshHandle,
+): Promise<void> {
   const manifestPath = resolveExtensionManifestPath(row.install_path);
   try {
     if (manifestPath === undefined) {
@@ -30,12 +47,18 @@ function verifyOneExtension(db: Database, logger: Logger, row: ExtensionRow, now
     }
     const manifestBytes = readFileSync(manifestPath);
     const manifestHex = sha256HexOfBytes(manifestBytes);
-    if (manifestHex !== row.manifest_hash) {
+    // S7-F8 — constant-time compare for stored hash vs computed hash.
+    if (!sha256HexEqualConstantTime(manifestHex, row.manifest_hash)) {
       logger.error(
         { extensionId: row.id, expected: row.manifest_hash, actual: manifestHex },
         "extensions: manifest hash mismatch — extension disabled",
       );
       setExtensionEnabled(db, row.id, false);
+      // S7-F10 — kill the running child so a tampered extension stops
+      // executing immediately, not at the next idle-disconnect.
+      if (mesh !== undefined) {
+        await mesh.stopExtensionClient(row.id);
+      }
       touchExtensionVerifiedAt(db, row.id, now);
       return;
     }
@@ -56,12 +79,15 @@ function verifyOneExtension(db: Database, logger: Logger, row: ExtensionRow, now
     }
     const entryBytes = readFileSync(entryPath);
     const entryHex = sha256HexOfBytes(entryBytes);
-    if (entryHex !== row.entry_hash) {
+    if (!sha256HexEqualConstantTime(entryHex, row.entry_hash)) {
       logger.error(
         { extensionId: row.id, expected: row.entry_hash, actual: entryHex },
         "extensions: entry hash mismatch — extension disabled",
       );
       setExtensionEnabled(db, row.id, false);
+      if (mesh !== undefined) {
+        await mesh.stopExtensionClient(row.id);
+      }
       touchExtensionVerifiedAt(db, row.id, now);
       return;
     }
@@ -87,7 +113,7 @@ export function verifyOneExtensionStrict(row: ExtensionRow): boolean {
   } catch {
     return false;
   }
-  if (sha256HexOfBytes(manifestBytes) !== row.manifest_hash) return false;
+  if (!sha256HexEqualConstantTime(sha256HexOfBytes(manifestBytes), row.manifest_hash)) return false;
   const manifest = parseExtensionManifestJson(manifestBytes.toString("utf8"));
   const entryRel =
     manifest.entry !== undefined && manifest.entry !== "" ? manifest.entry : "dist/index.js";
@@ -99,15 +125,22 @@ export function verifyOneExtensionStrict(row: ExtensionRow): boolean {
   } catch {
     return false;
   }
-  return sha256HexOfBytes(entryBytes) === row.entry_hash;
+  return sha256HexEqualConstantTime(sha256HexOfBytes(entryBytes), row.entry_hash);
 }
 
 /**
  * Verifies enabled extensions: manifest + entry file SHA-256 vs registry columns.
- * Logs warnings on most issues; manifest or entry hash mismatch logs ERROR and disables the extension.
+ * Logs warnings on most issues; manifest or entry hash mismatch logs ERROR
+ * and disables the extension. When `mesh` is supplied (S7-F10), a hash
+ * mismatch additionally calls `mesh.stopExtensionClient(extensionId)` so a
+ * tampered extension's running child process is terminated immediately.
  * Updates `last_verified_at` when checks complete.
  */
-export function verifyExtensionsBestEffort(db: Database, logger: Logger): void {
+export async function verifyExtensionsBestEffort(
+  db: Database,
+  logger: Logger,
+  mesh?: ExtensionMeshHandle,
+): Promise<void> {
   if (readIndexedUserVersion(db) < 10) {
     return;
   }
@@ -117,6 +150,6 @@ export function verifyExtensionsBestEffort(db: Database, logger: Logger): void {
   }
   const now = Date.now();
   for (const row of rows) {
-    verifyOneExtension(db, logger, row, now);
+    await verifyOneExtension(db, logger, row, now, mesh);
   }
 }

--- a/packages/gateway/src/index/lan-peers.test.ts
+++ b/packages/gateway/src/index/lan-peers.test.ts
@@ -16,11 +16,11 @@ describe("LocalIndex.addLanPeer (S3-F5)", () => {
       peerId: "peer-1",
       peerPubkey: pub,
       direction: "inbound",
-      hostIp: "10.0.0.1",
+      hostIp: "192.0.2.1",
     });
     const fetched = idx.getLanPeerByPubkey(pub);
     expect(fetched?.peer_id).toBe("peer-1");
-    expect(fetched?.host_ip).toBe("10.0.0.1");
+    expect(fetched?.host_ip).toBe("192.0.2.1");
   });
 
   test("re-pair from same pubkey is idempotent (no UNIQUE constraint throw)", () => {
@@ -30,18 +30,18 @@ describe("LocalIndex.addLanPeer (S3-F5)", () => {
       peerId: "peer-1",
       peerPubkey: pub,
       direction: "inbound",
-      hostIp: "10.0.0.1",
+      hostIp: "192.0.2.1",
     });
     expect(() =>
       idx.addLanPeer({
         peerId: "peer-1",
         peerPubkey: pub,
         direction: "inbound",
-        hostIp: "10.0.0.2",
+        hostIp: "192.0.2.2",
       }),
     ).not.toThrow();
     const fetched = idx.getLanPeerByPubkey(pub);
-    expect(fetched?.host_ip).toBe("10.0.0.2");
+    expect(fetched?.host_ip).toBe("192.0.2.2");
   });
 
   test("re-pair refreshes host_ip / host_port / display_name / paired_at", async () => {
@@ -51,7 +51,7 @@ describe("LocalIndex.addLanPeer (S3-F5)", () => {
       peerId: "peer-1",
       peerPubkey: pub,
       direction: "inbound",
-      hostIp: "10.0.0.1",
+      hostIp: "192.0.2.1",
       hostPort: 7475,
       displayName: "macbook",
     });
@@ -62,12 +62,12 @@ describe("LocalIndex.addLanPeer (S3-F5)", () => {
       peerId: "peer-1",
       peerPubkey: pub,
       direction: "outbound",
-      hostIp: "10.0.0.99",
+      hostIp: "192.0.2.99",
       hostPort: 9999,
       displayName: "phone",
     });
     const after = idx.getLanPeerByPubkey(pub);
-    expect(after?.host_ip).toBe("10.0.0.99");
+    expect(after?.host_ip).toBe("192.0.2.99");
     expect(after?.host_port).toBe(9999);
     expect(after?.display_name).toBe("phone");
     expect(after?.direction).toBe("outbound");
@@ -88,7 +88,7 @@ describe("LocalIndex.addLanPeer (S3-F5)", () => {
       peerId: "peer-grant",
       peerPubkey: pub,
       direction: "inbound",
-      hostIp: "10.0.0.5",
+      hostIp: "192.0.2.5",
     });
     // Re-pair must not reset write_allowed.
     expect(idx.getLanPeerByPubkey(pub)?.write_allowed).toBe(1);

--- a/packages/gateway/src/index/lan-peers.test.ts
+++ b/packages/gateway/src/index/lan-peers.test.ts
@@ -1,0 +1,102 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { LocalIndex } from "./local-index.ts";
+
+function newIdx(): LocalIndex {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return new LocalIndex(db);
+}
+
+describe("LocalIndex.addLanPeer (S3-F5)", () => {
+  test("first add inserts a row", () => {
+    const idx = newIdx();
+    const pub = new Uint8Array(32).fill(7);
+    idx.addLanPeer({
+      peerId: "peer-1",
+      peerPubkey: pub,
+      direction: "inbound",
+      hostIp: "10.0.0.1",
+    });
+    const fetched = idx.getLanPeerByPubkey(pub);
+    expect(fetched?.peer_id).toBe("peer-1");
+    expect(fetched?.host_ip).toBe("10.0.0.1");
+  });
+
+  test("re-pair from same pubkey is idempotent (no UNIQUE constraint throw)", () => {
+    const idx = newIdx();
+    const pub = new Uint8Array(32).fill(7);
+    idx.addLanPeer({
+      peerId: "peer-1",
+      peerPubkey: pub,
+      direction: "inbound",
+      hostIp: "10.0.0.1",
+    });
+    expect(() =>
+      idx.addLanPeer({
+        peerId: "peer-1",
+        peerPubkey: pub,
+        direction: "inbound",
+        hostIp: "10.0.0.2",
+      }),
+    ).not.toThrow();
+    const fetched = idx.getLanPeerByPubkey(pub);
+    expect(fetched?.host_ip).toBe("10.0.0.2");
+  });
+
+  test("re-pair refreshes host_ip / host_port / display_name / paired_at", async () => {
+    const idx = newIdx();
+    const pub = new Uint8Array(32).fill(11);
+    idx.addLanPeer({
+      peerId: "peer-1",
+      peerPubkey: pub,
+      direction: "inbound",
+      hostIp: "10.0.0.1",
+      hostPort: 7475,
+      displayName: "macbook",
+    });
+    const before = idx.getLanPeerByPubkey(pub);
+    // Sleep one millisecond so paired_at is provably advanced.
+    await new Promise((r) => setTimeout(r, 5));
+    idx.addLanPeer({
+      peerId: "peer-1",
+      peerPubkey: pub,
+      direction: "outbound",
+      hostIp: "10.0.0.99",
+      hostPort: 9999,
+      displayName: "phone",
+    });
+    const after = idx.getLanPeerByPubkey(pub);
+    expect(after?.host_ip).toBe("10.0.0.99");
+    expect(after?.host_port).toBe(9999);
+    expect(after?.display_name).toBe("phone");
+    expect(after?.direction).toBe("outbound");
+    expect(after?.paired_at).not.toBe(before?.paired_at);
+  });
+
+  test("re-pair preserves write_allowed grant (does not silently re-elevate)", () => {
+    const idx = newIdx();
+    const pub = new Uint8Array(32).fill(13);
+    idx.addLanPeer({
+      peerId: "peer-grant",
+      peerPubkey: pub,
+      direction: "inbound",
+    });
+    idx.grantLanWrite("peer-grant");
+    expect(idx.getLanPeerByPubkey(pub)?.write_allowed).toBe(1);
+    idx.addLanPeer({
+      peerId: "peer-grant",
+      peerPubkey: pub,
+      direction: "inbound",
+      hostIp: "10.0.0.5",
+    });
+    // Re-pair must not reset write_allowed.
+    expect(idx.getLanPeerByPubkey(pub)?.write_allowed).toBe(1);
+  });
+
+  test("getLanPeerByPubkey returns null/undefined for unknown pubkey", () => {
+    const idx = newIdx();
+    const got = idx.getLanPeerByPubkey(new Uint8Array(32).fill(99));
+    expect(got == null).toBe(true);
+  });
+});

--- a/packages/gateway/src/index/local-index.ts
+++ b/packages/gateway/src/index/local-index.ts
@@ -864,9 +864,21 @@ export class LocalIndex {
     hostPort?: number;
     displayName?: string;
   }): void {
+    // S3-F5 — idempotent on duplicate `peer_pubkey`. Re-pairing from a known
+    // peer used to throw `UNIQUE constraint failed: lan_peers.peer_pubkey`,
+    // silently dropping the pair_ok reply. ON CONFLICT(peer_pubkey) refreshes
+    // host_ip / host_port / display_name / paired_at while preserving the
+    // existing `write_allowed` grant — re-pairing must not re-elevate
+    // permission grants the user previously revoked.
     this.db.run(
       `INSERT INTO lan_peers (peer_id, peer_pubkey, direction, host_ip, host_port, display_name, write_allowed, paired_at)
-       VALUES (?, ?, ?, ?, ?, ?, 0, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, 0, ?)
+       ON CONFLICT(peer_pubkey) DO UPDATE SET
+         host_ip = excluded.host_ip,
+         host_port = excluded.host_port,
+         display_name = excluded.display_name,
+         direction = excluded.direction,
+         paired_at = excluded.paired_at`,
       [
         params.peerId,
         Buffer.from(params.peerPubkey),

--- a/packages/gateway/src/ipc/automation-rpc.ts
+++ b/packages/gateway/src/ipc/automation-rpc.ts
@@ -74,12 +74,18 @@ function handleValidateCondition(rec: Record<string, unknown> | undefined, db: D
   };
 }
 
+export interface AutomationRpcExtensionMeshHandle {
+  stopExtensionClient(extensionId: string): Promise<void>;
+}
+
 export function dispatchAutomationRpc(options: {
   method: string;
   params: unknown;
   db: Database;
   /** Required for `extension.install`. */
   extensionsDir?: string;
+  /** S7-F10 — `extension.disable` calls `stopExtensionClient` to terminate the running child. */
+  mesh?: AutomationRpcExtensionMeshHandle;
 }): Hit | { kind: "miss" } {
   const { method, db } = options;
   const rec = asRecord(options.params);
@@ -187,6 +193,13 @@ export function dispatchAutomationRpc(options: {
     case "extension.disable": {
       const id = requireString(rec, "id");
       const ok = setExtensionEnabled(db, id, false);
+      // S7-F10 — fire-and-forget: the IPC response shape is just { ok };
+      // callers don't wait for the child teardown. The disabled-flag is
+      // already flipped, so even if the stop is in flight, no new tool
+      // calls will reach the child.
+      if (ok && options.mesh !== undefined) {
+        void options.mesh.stopExtensionClient(id);
+      }
       return { kind: "hit", value: { ok } };
     }
 

--- a/packages/gateway/src/ipc/connector-rpc.test.ts
+++ b/packages/gateway/src/ipc/connector-rpc.test.ts
@@ -193,3 +193,63 @@ describe("connector.setConfig", () => {
     expect(calls).toContain("pause:github");
   });
 });
+
+describe("connector.startAuth deprecated alias (S4-F2)", () => {
+  test("connector.startAuth dispatches to the same handler as connector.auth", async () => {
+    // Both methods route through `handleConnectorAuth` which calls
+    // `parseServiceArg` first; passing an unknown service yields the same
+    // error from both paths, proving they share the handler.
+    const baseLocalIndex = makeIndex();
+    const start = dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: baseLocalIndex,
+      method: "connector.startAuth",
+      params: { service: "totally-not-a-real-connector" },
+    });
+    const auth = dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: baseLocalIndex,
+      method: "connector.auth",
+      params: { service: "totally-not-a-real-connector" },
+    });
+    // Both must reject with the same error class — proves they share the
+    // handler-side dispatch (parseServiceArg in handleConnectorAuth).
+    let startErr: unknown;
+    let authErr: unknown;
+    try {
+      await start;
+    } catch (e) {
+      startErr = e;
+    }
+    try {
+      await auth;
+    } catch (e) {
+      authErr = e;
+    }
+    expect(startErr).toBeDefined();
+    expect(authErr).toBeDefined();
+    expect((startErr as Error).constructor.name).toBe((authErr as Error).constructor.name);
+    expect((startErr as Error).message).toBe((authErr as Error).message);
+  });
+
+  test("connector.unknown returns miss; connector.startAuth does not", async () => {
+    const idx = makeIndex();
+    const miss = await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: idx,
+      method: "connector.unknownMethod",
+      params: {},
+    });
+    expect(miss.kind).toBe("miss");
+    // The alias case is hit, so it does NOT return miss — it routes to the
+    // auth handler which throws on a missing/invalid `service` param.
+    await expect(
+      dispatchConnectorRpc({
+        ...baseOpts,
+        localIndex: idx,
+        method: "connector.startAuth",
+        params: {},
+      }),
+    ).rejects.toBeDefined();
+  });
+});

--- a/packages/gateway/src/ipc/connector-rpc.ts
+++ b/packages/gateway/src/ipc/connector-rpc.ts
@@ -22,7 +22,6 @@ export { ConnectorRpcError } from "./connector-rpc-shared.ts";
 
 // S4-F2 — module-level once-flag so the deprecation warning logs at most
 // once per gateway boot. Mutated by dispatchConnectorRpc on first hit.
-// biome-ignore lint/style/useConst: intentionally mutable across module-scope writes
 let warnedConnectorStartAuth = false;
 
 export async function dispatchConnectorRpc(options: {
@@ -111,9 +110,12 @@ export async function dispatchConnectorRpc(options: {
     case "connector.auth": {
       if (method === "connector.startAuth" && !warnedConnectorStartAuth) {
         warnedConnectorStartAuth = true;
-        // No structured logger threaded through here yet; console.warn is
-        // captured by pino mirror and the redact-aware destination.
-        console.warn("connector.startAuth is deprecated; use connector.auth (S4-F2 alias)");
+        // No structured logger threaded through here yet; write to stderr
+        // directly so pino's mirror (when wired) and the daily log file
+        // both capture the deprecation notice exactly once.
+        process.stderr.write(
+          "connector.startAuth is deprecated; use connector.auth (S4-F2 alias)\n",
+        );
       }
       return handleConnectorAuth(ctx);
     }

--- a/packages/gateway/src/ipc/connector-rpc.ts
+++ b/packages/gateway/src/ipc/connector-rpc.ts
@@ -20,6 +20,11 @@ import { asRecord, ConnectorRpcError } from "./connector-rpc-shared.ts";
 
 export { ConnectorRpcError } from "./connector-rpc-shared.ts";
 
+// S4-F2 — module-level once-flag so the deprecation warning logs at most
+// once per gateway boot. Mutated by dispatchConnectorRpc on first hit.
+// biome-ignore lint/style/useConst: intentionally mutable across module-scope writes
+let warnedConnectorStartAuth = false;
+
 export async function dispatchConnectorRpc(options: {
   method: string;
   params: unknown;
@@ -96,9 +101,28 @@ export async function dispatchConnectorRpc(options: {
     }
     case "connector.sync":
       return handleConnectorSync(ctx);
-    case "connector.auth":
+    /**
+     * @deprecated S4-F2 — `connector.startAuth` is a compatibility alias
+     * retained for the WS5 onboarding flow (`Connect.tsx`) that still emits
+     * the older method name. Use `connector.auth` directly. Once the
+     * frontend migrates, this alias can be removed.
+     */
+    case "connector.startAuth":
+    case "connector.auth": {
+      if (method === "connector.startAuth" && !warnedConnectorStartAuth) {
+        warnedConnectorStartAuth = true;
+        // No structured logger threaded through here yet; console.warn is
+        // captured by pino mirror and the redact-aware destination.
+        console.warn("connector.startAuth is deprecated; use connector.auth (S4-F2 alias)");
+      }
       return handleConnectorAuth(ctx);
+    }
     default:
       return { kind: "miss" };
   }
+}
+
+/** Test-only — reset the deprecation once-flag so suites can isolate. */
+export function _resetStartAuthWarnFlagForTest(): void {
+  warnedConnectorStartAuth = false;
 }

--- a/packages/gateway/src/ipc/data-rpc.test.ts
+++ b/packages/gateway/src/ipc/data-rpc.test.ts
@@ -1,12 +1,22 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { memVault, newIndex } from "../../test/fixtures/data-test-helpers.ts";
+import { _addTestKdfProfile } from "../db/data-vault-crypto.ts";
 import type { ToolExecutor } from "../engine/executor.ts";
 import { DataRpcError, dispatchDataRpc } from "./data-rpc.ts";
 
 const testKdf = { t: 1, m: 1024, p: 1 } as const;
+
+// S2-F10 — register the test KDF profile so import-path tests succeed.
+let _restoreTestKdf: () => void;
+beforeAll(() => {
+  _restoreTestKdf = _addTestKdfProfile({ ...testKdf });
+});
+afterAll(() => {
+  _restoreTestKdf();
+});
 
 function emptyCtx(): Parameters<typeof dispatchDataRpc>[2] {
   return { index: undefined, vault: undefined, platform: "linux", nimbusVersion: "0.0.0-test" };

--- a/packages/gateway/src/ipc/lan-pairing.test.ts
+++ b/packages/gateway/src/ipc/lan-pairing.test.ts
@@ -40,4 +40,32 @@ describe("PairingWindow", () => {
     expect(w.consume("abc")).toBe(true);
     expect(w.consume("abc")).toBe(false);
   });
+
+  test("S3-F9 — getExpiresAt matches the windowMs the constructor was given", () => {
+    const t0 = 100_000;
+    const w = new PairingWindow(7_000, () => t0);
+    w.open("abc");
+    expect(w.getExpiresAt()).toBe(t0 + 7_000);
+  });
+
+  test("S3-F9 — getExpiresAt is null before open() and after close()", () => {
+    const w = new PairingWindow(5_000);
+    expect(w.getExpiresAt()).toBeNull();
+    w.open("abc");
+    expect(w.getExpiresAt()).not.toBeNull();
+    w.close();
+    expect(w.getExpiresAt()).toBeNull();
+  });
+
+  test("S3-F9 — consume() boundary aligns with getExpiresAt", () => {
+    const t0 = 100_000;
+    const w = new PairingWindow(5_000, () => t0);
+    w.open("abc");
+    const expiresAt = w.getExpiresAt();
+    expect(expiresAt).toBe(t0 + 5_000);
+    // Exactly at the boundary should still consume.
+    expect(w.consumeAt("abc", t0 + 5_000)).toBe(true);
+    // After consume the window is closed.
+    expect(w.getExpiresAt()).toBeNull();
+  });
 });

--- a/packages/gateway/src/ipc/lan-server-handshake.test.ts
+++ b/packages/gateway/src/ipc/lan-server-handshake.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Focused handshake integration tests for LanServer.
+ *
+ * - S3-F4: hello with unknown pubkey records a rate-limit failure.
+ * - S3-F6: lockout reply uses kind-aware code (hello_err for hello,
+ *   pair_err for pair) instead of always emitting pair_err.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { type BoxKeypair, generateBoxKeypair } from "./lan-crypto.ts";
+import { LanServer, type LanServerOptions } from "./lan-server.ts";
+
+let server: LanServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+type RateLimitCalls = { failures: string[]; allowed: boolean };
+
+function makeRateLimit(calls: RateLimitCalls): LanServerOptions["rateLimit"] {
+  return {
+    checkAllowed: () => calls.allowed,
+    recordFailure: (ip) => calls.failures.push(ip),
+    recordSuccess: () => {},
+  };
+}
+
+async function startServer(
+  rate: LanServerOptions["rateLimit"],
+  hostKp: BoxKeypair,
+  isKnown: LanServerOptions["isKnownPeer"] = () => null,
+): Promise<{ port: number }> {
+  server = new LanServer({
+    bind: "127.0.0.1",
+    port: 0,
+    hostKeypair: hostKp,
+    onMessage: async () => ({}),
+    isKnownPeer: isKnown,
+    rateLimit: rate,
+    pairing: {
+      isOpen: () => false,
+      consume: () => false,
+      open: () => {},
+      close: () => {},
+      getExpiresAt: () => undefined,
+    },
+    registerPeer: () => "peer-id",
+  });
+  await server.start();
+  const addr = server.listenAddr();
+  if (!addr) throw new Error("server.start did not produce a listen address");
+  return { port: addr.port };
+}
+
+function sendHandshake(
+  port: number,
+  kind: "hello" | "pair",
+  clientPubkey: Uint8Array,
+): Promise<{ kind?: string } | null> {
+  const msg = JSON.stringify({
+    kind,
+    client_pubkey: Buffer.from(clientPubkey).toString("base64"),
+  });
+  const bytes = new TextEncoder().encode(msg);
+  const header = new Uint8Array(4);
+  new DataView(header.buffer).setUint32(0, bytes.length, false);
+
+  return new Promise((resolve) => {
+    let received: Uint8Array = new Uint8Array(0);
+    const conn = Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        open(socket) {
+          socket.write(header);
+          socket.write(bytes);
+        },
+        data(_socket, chunk) {
+          const merged = new Uint8Array(received.length + chunk.length);
+          merged.set(received, 0);
+          merged.set(chunk, received.length);
+          received = merged;
+        },
+        close() {
+          if (received.length < 4) {
+            resolve(null);
+            return;
+          }
+          const view = new DataView(received.buffer, received.byteOffset, received.byteLength);
+          const len = view.getUint32(0, false);
+          const body = received.slice(4, 4 + len);
+          try {
+            const parsed = JSON.parse(new TextDecoder().decode(body)) as { kind?: string };
+            resolve(parsed);
+          } catch {
+            resolve(null);
+          }
+        },
+      },
+    });
+    // Belt-and-suspenders timeout in case the server hangs.
+    setTimeout(() => {
+      try {
+        conn.then((s) => s.end()).catch(() => {});
+      } catch {
+        /* ignore */
+      }
+      resolve(null);
+    }, 2_000);
+  });
+}
+
+describe("LanServer.handleHandshake — S3-F4 / S3-F6", () => {
+  test("S3-F4 — hello with unknown pubkey records a rate-limit failure and replies hello_err", async () => {
+    const calls: RateLimitCalls = { failures: [], allowed: true };
+    const hostKp = generateBoxKeypair();
+    const { port } = await startServer(makeRateLimit(calls), hostKp);
+    const reply = await sendHandshake(port, "hello", new Uint8Array(32).fill(7));
+    expect(reply?.kind).toBe("hello_err");
+    expect(calls.failures.length).toBe(1);
+    expect(calls.failures[0]).toBe("127.0.0.1");
+  });
+
+  test("S3-F6 — locked-out hello receives hello_err (not pair_err)", async () => {
+    const calls: RateLimitCalls = { failures: [], allowed: false };
+    const hostKp = generateBoxKeypair();
+    const { port } = await startServer(makeRateLimit(calls), hostKp);
+    const reply = await sendHandshake(port, "hello", new Uint8Array(32).fill(7));
+    expect(reply?.kind).toBe("hello_err");
+    // checkAllowed=false short-circuits before recordFailure runs.
+    expect(calls.failures.length).toBe(0);
+  });
+
+  test("S3-F6 — locked-out pair receives pair_err (not hello_err)", async () => {
+    const calls: RateLimitCalls = { failures: [], allowed: false };
+    const hostKp = generateBoxKeypair();
+    const { port } = await startServer(makeRateLimit(calls), hostKp);
+    const reply = await sendHandshake(port, "pair", new Uint8Array(32).fill(7));
+    expect(reply?.kind).toBe("pair_err");
+  });
+});

--- a/packages/gateway/src/ipc/lan-server.ts
+++ b/packages/gateway/src/ipc/lan-server.ts
@@ -155,7 +155,14 @@ export class LanServer {
 
     const ip = socket.data.peerIp;
     if (!this.opts.rateLimit.checkAllowed(ip)) {
-      this.writeFrame(socket, JSON.stringify({ kind: "pair_err" }));
+      // S3-F6 — kind-aware lockout reply: replying `pair_err` to a `hello`
+      // probe leaks the fact that the IP is locked-out from the pair flow,
+      // a small cross-kind side-channel. Match the request kind so a hello
+      // gets `hello_err` and a pair gets `pair_err`.
+      this.writeFrame(
+        socket,
+        JSON.stringify({ kind: msg.kind === "hello" ? "hello_err" : "pair_err" }),
+      );
       socket.end();
       return;
     }
@@ -192,6 +199,11 @@ export class LanServer {
     // kind === "hello"
     const match = this.opts.isKnownPeer(clientPubkey);
     if (!match) {
+      // S3-F4 — record the failure so an attacker cannot churn through
+      // unknown pubkeys without consuming the per-IP failure budget. Silent
+      // socket.end() previously left the rate limiter blind to scanning.
+      this.opts.rateLimit.recordFailure(ip);
+      this.writeFrame(socket, JSON.stringify({ kind: "hello_err" }));
       socket.end();
       return;
     }

--- a/packages/gateway/src/ipc/reindex-rpc.test.ts
+++ b/packages/gateway/src/ipc/reindex-rpc.test.ts
@@ -53,33 +53,21 @@ describe("dispatchReindexRpc", () => {
     ).rejects.toBeInstanceOf(ReindexRpcError);
   });
 
-  // S1-F7
-  test("metadata_only depth skips the HITL gate (administrative)", async () => {
-    let gateCalls = 0;
-    const idx = makeIdx();
-    const executor = makeFakeExecutor({ onGate: () => gateCalls++ });
-    const out = await dispatchReindexRpc(
-      "connector.reindex",
-      { service: "github", depth: "metadata_only" },
-      { index: idx, toolExecutor: executor },
-    );
-    expect(gateCalls).toBe(0);
-    expect(out.kind).toBe("hit");
-  });
-
-  // S1-F7
-  test("summary depth skips the HITL gate (administrative)", async () => {
-    let gateCalls = 0;
-    const idx = makeIdx();
-    const executor = makeFakeExecutor({ onGate: () => gateCalls++ });
-    const out = await dispatchReindexRpc(
-      "connector.reindex",
-      { service: "github", depth: "summary" },
-      { index: idx, toolExecutor: executor },
-    );
-    expect(gateCalls).toBe(0);
-    expect(out.kind).toBe("hit");
-  });
+  // S1-F7 — administrative depths skip the HITL gate.
+  for (const depth of ["metadata_only", "summary"] as const) {
+    test(`${depth} depth skips the HITL gate (administrative)`, async () => {
+      let gateCalls = 0;
+      const idx = makeIdx();
+      const executor = makeFakeExecutor({ onGate: () => gateCalls++ });
+      const out = await dispatchReindexRpc(
+        "connector.reindex",
+        { service: "github", depth },
+        { index: idx, toolExecutor: executor },
+      );
+      expect(gateCalls).toBe(0);
+      expect(out.kind).toBe("hit");
+    });
+  }
 
   // S1-F7
   test("full depth runs the HITL gate before reindex", async () => {
@@ -89,7 +77,7 @@ describe("dispatchReindexRpc", () => {
       onGate: (action) => {
         order.push("gate");
         expect(action.type).toBe("connector.reindex");
-        const payload = action.payload as Record<string, unknown> | undefined;
+        const payload = action.payload;
         expect(payload?.["service"]).toBe("github");
         expect(payload?.["depth"]).toBe("full");
       },

--- a/packages/gateway/src/ipc/reindex-rpc.test.ts
+++ b/packages/gateway/src/ipc/reindex-rpc.test.ts
@@ -1,5 +1,7 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
+import type { ToolExecutor } from "../engine/executor.ts";
+import type { PlannedAction } from "../engine/types.ts";
 import { LocalIndex } from "../index/local-index.ts";
 import { dispatchReindexRpc, ReindexRpcError } from "./reindex-rpc.ts";
 
@@ -7,6 +9,21 @@ function makeIdx(): LocalIndex {
   const db = new Database(":memory:");
   LocalIndex.ensureSchema(db);
   return new LocalIndex(db);
+}
+
+type GateOutcome = "proceed" | { status: "rejected"; reason: string };
+
+function makeFakeExecutor(opts?: {
+  outcome?: GateOutcome;
+  onGate?: (action: PlannedAction) => void;
+}): ToolExecutor {
+  const outcome: GateOutcome = opts?.outcome ?? "proceed";
+  return {
+    gate: async (action: PlannedAction) => {
+      opts?.onGate?.(action);
+      return outcome;
+    },
+  } as unknown as ToolExecutor;
 }
 
 describe("dispatchReindexRpc", () => {
@@ -33,6 +50,83 @@ describe("dispatchReindexRpc", () => {
     const idx = makeIdx();
     await expect(
       dispatchReindexRpc("connector.reindex", { depth: "metadata_only" }, { index: idx }),
+    ).rejects.toBeInstanceOf(ReindexRpcError);
+  });
+
+  // S1-F7
+  test("metadata_only depth skips the HITL gate (administrative)", async () => {
+    let gateCalls = 0;
+    const idx = makeIdx();
+    const executor = makeFakeExecutor({ onGate: () => gateCalls++ });
+    const out = await dispatchReindexRpc(
+      "connector.reindex",
+      { service: "github", depth: "metadata_only" },
+      { index: idx, toolExecutor: executor },
+    );
+    expect(gateCalls).toBe(0);
+    expect(out.kind).toBe("hit");
+  });
+
+  // S1-F7
+  test("summary depth skips the HITL gate (administrative)", async () => {
+    let gateCalls = 0;
+    const idx = makeIdx();
+    const executor = makeFakeExecutor({ onGate: () => gateCalls++ });
+    const out = await dispatchReindexRpc(
+      "connector.reindex",
+      { service: "github", depth: "summary" },
+      { index: idx, toolExecutor: executor },
+    );
+    expect(gateCalls).toBe(0);
+    expect(out.kind).toBe("hit");
+  });
+
+  // S1-F7
+  test("full depth runs the HITL gate before reindex", async () => {
+    const order: string[] = [];
+    const idx = makeIdx();
+    const executor = makeFakeExecutor({
+      onGate: (action) => {
+        order.push("gate");
+        expect(action.type).toBe("connector.reindex");
+        const payload = action.payload as Record<string, unknown> | undefined;
+        expect(payload?.["service"]).toBe("github");
+        expect(payload?.["depth"]).toBe("full");
+      },
+    });
+    const out = await dispatchReindexRpc(
+      "connector.reindex",
+      { service: "github", depth: "full" },
+      { index: idx, toolExecutor: executor },
+    );
+    order.push("after-dispatch");
+    expect(order).toEqual(["gate", "after-dispatch"]);
+    expect(out.kind).toBe("hit");
+  });
+
+  // S1-F7
+  test("full depth bypasses the gate when no toolExecutor is wired (internal callers)", async () => {
+    const idx = makeIdx();
+    const out = await dispatchReindexRpc(
+      "connector.reindex",
+      { service: "github", depth: "full" },
+      { index: idx },
+    );
+    expect(out.kind).toBe("hit");
+  });
+
+  // S1-F7
+  test("full depth declined consent throws ReindexRpcError", async () => {
+    const idx = makeIdx();
+    const executor = makeFakeExecutor({
+      outcome: { status: "rejected", reason: "User declined consent gate." },
+    });
+    await expect(
+      dispatchReindexRpc(
+        "connector.reindex",
+        { service: "github", depth: "full" },
+        { index: idx, toolExecutor: executor },
+      ),
     ).rejects.toBeInstanceOf(ReindexRpcError);
   });
 });

--- a/packages/gateway/src/ipc/reindex-rpc.ts
+++ b/packages/gateway/src/ipc/reindex-rpc.ts
@@ -1,7 +1,17 @@
 import { type ReindexDepth, reindexConnector } from "../connectors/reindex.ts";
+import type { ToolExecutor } from "../engine/executor.ts";
 import type { LocalIndex } from "../index/local-index.ts";
 
-export type ReindexRpcContext = { index: LocalIndex | undefined };
+export type ReindexRpcContext = {
+  index: LocalIndex | undefined;
+  /**
+   * Optional `ToolExecutor` for HITL-gating destructive `full`-depth reindexes
+   * (S1-F7). When omitted (e.g. internal callers without an IPC consent
+   * channel), the gate is skipped and reindex runs unguarded — the caller
+   * is responsible for upstream authorization.
+   */
+  toolExecutor?: ToolExecutor;
+};
 type RpcResult = { kind: "hit"; value: unknown } | { kind: "miss" };
 
 export class ReindexRpcError extends Error {
@@ -34,6 +44,19 @@ export async function dispatchReindexRpc(
   const depth = typeof depthRaw === "string" ? (depthRaw as ReindexDepth) : "metadata_only";
   if (!VALID_DEPTHS.has(depth)) {
     throw new ReindexRpcError(-32602, "Invalid depth: must be metadata_only|summary|full");
+  }
+  // S1-F7 — only `full` (deep, irreversible) reindex requires consent.
+  // `metadata_only` and `summary` are administrative and run without a gate
+  // to preserve the existing CLI/automation flow. Internal callers (no
+  // toolExecutor) bypass the gate by design.
+  if (depth === "full" && ctx.toolExecutor !== undefined) {
+    const gateResult = await ctx.toolExecutor.gate({
+      type: "connector.reindex",
+      payload: { service, depth },
+    });
+    if (gateResult !== "proceed" && gateResult.status === "rejected") {
+      throw new ReindexRpcError(-32000, gateResult.reason);
+    }
   }
   const result = await reindexConnector({ index: ctx.index, service, depth });
   return { kind: "hit", value: result };

--- a/packages/gateway/src/ipc/server-vault-gated.test.ts
+++ b/packages/gateway/src/ipc/server-vault-gated.test.ts
@@ -49,7 +49,7 @@ function makeFakeVault(): { vault: NimbusVault; counters: VaultCounters } {
     },
     async listKeys(): Promise<string[]> {
       counters.listKeysCalls++;
-      return Object.keys(state).sort();
+      return Object.keys(state).sort((a, b) => a.localeCompare(b));
     },
   };
   return { vault, counters };
@@ -95,7 +95,7 @@ describe("dispatchVaultGated (S2-F8)", () => {
       value: "ghp_super_secret",
     });
     expect(captured?.type).toBe("vault.set");
-    const payload = captured?.payload as Record<string, unknown> | undefined;
+    const payload = captured?.payload;
     expect(payload?.["key"]).toBe("github.pat");
     expect(payload?.["value"]).toBeUndefined();
   });

--- a/packages/gateway/src/ipc/server-vault-gated.test.ts
+++ b/packages/gateway/src/ipc/server-vault-gated.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolExecutor } from "../engine/executor.ts";
+import type { PlannedAction } from "../engine/types.ts";
+import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import { dispatchVaultGated } from "./server.ts";
+
+type GateOutcome = "proceed" | { status: "rejected"; reason: string };
+
+function makeFakeExecutor(opts?: {
+  outcome?: GateOutcome;
+  onGate?: (action: PlannedAction) => void;
+}): ToolExecutor {
+  const outcome: GateOutcome = opts?.outcome ?? "proceed";
+  return {
+    gate: async (action: PlannedAction) => {
+      opts?.onGate?.(action);
+      return outcome;
+    },
+  } as unknown as ToolExecutor;
+}
+
+type VaultCounters = {
+  setCalls: number;
+  getCalls: number;
+  deleteCalls: number;
+  listKeysCalls: number;
+};
+
+function makeFakeVault(): { vault: NimbusVault; counters: VaultCounters } {
+  const state: Record<string, string> = {};
+  const counters: VaultCounters = {
+    setCalls: 0,
+    getCalls: 0,
+    deleteCalls: 0,
+    listKeysCalls: 0,
+  };
+  const vault: NimbusVault = {
+    async set(k: string, v: string): Promise<void> {
+      counters.setCalls++;
+      state[k] = v;
+    },
+    async get(k: string): Promise<string | null> {
+      counters.getCalls++;
+      return state[k] ?? null;
+    },
+    async delete(k: string): Promise<void> {
+      counters.deleteCalls++;
+      delete state[k];
+    },
+    async listKeys(): Promise<string[]> {
+      counters.listKeysCalls++;
+      return Object.keys(state).sort();
+    },
+  };
+  return { vault, counters };
+}
+
+describe("dispatchVaultGated (S2-F8)", () => {
+  test("vault.set requires consent before persistence", async () => {
+    let gateCalls = 0;
+    const { vault, counters } = makeFakeVault();
+    const exec = makeFakeExecutor({ onGate: () => gateCalls++ });
+    await dispatchVaultGated(vault, exec, "vault.set", {
+      key: "github.pat",
+      value: "ghp_test",
+    });
+    expect(gateCalls).toBe(1);
+    expect(counters.setCalls).toBe(1);
+  });
+
+  test("vault.set runs gate BEFORE the underlying set call", async () => {
+    const order: string[] = [];
+    const exec = makeFakeExecutor({ onGate: () => order.push("gate") });
+    const vault: NimbusVault = {
+      set: async () => {
+        order.push("set");
+      },
+      get: async () => null,
+      delete: async () => {},
+      listKeys: async () => [],
+    };
+    await dispatchVaultGated(vault, exec, "vault.set", {
+      key: "github.pat",
+      value: "ghp_test",
+    });
+    expect(order).toEqual(["gate", "set"]);
+  });
+
+  test("vault.set redacts the value from the gate payload", async () => {
+    let captured: PlannedAction | undefined;
+    const exec = makeFakeExecutor({ onGate: (a) => (captured = a) });
+    const { vault } = makeFakeVault();
+    await dispatchVaultGated(vault, exec, "vault.set", {
+      key: "github.pat",
+      value: "ghp_super_secret",
+    });
+    expect(captured?.type).toBe("vault.set");
+    const payload = captured?.payload as Record<string, unknown> | undefined;
+    expect(payload?.["key"]).toBe("github.pat");
+    expect(payload?.["value"]).toBeUndefined();
+  });
+
+  test("vault.delete requires consent before deletion", async () => {
+    let gateCalls = 0;
+    const { vault, counters } = makeFakeVault();
+    await vault.set("github.pat", "ghp_existing");
+    const exec = makeFakeExecutor({ onGate: () => gateCalls++ });
+    await dispatchVaultGated(vault, exec, "vault.delete", { key: "github.pat" });
+    expect(gateCalls).toBe(1);
+    expect(counters.deleteCalls).toBe(1);
+  });
+
+  test("vault.get does NOT call the gate (read-only)", async () => {
+    let gateCalls = 0;
+    const { vault } = makeFakeVault();
+    await vault.set("github.pat", "x");
+    const exec = makeFakeExecutor({ onGate: () => gateCalls++ });
+    await dispatchVaultGated(vault, exec, "vault.get", { key: "github.pat" });
+    expect(gateCalls).toBe(0);
+  });
+
+  test("vault.listKeys does NOT call the gate (read-only)", async () => {
+    let gateCalls = 0;
+    const { vault } = makeFakeVault();
+    const exec = makeFakeExecutor({ onGate: () => gateCalls++ });
+    await dispatchVaultGated(vault, exec, "vault.listKeys", {});
+    expect(gateCalls).toBe(0);
+  });
+
+  test("internal callers (no toolExecutor) bypass the gate by design", async () => {
+    const { vault, counters } = makeFakeVault();
+    await dispatchVaultGated(vault, undefined, "vault.set", {
+      key: "github.pat",
+      value: "ghp_internal",
+    });
+    expect(counters.setCalls).toBe(1);
+  });
+
+  test("rejected consent throws and skips the underlying set", async () => {
+    const { vault, counters } = makeFakeVault();
+    const exec = makeFakeExecutor({
+      outcome: { status: "rejected", reason: "User declined consent gate." },
+    });
+    await expect(
+      dispatchVaultGated(vault, exec, "vault.set", { key: "github.pat", value: "x" }),
+    ).rejects.toThrow(/declined/i);
+    expect(counters.setCalls).toBe(0);
+  });
+});

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -412,10 +412,33 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     return phase4RpcSkipped;
   }
 
-  async function tryDispatchReindexRpc(method: string, params: unknown): Promise<unknown> {
+  async function tryDispatchReindexRpc(
+    method: string,
+    params: unknown,
+    clientId: string,
+  ): Promise<unknown> {
     if (method !== "connector.reindex") return phase4RpcSkipped;
     try {
-      const out = await dispatchReindexRpc(method, params, { index: options.localIndex });
+      // S1-F7 — bind a per-client `ToolExecutor` so `full`-depth reindex
+      // routes through the HITL consent gate. The dispatcher used here is
+      // a stub: gate() never calls dispatch().
+      const stubDispatcher: ConnectorDispatcher = {
+        dispatch(): Promise<unknown> {
+          return Promise.reject(new Error("IPC-native gate does not dispatch to MCP"));
+        },
+      };
+      const toolExecutor =
+        options.localIndex === undefined
+          ? undefined
+          : new ToolExecutor(
+              bindConsentChannel(consentImpl, clientId),
+              options.localIndex,
+              stubDispatcher,
+            );
+      const out = await dispatchReindexRpc(method, params, {
+        index: options.localIndex,
+        ...(toolExecutor === undefined ? {} : { toolExecutor }),
+      });
       if (out.kind === "hit") return out.value;
     } catch (e) {
       if (e instanceof ReindexRpcError) throw new RpcMethodError(e.rpcCode, e.message);
@@ -570,7 +593,7 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     if (lanOutcome !== phase4RpcSkipped) return lanOutcome;
     const profileOutcome = await tryDispatchProfileRpc(method, params);
     if (profileOutcome !== phase4RpcSkipped) return profileOutcome;
-    return tryDispatchReindexRpc(method, params);
+    return tryDispatchReindexRpc(method, params, clientId);
   }
 
   async function tryDispatchSessionRpc(method: string, params: unknown): Promise<unknown> {

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -557,12 +557,18 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     const rec = asRecord(params);
     switch (method) {
       case "lan.openPairingWindow": {
+        // S3-F9 — derive expiresAt from the same PairingWindow instance whose
+        // timer enforces consume(). Previously expiresAt was computed from a
+        // separate `lanPairingWindowMs` option that could diverge from the
+        // PairingWindow's configured windowMs (e.g. caller passes the option
+        // here but constructs PairingWindow elsewhere with the default 300_000),
+        // leaving the UI counting down to a moment when the gate has already
+        // closed. The single source of truth is now PairingWindow.getExpiresAt().
         const pw = requireLanPairingWindow();
         const pairingCode = generatePairingCode();
-        const windowMs = (options as Record<string, unknown>)["lanPairingWindowMs"];
-        const ms = typeof windowMs === "number" ? windowMs : 300_000;
         pw.open(pairingCode);
-        return { pairingCode, expiresAt: Date.now() + ms };
+        const expiresAt = pw.getExpiresAt() ?? Date.now();
+        return { pairingCode, expiresAt };
       }
       case "lan.closePairingWindow": {
         requireLanPairingWindow().close();

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -761,6 +761,9 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
           params,
           db: options.localIndex.getDatabase(),
           ...(options.extensionsDir === undefined ? {} : { extensionsDir: options.extensionsDir }),
+          // S7-F10 — pass the mesh so extension.disable can terminate the
+          // running child immediately (fire-and-forget inside the dispatcher).
+          ...(options.connectorMesh === undefined ? {} : { mesh: options.connectorMesh }),
         });
         if (out.kind === "hit") {
           return out.value;

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -93,6 +93,35 @@ type VaultDispatchHit = { readonly kind: "hit"; readonly value: unknown };
 type VaultDispatchMiss = { readonly kind: "miss" };
 type VaultDispatchOutcome = VaultDispatchHit | VaultDispatchMiss;
 
+/**
+ * S2-F8 — wrap `dispatchVaultIfPresent` with a HITL gate for writes
+ * (`vault.set`, `vault.delete`). Reads (`vault.get`, `vault.listKeys`) stay
+ * ungated — connector auth flows must read tokens without a prompt.
+ *
+ * Internal callers (auth/OAuth flows holding a typed `NimbusVault` reference
+ * directly) bypass this gate by design; they never traverse the IPC surface.
+ *
+ * The gate payload includes only the key, never the value — the consent UI
+ * must not echo a credential even though the renderer-side redactor would
+ * catch it.
+ */
+export async function dispatchVaultGated(
+  vault: NimbusVault,
+  toolExecutor: ToolExecutor | undefined,
+  method: string,
+  params: unknown,
+): Promise<VaultDispatchOutcome> {
+  if ((method === "vault.set" || method === "vault.delete") && toolExecutor !== undefined) {
+    const rec = asRecord(params);
+    const key = rec !== undefined && typeof rec["key"] === "string" ? rec["key"] : "";
+    const gateResult = await toolExecutor.gate({ type: method, payload: { key } });
+    if (gateResult !== "proceed" && gateResult.status === "rejected") {
+      throw new RpcMethodError(-32000, gateResult.reason);
+    }
+  }
+  return dispatchVaultIfPresent(vault, method, params);
+}
+
 async function dispatchVaultIfPresent(
   vault: NimbusVault,
   method: string,
@@ -930,8 +959,28 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     return options.localIndex.listAudit(limit);
   }
 
-  async function rpcVaultOrMethodNotFound(method: string, params: unknown): Promise<unknown> {
-    const vaultOutcome = await dispatchVaultIfPresent(options.vault, method, params);
+  async function rpcVaultOrMethodNotFound(
+    method: string,
+    params: unknown,
+    clientId: string,
+  ): Promise<unknown> {
+    // S2-F8 — bind a per-client `ToolExecutor` so vault writes route through
+    // the HITL consent gate. The dispatcher used here is a stub: the gate
+    // never calls dispatch().
+    const stubDispatcher: ConnectorDispatcher = {
+      dispatch(): Promise<unknown> {
+        return Promise.reject(new Error("IPC-native gate does not dispatch to MCP"));
+      },
+    };
+    const toolExecutor =
+      options.localIndex === undefined
+        ? undefined
+        : new ToolExecutor(
+            bindConsentChannel(consentImpl, clientId),
+            options.localIndex,
+            stubDispatcher,
+          );
+    const vaultOutcome = await dispatchVaultGated(options.vault, toolExecutor, method, params);
     if (vaultOutcome.kind === "hit") {
       return vaultOutcome.value;
     }
@@ -1051,7 +1100,7 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
       }
 
       default:
-        return await rpcVaultOrMethodNotFound(method, params);
+        return await rpcVaultOrMethodNotFound(method, params, clientId);
     }
   }
 

--- a/packages/gateway/src/people/person-store.ts
+++ b/packages/gateway/src/people/person-store.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 
+import { dbRun } from "../db/write.ts";
 import type { PersonRecord } from "./person-types.ts";
 
 export function normalizeEmail(raw: string): string {
@@ -234,61 +235,53 @@ export function updatePersonHandles(
     linked?: boolean;
   },
 ): void {
-  const sets: string[] = [];
-  const params: Array<string | number | null> = [];
-  if (patch.displayName !== undefined) {
-    sets.push("display_name = ?");
-    params.push(patch.displayName);
-  }
-  if (patch.canonicalEmail !== undefined) {
-    sets.push("canonical_email = ?");
-    params.push(patch.canonicalEmail);
-  }
-  if (patch.githubLogin !== undefined) {
-    sets.push("github_login = ?");
-    params.push(patch.githubLogin);
-  }
-  if (patch.gitlabLogin !== undefined) {
-    sets.push("gitlab_login = ?");
-    params.push(patch.gitlabLogin);
-  }
-  if (patch.slackHandle !== undefined) {
-    sets.push("slack_handle = ?");
-    params.push(patch.slackHandle);
-  }
-  if (patch.linearMemberId !== undefined) {
-    sets.push("linear_member_id = ?");
-    params.push(patch.linearMemberId);
-  }
-  if (patch.jiraAccountId !== undefined) {
-    sets.push("jira_account_id = ?");
-    params.push(patch.jiraAccountId);
-  }
-  if (patch.notionUserId !== undefined) {
-    sets.push("notion_user_id = ?");
-    params.push(patch.notionUserId);
-  }
-  if (patch.bitbucketUuid !== undefined) {
-    sets.push("bitbucket_uuid = ?");
-    params.push(patch.bitbucketUuid);
-  }
-  if (patch.microsoftUserId !== undefined) {
-    sets.push("microsoft_user_id = ?");
-    params.push(patch.microsoftUserId);
-  }
-  if (patch.discordUserId !== undefined) {
-    sets.push("discord_user_id = ?");
-    params.push(patch.discordUserId);
-  }
-  if (patch.linked !== undefined) {
-    sets.push("linked = ?");
-    params.push(patch.linked ? 1 : 0);
-  }
-  if (sets.length === 0) {
-    return;
-  }
-  params.push(id);
-  db.run(`UPDATE person SET ${sets.join(", ")} WHERE id = ?`, params);
+  // S5-F5 — replace the prior `sets.join(", ")` template-literal SQL with
+  // discrete dbRun() calls per field. The discrete calls run inside a single
+  // transaction so multi-field patches stay atomic, and each UPDATE routes
+  // through dbRun's SQLITE_FULL → DiskFullError translation. The UPDATE
+  // skeleton is no longer constructed from a runtime list, eliminating the
+  // template-literal-SQL pattern entirely.
+  db.transaction(() => {
+    if (patch.displayName !== undefined) {
+      dbRun(db, "UPDATE person SET display_name = ? WHERE id = ?", [patch.displayName, id]);
+    }
+    if (patch.canonicalEmail !== undefined) {
+      dbRun(db, "UPDATE person SET canonical_email = ? WHERE id = ?", [patch.canonicalEmail, id]);
+    }
+    if (patch.githubLogin !== undefined) {
+      dbRun(db, "UPDATE person SET github_login = ? WHERE id = ?", [patch.githubLogin, id]);
+    }
+    if (patch.gitlabLogin !== undefined) {
+      dbRun(db, "UPDATE person SET gitlab_login = ? WHERE id = ?", [patch.gitlabLogin, id]);
+    }
+    if (patch.slackHandle !== undefined) {
+      dbRun(db, "UPDATE person SET slack_handle = ? WHERE id = ?", [patch.slackHandle, id]);
+    }
+    if (patch.linearMemberId !== undefined) {
+      dbRun(db, "UPDATE person SET linear_member_id = ? WHERE id = ?", [patch.linearMemberId, id]);
+    }
+    if (patch.jiraAccountId !== undefined) {
+      dbRun(db, "UPDATE person SET jira_account_id = ? WHERE id = ?", [patch.jiraAccountId, id]);
+    }
+    if (patch.notionUserId !== undefined) {
+      dbRun(db, "UPDATE person SET notion_user_id = ? WHERE id = ?", [patch.notionUserId, id]);
+    }
+    if (patch.bitbucketUuid !== undefined) {
+      dbRun(db, "UPDATE person SET bitbucket_uuid = ? WHERE id = ?", [patch.bitbucketUuid, id]);
+    }
+    if (patch.microsoftUserId !== undefined) {
+      dbRun(db, "UPDATE person SET microsoft_user_id = ? WHERE id = ?", [
+        patch.microsoftUserId,
+        id,
+      ]);
+    }
+    if (patch.discordUserId !== undefined) {
+      dbRun(db, "UPDATE person SET discord_user_id = ? WHERE id = ?", [patch.discordUserId, id]);
+    }
+    if (patch.linked !== undefined) {
+      dbRun(db, "UPDATE person SET linked = ? WHERE id = ?", [patch.linked ? 1 : 0, id]);
+    }
+  })();
 }
 
 export function listPersons(

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -269,8 +269,6 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
 
   const sessionMemoryStore = maybeAttachSessionMemoryStore(db, rt, sessionToml, sidecarStops);
 
-  verifyExtensionsBestEffort(db, syncLogger);
-
   const { syncScheduler, connectorMesh } = await createSchedulerWithMesh(
     paths,
     vault,
@@ -280,6 +278,12 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     notifications,
     syncLogger,
   );
+
+  // S7-F10 — pass the mesh so a hash mismatch can terminate the running
+  // child. Must run AFTER mesh creation; the mesh handle did not exist
+  // pre-G7 so this call was placed before mesh creation in the original
+  // wiring.
+  await verifyExtensionsBestEffort(db, syncLogger, connectorMesh);
   rt?.startBackgroundJobs();
   const ipcOpts: Parameters<typeof createIpcServer>[0] = {
     listenPath: paths.socketPath,

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -205,6 +205,10 @@ async function createSchedulerWithMesh(
   }
   const connectorMesh = await createLazyConnectorMesh(paths, vault, {
     listUserMcpConnectors: () => listUserMcpConnectors(db),
+    // S8-F9 — pass db + logger so args_json failures surface as
+    // persistent_error in connector health and a warn log line.
+    healthDb: db,
+    logger: syncLogger,
   });
   registerConnectorMeshSyncables(syncScheduler, connectorMesh);
   registerUserMcpSyncablesFromDatabase(db, syncScheduler, connectorMesh);

--- a/packages/gateway/src/platform/gateway-log-file.ts
+++ b/packages/gateway/src/platform/gateway-log-file.ts
@@ -108,11 +108,13 @@ function pinoLogFormatter(o: Record<string, unknown>): Record<string, unknown> {
   const e = out["err"];
   if (e !== null && typeof e === "object") {
     const eObj = { ...(e as Record<string, unknown>) };
-    if (typeof eObj["message"] === "string") {
-      eObj["message"] = scrubRedactedValuePatterns(eObj["message"] as string);
+    const msg = eObj["message"];
+    if (typeof msg === "string") {
+      eObj["message"] = scrubRedactedValuePatterns(msg);
     }
-    if (typeof eObj["stack"] === "string") {
-      eObj["stack"] = scrubRedactedValuePatterns(eObj["stack"] as string);
+    const stack = eObj["stack"];
+    if (typeof stack === "string") {
+      eObj["stack"] = scrubRedactedValuePatterns(stack);
     }
     out["err"] = eObj;
   }

--- a/packages/gateway/src/platform/gateway-log-file.ts
+++ b/packages/gateway/src/platform/gateway-log-file.ts
@@ -24,13 +24,116 @@ export function gatewayDailyLogPath(logDir: string): string {
   return join(logDir, gatewayLogBasename());
 }
 
+/**
+ * S2-F9 — paths consumed by `pino`'s redact config. Covers the most common
+ * third-party SDK error shapes (Authorization headers, nested config.headers,
+ * common token field names) so an OpenAI/Anthropic/Slack SDK error chain
+ * cannot smuggle credentials through these structured paths.
+ *
+ * Both top-level (`apiKey`, `token`) and one-level-deep (`*.apiKey`,
+ * `err.apiKey`) variants are listed because pino's redact path syntax does
+ * not match implicitly across depths.
+ */
 const PINO_REDACT_PATHS: readonly string[] = [
+  // Legacy paths
   "*.token",
   "*.secret",
   "oauth.*",
   "*.password",
   "*.key",
+  // Top-level direct names (pino's `*.foo` does not match top-level `foo`).
+  "apiKey",
+  "api_key",
+  "token",
+  "secret",
+  "password",
+  "accessToken",
+  "refreshToken",
+  "bot_token",
+  "app_password",
+  "authorization",
+  "Authorization",
+  // One-level-deep
+  "*.apiKey",
+  "*.api_key",
+  "*.accessToken",
+  "*.refreshToken",
+  "*.bot_token",
+  "*.app_password",
+  // Header chains
+  "*.headers.authorization",
+  "*.headers.Authorization",
+  "*.config.headers.authorization",
+  "*.config.headers.Authorization",
+  "err.headers.authorization",
+  "err.headers.Authorization",
+  "err.config.headers.authorization",
+  "err.config.headers.Authorization",
+  "err.apiKey",
+  "err.api_key",
+  "err.token",
+  "err.accessToken",
 ];
+
+/**
+ * S2-F9 — value-level patterns scrubbed from `msg` and from `err.message` /
+ * `err.stack`. Defends against future third-party SDK error formats that
+ * embed credentials in the bare message string instead of structured fields.
+ */
+export const REDACT_VALUE_PATTERNS: ReadonlyArray<RegExp> = [
+  /Bearer\s+[A-Za-z0-9._\-+/=]+/g,
+  /sk-[A-Za-z0-9_-]{16,}/g,
+  /sk-ant-[A-Za-z0-9_-]{16,}/g,
+  /ghp_[A-Za-z0-9]{16,}/g,
+  /gho_[A-Za-z0-9]{16,}/g,
+  /xox[baprs]-[A-Za-z0-9-]{8,}/g,
+  /AKIA[0-9A-Z]{16}/g,
+  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+];
+
+export function scrubRedactedValuePatterns(s: string): string {
+  let out = s;
+  for (const re of REDACT_VALUE_PATTERNS) {
+    out = out.replace(re, "[REDACTED]");
+  }
+  return out;
+}
+
+function pinoLogFormatter(o: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...o };
+  // pino calls `formatters.log` on the merged input bindings (the first
+  // object arg). The bare `msg` string is NOT in this object — it is added
+  // separately by pino — so message-string scrubbing happens in the
+  // `hooks.logMethod` stage below.
+  const e = out["err"];
+  if (e !== null && typeof e === "object") {
+    const eObj = { ...(e as Record<string, unknown>) };
+    if (typeof eObj["message"] === "string") {
+      eObj["message"] = scrubRedactedValuePatterns(eObj["message"] as string);
+    }
+    if (typeof eObj["stack"] === "string") {
+      eObj["stack"] = scrubRedactedValuePatterns(eObj["stack"] as string);
+    }
+    out["err"] = eObj;
+  }
+  return out;
+}
+
+/**
+ * S2-F9 — intercept user-supplied log args and scrub credential-shaped
+ * substrings from any string arg before pino formats them. Catches the
+ * common case `logger.warn("token rejected: Bearer abc...")` where the
+ * sensitive value is in the bare msg string, never reaching the
+ * `formatters.log` hook.
+ */
+function pinoLogMethodHook(
+  this: unknown,
+  args: unknown[],
+  method: (...a: unknown[]) => void,
+): void {
+  const scrubbed = args.map((a) => (typeof a === "string" ? scrubRedactedValuePatterns(a) : a));
+  method.apply(this, scrubbed);
+}
 
 const ALLOWED_LEVELS = new Set<string>([
   "fatal",
@@ -53,6 +156,11 @@ function resolveLogLevel(): string {
 /**
  * Pino logger: always appends JSON lines to the daily file under `logDir`.
  * When stdout is a TTY, also mirrors to stdout for local development.
+ *
+ * S2-F9 — applies both pino's `redact` config (structured paths) and a
+ * value-level scrubber via `formatters.log` for `msg` / `err.message` /
+ * `err.stack` so unstructured credential leakage from third-party SDK
+ * error chains is also stripped.
  */
 export function createGatewayPinoLogger(logDir: string): Logger {
   const level = resolveLogLevel();
@@ -60,6 +168,8 @@ export function createGatewayPinoLogger(logDir: string): Logger {
   const baseOpts = {
     level,
     redact: [...PINO_REDACT_PATHS],
+    formatters: { log: pinoLogFormatter },
+    hooks: { logMethod: pinoLogMethodHook },
   };
 
   const fileDest = pino.destination({ dest: logPath, sync: false });
@@ -74,6 +184,26 @@ export function createGatewayPinoLogger(logDir: string): Logger {
     );
   }
   return pino(baseOpts, fileDest);
+}
+
+/**
+ * Test-only — build a pino logger that writes to the supplied stream and
+ * applies the production redact config. Used by S2-F9 unit tests so they
+ * can capture log lines without touching the filesystem.
+ */
+export function createGatewayPinoLoggerForStream(
+  stream: NodeJS.WritableStream,
+  level = "warn",
+): Logger {
+  return pino(
+    {
+      level,
+      redact: [...PINO_REDACT_PATHS],
+      formatters: { log: pinoLogFormatter },
+      hooks: { logMethod: pinoLogMethodHook },
+    },
+    stream,
+  );
 }
 
 /**

--- a/packages/gateway/src/platform/gateway-log-redact.test.ts
+++ b/packages/gateway/src/platform/gateway-log-redact.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { Writable } from "node:stream";
+import {
+  createGatewayPinoLoggerForStream,
+  scrubRedactedValuePatterns,
+} from "./gateway-log-file.ts";
+
+function captureLogs(): { writer: Writable; lines: () => string[] } {
+  const collected: string[] = [];
+  const writer = new Writable({
+    write(chunk, _enc, cb): void {
+      collected.push(chunk.toString("utf8"));
+      cb();
+    },
+  });
+  return { writer, lines: () => collected };
+}
+
+describe("scrubRedactedValuePatterns (S2-F9)", () => {
+  test("strips Bearer tokens", () => {
+    expect(scrubRedactedValuePatterns("Authorization: Bearer abc.def-123/xyz=+")).toBe(
+      "Authorization: [REDACTED]",
+    );
+  });
+
+  test("strips OpenAI sk- prefixes", () => {
+    expect(scrubRedactedValuePatterns("Invalid API key starting with sk-abc1234567890_xyz")).toBe(
+      "Invalid API key starting with [REDACTED]",
+    );
+  });
+
+  test("strips Anthropic sk-ant- prefixes", () => {
+    expect(scrubRedactedValuePatterns("token=sk-ant-abc1234567890zzzz")).toBe("token=[REDACTED]");
+  });
+
+  test("strips GitHub ghp_ tokens", () => {
+    expect(scrubRedactedValuePatterns("auth ghp_AbCdEf1234567890abcd")).toBe("auth [REDACTED]");
+  });
+
+  test("strips Slack xoxb tokens", () => {
+    expect(scrubRedactedValuePatterns("token=xoxb-1234-5678-AbCdEf")).toBe("token=[REDACTED]");
+  });
+
+  test("strips AWS access key ids", () => {
+    expect(scrubRedactedValuePatterns("AKIAIOSFODNN7EXAMPLE in stack")).toBe("[REDACTED] in stack");
+  });
+
+  test("strips JWT tokens", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiIs.eyJzdWIiOiIxMjM0NX0.SflKxwRJSMeKKF2QT4fwpMeJ";
+    expect(scrubRedactedValuePatterns(`bearer ${jwt}`)).toBe("bearer [REDACTED]");
+  });
+
+  test("leaves a plain message unchanged", () => {
+    expect(scrubRedactedValuePatterns("normal log line")).toBe("normal log line");
+  });
+});
+
+describe("createGatewayPinoLoggerForStream — redaction (S2-F9)", () => {
+  test("strips a Bearer token from a logged err.headers.Authorization", () => {
+    const { writer, lines } = captureLogs();
+    const logger = createGatewayPinoLoggerForStream(writer, "warn");
+    const err = new Error("upstream failed") as Error & {
+      headers?: Record<string, string>;
+    };
+    err.headers = { Authorization: "Bearer top-secret-token-1234567890" };
+    logger.warn({ err }, "OpenAI embedder init failed");
+    const blob = lines().join("");
+    expect(blob.includes("top-secret-token-1234567890")).toBe(false);
+    // The bare label must remain so the operator sees what failed.
+    expect(blob.includes("OpenAI embedder init failed")).toBe(true);
+  });
+
+  test("strips an sk- key embedded in err.message via the value scrubber", () => {
+    const { writer, lines } = captureLogs();
+    const logger = createGatewayPinoLoggerForStream(writer, "warn");
+    const err = new Error("Invalid API key starting with sk-leakedkeythatislongenough");
+    logger.warn({ err }, "init failed");
+    const blob = lines().join("");
+    expect(blob.includes("sk-leakedkeythatislongenough")).toBe(false);
+  });
+
+  test("strips token-shaped values in `msg`", () => {
+    const { writer, lines } = captureLogs();
+    const logger = createGatewayPinoLoggerForStream(writer, "warn");
+    logger.warn(`token rejected: Bearer abcdefghijklmnopqrst`);
+    const blob = lines().join("");
+    expect(blob.includes("Bearer abcdefghijklmnopqrst")).toBe(false);
+    expect(blob.includes("token rejected")).toBe(true);
+  });
+
+  test("strips top-level apiKey via the redact paths config", () => {
+    const { writer, lines } = captureLogs();
+    const logger = createGatewayPinoLoggerForStream(writer, "warn");
+    logger.warn({ apiKey: "sk-thisshouldbescrubbed12345" }, "auth failed");
+    const blob = lines().join("");
+    expect(blob.includes("sk-thisshouldbescrubbed12345")).toBe(false);
+  });
+});

--- a/packages/gateway/src/platform/gateway-log-redact.test.ts
+++ b/packages/gateway/src/platform/gateway-log-redact.test.ts
@@ -38,6 +38,7 @@ describe("scrubRedactedValuePatterns (S2-F9)", () => {
   });
 
   test("strips Slack xoxb tokens", () => {
+    // gitleaks:allow — synthetic fixture for redaction unit test
     expect(scrubRedactedValuePatterns("token=xoxb-1234-5678-AbCdEf")).toBe("token=[REDACTED]");
   });
 
@@ -46,6 +47,7 @@ describe("scrubRedactedValuePatterns (S2-F9)", () => {
   });
 
   test("strips JWT tokens", () => {
+    // gitleaks:allow — synthetic fixture for redaction unit test
     const jwt = "eyJhbGciOiJIUzI1NiIs.eyJzdWIiOiIxMjM0NX0.SflKxwRJSMeKKF2QT4fwpMeJ";
     expect(scrubRedactedValuePatterns(`bearer ${jwt}`)).toBe("bearer [REDACTED]");
   });

--- a/packages/gateway/src/updater/manifest-fetcher.ts
+++ b/packages/gateway/src/updater/manifest-fetcher.ts
@@ -1,11 +1,29 @@
 import type { PlatformTarget, UpdateManifest } from "./types.ts";
 
+/**
+ * S6-F9 — strip URL userinfo before it lands in any error message. Mirror
+ * of `redactUrlUserinfo` in updater.ts; kept here too to avoid a circular
+ * import.
+ */
+function redactUrlUserinfoInMessage(message: string): string {
+  return message.replace(/[a-zA-Z0-9+\-.]+:\/\/[^\s/]+@[^\s/]+/g, (urlMatch) => {
+    try {
+      const u = new URL(urlMatch);
+      u.username = "";
+      u.password = "";
+      return u.toString();
+    } catch {
+      return "[REDACTED-URL]";
+    }
+  });
+}
+
 export class ManifestFetchError extends Error {
   constructor(
     message: string,
     public override readonly cause?: unknown,
   ) {
-    super(message);
+    super(redactUrlUserinfoInMessage(message));
     this.name = "ManifestFetchError";
   }
 }
@@ -34,6 +52,11 @@ export function isPermittedSchemeForUpdater(url: string): boolean {
 }
 
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+/**
+ * S6-F11 — accept either a bare ISO date (`2026-04-26`) or a full ISO-8601
+ * datetime with timezone (`2026-04-26T12:34:56Z` or `+02:00` offset).
+ */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))?$/;
 
 const PLATFORM_TARGETS = new Set<string>([
   "darwin-x86_64",
@@ -73,6 +96,12 @@ function validateManifest(raw: unknown): UpdateManifest {
   const pub_date = m["pub_date"];
   if (typeof pub_date !== "string") {
     throw new ManifestFetchError("manifest.pub_date must be a string");
+  }
+  // S6-F11 — pub_date must be a well-formed ISO-8601 date so any future
+  // consumer (sort, freshness check, audit row) can parse it without ad-hoc
+  // string checks downstream.
+  if (!ISO_DATE_RE.test(pub_date)) {
+    throw new ManifestFetchError(`manifest.pub_date is not well-formed ISO-8601: ${pub_date}`);
   }
   if (typeof m["platforms"] !== "object" || m["platforms"] === null) {
     throw new ManifestFetchError("manifest.platforms must be an object");

--- a/packages/gateway/src/updater/manifest-fetcher.ts
+++ b/packages/gateway/src/updater/manifest-fetcher.ts
@@ -3,10 +3,12 @@ import type { PlatformTarget, UpdateManifest } from "./types.ts";
 /**
  * S6-F9 — strip URL userinfo before it lands in any error message. Mirror
  * of `redactUrlUserinfo` in updater.ts; kept here too to avoid a circular
- * import.
+ * import. Bounded repetition prevents super-linear backtracking.
  */
+const URL_USERINFO_RE = /[a-zA-Z0-9+\-.]{1,32}:\/\/[^\s/@]{1,256}@[^\s/]{1,256}/g;
+
 function redactUrlUserinfoInMessage(message: string): string {
-  return message.replace(/[a-zA-Z0-9+\-.]+:\/\/[^\s/]+@[^\s/]+/g, (urlMatch) => {
+  return message.replaceAll(URL_USERINFO_RE, (urlMatch) => {
     try {
       const u = new URL(urlMatch);
       u.username = "";
@@ -55,8 +57,15 @@ const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 /**
  * S6-F11 — accept either a bare ISO date (`2026-04-26`) or a full ISO-8601
  * datetime with timezone (`2026-04-26T12:34:56Z` or `+02:00` offset).
+ *
+ * Two simpler regexes (each below Sonar's complexity limit) combined via
+ * `isWellFormedIso8601`.
  */
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))?$/;
+const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+function isWellFormedIso8601(s: string): boolean {
+  return ISO_DATE_ONLY_RE.test(s) || ISO_DATETIME_RE.test(s);
+}
 
 const PLATFORM_TARGETS = new Set<string>([
   "darwin-x86_64",
@@ -100,7 +109,7 @@ function validateManifest(raw: unknown): UpdateManifest {
   // S6-F11 — pub_date must be a well-formed ISO-8601 date so any future
   // consumer (sort, freshness check, audit row) can parse it without ad-hoc
   // string checks downstream.
-  if (!ISO_DATE_RE.test(pub_date)) {
+  if (!isWellFormedIso8601(pub_date)) {
     throw new ManifestFetchError(`manifest.pub_date is not well-formed ISO-8601: ${pub_date}`);
   }
   if (typeof m["platforms"] !== "object" || m["platforms"] === null) {

--- a/packages/gateway/src/updater/updater.test.ts
+++ b/packages/gateway/src/updater/updater.test.ts
@@ -427,3 +427,152 @@ describe("G6 — updater hardening", () => {
     expect(events).toContain("system.update.failed");
   });
 });
+
+describe("G6 — updater polish (S6-F8 / S6-F9 / S6-F10 / S6-F11)", () => {
+  afterEach(() => {
+    server?.stop(true);
+    downloadServer?.stop(true);
+  });
+
+  function startManifestAndDownloadServers(binary: Uint8Array) {
+    downloadServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response(binary),
+    });
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        jsonResponse(
+          buildSignedManifest(binary, kp, `http://127.0.0.1:${downloadServer.port}/bin`),
+        ),
+    });
+  }
+
+  test("S6-F8 — temp directory is removed after successful applyUpdate", async () => {
+    const binary = new Uint8Array(randomBytes(256));
+    startManifestAndDownloadServers(binary);
+    let installerPath = "";
+    const u = makeUpdater({
+      invokeInstaller: async (p: string) => {
+        installerPath = p;
+      },
+    });
+    await u.checkNow();
+    await u.applyUpdate();
+    const { existsSync } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    expect(installerPath).not.toBe("");
+    expect(existsSync(dirname(installerPath))).toBe(false);
+  });
+
+  test("S6-F8 — temp directory is removed when invokeInstaller throws", async () => {
+    const binary = new Uint8Array(randomBytes(256));
+    startManifestAndDownloadServers(binary);
+    let installerPath = "";
+    const u = makeUpdater({
+      invokeInstaller: async (p: string) => {
+        installerPath = p;
+        throw new Error("simulated install failure");
+      },
+    });
+    await u.checkNow();
+    await expect(u.applyUpdate()).rejects.toThrow(/simulated/);
+    const { existsSync } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    expect(installerPath).not.toBe("");
+    expect(existsSync(dirname(installerPath))).toBe(false);
+  });
+
+  test("S6-F9 — getStatus.lastError strips URL userinfo from a fetch error", async () => {
+    // Use a non-loopback URL with userinfo so isPermittedSchemeForUpdater
+    // rejects it before fetch — the rejection message would otherwise
+    // echo the bare URL with credentials.
+    const u = new Updater({
+      currentVersion: "0.1.0",
+      manifestUrl: "https://user:supersecret@cdn.example.com/latest.json",
+      publicKey: kp.publicKey,
+      target: "linux-x86_64",
+      emit: () => {},
+      timeoutMs: 2000,
+    });
+    await expect(u.checkNow()).rejects.toBeDefined();
+    const status = u.getStatus();
+    expect(status.lastError).toBeDefined();
+    expect(status.lastError ?? "").not.toContain("supersecret");
+    expect(status.lastError ?? "").not.toContain("user:supersecret@");
+  });
+
+  test("S6-F10 — sha256HexEqualConstantTime is used (mismatch still rejected)", async () => {
+    const binary = new Uint8Array(randomBytes(512));
+    const tampered = new Uint8Array(randomBytes(512));
+    downloadServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response(tampered),
+    });
+    const manifest = buildSignedManifest(binary, kp, `http://127.0.0.1:${downloadServer.port}/bin`);
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => jsonResponse(manifest),
+    });
+    const u = makeUpdater();
+    await u.checkNow();
+    await expect(u.applyUpdate()).rejects.toThrow(/hash|signature/i);
+  });
+});
+
+describe("G6 — manifest-fetcher (S6-F11)", () => {
+  afterEach(() => {
+    server?.stop(true);
+  });
+
+  test("rejects malformed pub_date", async () => {
+    const binary = new Uint8Array(randomBytes(512));
+    const goodManifest = buildSignedManifest(binary, kp, "https://cdn.example.com/bin");
+    const tampered: Record<string, unknown> = {
+      ...(goodManifest as unknown as Record<string, unknown>),
+      pub_date: "yesterday",
+    };
+    server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => jsonResponse(tampered) });
+    const u = makeUpdater();
+    await expect(u.checkNow()).rejects.toThrow(/pub_date.*ISO-8601/i);
+  });
+
+  test("accepts ISO-date-only pub_date (no time component)", async () => {
+    const binary = new Uint8Array(randomBytes(512));
+    const goodManifest = buildSignedManifest(binary, kp, "https://cdn.example.com/bin");
+    const variant: Record<string, unknown> = {
+      ...(goodManifest as unknown as Record<string, unknown>),
+      pub_date: "2026-04-26",
+    };
+    server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => jsonResponse(variant) });
+    const u = makeUpdater();
+    const out = await u.checkNow();
+    expect(out.latestVersion).toBeDefined();
+  });
+
+  test("accepts full ISO-8601 datetime with TZ offset", async () => {
+    const binary = new Uint8Array(randomBytes(512));
+    const goodManifest = buildSignedManifest(binary, kp, "https://cdn.example.com/bin");
+    const variant: Record<string, unknown> = {
+      ...(goodManifest as unknown as Record<string, unknown>),
+      pub_date: "2026-04-26T14:30:00+02:00",
+    };
+    server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => jsonResponse(variant) });
+    const u = makeUpdater();
+    const out = await u.checkNow();
+    expect(out.latestVersion).toBeDefined();
+  });
+
+  test("ManifestFetchError redacts URL userinfo from constructed messages", async () => {
+    const { ManifestFetchError } = await import("./manifest-fetcher.ts");
+    const e = new ManifestFetchError(
+      "fetch failed at https://user:topsecret@cdn.example.com/latest.json",
+    );
+    expect(e.message).not.toContain("topsecret");
+    expect(e.message).not.toContain("user:topsecret@");
+  });
+});

--- a/packages/gateway/src/updater/updater.test.ts
+++ b/packages/gateway/src/updater/updater.test.ts
@@ -28,6 +28,32 @@ function makeUpdater(overrides?: Partial<UpdaterOptions>): Updater {
   });
 }
 
+type ManifestBuilder = (
+  binary: Uint8Array,
+  downloadUrl: string,
+) => ReturnType<typeof buildSignedManifest>;
+
+/**
+ * Spin up a download server + manifest server pair. Returns the binary so
+ * tests can derive expectations from it.
+ */
+function startManifestAndDownloadServers(
+  binary: Uint8Array,
+  build: ManifestBuilder = (b, url) => buildSignedManifest(b, kp, url, "0.2.0"),
+): void {
+  downloadServer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response(binary),
+  });
+  const downloadUrl = `http://127.0.0.1:${downloadServer.port}/bin`;
+  server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => jsonResponse(build(binary, downloadUrl)),
+  });
+}
+
 describe("Updater state machine", () => {
   afterEach(() => {
     server?.stop(true);
@@ -277,32 +303,6 @@ describe("G6 — updater hardening", () => {
     downloadServer?.stop(true);
   });
 
-  type ManifestBuilder = (
-    binary: Uint8Array,
-    downloadUrl: string,
-  ) => ReturnType<typeof buildSignedManifest>;
-
-  /**
-   * Spin up a download server + manifest server pair. Returns the binary so
-   * tests can derive expectations from it.
-   */
-  function startManifestAndDownloadServers(
-    binary: Uint8Array,
-    build: ManifestBuilder = (b, url) => buildSignedManifest(b, kp, url, "0.2.0"),
-  ): void {
-    downloadServer = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch: () => new Response(binary),
-    });
-    const downloadUrl = `http://127.0.0.1:${downloadServer.port}/bin`;
-    server = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch: () => jsonResponse(build(binary, downloadUrl)),
-    });
-  }
-
   test("downloadAsset rejects body that exceeds the configured cap (S6-F3)", async () => {
     // Use a small cap (1 KiB) and stream more than that; runtime accumulator
     // fires before MAX_DOWNLOAD_BYTES is even relevant. This validates the
@@ -434,56 +434,30 @@ describe("G6 — updater polish (S6-F8 / S6-F9 / S6-F10 / S6-F11)", () => {
     downloadServer?.stop(true);
   });
 
-  function startManifestAndDownloadServers(binary: Uint8Array) {
-    downloadServer = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch: () => new Response(binary),
-    });
-    server = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch: () =>
-        jsonResponse(
-          buildSignedManifest(binary, kp, `http://127.0.0.1:${downloadServer.port}/bin`),
-        ),
+  // S6-F8 — temp dir is removed regardless of installer success or failure.
+  for (const variant of ["success", "failure"] as const) {
+    test(`S6-F8 — temp directory is removed after applyUpdate ${variant}`, async () => {
+      const binary = new Uint8Array(randomBytes(256));
+      startManifestAndDownloadServers(binary);
+      let installerPath = "";
+      const u = makeUpdater({
+        invokeInstaller: async (p: string) => {
+          installerPath = p;
+          if (variant === "failure") throw new Error("simulated install failure");
+        },
+      });
+      await u.checkNow();
+      if (variant === "failure") {
+        await expect(u.applyUpdate()).rejects.toThrow(/simulated/);
+      } else {
+        await u.applyUpdate();
+      }
+      const { existsSync } = await import("node:fs");
+      const { dirname } = await import("node:path");
+      expect(installerPath).not.toBe("");
+      expect(existsSync(dirname(installerPath))).toBe(false);
     });
   }
-
-  test("S6-F8 — temp directory is removed after successful applyUpdate", async () => {
-    const binary = new Uint8Array(randomBytes(256));
-    startManifestAndDownloadServers(binary);
-    let installerPath = "";
-    const u = makeUpdater({
-      invokeInstaller: async (p: string) => {
-        installerPath = p;
-      },
-    });
-    await u.checkNow();
-    await u.applyUpdate();
-    const { existsSync } = await import("node:fs");
-    const { dirname } = await import("node:path");
-    expect(installerPath).not.toBe("");
-    expect(existsSync(dirname(installerPath))).toBe(false);
-  });
-
-  test("S6-F8 — temp directory is removed when invokeInstaller throws", async () => {
-    const binary = new Uint8Array(randomBytes(256));
-    startManifestAndDownloadServers(binary);
-    let installerPath = "";
-    const u = makeUpdater({
-      invokeInstaller: async (p: string) => {
-        installerPath = p;
-        throw new Error("simulated install failure");
-      },
-    });
-    await u.checkNow();
-    await expect(u.applyUpdate()).rejects.toThrow(/simulated/);
-    const { existsSync } = await import("node:fs");
-    const { dirname } = await import("node:path");
-    expect(installerPath).not.toBe("");
-    expect(existsSync(dirname(installerPath))).toBe(false);
-  });
 
   test("S6-F9 — getStatus.lastError strips URL userinfo from a fetch error", async () => {
     // Use a non-loopback URL with userinfo so isPermittedSchemeForUpdater

--- a/packages/gateway/src/updater/updater.ts
+++ b/packages/gateway/src/updater/updater.ts
@@ -1,6 +1,27 @@
+import { sha256HexEqualConstantTime } from "../util/hex-compare.ts";
 import { fetchUpdateManifest, isPermittedSchemeForUpdater } from "./manifest-fetcher.ts";
 import { sha256Hex, verifyBinarySignature, verifyManifestEnvelope } from "./signature-verifier.ts";
 import type { PlatformTarget, UpdateManifest, UpdaterStatus } from "./types.ts";
+
+/**
+ * S6-F9 — strip URL userinfo (user:pass@) from a message string before it
+ * lands in `lastError` or in any externally-visible field. The scheme pattern
+ * permits compound schemes (`git+https://`, `chrome-extension://`) and the
+ * authority pattern stops at the first `/` so paths containing `@` (mailto-
+ * like, query strings) are bounded.
+ */
+export function redactUrlUserinfo(message: string): string {
+  return message.replace(/[a-zA-Z0-9+\-.]+:\/\/[^\s/]+@[^\s/]+/g, (urlMatch) => {
+    try {
+      const u = new URL(urlMatch);
+      u.username = "";
+      u.password = "";
+      return u.toString();
+    } catch {
+      return "[REDACTED-URL]";
+    }
+  });
+}
 
 /** S6-F3 — manifest-controlled OOM defence. 500 MiB is well above any realistic Nimbus binary. */
 export const MAX_DOWNLOAD_BYTES = 500 * 1024 * 1024;
@@ -78,7 +99,10 @@ export class Updater {
       return result;
     } catch (err) {
       this.state = "failed";
-      this.lastError = err instanceof Error ? err.message : String(err);
+      // S6-F9 — never echo URL userinfo into `lastError`. The fetch error chain
+      // sometimes embeds the request URL verbatim, which can include
+      // user:pass@ if a misconfigured manifestUrl carries credentials.
+      this.lastError = redactUrlUserinfo(err instanceof Error ? err.message : String(err));
       throw err;
     }
   }
@@ -124,7 +148,10 @@ export class Updater {
 
     this.state = "verifying";
     const computedSha = sha256Hex(bytes);
-    if (computedSha !== asset.sha256) {
+    // S6-F10 — constant-time compare. Prevents partial-prefix timing
+    // information leaking across many upload attempts during an active
+    // attack on the manifest endpoint.
+    if (!sha256HexEqualConstantTime(computedSha, asset.sha256)) {
       this.state = "rolled_back";
       this.opts.emit("updater.verifyFailed", { reason: "hash_mismatch" });
       this.opts.emit("updater.rolledBack", { reason: "hash_mismatch" });
@@ -169,7 +196,12 @@ export class Updater {
     }
 
     this.state = "applying";
-    const binaryPath = await writeToTempFile(bytes);
+    // S6-F8 — write the installer to a fresh temp dir, run the installer,
+    // and ALWAYS clean up the temp dir in finally — success and failure
+    // alike. Without the cleanup the verified binary lingers on disk
+    // between updates, accumulating one mode-0o600 file per update under
+    // /tmp until the OS sweeps it.
+    const { dir, path: binaryPath } = await writeToTempFile(bytes);
     try {
       if (this.opts.invokeInstaller) {
         await this.opts.invokeInstaller(binaryPath);
@@ -185,13 +217,20 @@ export class Updater {
       this.state = "idle";
     } catch (err) {
       this.state = "failed";
-      this.lastError = err instanceof Error ? err.message : String(err);
+      this.lastError = redactUrlUserinfo(err instanceof Error ? err.message : String(err));
       this.opts.emit("updater.rolledBack", { reason: "installer_failed" });
       this.opts.recordUpdateEvent?.("system.update.failed", {
         toVersion: this.lastManifest.version,
         reason: "installer_failed",
       });
       throw err;
+    } finally {
+      try {
+        const { rmSync } = await import("node:fs");
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup */
+      }
     }
   }
 
@@ -266,15 +305,22 @@ function semverGreater(a: string, b: string): boolean {
   return false;
 }
 
-async function writeToTempFile(bytes: Uint8Array): Promise<string> {
-  const { mkdtempSync, writeFileSync } = await import("node:fs");
+async function writeToTempFile(bytes: Uint8Array): Promise<{ dir: string; path: string }> {
+  const { chmodSync, mkdtempSync, writeFileSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");
   const { join } = await import("node:path");
   const dir = mkdtempSync(join(tmpdir(), "nimbus-update-"));
   const path = join(dir, "installer.bin");
-  // Bytes are SHA-256 and Ed25519 verified by the caller before reaching here. // lgtm[js/path-injection,js/unsafe-deserialization]
-  writeFileSync(path, bytes); // lgtm[js/network-data-written-to-file]
-  return path;
+  // S6-F8 — explicit 0o600 so the installer binary is never readable by
+  // other users on a shared machine. Bytes are SHA-256 and Ed25519 verified
+  // by the caller before reaching here. // lgtm[js/path-injection,js/unsafe-deserialization]
+  writeFileSync(path, bytes, { mode: 0o600 }); // lgtm[js/network-data-written-to-file]
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    /* belt-and-suspenders for filesystems that ignore the create-mode */
+  }
+  return { dir, path };
 }
 
 export { ManifestFetchError } from "./manifest-fetcher.ts";

--- a/packages/gateway/src/updater/updater.ts
+++ b/packages/gateway/src/updater/updater.ts
@@ -5,13 +5,18 @@ import type { PlatformTarget, UpdateManifest, UpdaterStatus } from "./types.ts";
 
 /**
  * S6-F9 — strip URL userinfo (user:pass@) from a message string before it
- * lands in `lastError` or in any externally-visible field. The scheme pattern
- * permits compound schemes (`git+https://`, `chrome-extension://`) and the
- * authority pattern stops at the first `/` so paths containing `@` (mailto-
- * like, query strings) are bounded.
+ * lands in `lastError` or in any externally-visible field.
+ *
+ * Bounded repetition prevents catastrophic backtracking on adversarial
+ * inputs: scheme ≤32 chars, userinfo ≤256 chars, host ≤256 chars. The
+ * scheme pattern permits compound schemes (`git+https://`, `chrome-extension://`)
+ * and the authority pattern stops at the first `/` so paths containing `@`
+ * (mailto-like, query strings) are bounded.
  */
+const URL_USERINFO_RE = /[a-zA-Z0-9+\-.]{1,32}:\/\/[^\s/@]{1,256}@[^\s/]{1,256}/g;
+
 export function redactUrlUserinfo(message: string): string {
-  return message.replace(/[a-zA-Z0-9+\-.]+:\/\/[^\s/]+@[^\s/]+/g, (urlMatch) => {
+  return message.replaceAll(URL_USERINFO_RE, (urlMatch) => {
     try {
       const u = new URL(urlMatch);
       u.username = "";
@@ -108,6 +113,23 @@ export class Updater {
   }
 
   async applyUpdate(): Promise<void> {
+    const { manifest, asset } = this.requireApplyPreconditions();
+    this.opts.recordUpdateEvent?.("system.update.start", {
+      fromVersion: this.opts.currentVersion,
+      toVersion: manifest.version,
+      manifestUrl: this.opts.manifestUrl,
+      sha256: asset.sha256,
+      target: this.opts.target,
+    });
+    const bytes = await this.downloadOrFail(asset.url, manifest.version);
+    this.verifyOrFail(bytes, asset, manifest.version);
+    await this.installOrFail(bytes, manifest.version);
+  }
+
+  private requireApplyPreconditions(): {
+    manifest: UpdateManifest;
+    asset: { url: string; sha256: string; signature: string };
+  } {
     if (!this.lastManifest) {
       throw new Error("no manifest loaded — call checkNow() first");
     }
@@ -121,86 +143,69 @@ export class Updater {
     if (!asset) {
       throw new Error(`no asset for target ${this.opts.target}`);
     }
+    return { manifest: this.lastManifest, asset };
+  }
 
-    // S6-F7 — pre-flight audit row.
-    this.opts.recordUpdateEvent?.("system.update.start", {
-      fromVersion: this.opts.currentVersion,
-      toVersion: this.lastManifest.version,
-      manifestUrl: this.opts.manifestUrl,
-      sha256: asset.sha256,
-      target: this.opts.target,
-    });
-
+  private async downloadOrFail(url: string, toVersion: string): Promise<Uint8Array> {
     this.state = "downloading";
-    let bytes: Uint8Array;
     try {
-      bytes = await this.downloadAsset(asset.url);
+      return await this.downloadAsset(url);
     } catch (err) {
       this.state = "failed";
       this.lastError = err instanceof Error ? err.message : String(err);
       this.opts.emit("updater.rolledBack", { reason: "download_failed" });
       this.opts.recordUpdateEvent?.("system.update.failed", {
-        toVersion: this.lastManifest.version,
+        toVersion,
         reason: "download_failed",
       });
       throw err;
     }
+  }
 
+  private verifyOrFail(
+    bytes: Uint8Array,
+    asset: { sha256: string; signature: string },
+    toVersion: string,
+  ): void {
     this.state = "verifying";
     const computedSha = sha256Hex(bytes);
-    // S6-F10 — constant-time compare. Prevents partial-prefix timing
-    // information leaking across many upload attempts during an active
-    // attack on the manifest endpoint.
+    // S6-F10 — constant-time compare prevents partial-prefix timing leakage.
     if (!sha256HexEqualConstantTime(computedSha, asset.sha256)) {
-      this.state = "rolled_back";
-      this.opts.emit("updater.verifyFailed", { reason: "hash_mismatch" });
-      this.opts.emit("updater.rolledBack", { reason: "hash_mismatch" });
-      this.opts.recordUpdateEvent?.("system.update.failed", {
-        toVersion: this.lastManifest.version,
-        reason: "hash_mismatch",
-      });
+      this.failVerification(toVersion, "hash_mismatch");
       throw new Error(`binary hash mismatch: expected ${asset.sha256}, got ${computedSha}`);
     }
     const sigBytes = new Uint8Array(Buffer.from(asset.signature, "base64"));
-    // S6-F6 — primary defence is the envelope. Fall back to bare-SHA verification
-    // only during the migration window of one release; the verifier still
-    // emits an audit event noting which mode succeeded.
+    // S6-F6 — envelope-signed first, then fall back to bare-binary signature
+    // for one-release migration window. Either path emits a verified audit row.
     const envelopeOk = verifyManifestEnvelope({
-      version: this.lastManifest.version,
+      version: toVersion,
       target: this.opts.target,
       sha256: asset.sha256,
       signature: sigBytes,
       publicKey: this.opts.publicKey,
     });
     if (envelopeOk) {
-      this.opts.recordUpdateEvent?.("system.update.verified", {
-        toVersion: this.lastManifest.version,
-        envelope: true,
-      });
-    } else {
-      const bareOk = verifyBinarySignature(bytes, sigBytes, this.opts.publicKey);
-      if (!bareOk) {
-        this.state = "rolled_back";
-        this.opts.emit("updater.verifyFailed", { reason: "signature_invalid" });
-        this.opts.emit("updater.rolledBack", { reason: "signature_invalid" });
-        this.opts.recordUpdateEvent?.("system.update.failed", {
-          toVersion: this.lastManifest.version,
-          reason: "signature_invalid",
-        });
-        throw new Error("Ed25519 signature verification failed");
-      }
-      this.opts.recordUpdateEvent?.("system.update.verified", {
-        toVersion: this.lastManifest.version,
-        envelope: false,
-      });
+      this.opts.recordUpdateEvent?.("system.update.verified", { toVersion, envelope: true });
+      return;
     }
+    if (!verifyBinarySignature(bytes, sigBytes, this.opts.publicKey)) {
+      this.failVerification(toVersion, "signature_invalid");
+      throw new Error("Ed25519 signature verification failed");
+    }
+    this.opts.recordUpdateEvent?.("system.update.verified", { toVersion, envelope: false });
+  }
 
+  private failVerification(toVersion: string, reason: "hash_mismatch" | "signature_invalid"): void {
+    this.state = "rolled_back";
+    this.opts.emit("updater.verifyFailed", { reason });
+    this.opts.emit("updater.rolledBack", { reason });
+    this.opts.recordUpdateEvent?.("system.update.failed", { toVersion, reason });
+  }
+
+  private async installOrFail(bytes: Uint8Array, toVersion: string): Promise<void> {
     this.state = "applying";
-    // S6-F8 — write the installer to a fresh temp dir, run the installer,
-    // and ALWAYS clean up the temp dir in finally — success and failure
-    // alike. Without the cleanup the verified binary lingers on disk
-    // between updates, accumulating one mode-0o600 file per update under
-    // /tmp until the OS sweeps it.
+    // S6-F8 — write to a fresh temp dir, ALWAYS clean up in finally so the
+    // verified binary doesn't linger on disk between updates.
     const { dir, path: binaryPath } = await writeToTempFile(bytes);
     try {
       if (this.opts.invokeInstaller) {
@@ -208,11 +213,11 @@ export class Updater {
       }
       this.opts.recordUpdateEvent?.("system.update.installed", {
         fromVersion: this.opts.currentVersion,
-        toVersion: this.lastManifest.version,
+        toVersion,
       });
       this.opts.emit("updater.restarting", {
         fromVersion: this.opts.currentVersion,
-        toVersion: this.lastManifest.version,
+        toVersion,
       });
       this.state = "idle";
     } catch (err) {
@@ -220,7 +225,7 @@ export class Updater {
       this.lastError = redactUrlUserinfo(err instanceof Error ? err.message : String(err));
       this.opts.emit("updater.rolledBack", { reason: "installer_failed" });
       this.opts.recordUpdateEvent?.("system.update.failed", {
-        toVersion: this.lastManifest.version,
+        toVersion,
         reason: "installer_failed",
       });
       throw err;

--- a/packages/gateway/src/util/hex-compare.test.ts
+++ b/packages/gateway/src/util/hex-compare.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { sha256HexEqualConstantTime } from "./hex-compare.ts";
 
 const HEX_A = "0".repeat(64);
-const HEX_B = "0".repeat(63) + "1";
+const HEX_B = `${"0".repeat(63)}1`;
 const HEX_C = "f".repeat(64);
 
 describe("sha256HexEqualConstantTime", () => {

--- a/packages/gateway/src/util/hex-compare.test.ts
+++ b/packages/gateway/src/util/hex-compare.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { sha256HexEqualConstantTime } from "./hex-compare.ts";
+
+const HEX_A = "0".repeat(64);
+const HEX_B = "0".repeat(63) + "1";
+const HEX_C = "f".repeat(64);
+
+describe("sha256HexEqualConstantTime", () => {
+  test("equal full-length hashes return true", () => {
+    expect(sha256HexEqualConstantTime(HEX_A, HEX_A)).toBe(true);
+    expect(sha256HexEqualConstantTime(HEX_C, HEX_C)).toBe(true);
+  });
+
+  test("differ-by-one-bit returns false", () => {
+    expect(sha256HexEqualConstantTime(HEX_A, HEX_B)).toBe(false);
+  });
+
+  test("length mismatch returns false (no throw)", () => {
+    expect(sha256HexEqualConstantTime("abc", "abcd")).toBe(false);
+    expect(sha256HexEqualConstantTime(HEX_A, "abc")).toBe(false);
+  });
+
+  test("non-64-char inputs return false", () => {
+    expect(sha256HexEqualConstantTime("abc", "abc")).toBe(false);
+  });
+
+  test("invalid hex characters return false", () => {
+    expect(sha256HexEqualConstantTime("z".repeat(64), "z".repeat(64))).toBe(false);
+    expect(sha256HexEqualConstantTime(HEX_A, "z".repeat(64))).toBe(false);
+  });
+
+  test("uppercase and lowercase variants compare equal", () => {
+    const lower = "abc123def456".padEnd(64, "0");
+    const upper = lower.toUpperCase();
+    expect(sha256HexEqualConstantTime(lower, upper)).toBe(true);
+  });
+});

--- a/packages/gateway/src/util/hex-compare.ts
+++ b/packages/gateway/src/util/hex-compare.ts
@@ -1,0 +1,27 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time SHA-256 hex string equality.
+ *
+ * S6-F10 / S7-F8 — replaces direct `!==` comparison of hash hex strings,
+ * which can leak partial-match timing information across many calls.
+ *
+ * Returns `false` (not throws) on length mismatch, non-64-char inputs, or
+ * malformed hex — invalid hex is rejected before reaching `timingSafeEqual`
+ * so the constant-time guarantee only covers the valid-input fast path.
+ */
+export function sha256HexEqualConstantTime(a: string, b: string): boolean {
+  if (a.length !== b.length || a.length !== 64) return false;
+  let bufA: Buffer;
+  let bufB: Buffer;
+  try {
+    bufA = Buffer.from(a, "hex");
+    bufB = Buffer.from(b, "hex");
+  } catch {
+    return false;
+  }
+  if (bufA.length !== 32 || bufB.length !== 32) return false;
+  // Buffer.from(hex) silently drops invalid characters and produces a
+  // shorter buffer — so the length check above also catches malformed hex.
+  return timingSafeEqual(bufA, bufB);
+}

--- a/packages/gateway/src/vault/key-format.ts
+++ b/packages/gateway/src/vault/key-format.ts
@@ -1,12 +1,18 @@
 /**
  * Vault key shape: "<segment>.<segment>" — shared by all vault implementations.
+ *
+ * The regex is intentionally case-sensitive (S2-F7): mixed-case keys would
+ * collide on Windows NTFS (case-insensitive by default) and on macOS HFS+
+ * with case-insensitive volumes. Forcing lowercase removes the ambiguity at
+ * the validation boundary and keeps every backend's storage layout
+ * deterministic.
  */
 
 export function isWellFormedVaultKey(key: string): boolean {
   if (key.length === 0 || key.length > 256) {
     return false;
   }
-  return /^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$/i.test(key);
+  return /^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$/.test(key);
 }
 
 /** Throws a generic error — never include secret material in the message. */

--- a/packages/gateway/src/vault/vault.test.ts
+++ b/packages/gateway/src/vault/vault.test.ts
@@ -22,7 +22,8 @@ function dpapiVaultTestPaths(root: string, socketPath: string): PlatformPaths {
 describe("vault key validation", () => {
   test("accepts documented service.type shape", () => {
     expect(isWellFormedVaultKey("gmail.oauth")).toBe(true);
-    expect(isWellFormedVaultKey("OneDrive.Refresh")).toBe(true);
+    expect(isWellFormedVaultKey("onedrive.refresh")).toBe(true);
+    expect(isWellFormedVaultKey("google_drive.oauth")).toBe(true);
   });
 
   test("rejects empty and oversize keys", () => {
@@ -37,6 +38,17 @@ describe("vault key validation", () => {
     expect(isWellFormedVaultKey("gmail.oauth.extra")).toBe(false);
     expect(isWellFormedVaultKey("9mail.oauth")).toBe(false);
     expect(isWellFormedVaultKey("gmail.o auth")).toBe(false);
+  });
+
+  // S2-F7 — mixed-case keys would silently collide on case-insensitive
+  // filesystems (NTFS by default, HFS+ optionally). Reject them at the
+  // validation boundary to keep backend storage deterministic.
+  test("rejects uppercase to prevent NTFS / HFS+ case-fold collisions", () => {
+    expect(isWellFormedVaultKey("Github.pat")).toBe(false);
+    expect(isWellFormedVaultKey("github.PAT")).toBe(false);
+    expect(isWellFormedVaultKey("GITHUB.pat")).toBe(false);
+    expect(isWellFormedVaultKey("OneDrive.Refresh")).toBe(false);
+    expect(isWellFormedVaultKey("Onedrive.refresh")).toBe(false);
   });
 });
 

--- a/packages/gateway/src/vault/win32-entropy.test.ts
+++ b/packages/gateway/src/vault/win32-entropy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const isWin = process.platform === "win32";
+const describeWin = isWin ? describe : describe.skip;
+
+describeWin("DpapiVault — optional entropy (S2-F4)", () => {
+  test("set generates a 32-byte .entropy file in the vault dir", async () => {
+    const { DpapiVault } = await import("./win32.ts");
+    const cfg = mkdtempSync(join(tmpdir(), "nimbus-dpapi-entropy-"));
+    const vault = new DpapiVault({ configDir: cfg } as never);
+    await vault.set("github.pat", "ghp_test_value");
+    const entropyPath = join(cfg, "vault", ".entropy");
+    expect(existsSync(entropyPath)).toBe(true);
+    const buf = readFileSync(entropyPath);
+    expect(buf.length).toBe(32);
+  });
+
+  test("round-trips a value across vault instances using the persisted entropy", async () => {
+    const { DpapiVault } = await import("./win32.ts");
+    const cfg = mkdtempSync(join(tmpdir(), "nimbus-dpapi-roundtrip-"));
+    const v1 = new DpapiVault({ configDir: cfg } as never);
+    await v1.set("github.pat", "ghp_round_trip");
+    const v2 = new DpapiVault({ configDir: cfg } as never);
+    expect(await v2.get("github.pat")).toBe("ghp_round_trip");
+  });
+
+  test("a tampered .entropy file makes existing entries unrecoverable (security boundary)", async () => {
+    const { spawnSync } = await import("node:child_process");
+    const { DpapiVault } = await import("./win32.ts");
+    const cfg = mkdtempSync(join(tmpdir(), "nimbus-dpapi-tamper-"));
+    const v1 = new DpapiVault({ configDir: cfg } as never);
+    await v1.set("github.pat", "ghp_value");
+    // Strip Hidden+System attrs (we set them at creation time as a casual-
+    // delete defense) so the test harness can overwrite. The clear is part
+    // of the simulated tamper, not part of the security boundary itself.
+    const entropyPath = join(cfg, "vault", ".entropy");
+    spawnSync("attrib", ["-H", "-S", entropyPath], { windowsHide: true });
+    // Overwrite entropy with new random bytes — simulates a different
+    // process / user attempting to decrypt. DPAPI decrypt should fail and
+    // the legacy fallback (no-entropy) should also fail.
+    const newEntropy = Buffer.alloc(32, 0xab);
+    writeFileSync(entropyPath, newEntropy);
+    const v2 = new DpapiVault({ configDir: cfg } as never);
+    await expect(v2.get("github.pat")).rejects.toThrow(/Vault decryption failed/i);
+  });
+
+  test("legacy entry without entropy is migrated on first read", async () => {
+    const { DpapiVault, _legacyEncryptForTest } = await import("./win32.ts");
+    const cfg = mkdtempSync(join(tmpdir(), "nimbus-dpapi-legacy-"));
+    const vaultDir = join(cfg, "vault");
+    // Build the vault dir + write a pre-fix entry encrypted without entropy.
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(vaultDir, { recursive: true });
+    const blob = _legacyEncryptForTest("legacy_value");
+    writeFileSync(join(vaultDir, "github.pat.enc"), blob.toString("base64"), "utf8");
+
+    const v1 = new DpapiVault({ configDir: cfg } as never);
+    expect(await v1.get("github.pat")).toBe("legacy_value");
+
+    // After migration the entry should decrypt with entropy on a fresh handle.
+    const v2 = new DpapiVault({ configDir: cfg } as never);
+    expect(await v2.get("github.pat")).toBe("legacy_value");
+  });
+});

--- a/packages/gateway/src/vault/win32-entropy.test.ts
+++ b/packages/gateway/src/vault/win32-entropy.test.ts
@@ -36,8 +36,12 @@ describeWin("DpapiVault — optional entropy (S2-F4)", () => {
     // Strip Hidden+System attrs (we set them at creation time as a casual-
     // delete defense) so the test harness can overwrite. The clear is part
     // of the simulated tamper, not part of the security boundary itself.
+    // Use the absolute path (matches the production caller in win32.ts).
     const entropyPath = join(cfg, "vault", ".entropy");
-    spawnSync("attrib", ["-H", "-S", entropyPath], { windowsHide: true });
+    const winDir = process.env["SystemRoot"] ?? process.env["windir"] ?? "C:\\Windows";
+    spawnSync(`${winDir}\\System32\\attrib.exe`, ["-H", "-S", entropyPath], {
+      windowsHide: true,
+    });
     // Overwrite entropy with new random bytes — simulates a different
     // process / user attempting to decrypt. DPAPI decrypt should fail and
     // the legacy fallback (no-entropy) should also fail.

--- a/packages/gateway/src/vault/win32.ts
+++ b/packages/gateway/src/vault/win32.ts
@@ -118,9 +118,16 @@ function loadOrCreateEntropy(vaultDir: string): Buffer {
     // Hidden + System so a casual file-explorer browse does not surface the
     // entropy file. Defense against accidental deletion — losing .entropy
     // makes every vault entry unrecoverable until rotation.
+    //
+    // Use the absolute path under the Windows directory rather than relying
+    // on PATH lookup, so a poisoned PATH (e.g. attacker-controlled directory
+    // earlier in PATH containing a binary named `attrib.exe`) cannot
+    // hijack this call.
     if (process.platform === "win32") {
       try {
-        spawnSync("attrib", ["+H", "+S", path], { windowsHide: true });
+        const winDir = process.env["SystemRoot"] ?? process.env["windir"] ?? "C:\\Windows";
+        const attribExe = `${winDir}\\System32\\attrib.exe`;
+        spawnSync(attribExe, ["+H", "+S", path], { windowsHide: true });
       } catch {
         /* best effort — entropy still works without the attribute */
       }

--- a/packages/gateway/src/vault/win32.ts
+++ b/packages/gateway/src/vault/win32.ts
@@ -1,9 +1,20 @@
 /**
  * Windows DPAPI vault — encrypted blobs under configDir/vault/*.enc
+ *
+ * S2-F4 — every CryptProtectData / CryptUnprotectData call now passes an
+ * `pOptionalEntropy` blob loaded from <vaultDir>/.entropy. The entropy file
+ * is generated on first use, written 0o600, and (best-effort) marked
+ * Hidden + System so casual file-explorer browsing does not surface it.
+ * This raises the bar for vault decryption from "any same-uid process" to
+ * "any process that can read .entropy". Pre-fix entries (encrypted without
+ * entropy) decrypt via a legacy fallback and are silently re-encrypted with
+ * entropy on the next read.
  */
 
 import { dlopen, FFIType, ptr, toArrayBuffer } from "bun:ffi";
+import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdir, open, readdir, readFile, rename, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -51,6 +62,8 @@ const kernel32 = dlopen("kernel32.dll", {
 });
 
 const DATA_BLOB_LAYOUT_BYTES = 16;
+const ENTROPY_FILENAME = ".entropy";
+const ENTROPY_LEN = 32;
 
 function writeDataBlob(target: Buffer, cbData: number, pbDataPtr: bigint): void {
   target.writeUInt32LE(cbData, 0);
@@ -81,11 +94,146 @@ function bufferFromPointer(addr: bigint, byteLength: number): Buffer {
   return Buffer.from(src.slice());
 }
 
+/**
+ * Load existing entropy from `<vaultDir>/.entropy` or generate fresh 32 bytes.
+ *
+ * Race-safe: write uses `wx` so a concurrent boot losing the create race
+ * falls back to reading the winner's file.
+ */
+function loadOrCreateEntropy(vaultDir: string): Buffer {
+  const path = join(vaultDir, ENTROPY_FILENAME);
+  if (existsSync(path)) {
+    const buf = readFileSync(path);
+    if (buf.length === ENTROPY_LEN) return buf;
+  }
+  mkdirSync(vaultDir, { recursive: true });
+  const generated = randomBytes(ENTROPY_LEN);
+  try {
+    writeFileSync(path, generated, { mode: 0o600, flag: "wx" });
+    try {
+      chmodSync(path, 0o600);
+    } catch {
+      /* Windows ignores chmod for non-FAT volumes */
+    }
+    // Hidden + System so a casual file-explorer browse does not surface the
+    // entropy file. Defense against accidental deletion — losing .entropy
+    // makes every vault entry unrecoverable until rotation.
+    if (process.platform === "win32") {
+      try {
+        spawnSync("attrib", ["+H", "+S", path], { windowsHide: true });
+      } catch {
+        /* best effort — entropy still works without the attribute */
+      }
+    }
+    return generated;
+  } catch (err: unknown) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "EEXIST"
+    ) {
+      const buf = readFileSync(path);
+      if (buf.length === ENTROPY_LEN) return buf;
+    }
+    throw err;
+  }
+}
+
+function dpapiEncrypt(plain: Buffer, entropy: Buffer | null): Buffer {
+  const inBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
+  const plainPtr = ptr(plain);
+  writeDataBlob(inBlob, plain.length, pointerToBigInt(plainPtr));
+
+  let entropyArg: ReturnType<typeof ptr> | null = null;
+  let entropyBlob: Buffer | undefined;
+  if (entropy !== null && entropy.length > 0) {
+    entropyBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
+    const entropyPtr = ptr(entropy);
+    writeDataBlob(entropyBlob, entropy.length, pointerToBigInt(entropyPtr));
+    entropyArg = ptr(entropyBlob);
+  }
+
+  const outBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
+  outBlob.fill(0);
+
+  const ok = crypt32.symbols.CryptProtectData(
+    ptr(inBlob),
+    null,
+    entropyArg,
+    null,
+    null,
+    0,
+    ptr(outBlob),
+  );
+  if (ok === 0) {
+    throw new Error("Vault encryption failed");
+  }
+
+  const outLen = readCbData(outBlob);
+  const outPb = readPbDataPtr(outBlob);
+  try {
+    return bufferFromPointer(outPb, outLen);
+  } finally {
+    kernel32.symbols.LocalFree(addressAsPointer(outPb));
+  }
+}
+
+function dpapiDecrypt(encrypted: Buffer, entropy: Buffer | null): Buffer | null {
+  const inBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
+  const encPtr = ptr(encrypted);
+  writeDataBlob(inBlob, encrypted.length, pointerToBigInt(encPtr));
+
+  let entropyArg: ReturnType<typeof ptr> | null = null;
+  let entropyBlob: Buffer | undefined;
+  if (entropy !== null && entropy.length > 0) {
+    entropyBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
+    const entropyPtr = ptr(entropy);
+    writeDataBlob(entropyBlob, entropy.length, pointerToBigInt(entropyPtr));
+    entropyArg = ptr(entropyBlob);
+  }
+
+  const outBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
+  outBlob.fill(0);
+
+  const ok = crypt32.symbols.CryptUnprotectData(
+    ptr(inBlob),
+    null,
+    entropyArg,
+    null,
+    null,
+    0,
+    ptr(outBlob),
+  );
+  if (ok === 0) return null;
+
+  const outLen = readCbData(outBlob);
+  const outPb = readPbDataPtr(outBlob);
+  try {
+    return bufferFromPointer(outPb, outLen);
+  } finally {
+    kernel32.symbols.LocalFree(addressAsPointer(outPb));
+  }
+}
+
+/** Test-only helper — encrypts without entropy to simulate pre-fix vault entries. */
+export function _legacyEncryptForTest(plaintext: string): Buffer {
+  return dpapiEncrypt(Buffer.from(plaintext, "utf8"), null);
+}
+
 export class DpapiVault implements NimbusVault {
   private readonly vaultDir: string;
+  private cachedEntropy: Buffer | undefined;
 
   constructor(paths: PlatformPaths) {
     this.vaultDir = join(paths.configDir, "vault");
+  }
+
+  private getEntropy(): Buffer {
+    if (this.cachedEntropy === undefined) {
+      this.cachedEntropy = loadOrCreateEntropy(this.vaultDir);
+    }
+    return this.cachedEntropy;
   }
 
   private encPath(key: string): string {
@@ -95,35 +243,8 @@ export class DpapiVault implements NimbusVault {
   async set(key: string, value: string): Promise<void> {
     validateVaultKeyOrThrow(key);
     await mkdir(this.vaultDir, { recursive: true });
-    const plain = Buffer.from(value, "utf8");
-    const inBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
-    const plainPtr = ptr(plain);
-    writeDataBlob(inBlob, plain.length, pointerToBigInt(plainPtr));
-
-    const outBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
-    outBlob.fill(0);
-
-    const ok = crypt32.symbols.CryptProtectData(
-      ptr(inBlob),
-      null,
-      null,
-      null,
-      null,
-      0,
-      ptr(outBlob),
-    );
-    if (ok === 0) {
-      throw new Error("Vault encryption failed");
-    }
-
-    const outLen = readCbData(outBlob);
-    const outPb = readPbDataPtr(outBlob);
-    let encrypted: Buffer;
-    try {
-      encrypted = bufferFromPointer(outPb, outLen);
-    } finally {
-      kernel32.symbols.LocalFree(addressAsPointer(outPb));
-    }
+    const entropy = this.getEntropy();
+    const encrypted = dpapiEncrypt(Buffer.from(value, "utf8"), entropy);
 
     const b64 = encrypted.toString("base64");
     const finalPath = this.encPath(key);
@@ -196,36 +317,24 @@ export class DpapiVault implements NimbusVault {
       throw new Error("Vault read failed");
     }
 
-    const inBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
-    const encPtr = ptr(encrypted);
-    writeDataBlob(inBlob, encrypted.length, pointerToBigInt(encPtr));
-
-    const outBlob = Buffer.alloc(DATA_BLOB_LAYOUT_BYTES);
-    outBlob.fill(0);
-
-    const ok = crypt32.symbols.CryptUnprotectData(
-      ptr(inBlob),
-      null,
-      null,
-      null,
-      null,
-      0,
-      ptr(outBlob),
-    );
-    if (ok === 0) {
+    const entropy = this.getEntropy();
+    const withEntropy = dpapiDecrypt(encrypted, entropy);
+    if (withEntropy !== null) {
+      return withEntropy.toString("utf8");
+    }
+    // S2-F4 — legacy migration: try without entropy. On success, re-encrypt
+    // with entropy via set() so the next read takes the fast path.
+    const legacy = dpapiDecrypt(encrypted, null);
+    if (legacy === null) {
       throw new Error("Vault decryption failed");
     }
-
-    const outLen = readCbData(outBlob);
-    const outPb = readPbDataPtr(outBlob);
-    let plain: Buffer;
+    const plaintext = legacy.toString("utf8");
     try {
-      plain = bufferFromPointer(outPb, outLen);
-    } finally {
-      kernel32.symbols.LocalFree(addressAsPointer(outPb));
+      await this.set(key, plaintext);
+    } catch {
+      /* best effort — return the recovered value even if re-encrypt fails */
     }
-
-    return plain.toString("utf8");
+    return plaintext;
   }
 
   async delete(key: string): Promise<void> {

--- a/packages/gateway/test/integration/data/roundtrip.test.ts
+++ b/packages/gateway/test/integration/data/roundtrip.test.ts
@@ -1,13 +1,24 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runDataExport } from "../../../src/commands/data-export.ts";
 import { runDataImport } from "../../../src/commands/data-import.ts";
 import { verifyAuditChain } from "../../../src/db/audit-verify.ts";
+import { _addTestKdfProfile } from "../../../src/db/data-vault-crypto.ts";
 import type { LocalIndex } from "../../../src/index/local-index.ts";
 import { CURRENT_SCHEMA_VERSION } from "../../../src/index/local-index.ts";
 import { memVault, newIndex } from "../../fixtures/data-test-helpers.ts";
+
+// S2-F10 — register the FAST_KDF profile used by the round-trip integration
+// test so decryptVaultManifest accepts the bundle on import.
+let _restoreTestKdf: () => void;
+beforeAll(() => {
+  _restoreTestKdf = _addTestKdfProfile({ t: 1, m: 1024, p: 1 });
+});
+afterAll(() => {
+  _restoreTestKdf();
+});
 
 function seed(idx: LocalIndex, service: string, count: number): void {
   for (let i = 0; i < count; i++) {

--- a/packages/ui/src-tauri/src/gateway_bridge.rs
+++ b/packages/ui/src-tauri/src/gateway_bridge.rs
@@ -421,10 +421,16 @@ mod tests {
         assert!(!is_method_allowed("vault.get"));
         assert!(!is_method_allowed("vault.set"));
         assert!(!is_method_allowed("vault.list"));
+        assert!(!is_method_allowed("vault.delete"));
+        assert!(!is_method_allowed("vault.listKeys"));
         assert!(!is_method_allowed("db.put"));
         assert!(!is_method_allowed("db.delete"));
         assert!(!is_method_allowed("config.set"));
         assert!(!is_method_allowed("index.rebuild"));
+        // S5-F7 — `index.querySql` is the raw-SQL escape hatch behind the
+        // CLI `nimbus query --sql` flag; the renderer must not be able to
+        // reach it. Explicit guard against future allowlist drift.
+        assert!(!is_method_allowed("index.querySql"));
     }
 
     #[test]

--- a/packages/ui/src/ipc/client.ts
+++ b/packages/ui/src/ipc/client.ts
@@ -177,12 +177,12 @@ function redactSensitiveSubstrings(input: string): string {
   // sensitive-key pattern. Catches connector secret names: apiToken,
   // clientSecret, accessToken, refreshToken, bot_token, api_key,
   // app_password, Authorization header values, etc.
-  out = out.replace(
+  out = out.replaceAll(
     /"(\w*(?:token|key|secret|password|credential|bearer|auth)\w*)"\s*:\s*"[^"]*"/gi,
     (_match, k: string) => `"${k}":"[REDACTED]"`,
   );
   // Bare `key=value` form for the same key shapes.
-  out = out.replace(
+  out = out.replaceAll(
     /(\b\w*(?:token|key|secret|password|credential|bearer|auth)\w*)\s*[=:]\s*"?([^\s",}]+)"?/gi,
     (_match, k: string) => `${k}=[REDACTED]`,
   );

--- a/packages/ui/src/ipc/client.ts
+++ b/packages/ui/src/ipc/client.ts
@@ -140,7 +140,28 @@ const FORBIDDEN_VALUE_KEYS: readonly string[] = [
   "mnemonic",
   "privateKey",
   "encryptedVaultManifest",
+  // S2-F6 — `pat` is a common shorthand for personal-access-token in the
+  // GitHub / GitLab / Bitbucket connector vocabulary. The generic
+  // SENSITIVE_KEY_PATTERN below would not catch the bare 3-letter form,
+  // so add it explicitly.
+  "pat",
 ];
+
+/**
+ * S2-F6 — mirror gateway-side `executor.ts:SENSITIVE_PAYLOAD_KEY` so the
+ * renderer-side redactor catches the same connector-secret names that the
+ * gateway audit redactor catches: `apiToken`, `clientSecret`, `accessToken`,
+ * `refreshToken`, `bot_token`, `api_key`, `app_password`, etc.
+ *
+ * Keep this exact pattern in sync with packages/gateway/src/engine/executor.ts.
+ */
+const SENSITIVE_KEY_PATTERN = /(token|key|secret|password|credential|bearer|auth)/i;
+
+function isSensitiveKeyName(name: string): boolean {
+  return SENSITIVE_KEY_PATTERN.test(name);
+}
+
+export { isSensitiveKeyName };
 
 function redactSensitiveSubstrings(input: string): string {
   let out = input;
@@ -152,8 +173,23 @@ function redactSensitiveSubstrings(input: string): string {
     const jsonRe = new RegExp(String.raw`"${key}"\s*:\s*"[^"]*"`, "gi");
     out = out.replace(jsonRe, `"${key}":"[REDACTED]"`);
   }
+  // S2-F6 — generic redaction of any JSON key whose name matches the
+  // sensitive-key pattern. Catches connector secret names: apiToken,
+  // clientSecret, accessToken, refreshToken, bot_token, api_key,
+  // app_password, Authorization header values, etc.
+  out = out.replace(
+    /"(\w*(?:token|key|secret|password|credential|bearer|auth)\w*)"\s*:\s*"[^"]*"/gi,
+    (_match, k: string) => `"${k}":"[REDACTED]"`,
+  );
+  // Bare `key=value` form for the same key shapes.
+  out = out.replace(
+    /(\b\w*(?:token|key|secret|password|credential|bearer|auth)\w*)\s*[=:]\s*"?([^\s",}]+)"?/gi,
+    (_match, k: string) => `${k}=[REDACTED]`,
+  );
   return out;
 }
+
+export { redactSensitiveSubstrings };
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === "object" && !Array.isArray(v);

--- a/packages/ui/src/store/partialize.ts
+++ b/packages/ui/src/store/partialize.ts
@@ -30,12 +30,33 @@ export const FORBIDDEN_PERSIST_KEYS = [
   "encryptedVaultManifest",
 ] as const;
 
+/**
+ * S2-F6 — mirror gateway-side `executor.ts:SENSITIVE_PAYLOAD_KEY` so the
+ * persist-side scrubber catches the same connector-secret names. Catches
+ * `apiToken`, `clientSecret`, `accessToken`, `refreshToken`, `bot_token`,
+ * `api_key`, `app_password`, `Authorization`, etc. — independent of the
+ * `FORBIDDEN_PERSIST_KEYS` exact-match list, which remains unchanged for
+ * cross-surface stability.
+ *
+ * Keep in sync with packages/gateway/src/engine/executor.ts.
+ */
+const SENSITIVE_KEY_PATTERN = /(token|key|secret|password|credential|bearer|auth)/i;
+// `pat` is short and would not match the generic pattern; treat it as exact.
+const EXTRA_EXACT_KEYS: readonly string[] = ["pat"];
+
+function isForbiddenKeyName(name: string): boolean {
+  if ((FORBIDDEN_PERSIST_KEYS as readonly string[]).includes(name)) return true;
+  if (EXTRA_EXACT_KEYS.includes(name)) return true;
+  return SENSITIVE_KEY_PATTERN.test(name);
+}
+
 type Whitelisted = (typeof WHITELISTED_PERSIST_KEYS)[number];
 
 /**
- * Recursively walks `value` and deletes any key matching `FORBIDDEN_PERSIST_KEYS`,
- * regardless of nesting depth. Tolerates cycles via a seen-set. Mutates `value`
- * in place — callers supply an already-cloned/new value.
+ * Recursively walks `value` and deletes any key matching `FORBIDDEN_PERSIST_KEYS`
+ * OR the gateway-side sensitive-key pattern (S2-F6), regardless of nesting
+ * depth. Tolerates cycles via a seen-set. Mutates `value` in place — callers
+ * supply an already-cloned/new value.
  */
 function deepScrubForbidden(value: unknown, seen: WeakSet<object> = new WeakSet()): void {
   if (value === null || typeof value !== "object") return;
@@ -46,9 +67,9 @@ function deepScrubForbidden(value: unknown, seen: WeakSet<object> = new WeakSet(
     return;
   }
   const rec = value as Record<string, unknown>;
-  for (const forbidden of FORBIDDEN_PERSIST_KEYS) {
-    if (forbidden in rec) {
-      delete rec[forbidden];
+  for (const k of Object.keys(rec)) {
+    if (isForbiddenKeyName(k)) {
+      delete rec[k];
     }
   }
   for (const child of Object.values(rec)) {

--- a/packages/ui/src/store/partialize.ts
+++ b/packages/ui/src/store/partialize.ts
@@ -42,11 +42,12 @@ export const FORBIDDEN_PERSIST_KEYS = [
  */
 const SENSITIVE_KEY_PATTERN = /(token|key|secret|password|credential|bearer|auth)/i;
 // `pat` is short and would not match the generic pattern; treat it as exact.
-const EXTRA_EXACT_KEYS: readonly string[] = ["pat"];
+const EXTRA_EXACT_KEYS = new Set<string>(["pat"]);
+const FORBIDDEN_KEYS_SET = new Set<string>(FORBIDDEN_PERSIST_KEYS);
 
 function isForbiddenKeyName(name: string): boolean {
-  if ((FORBIDDEN_PERSIST_KEYS as readonly string[]).includes(name)) return true;
-  if (EXTRA_EXACT_KEYS.includes(name)) return true;
+  if (FORBIDDEN_KEYS_SET.has(name)) return true;
+  if (EXTRA_EXACT_KEYS.has(name)) return true;
   return SENSITIVE_KEY_PATTERN.test(name);
 }
 

--- a/packages/ui/test/ipc/parse-error-redaction.test.ts
+++ b/packages/ui/test/ipc/parse-error-redaction.test.ts
@@ -59,3 +59,31 @@ describe("parseError — credential redaction", () => {
     });
   }
 });
+
+describe("parseError — S2-F6 connector-secret coverage (sensitive-key pattern)", () => {
+  const cases: ReadonlyArray<[string, string]> = [
+    ["apiToken", "ghp_xyz_secret_one"],
+    ["clientSecret", "csec_super_long_secret"],
+    ["pat", "ghp_pat_value"],
+    ["accessToken", "at_access_secret"],
+    ["refreshToken", "rt_refresh_secret"],
+    ["bot_token", "xoxb_bot_secret"],
+    ["api_key", "sk_api_key_secret"],
+    ["app_password", "abc_app_password_secret"],
+    ["Authorization", "Bearer top_secret_bearer_token"],
+  ];
+  for (const [key, value] of cases) {
+    it(`redacts JSON form for ${key}`, async () => {
+      const leaking = JSON.stringify({ [key]: value });
+      invokeMock.mockRejectedValueOnce(leaking);
+      let thrown: Error | null = null;
+      try {
+        await createIpcClient().call("connector.auth", {});
+      } catch (e) {
+        thrown = e as Error;
+      }
+      expect(thrown).not.toBeNull();
+      expect(thrown?.message).not.toContain(value);
+    });
+  }
+});

--- a/packages/ui/test/store/partialize.test.ts
+++ b/packages/ui/test/store/partialize.test.ts
@@ -128,3 +128,62 @@ describe("persistPartialize — Data slice (Plan 5)", () => {
     expect(WHITELISTED_PERSIST_KEYS).toHaveLength(5);
   });
 });
+
+describe("persistPartialize — S2-F6 connector-secret deep scrub", () => {
+  const cases: ReadonlyArray<[string, string]> = [
+    ["apiToken", "ghp_xyz"],
+    ["clientSecret", "csec_secret"],
+    ["pat", "ghp_pat_value"],
+    ["accessToken", "at_secret"],
+    ["refreshToken", "rt_secret"],
+    ["bot_token", "xoxb_secret"],
+    ["api_key", "sk_secret"],
+    ["app_password", "app_secret"],
+    ["Authorization", "Bearer secret"],
+  ];
+  for (const [key, value] of cases) {
+    it(`strips ${key} nested inside a whitelisted slice value`, () => {
+      const state = {
+        connectorsList: [
+          {
+            service: "github",
+            credentials: { [key]: value },
+          },
+        ],
+        installedModels: [],
+        activePullId: null,
+        active: null,
+        profiles: [],
+      } as unknown as Record<string, unknown>;
+      const out = persistPartialize(state);
+      const flat = JSON.stringify(out);
+      expect(flat).not.toContain(value);
+      // Whitelisted neighbours must survive.
+      expect(flat).toContain("github");
+    });
+  }
+
+  it("strips multiple sensitive keys in the same connector entry", () => {
+    const state = {
+      connectorsList: [
+        {
+          service: "slack",
+          apiToken: "tok-1",
+          accessToken: "tok-2",
+          refresh_token: "tok-3",
+          bot_token: "tok-4",
+          headers: { Authorization: "Bearer tok-5" },
+        },
+      ],
+      installedModels: [],
+      activePullId: null,
+      active: null,
+      profiles: [],
+    } as unknown as Record<string, unknown>;
+    const out = persistPartialize(state);
+    const flat = JSON.stringify(out);
+    for (const v of ["tok-1", "tok-2", "tok-3", "tok-4", "tok-5"]) {
+      expect(flat).not.toContain(v);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining Low-severity findings from `docs/superpowers/specs/2026-04-25-security-audit-results.md`. Follows the High PR (`#112`, merged 2026-04-26) and the Medium PR (`#113`, merged 2026-04-26). Final tier of the 3-PR security cleanup.

Each commit group targets one root cause (see `docs/superpowers/plans/2026-04-26-security-fixes-low-tier.md`):

- **G1** — full-depth `connector.reindex` HITL gate + frozen-facade `add()` guard (S1-F7, S1-F8)
- **G2** — vault hardening: key-format `/i` removal, DPAPI optional entropy, `vault.set/delete` HITL gate, KDF param allowlist on import (S2-F4, S2-F7, S2-F8, S2-F10)
- **G3** — frontend redaction unification + pino redact config (S2-F6, S2-F9)
- **G4** — SQL hygiene: `verify.ts` doc fix, `person-store.ts` SQL refactor, `repair.ts` identifier guard (S5-F1, S5-F5, S5-F6)
- **G5** — LAN polish: handshake `recordFailure`, peer dedupe, kind-aware lockout reply, pairing window timer alignment (S3-F4, S3-F5, S3-F6, S3-F9)
- **G6** — updater polish: temp cleanup, URL scrubbing, timing-safe equal, semver validation (S6-F8, S6-F9, S6-F10, S6-F11)
- **G7** — extension polish: shared timing-safe hex compare, ID length cap, signal child on disable (S7-F8, S7-F9, S7-F10)
- **G8** — MCP polish: UUID ids + observable `args_json` errors (S8-F8, S8-F9)
- **G9** — `connector.startAuth` deprecated alias (one-shot warn log, `@deprecated` JSDoc) + Tauri allowlist test guards (S4-F2, S5-F7)

## Findings deferred (documented in the plan)

- S3-F8 — forward secrecy → multi-PR architectural change (Phase 7 LAN hardening)
- S4-F6, S4-F8 — Tauri-native dialog rebuild (UI-rebuild PR)
- S5-F4 — 79 \`db.run()\` call-site refactor (separate PR)
- S6-F1 — informational; updater is dormant
- S8-F10 — out of Phase 4 scope per spec

## Test plan

- [x] \`bun run typecheck\` (zero errors)
- [x] \`bun run lint\` (zero errors)
- [x] \`bun run build\` (all packages green)
- [x] \`bun run test\` — 1244 pass / 1 fail (pre-existing flaky Windows EBUSY in \`platform.test.ts\`; passes in isolation)
- [x] \`cd packages/ui && bunx vitest run\` — 493/493 pass
- [x] \`cd packages/ui/src-tauri && cargo test --lib\` — 25/25 pass
- [x] Affected coverage gates at or above their threshold: engine ≥85, vault ≥90, db ≥85, lan ≥80, updater ≥80, extensions ≥85, mcp ≥70
- [ ] Manual smoke: enable LAN, attempt re-pair from a known peer, observe pair_ok (no UNIQUE constraint throw)
- [ ] Manual smoke (Windows VM): set vault entry, confirm \`<configDir>/vault/.entropy\` is created and read on next boot; confirm a legacy entry without entropy is migrated on first read
- [ ] Manual smoke: \`nimbus connector reindex github --depth full\` triggers a HITL prompt; \`--depth metadata_only\` does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)