### PR TITLE
fix(ci): repair three Actions failures on main

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/stale@28ca10303b08b999284b11c131200f32a3f7c9ff # v9.1.0
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'

--- a/docs/perf/slo.md
+++ b/docs/perf/slo.md
@@ -28,7 +28,7 @@ A bench fails when either:
 | S4 | p95_ms | **≤500 ms** | ≤2 500 ms | 25 %, 50 ms |
 | S5 | p95_ms | **≤200 ms** | ≤1 000 ms | 25 %, 25 ms |
 | S11-a | p95_ms | **≤300 ms** | ≤1 500 ms | 25 %, 50 ms |
-| S11-b | p95_ms | **≤50 ms** | ≤400 ms | 25 %, 10 ms |
+| S11-b | p95_ms | **≤50 ms** | ≤600 ms | 25 %, 10 ms |
 
 ## Workload surfaces
 

--- a/packages/cli/src/tui/QueryInput.tsx
+++ b/packages/cli/src/tui/QueryInput.tsx
@@ -114,9 +114,16 @@ function handleSubmit(ctx: ProcessContext): void {
   if (trimmed === "") {
     return;
   }
-  void appendQuery(ctx.historyPathRef.current, trimmed).then(async () => {
-    ctx.historyRef.current = await readHistory(ctx.historyPathRef.current);
-  });
+  void appendQuery(ctx.historyPathRef.current, trimmed)
+    .then(async () => {
+      ctx.historyRef.current = await readHistory(ctx.historyPathRef.current);
+    })
+    .catch(() => {
+      // History persistence is best-effort; swallow filesystem errors so
+      // the rejection does not become an unhandled promise rejection
+      // (e.g. when a test's afterEach removes the temp dir before the
+      // background write completes).
+    });
   ctx.onSubmit(trimmed);
   ctx.bufRef.current = "";
   ctx.histCursorRef.current = null;

--- a/packages/gateway/src/perf/slo-thresholds.ts
+++ b/packages/gateway/src/perf/slo-thresholds.ts
@@ -132,15 +132,19 @@ const NON_S8_THRESHOLDS: readonly SloThreshold[] = [
     metric: "p95_ms",
     refMax: 50,
     // Spec § 3.2 originally proposed `ghaMax: 250` (5× refMax). Empirical
-    // GHA data on PR-C-1 shows Linux ~190-210 ms but Windows ~287 ms — Bun
-    // process-spawn overhead on `windows-2025` is intrinsically higher than
-    // on `ubuntu-24.04`, so the 5× rule of thumb breaks down on fast UX
-    // surfaces where OS spawn cost dominates. Bumped to 400 ms (≈8× refMax,
-    // ~40 % headroom over observed Windows p95) so the GHA threshold is
-    // achievable on all three runners. Refines spec § 3.2; the `refMax`
-    // budget is unchanged (PR-C-2 will recalibrate from a real M1 Air
-    // measurement).
-    ghaMax: 400,
+    // GHA data on PR-C-1 / PR-C-2a shows Linux ~190-210 ms, macOS ~135-
+    // 195 ms, and Windows 359-425 ms across recent runs — Bun process-spawn
+    // overhead on `windows-2025` is intrinsically higher than on
+    // `ubuntu-24.04`, and the runner exhibits ≈18 % p95-to-p95 variance
+    // across same-sha runs (359 → 425 ms). The 5× rule of thumb breaks
+    // down on fast UX surfaces where OS spawn cost dominates. Bumped to
+    // 600 ms (12× refMax, ~40 % headroom over the observed Windows peak
+    // of 425 ms) so the GHA threshold is achievable on all three runners
+    // without false-failing on Windows infrastructure noise. Refines
+    // spec § 3.2; the `refMax` budget is unchanged (PR-C-2 will
+    // recalibrate from a real M1 Air measurement). The `gated: true`
+    // delta check (`noiseFloorPct: 25`) still catches a real regression.
+    ghaMax: 600,
     gated: true,
     noiseFloorPct: 25,
     noiseFloorAbs: 10,


### PR DESCRIPTION
## Summary

After the merge of #129, the Actions tab showed three failing workflows on `main`. Investigated each and fixed at the root.

- **CI / Coverage — TUI (windows-2025)** — flaky test "Down past the bottom returns to empty draft". The previous test's `handleSubmit` fires a fire-and-forget `appendQuery` Promise; when `afterEach` removes the temp dir before the background `writeFile` completes, the Promise rejects with ENOENT. Without a `.catch`, Bun reports it as an unhandled rejection during the *next* test and marks that test failed. Local 10/10 pass, three older CI runs pass (187ms each), the failing run shows the rejection's stack pointing at `query-history.ts:56` immediately before the (fail) line. Added a `.catch()` — history persistence is best-effort UI state.
- **Performance Benchmarks / Bench (windows-2025)** — S11-b absolute-fail. The 400 ms `ghaMax` was set yesterday from a single 287 ms sample + 40 % headroom; same-sha runs since show 18 % p95-to-p95 variance (359 → 425 ms) and the threshold has already false-failed twice on main (425.37 ms scheduled, 400.47 ms post-#129 merge — over by 0.47 ms). Bumped to 600 ms (12× refMax, ~40 % over the 425 ms peak). Regenerated `docs/perf/slo.md`. The gated delta check (25 %, 10 ms floor) still catches real regressions.
- **Close stale issues and PRs** — `actions/stale@28ca10303b...` doesn't exist in the action's repo (GitHub API returns 422 for the SHA). The nightly job has failed on this since the SHA landed. Repinned to the real `v9.1.0` commit `5bef64f19d7facfb25b37b414482c7164d639639` (verified via `gh api repos/actions/stale/git/refs/tags/v9.1.0`).

## Test plan

- [x] `bun run typecheck` — clean across all packages
- [x] `bun run test:coverage:tui` — 72 pass, 0 fail (TUI gate)
- [x] `bun run test:coverage:perf` — 167 pass, 0 fail (perf gate)
- [x] `bun test packages/gateway/src/perf/slo-thresholds.test.ts` — 9 pass
- [x] `bun scripts/regen-slo.ts --check` — clean
- [ ] CI run on this branch is green (pending push)
- [ ] Next scheduled `Performance Benchmarks` and `Close stale issues and PRs` runs succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)