### PR TITLE
security: triage code-scanning alerts

### DIFF
--- a/.github/workflows/_perf-reference.yml
+++ b/.github/workflows/_perf-reference.yml
@@ -30,6 +30,11 @@ concurrency:
   group: bench-reference
   cancel-in-progress: false
 
+# Default-deny at the workflow level (Scorecard `Token-Permissions`).
+# The `reference-run` job grants the specific scopes it needs (contents:
+# write to push the perf branch, pull-requests: write for `gh pr create`).
+permissions: {}
+
 jobs:
   reference-run:
     name: Reference benchmark run (M1 Air)

--- a/.github/workflows/_perf.yml
+++ b/.github/workflows/_perf.yml
@@ -21,11 +21,17 @@ on:
     - cron: "0 4 * * 1-6"   # Mon–Sat 04:00 UTC — Linux only (cost-fallback gate, D-W/D-AB)
     - cron: "0 4 * * 0"     # Sunday 04:00 UTC — full three-OS coverage
 
-# Note: permissions and concurrency are set per-job (not per-workflow)
+# Note: per-job permissions and concurrency are used (not workflow-level)
 # per SonarQube `githubactions:S8264` / `S8233` (least-privilege at the
 # narrowest scope) and because workflow-level `concurrency` cannot read
 # `matrix.*` — it would degrade to one shared group across all OSes and
 # serialise the matrix.
+#
+# A workflow-level `permissions: {}` baseline is still set so any job
+# that omits its own permissions block inherits no token scopes (Scorecard
+# `Token-Permissions` requires a top-level declaration). Each job below
+# explicitly grants only the scopes it actually uses.
+permissions: {}
 
 jobs:
   detect-trigger:

--- a/packages/gateway/src/perf/bench-ci.ts
+++ b/packages/gateway/src/perf/bench-ci.ts
@@ -10,7 +10,7 @@
  * Spec source: § 5.4 of the PR-C-1 design.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { GhCli } from "./bench-ci-gh.ts";
@@ -139,7 +139,14 @@ async function upsertComment(
   tmpDir: string,
   env: Record<string, string | undefined>,
 ): Promise<void> {
-  const bodyFile = join(tmpDir, `comment-${runner}.md`);
+  // Write the comment body to a file inside a freshly-created per-call
+  // scratch dir, not to a predictable path under `tmpDir`. CodeQL
+  // (`js/insecure-temporary-file`) flags writeFileSync on a fixed name
+  // in os tmpdir as a TOCTOU/symlink-attack hazard. `mkdtempSync` returns
+  // a unique 0700 directory we own, so the bodyFile path is not
+  // predictable to a coresident process.
+  const scratchDir = mkdtempSync(join(tmpDir, `bench-ci-comment-${runner}-`));
+  const bodyFile = join(scratchDir, "body.md");
   writeFileSync(bodyFile, body, "utf8");
 
   const marker = `<!-- ${COMMENT_MARKER_PREFIX}:${runner} -->`;


### PR DESCRIPTION
## Summary

Worked through the 9 open code-scanning alerts in the Security tab. Result: 5 dismissed (with traceable rationale), 3 fixed by code, 1 already addressed but pending CodeQL/Scorecard re-scan.

### Fixed in this PR (3 alerts)

- **CodeQL #52 — `js/insecure-temporary-file`** (`packages/gateway/src/perf/bench-ci.ts:143`). `upsertComment` was writing to `${tmpDir}/comment-${runner}.md` — a predictable path inside `os.tmpdir()`, which CodeQL flags as a TOCTOU / symlink-attack vector. Switched to `mkdtempSync` for a unique per-call scratch dir, mirroring what the bench-ci tests already do.
- **Scorecard #54 / #55 — `Token-Permissions`** (`.github/workflows/_perf.yml`, `.github/workflows/_perf-reference.yml`). Both lacked a workflow-level `permissions:` block. The maintainer's existing comment in `_perf.yml` documents the deliberate per-job choice (SonarQube `S8264`/`S8233`, plus matrix concurrency). Added a workflow-level `permissions: {}` default-deny baseline that complements (does not replace) the per-job grants — Scorecard is satisfied and the per-job least-privilege model is preserved.

### Dismissed in the Security tab (5 alerts)

- **CodeQL #46 — `js/clear-text-logging`** (`packages/cli/src/commands/data.ts:82`). `oauthEntriesFlagged` is an integer count of vault keys ending in `.oauth` — not a credential value. Pre-existing `lgtm`/`NOSONAR` comments at the call site already document this; modern CodeQL no longer honours `lgtm[...]` inline comments. Dismissed as **false positive**.
- **Scorecard #50 — `release-please.yml:17` `contents: write`**. Required by `googleapis/release-please-action` to push release commits/tags and open release PRs. Dismissed as **won't fix** (documented action requirement).
- **Scorecard #53 — `_perf-reference.yml:41` `contents: write`**. Reference-run job pushes a perf branch and opens a PR via `gh pr create`. `workflow_dispatch`-only with operator attestation. Dismissed as **won't fix**.
- **Scorecard #25 / #23 — `ci.yml:65` and `ci.yml:177` `checks: write`**. Required to publish check-run results from the reusable test suite and the E2E desktop job. Top-level remains read-only; only these specific jobs opt in. Dismissed as **won't fix**.
- **Scorecard #44 — Vulnerabilities (19 RUSTSEC advisories)**. All 19 are `unmaintained` (17) or `unsound` (2) — **zero CVEs**. Each is explicitly accepted in `packages/ui/src-tauri/deny.toml` with rationale (most are gtk3-rs transitives waiting on Tauri's GTK4 migration; the two `unsound` are `glib` GTK iteration on malformed input and `rand 0.7.3` build-time only). The project's CI gate is `cargo-deny`, which already honours `deny.toml`. Scorecard runs `cargo audit` externally without picking up that config, hence the surfaced alert. Dismissed as **won't fix** (covered by `deny.toml`).

## Test plan

- [x] `bun test packages/gateway/src/perf/bench-ci.test.ts` — 5 pass, 0 fail
- [x] `bunx biome check` on changed files — clean
- [ ] CodeQL re-scan on this branch resolves alert #52
- [ ] Scorecard re-scan on this branch resolves alerts #54 and #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)