### PR TITLE
fix(perf): bump S11-b noiseFloorPct 25% → 40% (macOS-15 GHA variance)

### DIFF
--- a/docs/perf/slo.md
+++ b/docs/perf/slo.md
@@ -28,7 +28,7 @@ A bench fails when either:
 | S4 | p95_ms | **≤500 ms** | ≤2 500 ms | 25 %, 50 ms |
 | S5 | p95_ms | **≤200 ms** | ≤1 000 ms | 25 %, 25 ms |
 | S11-a | p95_ms | **≤300 ms** | ≤1 500 ms | 25 %, 50 ms |
-| S11-b | p95_ms | **≤50 ms** | ≤600 ms | 25 %, 10 ms |
+| S11-b | p95_ms | **≤50 ms** | ≤600 ms | 40 %, 10 ms |
 
 ## Workload surfaces
 

--- a/packages/gateway/src/perf/slo-thresholds.ts
+++ b/packages/gateway/src/perf/slo-thresholds.ts
@@ -143,10 +143,18 @@ const NON_S8_THRESHOLDS: readonly SloThreshold[] = [
     // without false-failing on Windows infrastructure noise. Refines
     // spec § 3.2; the `refMax` budget is unchanged (PR-C-2 will
     // recalibrate from a real M1 Air measurement). The `gated: true`
-    // delta check (`noiseFloorPct: 25`) still catches a real regression.
+    // delta check still catches a real regression.
+    //
+    // 2026-04-30: bumped `noiseFloorPct` from 25 % → 40 %. macOS-15 GHA
+    // runners showed ~18 % p95-to-p95 variance across two same-sha runs
+    // (135 → 144 → 170 ms on `22f6564`); the 25 % floor was tripping
+    // delta-fail on noise alone. 40 % matches the empirical envelope
+    // and still flags a real ≥40 % regression. `noiseFloorAbs: 10` is
+    // unchanged — bumping it would loosen the M1 Air reference path
+    // (where prev ≈ refMax = 50 ms) far more than intended.
     ghaMax: 600,
     gated: true,
-    noiseFloorPct: 25,
+    noiseFloorPct: 40,
     noiseFloorAbs: 10,
     noiseFloorAbsUnit: "ms",
   },


### PR DESCRIPTION
## Summary

Same shape as the existing S11-b `ghaMax` bump for Windows variance — empirical macOS-15 GHA noise tripping the per-surface delta floor on noise alone, no code change between baseline and current.

## Evidence

Two consecutive `_perf.yml` runs on `22f6564` (no code change) gave different gating failures:

| Run | Surface | Previous | Current | Δ | Status |
|---|---|---|---|---|---|
| 1 | S2-b  | 16.02 | 34.20  | +113.5% | ⚠️ delta-fail (floor 62.4%) |
| 2 | S11-b | 135.09 | 170.47 | +26.2% | ⚠️ delta-fail (floor 25.0%) |

S2-b's spike was a one-off outlier; the rerun showed +3.6%. S11-b's three observed values on this sha (135 → 144 → 170 ms) exhibit ~18% p95-to-p95 variance — the same shape already documented in the existing source comment for windows-2025.

## Decision

Bumped `S11-b.noiseFloorPct` from 25% → 40%. At `prev = 135 ms`, the effective floor becomes 40% (was 25%); the +26.2% delta now passes; a real ≥40% regression still gates. `noiseFloorAbs: 10` is left alone — bumping it would also loosen the M1 Air reference path (where `prev ≈ refMax = 50 ms`, so `abs / prev` dominates), which we explicitly do not want.

## Ruled out before threshold change

PR #131 was the only non-trivial change between baseline (`4deb243`) and current (`22f6564`). It touched `_perf-reference.yml`, `_perf.yml`, and `bench-ci.ts` (post-bench comparator) — none of which run during S11-b's measurement. So it cannot have slowed CLI startup; this is runner noise.

## Test plan

- [x] `bun scripts/regen-slo.ts` regenerates `slo.md`; `bun run regen-slo:check` passes.
- [x] `bun run typecheck` passes.
- [x] `bun run lint` passes.
- [x] `bun run test:coverage:perf` passes (167 tests).
- [ ] `_perf.yml` runs on this PR; macOS-15 leg's S11-b delta now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)