### PR TITLE
fix(perf): metric-direction-aware threshold comparator (PR-C-2c)

### DIFF
--- a/packages/gateway/src/perf/pr-comment-formatter.test.ts
+++ b/packages/gateway/src/perf/pr-comment-formatter.test.ts
@@ -53,6 +53,26 @@ describe("formatPrComment", () => {
     expect(out).toContain("absolute-fail");
     expect(out).toContain("12000");
     expect(out).toContain("10000");
+    // ceiling metric: regression direction is up
+    expect(out).toContain("12000 > 10000");
+  });
+
+  test("absolute-fail for floor metric renders `<` instead of `>`", () => {
+    const out = formatPrComment(
+      [
+        {
+          surfaceId: "S6-drive",
+          metric: "throughput_per_sec",
+          status: { kind: "absolute-fail", measured: 40, threshold: 60 },
+        },
+      ],
+      fakeLine("gha-ubuntu"),
+      fakeLine("gha-ubuntu"),
+    );
+    expect(out).toContain("absolute-fail");
+    // floor metric: regression direction is down — observed is below the floor
+    expect(out).toContain("40 < 60");
+    expect(out).not.toContain("40 > 60");
   });
 
   test("renders delta-fail with delta percentage", () => {

--- a/packages/gateway/src/perf/pr-comment-formatter.ts
+++ b/packages/gateway/src/perf/pr-comment-formatter.ts
@@ -7,7 +7,7 @@
  */
 
 import type { HistoryLine, HistoryLineSurface } from "./history-line.ts";
-import type { SurfaceComparison } from "./threshold-comparator.ts";
+import { isFloorMetric, type SurfaceComparison } from "./threshold-comparator.ts";
 
 export const COMMENT_MARKER_PREFIX = "nimbus-perf-delta";
 
@@ -49,8 +49,10 @@ function statusCell(c: SurfaceComparison): string {
   switch (c.status.kind) {
     case "pass":
       return "✅ pass";
-    case "absolute-fail":
-      return `❌ absolute-fail (${fmtNum(c.status.measured)} > ${fmtNum(c.status.threshold)})`;
+    case "absolute-fail": {
+      const op = isFloorMetric(c.metric) ? "<" : ">";
+      return `❌ absolute-fail (${fmtNum(c.status.measured)} ${op} ${fmtNum(c.status.threshold)})`;
+    }
     case "delta-fail":
       return `⚠️ delta-fail (floor ${c.status.floorPct.toFixed(1)}%)`;
     case "no-baseline":

--- a/packages/gateway/src/perf/threshold-comparator.test.ts
+++ b/packages/gateway/src/perf/threshold-comparator.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import type { HistoryLine } from "./history-line.ts";
-import { SLO_THRESHOLDS } from "./slo-thresholds.ts";
-import { compareAgainstHistory, isFailingComparison } from "./threshold-comparator.ts";
+import { SLO_THRESHOLDS, type SloThreshold } from "./slo-thresholds.ts";
+import {
+  compareAgainstHistory,
+  isFailingComparison,
+  isFloorMetric,
+} from "./threshold-comparator.ts";
 
 function fakeLine(runner: HistoryLine["runner"], surfaces: HistoryLine["surfaces"]): HistoryLine {
   return {
@@ -91,6 +95,134 @@ describe("compareAgainstHistory", () => {
     const out = compareAgainstHistory(current, null, SLO_THRESHOLDS, "gha-ubuntu");
     const s3 = out.find((c) => c.surfaceId === "S3");
     expect(s3?.status).toEqual({ kind: "skipped", reason: "stub" });
+  });
+});
+
+describe("isFloorMetric", () => {
+  test("returns true for floor metrics", () => {
+    expect(isFloorMetric("throughput_per_sec")).toBe(true);
+    expect(isFloorMetric("tokens_per_sec")).toBe(true);
+  });
+
+  test("returns false for ceiling metrics", () => {
+    expect(isFloorMetric("p95_ms")).toBe(false);
+    expect(isFloorMetric("p50_ms")).toBe(false);
+    expect(isFloorMetric("rss_bytes_p95")).toBe(false);
+    expect(isFloorMetric("first_token_ms")).toBe(false);
+  });
+});
+
+describe("compareAgainstHistory — floor metrics", () => {
+  // No production row currently has floor metric + numeric ghaMax + gated:true
+  // (PR-C-2b will eventually flip them after PR-C-2c lands). Construct a
+  // synthetic row to exercise the direction-aware branches.
+  const floorRow: SloThreshold = {
+    surfaceId: "S6-drive",
+    metric: "throughput_per_sec",
+    refMax: 100,
+    ghaMax: 60,
+    gated: true,
+    noiseFloorPct: 25,
+    noiseFloorAbs: 5,
+    noiseFloorAbsUnit: "items_per_sec",
+  };
+
+  test("absolute-fail when throughput drops below ghaMax floor", () => {
+    const current = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 50 },
+    });
+    const out = compareAgainstHistory(current, null, [floorRow], "gha-ubuntu");
+    const s6 = out.find((c) => c.surfaceId === "S6-drive");
+    expect(s6?.status).toEqual({ kind: "absolute-fail", measured: 50, threshold: 60 });
+  });
+
+  test("absolute-pass when throughput is above ghaMax floor (no baseline → no-baseline)", () => {
+    const current = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 80 },
+    });
+    const out = compareAgainstHistory(current, null, [floorRow], "gha-ubuntu");
+    const s6 = out.find((c) => c.surfaceId === "S6-drive");
+    expect(s6?.status).toEqual({ kind: "no-baseline", current: 80 });
+  });
+
+  test("absolute-pass at exactly the floor (boundary — strict <, not <=)", () => {
+    const current = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 60 },
+    });
+    const out = compareAgainstHistory(current, null, [floorRow], "gha-ubuntu");
+    const s6 = out.find((c) => c.surfaceId === "S6-drive");
+    expect(s6?.status).toEqual({ kind: "no-baseline", current: 60 });
+  });
+
+  test("delta-fail when throughput drops more than the noise floor; deltaPct stays signed", () => {
+    // Previous 100, current 70 → -30% drop, exceeds 25% floor, fail.
+    const previous = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 100 },
+    });
+    const current = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 70 },
+    });
+    const out = compareAgainstHistory(current, previous, [floorRow], "gha-ubuntu");
+    const s6 = out.find((c) => c.surfaceId === "S6-drive");
+    expect(s6?.status).toMatchObject({
+      kind: "delta-fail",
+      previous: 100,
+      current: 70,
+      // natural sign preserved so the formatter renders `-30.0%`
+      deltaPct: -30,
+    });
+  });
+
+  test("improvement (throughput rises) is never a delta-fail", () => {
+    // Previous 70, current 100 → +43% rise; ceiling-style this would fail
+    // delta floor 25%, but for a floor metric an increase is good.
+    const previous = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 70 },
+    });
+    const current = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 100 },
+    });
+    const out = compareAgainstHistory(current, previous, [floorRow], "gha-ubuntu");
+    const s6 = out.find((c) => c.surfaceId === "S6-drive");
+    expect(s6?.status).toEqual({ kind: "pass" });
+  });
+
+  test("small drop within the noise floor passes", () => {
+    // Previous 100, current 85 → -15%, within the 25% noise floor.
+    const previous = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 100 },
+    });
+    const current = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 85 },
+    });
+    const out = compareAgainstHistory(current, previous, [floorRow], "gha-ubuntu");
+    const s6 = out.find((c) => c.surfaceId === "S6-drive");
+    expect(s6?.status).toEqual({ kind: "pass" });
+  });
+
+  test("absolute-fail (measured below ghaMax) fires before delta-fail considered", () => {
+    // Previous 70 (already below floor), current 50 → both ≤ ghaMax 60.
+    // Absolute fires first with the current measured value.
+    const previous = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 70 },
+    });
+    const current = fakeLine("gha-ubuntu", {
+      "S6-drive": { samples_count: 100, throughput_per_sec: 50 },
+    });
+    const out = compareAgainstHistory(current, previous, [floorRow], "gha-ubuntu");
+    const s6 = out.find((c) => c.surfaceId === "S6-drive");
+    expect(s6?.status).toEqual({ kind: "absolute-fail", measured: 50, threshold: 60 });
+  });
+});
+
+describe("compareAgainstHistory — ceiling metrics regression direction", () => {
+  test("ceiling-metric improvement (latency drop) does not fail delta", () => {
+    // S2-a: prev 100ms → current 50ms. -50% delta. Ceiling-metric improvement.
+    const previous = fakeLine("gha-ubuntu", { "S2-a": { samples_count: 500, p95_ms: 100 } });
+    const current = fakeLine("gha-ubuntu", { "S2-a": { samples_count: 500, p95_ms: 50 } });
+    const out = compareAgainstHistory(current, previous, SLO_THRESHOLDS, "gha-ubuntu");
+    const s2a = out.find((c) => c.surfaceId === "S2-a");
+    expect(s2a?.status).toEqual({ kind: "pass" });
   });
 });
 

--- a/packages/gateway/src/perf/threshold-comparator.ts
+++ b/packages/gateway/src/perf/threshold-comparator.ts
@@ -3,10 +3,18 @@
  * `HistoryLine` for the same runner, and the SLO_THRESHOLDS table,
  * returns one `SurfaceComparison` per SLO row. No I/O.
  *
- * Spec § 3.1 fail conditions:
- *   (a) measured > absolute threshold (`refMax` for reference, `ghaMax`
- *       for GHA — selected by `runner`)
- *   (b) delta_pct > max(noiseFloorPct, noiseFloorAbs / previous * 100)
+ * Spec § 3.1 fail conditions, direction-aware:
+ *   (a) Ceiling metrics (`p95_ms`, `p50_ms`, `rss_bytes_p95`,
+ *       `first_token_ms`): fail when `measured > absolute threshold`
+ *       (`refMax` for reference, `ghaMax` for GHA — selected by `runner`)
+ *       and when `deltaPct > max(noiseFloorPct, noiseFloorAbs / prev *
+ *       100)` (positive delta = regression).
+ *   (b) Floor metrics (`throughput_per_sec`, `tokens_per_sec`): fail
+ *       when `measured < absolute threshold` and when the *drop*
+ *       exceeds the noise floor (`-deltaPct > effectiveFloorPct`).
+ *       The `delta-fail` status keeps `deltaPct` in its natural sign
+ *       (negative for a throughput regression) so the PR-comment
+ *       formatter can render `-X%` directly.
  *
  * Workload rows have `gated: false`; `isFailingComparison()` short-
  * circuits to `false` for them regardless of status. C-1 callers
@@ -57,6 +65,14 @@ function isStub(s: HistoryLineSurface | undefined): boolean {
   return s?.samples_count === 0;
 }
 
+/**
+ * Floor metrics: higher = better, so the regression direction is *down*
+ * and the absolute threshold is a minimum. Ceiling metrics flip both.
+ */
+export function isFloorMetric(metric: SloThreshold["metric"]): boolean {
+  return metric === "throughput_per_sec" || metric === "tokens_per_sec";
+}
+
 function classifySkip(slo: SloThreshold, runner: RunnerKind): ComparisonStatus | null {
   // S2-c, S7-c, S9 — `ghaMax === "skipped"` means reference-only.
   if (slo.ghaMax === "skipped" && runner !== "reference-m1air") {
@@ -97,8 +113,11 @@ function compareOne(
 
   // Absolute check — only meaningful when ghaMax is numeric.
   const threshold = pickAbsoluteThreshold(slo, runner);
-  if (threshold !== undefined && measured > threshold) {
-    return { kind: "absolute-fail", measured, threshold };
+  if (threshold !== undefined) {
+    const absoluteFail = isFloorMetric(slo.metric) ? measured < threshold : measured > threshold;
+    if (absoluteFail) {
+      return { kind: "absolute-fail", measured, threshold };
+    }
   }
 
   // Delta check requires previous.
@@ -106,10 +125,14 @@ function compareOne(
   const prev = readMetric(previous, slo.metric);
   if (prev === undefined || prev <= 0) return { kind: "no-baseline", current: measured };
 
+  // deltaPct stays in its natural sign so the PR-comment formatter shows
+  // `-X%` for a throughput drop. regressionPct is the direction-aware
+  // magnitude — positive when the surface got worse.
   const deltaPct = ((measured - prev) / prev) * 100;
+  const regressionPct = isFloorMetric(slo.metric) ? -deltaPct : deltaPct;
   const floorAbsAsPct = (slo.noiseFloorAbs / prev) * 100;
   const effectiveFloorPct = Math.max(slo.noiseFloorPct, floorAbsAsPct);
-  if (deltaPct > effectiveFloorPct) {
+  if (regressionPct > effectiveFloorPct) {
     return {
       kind: "delta-fail",
       previous: prev,


### PR DESCRIPTION
## Summary

Found while applying review feedback to the PR-C-2b plan: `threshold-comparator.ts:100` (and the delta check on line 112) treats every metric's `ghaMax` as a ceiling and only flags positive deltas. That's right for latency / RSS / `first_token_ms` and inverted for floor metrics (`throughput_per_sec`, `tokens_per_sec`). Latent today because every floor-metric workload row is `ghaMax: "tbd-c2"` + `gated: false`, but PR-C-2b would surface it the moment it flips a floor row to numeric + gated.

## What changes

- `isFloorMetric(metric)` helper, exported from `threshold-comparator.ts`.
- `compareOne` absolute check: invert for floor metrics (`measured < threshold = fail`).
- `compareOne` delta check: `regressionPct = isFloorMetric ? -deltaPct : deltaPct`. Status field keeps `deltaPct` in its natural sign so the formatter renders `-30.0%` for a throughput drop without extra direction logic on its side.
- `pr-comment-formatter.ts` `statusCell`: render `<` instead of `>` for floor-metric `absolute-fail`. `40 < 60` reads naturally for "throughput dropped below the floor."
- JSDoc header in `threshold-comparator.ts` reframed § 3.1 fail conditions in direction-aware form.

## Why now (and the link to PR-C-2b)

The PR-C-2b plan currently carves out a "Pattern E" — set `refMax` for floor-metric workload surfaces but leave `ghaMax: "tbd-c2"` + `gated: false`. That's a workaround for the comparator limitation this PR fixes. Once this merges, the plan can drop Pattern E and gate every workload row symmetrically when the M1 Air reference run finally lands.

## Tests

- `isFloorMetric` truth table (throughput / tokens true; p95 / p50 / rss / first_token false).
- New `describe("compareAgainstHistory — floor metrics")` block — 7 cases:
  - absolute-fail when measured < floor
  - absolute-pass when measured > floor (`no-baseline` without previous)
  - exactly-at-floor passes (strict `<`, not `<=`)
  - delta-fail when throughput drops more than the noise floor; `deltaPct` stays signed (`-30`)
  - improvement (throughput rises) is never a delta-fail
  - small drop within the noise floor passes
  - absolute-fail fires before delta-fail when both apply
- New `describe("compareAgainstHistory — ceiling metrics regression direction")` regression-guard: a latency improvement does not delta-fail.
- `pr-comment-formatter` test: `40 < 60` for throughput absolute-fail; existing `12000 > 10000` assertion strengthened to substring rather than fragments.

29 comparator + formatter tests pass (was 18); 178 perf-package tests pass; `typecheck`, `lint`, `regen-slo:check` all green.

## Test plan

- [x] `bun test packages/gateway/src/perf/threshold-comparator.test.ts packages/gateway/src/perf/pr-comment-formatter.test.ts` exits 0.
- [x] `bun run test:coverage:perf` exits 0.
- [x] `bun run typecheck` exits 0.
- [x] `bun run lint` exits 0.
- [x] `bun run regen-slo:check` exits 0 (no SLO_THRESHOLDS change).
- [ ] CI on this PR: per-OS bench comparator delta comments still render correctly; UX-row gating semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)