### PR TITLE
fix(test): harden flaky Windows tests (platform.test.ts EBUSY + QueryInput.test.tsx timing)

### DIFF
--- a/packages/cli/src/tui/QueryInput.test.tsx
+++ b/packages/cli/src/tui/QueryInput.test.tsx
@@ -5,6 +5,34 @@ import { join } from "node:path";
 import { render } from "ink-testing-library";
 import { QueryInput } from "./QueryInput.tsx";
 
+/**
+ * Polls `check` until it returns a truthy value or the timeout elapses.
+ * Used in place of fixed setTimeout waits for post-action assertions, so
+ * tests don't flake on busy CI hosts (notably Windows under full-suite
+ * parallelism where Ink render → file load → React state update → submit →
+ * persist can take much longer than a fixed 20–30ms wait).
+ */
+async function waitFor<T>(
+  check: () => T | null | undefined,
+  opts: { timeout?: number; interval?: number } = {},
+): Promise<T> {
+  const timeout = opts.timeout ?? 2000;
+  const interval = opts.interval ?? 10;
+  const start = Date.now();
+  while (true) {
+    try {
+      const result = check();
+      if (result) return result;
+    } catch {
+      // ignore and retry
+    }
+    if (Date.now() - start > timeout) {
+      throw new Error(`waitFor timed out after ${timeout}ms`);
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}
+
 let tmpDir: string;
 let historyPath: string;
 
@@ -195,7 +223,8 @@ describe("QueryInput — history cycling", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(lastFrame() ?? "").toContain("one");
     stdin.write("\r");
-    await new Promise((r) => setTimeout(r, 20));
+    // Poll for submit callback rather than fixed wait — survives busy hosts.
+    await waitFor(() => lastSubmitted === "one" || null, { timeout: 2000, interval: 10 });
     expect(lastSubmitted).toBe("one");
     unmount();
   });
@@ -236,11 +265,22 @@ describe("QueryInput — history cycling", () => {
         showCancelHint={false}
       />,
     );
-    await new Promise((r) => setTimeout(r, 20));
+    // Small grace period for the component to hydrate the existing entry from
+    // disk before we submit; without it the submit can race the load and the
+    // result becomes ["new"] only.
+    await new Promise((r) => setTimeout(r, 50));
     stdin.write("new");
     stdin.write("\r");
-    await new Promise((r) => setTimeout(r, 30));
-    const parsed = JSON.parse(readFileSync(historyPath, "utf-8")) as { entries: string[] };
+    // Poll the history file until the new entry has been persisted, instead
+    // of a fixed setTimeout which intermittently flaked on Windows under
+    // full-suite parallelism.
+    const parsed = await waitFor(
+      () => {
+        const p = JSON.parse(readFileSync(historyPath, "utf-8")) as { entries: string[] };
+        return p.entries.length >= 2 ? p : null;
+      },
+      { timeout: 2000, interval: 10 },
+    );
     expect(parsed.entries).toEqual(["old", "new"]);
     unmount();
   });

--- a/packages/gateway/src/platform/platform.test.ts
+++ b/packages/gateway/src/platform/platform.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import { platform, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -31,12 +32,30 @@ describe("Platform Abstraction Layer", () => {
     processEnvSet("XDG_RUNTIME_DIR", tmpDir);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     processEnvDelete("NIMBUS_SKIP_EMBEDDING_RUNTIME");
     for (const [key, val] of Object.entries(originalEnv)) {
       processEnvSet(key, val);
     }
-    rmSync(tmpDir, { recursive: true, force: true });
+    // Async fs.promises.rm with retries — the documented Windows-EBUSY
+    // workaround. Several tests in this file import ./index.ts, which
+    // constructs full PlatformServices (sync scheduler, connector mesh,
+    // lazy-loaded embedding runtime); under full-suite parallelism those
+    // services may still hold OS file handles inside tmpDir when this hook
+    // runs. POSIX unlinks open files happily and won't retry; Windows
+    // refuses deletion. If retries still fail (services that hold handles
+    // longer than the retry budget), the cleanup is logged-and-deferred to
+    // the OS temp reaper — failing the suite over a racy cleanup of a temp
+    // dir is worse than the leak.
+    try {
+      await rm(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "EBUSY" && code !== "ENOTEMPTY" && code !== "EPERM") {
+        throw err;
+      }
+      console.warn(`[platform.test] tmpDir cleanup deferred to OS (${code}): ${tmpDir}`);
+    }
   });
 
   it("createPlatformServices is exported", async () => {


### PR DESCRIPTION
## Summary

Two Windows-only test flakes hardened, both well-known patterns, both ~independent.

- **platform.test.ts EBUSY race** — afterEach's sync `rmSync` raced with PAL services' open file handles on Windows; switched to async `fs.promises.rm` with `maxRetries: 5, retryDelay: 100`, plus a logged-and-deferred fallback for the cases where retries still don't drain (the cleanup target lives under the OS temp directory and will be reaped — failing the suite over a racy temp-dir cleanup is worse than the leak). Idempotent on POSIX.
- **QueryInput.test.tsx timing race** — fixed-delay `setTimeout(30ms)` wait for post-submit history-file persist intermittently flaked on busy Windows hosts. Switched to polling with 2s timeout / 10ms interval. Same shape applied to one sibling test ("Up cycles to oldest entry and stops") which had the same post-submit-and-check-callback race.

Both files pass 100% of their tests in isolation pre-fix; the flakes only surfaced under full-suite parallelism. Verified post-fix that the broader test suites pass repeatedly.

## What's NOT in this PR

- Any feature-code changes.
- Coverage threshold changes.
- Other timing-sensitive tests in the repo (out of scope; one bite at a time).

## Test plan

- [x] On Windows: `bun test packages/gateway/src/platform/platform.test.ts` passes 7/7 (verified 5 consecutive runs).
- [x] On Windows: `bun test packages/cli/src/tui/QueryInput.test.tsx` passes 11/11 (verified 5 consecutive runs).
- [x] On Windows: `bun test packages/gateway/src/platform/ packages/cli/src/tui/` passes 94/94 (verified 3 consecutive runs of joint suite — this combination was the most reliable repro pre-fix).
- [x] `bun run typecheck` exits 0.
- [x] `bun run lint` (Biome) exits 0.
- [ ] CI Linux/macOS: same commands pass (no regression on POSIX expected — `fs.promises.rm` retry is a no-op on POSIX where the first call always succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)