### PR TITLE
fix(connectors): route sync-connector spawns through extensionProcessEnv (D10 / I1)

### DIFF
--- a/packages/gateway/src/connectors/aws-sync.ts
+++ b/packages/gateway/src/connectors/aws-sync.ts
@@ -1,3 +1,4 @@
+import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { clampSyncTitle, syncPassCursorParseEmpty } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
@@ -33,7 +34,7 @@ function decodeCursor(raw: string | null): AwsCursorV1 | null {
   return { nextMarker: typeof m === "string" && m !== "" ? m : null };
 }
 
-async function awsProcessEnv(ctx: SyncContext): Promise<Record<string, string | undefined> | null> {
+async function awsCredentialsExtra(ctx: SyncContext): Promise<Record<string, string> | null> {
   const ak = (await ctx.vault.get("aws.access_key_id"))?.trim() ?? "";
   const sk = (await ctx.vault.get("aws.secret_access_key"))?.trim() ?? "";
   const reg = (await ctx.vault.get("aws.default_region"))?.trim() ?? "";
@@ -42,32 +43,32 @@ async function awsProcessEnv(ctx: SyncContext): Promise<Record<string, string | 
   if (!ok) {
     return null;
   }
-  const e = { ...process.env } as Record<string, string | undefined>;
+  const extra: Record<string, string> = {};
   if (ak !== "") {
-    e["AWS_ACCESS_KEY_ID"] = ak;
+    extra["AWS_ACCESS_KEY_ID"] = ak;
   }
   if (sk !== "") {
-    e["AWS_SECRET_ACCESS_KEY"] = sk;
+    extra["AWS_SECRET_ACCESS_KEY"] = sk;
   }
   if (reg !== "") {
-    e["AWS_DEFAULT_REGION"] = reg;
+    extra["AWS_DEFAULT_REGION"] = reg;
   }
   if (prof !== "") {
-    e["AWS_PROFILE"] = prof;
+    extra["AWS_PROFILE"] = prof;
   }
-  return e;
+  return extra;
 }
 
 async function awsCliJson(
   ctx: SyncContext,
   args: string[],
 ): Promise<{ ok: boolean; text: string }> {
-  const env = await awsProcessEnv(ctx);
-  if (env === null) {
+  const extra = await awsCredentialsExtra(ctx);
+  if (extra === null) {
     return { ok: false, text: "" };
   }
   const proc = Bun.spawn(["aws", ...args, "--output", "json"], {
-    env,
+    env: extensionProcessEnv(extra),
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -166,8 +167,8 @@ export function createAwsSyncable(options: AwsSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureAwsMcpRunning();
-      const env = await awsProcessEnv(ctx);
-      if (env === null) {
+      const extra = await awsCredentialsExtra(ctx);
+      if (extra === null) {
         return syncNoopResult(cursor, t0);
       }
 

--- a/packages/gateway/src/connectors/azure-sync.ts
+++ b/packages/gateway/src/connectors/azure-sync.ts
@@ -1,3 +1,4 @@
+import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import {
   clampSyncTitle,
@@ -32,14 +33,12 @@ async function azureCliJson(
   if (tenant === "" || clientId === "" || secret === "") {
     return { ok: false, text: "" };
   }
-  const env = {
-    ...process.env,
-    AZURE_TENANT_ID: tenant,
-    AZURE_CLIENT_ID: clientId,
-    AZURE_CLIENT_SECRET: secret,
-  } as Record<string, string | undefined>;
   const proc = Bun.spawn(["az", ...args, "-o", "json"], {
-    env,
+    env: extensionProcessEnv({
+      AZURE_TENANT_ID: tenant,
+      AZURE_CLIENT_ID: clientId,
+      AZURE_CLIENT_SECRET: secret,
+    }),
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -4,6 +4,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import type { NimbusFilesystemRootToml } from "../config/filesystem-toml.ts";
+import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
@@ -66,18 +67,20 @@ async function gitLogRecords(
   root: string,
   maxCount: number,
 ): Promise<{ sha: string; ct: number; subject: string }[]> {
-  const proc = Bun.spawn(
-    [
-      "git",
-      "-C",
-      root,
-      "log",
-      `--max-count=${String(maxCount)}`,
-      "-z",
-      "--pretty=format:%H%x00%ct%x00%s",
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
+  const args = [
+    "git",
+    "-C",
+    root,
+    "log",
+    `--max-count=${String(maxCount)}`,
+    "-z",
+    "--pretty=format:%H%x00%ct%x00%s",
+  ];
+  const proc = Bun.spawn(args, {
+    env: extensionProcessEnv({}),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const code = await proc.exited;
   const out = await new Response(proc.stdout).text();
   if (code !== 0) {

--- a/packages/gateway/src/connectors/gcp-sync.ts
+++ b/packages/gateway/src/connectors/gcp-sync.ts
@@ -1,3 +1,4 @@
+import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import {
   clampSyncTitle,
@@ -30,12 +31,8 @@ async function gcloudJson(
   if (credPath === "") {
     return { ok: false, text: "" };
   }
-  const env = {
-    ...process.env,
-    GOOGLE_APPLICATION_CREDENTIALS: credPath,
-  } as Record<string, string | undefined>;
   const proc = Bun.spawn(["gcloud", ...args, "--format", "json"], {
-    env,
+    env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/packages/gateway/src/connectors/kubernetes-sync.ts
+++ b/packages/gateway/src/connectors/kubernetes-sync.ts
@@ -1,3 +1,4 @@
+import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { syncPassCursorParseEmpty } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
@@ -109,7 +110,7 @@ async function kubectlDeploymentsJson(
   }
   args.push("get", "deployments", "-A", "-o", "json");
   const proc = Bun.spawn(args, {
-    env: { ...process.env, KUBECONFIG: kubeconfig },
+    env: extensionProcessEnv({ KUBECONFIG: kubeconfig }),
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
## Summary

Fixes all 5 D10 violations surfaced by the Phase 1/2 structure audit.
Each was a `Bun.spawn(...)` under `packages/gateway/src/connectors/`
that built the child env from `{ ...process.env, ... }` (or omitted
`env` entirely, which Bun treats as full-inheritance). That regresses
**security invariant I1** in [`docs/SECURITY-INVARIANTS.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/SECURITY-INVARIANTS.md)
— gateway-private vars (OAuth client secrets, LLM API keys, updater overrides)
were leaking into the AWS/Azure/gcloud/kubectl/git child processes.

`audit:invariants` D10 count: **5 → 0**.

## The 5 fixes

| File | Shape | Note |
|---|---|---|
| `connectors/aws-sync.ts` | helper refactor + inline at spawn | Renamed `awsProcessEnv` → `awsCredentialsExtra` (now returns just the AWS extras); the call site in `awsCliJson` builds the full child env via `extensionProcessEnv(extra)` inline. |
| `connectors/azure-sync.ts` | inline at spawn | `{ ...process.env, AZURE_* }` → `extensionProcessEnv({ AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET })`. |
| `connectors/gcp-sync.ts` | inline at spawn | `{ ...process.env, GOOGLE_APPLICATION_CREDENTIALS }` → `extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS })`. |
| `connectors/kubernetes-sync.ts` | inline at spawn | `{ ...process.env, KUBECONFIG }` → `extensionProcessEnv({ KUBECONFIG })`. |
| `connectors/filesystem-v2-sync.ts` | additive | The `git log` spawn previously omitted `env`; added `env: extensionProcessEnv({})`. Hoisted the args list to a const so the call fits in the audit's six-line window. |

## Plan deviation

The plan ([`2026-05-01-structure-fixes-d10-sync-connector-spawn.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/plans/2026-05-01-structure-fixes-d10-sync-connector-spawn.md))
said fixing the `aws-sync` *helper* would resolve the audit "transitively".
It doesn't — `checkSpawnInvariant` does a lexical 6-line window scan
starting at the spawn line and can't see across functions. I kept the
helper-as-source-of-truth pattern but moved the `extensionProcessEnv(...)`
call inline at the `Bun.spawn` site (matching the pattern used by the
other four connectors). Same end state, audit-clean.

## Verification

- `bun run audit:invariants 2>&1 | grep -c "D10 spawn"` → **0**
- `bun run audit:boundaries` → clean
- `bun scripts/structure-audit/count-any-usage.ts --check` → clean
- `bun run lint` → 949 files clean
- `bun run --filter @nimbus/gateway typecheck` → clean
- `bun test packages/gateway/src/security-invariants.test.ts packages/gateway/src/connectors/` → 116/116 pass

`audit:invariants` still exits 1 because D11 has 56 violations (untouched here).
That's expected — D11 Bucket A is a separate plan
([`2026-05-01-structure-fixes-d11-bucket-a-fp-suppression.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/plans/2026-05-01-structure-fixes-d11-bucket-a-fp-suppression.md)).

This PR does **not** wire `_structure.yml` into `ci.yml` — that's
reserved for whichever top-5 fix lands last (when `audit:invariants`
exits 0 cleanly).

Spec ref: [`docs/superpowers/specs/2026-04-30-structure-audit-design.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/specs/2026-04-30-structure-audit-design.md) § 6.2.

## Test plan

- [ ] CI green on Ubuntu (`pr-quality-ts`, `pr-quality-rust`, `pr-quality-duplication`)
- [ ] No regression in any `*-sync.test.ts` connector test
- [ ] `security-invariants.test.ts` continues to pass (I1 enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)