### PR TITLE
docs(pages): wire up GitHub Pages deploy for Astro Starlight site

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -75,6 +75,34 @@ After workflows have run at least once, add as **required checks**:
 
 **Note:** Required checks must match the **exact** job names shown in the Actions UI. After changing workflow job names, update the rule accordingly. Marking every Security job as required ensures `bun audit`, Trivy, gateway contract tests, and `cargo audit` all block merges when they fail.
 
+## Currently active required checks (`General` ruleset on `main`)
+
+The `General` ruleset (id `14784377`) currently requires the following 10 checks to pass before a PR can merge to `main`. These names are matched **verbatim** against the Actions UI; renaming a job in the workflow YAML without updating the ruleset will break merges.
+
+| Required check | Source workflow | Notes |
+|---|---|---|
+| `PR quality — TS/Bun (ubuntu-24.04) / Test — ubuntu-24.04` | `_test-suite.yml` (called by `ci.yml` on PR) | Unit tests + UI Vitest + integration + e2e on Ubuntu |
+| `PR quality — Duplication scan` | `ci.yml` | jscpd |
+| `Dependency audit` | `security.yml` | `bun audit` |
+| `Trivy vulnerability scan` | `security.yml` | filesystem scan + SARIF upload |
+| `Gitleaks secret scan` | `security.yml` | committed-secret detection |
+| `Gateway audit JSON + connector.remove vault restore` | `security.yml` | Gateway contract tests |
+| `Cargo audit (Tauri)` | `security.yml` | Rust dep advisories |
+| `Cargo deny (licenses + advisories + bans)` | `security.yml` | License + bans + registry pinning |
+| `Analyze (javascript-typescript)` | `codeql.yml` | CodeQL JS/TS security-extended |
+| `Analyze (rust)` | `codeql.yml` | CodeQL Rust security-extended |
+
+**Conditional jobs intentionally excluded** from required checks — they skip on PRs that don't touch their domain, and a skipped check would block merge:
+
+- `PR quality — Rust/Tauri (ubuntu-24.04)` (skips when no `packages/ui/src-tauri/` change)
+- `E2E Desktop (PR) — ubuntu-24.04` (only on PRs labelled `ci:e2e-desktop`)
+- `Bench (${{ matrix.os }})` (only on `perf`-labelled PRs)
+- The 22 `Coverage — *` matrix jobs (granular signals folded into the parent `Test —` job's pass/fail)
+
+**When job names change:** `gh api repos/asafgolombek/Nimbus/rulesets/14784377` exposes the current `required_status_checks` array. Update via `PUT repos/asafgolombek/Nimbus/rulesets/14784377` with the corrected `context` strings.
+
+**Solo-dev approval policy:** the same ruleset has `required_approving_review_count: 0` and `bypass_mode: pull_request` — PRs are mandatory, status checks are mandatory, but human approval is not (see `docs/SECURITY.md` and the threat model around AI-assisted review).
+
 ## Security features (org or repo)
 
 - **Secret scanning** — detect leaked secrets in the repository.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,9 @@ name: CodeQL
 on:
   push:
     branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "25 4 * * 1"
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,19 +12,16 @@ on:
       - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
 
-# Reading content + writing the Pages artifact + minting OIDC tokens for
-# actions/deploy-pages. Job-level `permissions` already minimize beyond this.
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Only one Pages deploy can run at a time; queueing prevents racey
 # overwrite of the live site. `cancel-in-progress: false` lets each push
 # finish so we don't ship partial builds.
 concurrency:
   group: pages
   cancel-in-progress: false
+
+# Permissions are scoped per-job so neither token carries privileges
+# the other doesn't need: `build` only reads source; `deploy` only writes
+# Pages + mints the OIDC token actions/deploy-pages requires.
 
 jobs:
   build:
@@ -67,6 +64,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,78 @@
+# Build and deploy the Astro Starlight docs site (packages/docs) to GitHub Pages.
+# Site URL: https://asafgolombek.github.io/Nimbus/ (project pages — base = /Nimbus/).
+# Configured under repo Settings → Pages → Source = GitHub Actions (build_type=workflow).
+
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/docs/**"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
+
+# Reading content + writing the Pages artifact + minting OIDC tokens for
+# actions/deploy-pages. Job-level `permissions` already minimize beyond this.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deploy can run at a time; queueing prevents racey
+# overwrite of the live site. `cancel-in-progress: false` lets each push
+# finish so we don't ship partial builds.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-nimbus-ci
+
+      - name: Build Astro Starlight site
+        run: bun run --filter @nimbus/docs build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: packages/docs/dist
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -3,7 +3,12 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 import starlightLinksValidator from "starlight-links-validator";
 
+// GitHub Pages publishes this site at https://asafgolombek.github.io/Nimbus/
+// — the `base` prefix makes Starlight emit asset URLs and internal links
+// under that subpath so they resolve when served from project-pages.
 export default defineConfig({
+  site: "https://asafgolombek.github.io",
+  base: "/Nimbus/",
   integrations: [
     starlight({
       title: "Nimbus",

--- a/packages/docs/src/content/docs/getting-started.mdx
+++ b/packages/docs/src/content/docs/getting-started.mdx
@@ -8,7 +8,7 @@ description: Install Bun, run the Gateway, and verify the CLI — under 10 minut
 1. Install [Bun](https://bun.sh/) v1.2 or newer.
 2. Clone the Nimbus repository and run `bun install` at the repo root.
 
-See [First-party connectors](/connectors/overview/) for how to authenticate and sync each service.
+See [First-party connectors](/Nimbus/connectors/overview/) for how to authenticate and sync each service.
 
 ## Run the Gateway
 
@@ -27,4 +27,4 @@ nimbus help
 nimbus doctor
 ```
 
-Return to the [home page](/) for an overview of the project.
+Return to the [home page](/Nimbus/) for an overview of the project.


### PR DESCRIPTION
## Summary

`has_pages: true` was set with `build_type: workflow` during the post-D11
repo-settings audit, but no workflow existed to publish content. This PR
closes the loop so the docs site at https://asafgolombek.github.io/Nimbus/
actually serves the Astro Starlight build.

## Changes

- **`packages/docs/astro.config.mjs`** — added `site:` + `base: "/Nimbus/"`
  so Starlight emits href + asset URLs prefixed for the project-pages
  subpath.
- **`packages/docs/src/content/docs/getting-started.mdx`** — prefixed the
  two existing absolute internal links with `/Nimbus/`. Astro does NOT
  auto-prepend `base` to MDX absolute links, and `starlight-links-validator`
  rightly flags them as broken without the prefix.
- **`.github/workflows/deploy-docs.yml`** — new build + deploy workflow:
  - Triggers on push to `main` when `packages/docs/**` or the workflow
    itself changes; also `workflow_dispatch` for manual rebuilds.
  - `build` job uses the existing `setup-nimbus-ci` composite action,
    runs `bun run --filter @nimbus/docs build`, uploads
    `packages/docs/dist` as a Pages artifact.
  - `deploy` job publishes via `actions/deploy-pages` to the
    `github-pages` environment.
  - All actions SHA-pinned (repo enforces `sha_pinning_required: true`).
  - Scoped permissions: build job is `contents: read` only;
    `pages: write` + `id-token: write` only at workflow level for the
    deploy job to mint its OIDC token.
- **`.github/BRANCH_PROTECTION.md`** — documented the 10 currently-active
  required status checks on the `General` ruleset, listed conditional
  jobs intentionally excluded, and the maintenance procedure when
  workflow job names change. Also notes the solo-dev approval policy
  (`required_approving_review_count: 0`, `bypass_mode: pull_request`).

## Verification

- `bun run --filter @nimbus/docs build` → 9 pages, all internal links valid
- Confirmed dist `href` attributes carry the `/Nimbus/` prefix
  (e.g. `href=\"/Nimbus/connectors/overview/\"`)
- `bun run lint` → 949 files clean
- YAML parses cleanly (`bunx js-yaml`)

## Test plan

- [ ] CI green on Ubuntu (`pr-quality-ts`, `pr-quality-duplication`,
      security checks, CodeQL)
- [ ] After merge, deploy-docs.yml runs on `main` and publishes the
      Astro Starlight site
- [ ] https://asafgolombek.github.io/Nimbus/ loads correctly with
      working internal links + assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)