### PR TITLE
fix(deploy-docs): install Node 22 so Astro 6 build succeeds

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # Astro 6 enforces Node >=22.12.0 at runtime (its check.ts shells out to
+      # Node, not Bun, so Bun's own runtime version doesn't satisfy this).
+      # The default GHA ubuntu image ships Node 20.x, which Astro rejects.
+      - name: Setup Node.js (Astro requires >=22.12.0)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
 


### PR DESCRIPTION
## Summary

The Pages deploy workflow added in #140 failed on its first run with:

\`\`\`
@nimbus/docs build: Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: \">=22.12.0\"
\`\`\`

The GHA \`ubuntu-24.04\` image ships Node 20.x. Bun runs the rest of the
project's JS/TS, but \`astro check\` (run as part of \`bun run --filter
@nimbus/docs build\`) shells out to the system Node — its TypeScript
checker is a Node subprocess — so Bun's own runtime version is moot;
Astro sees the OS Node and bails.

## Fix

Added \`actions/setup-node@v6.4.0\` (SHA-pinned) before the build step
in \`.github/workflows/deploy-docs.yml\` to install Node 22 on the runner.

Scoped to \`deploy-docs.yml\` only — no other workflow builds Astro.

## Verification

- YAML parses (\`bunx js-yaml\`)
- After merge, \`deploy-docs.yml\` re-runs against the merge commit and
  publishes the Astro Starlight site to https://asafgolombek.github.io/Nimbus/

## Test plan

- [ ] CI green on Ubuntu (8 required checks)
- [ ] After merge, deploy-docs.yml run completes both \`build\` and \`deploy\` jobs
- [ ] https://asafgolombek.github.io/Nimbus/ loads