### PR TITLE
refactor(structure-audit): D11 Bucket B — route 11 sites through readConnectorSecret

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ runs. See `docs/structure-audit/baseline.md` for current findings.
 | `packages/gateway/src/auth/oauth-vault-tokens.ts` | Generic OAuth token storage/refresh helpers — `getValidVaultOAuthAccessToken()`, `microsoftOAuthAccessFromConfig()` |
 | `packages/gateway/src/connectors/` | MCP connector mesh (`lazy-mesh.ts` — Phase 3 bundle spawns AWS/Azure/GCP/IaC/observability MCPs when vault keys exist) |
 | `packages/gateway/src/connectors/health.ts` | Connector health state machine — `transitionHealth()`, `ConnectorHealthSnapshot` |
-| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()` (Phase 4) |
+| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers + typed connector-secret reader — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()`, `readConnectorSecret()` (Phase 4 / D11 Bucket B) |
 | `packages/gateway/src/connectors/connector-secrets-manifest.ts` | `CONNECTOR_VAULT_SECRET_KEYS` — per-connector PAT/API-key vault manifest; `clearConnectorVaultSecretKeys()` |
 | `packages/gateway/src/connectors/remove-intent.ts` | Connector removal — cascade vault + index cleanup via `executeRemoveIntent()` |
 | `packages/gateway/src/automation/graph-predicate.ts` | Graph predicate types, parser, evaluator; `parseGraphPredicate` / `itemMatchesGraphPredicate` / `countItemsMatchingGraphPredicate` / `listCandidateGraphRelations` |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -70,7 +70,7 @@ runs. See `docs/structure-audit/baseline.md` for current findings.
 | `packages/gateway/src/auth/oauth-vault-tokens.ts` | Generic OAuth token storage/refresh helpers — `getValidVaultOAuthAccessToken()`, `microsoftOAuthAccessFromConfig()` |
 | `packages/gateway/src/connectors/` | MCP connector mesh (`lazy-mesh.ts` — Phase 3 bundle spawns AWS/Azure/GCP/IaC/observability MCPs when vault keys exist) |
 | `packages/gateway/src/connectors/health.ts` | Connector health state machine — `transitionHealth()`, `ConnectorHealthSnapshot` |
-| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()` (Phase 4) |
+| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers + typed connector-secret reader — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()`, `readConnectorSecret()` (Phase 4 / D11 Bucket B) |
 | `packages/gateway/src/connectors/connector-secrets-manifest.ts` | `CONNECTOR_VAULT_SECRET_KEYS` — per-connector PAT/API-key vault manifest; `clearConnectorVaultSecretKeys()` |
 | `packages/gateway/src/connectors/remove-intent.ts` | Connector removal — cascade vault + index cleanup via `executeRemoveIntent()` |
 | `packages/gateway/src/automation/graph-predicate.ts` | Graph predicate types, parser, evaluator; `parseGraphPredicate` / `itemMatchesGraphPredicate` / `countItemsMatchingGraphPredicate` / `listCandidateGraphRelations` |

--- a/docs/structure-audit/baseline.md
+++ b/docs/structure-audit/baseline.md
@@ -25,6 +25,14 @@ ranks deviations from these baselines.
 | D11 | F | Vault-key construction outside allow-list | 56 violations | `bun run audit:invariants` (binary) |
 | D12 | F | `db.run()` outside `db/write.ts` (census) | 94 sites | `docs/structure-audit/db-run-census.json` |
 
+## Phase 2 follow-up — post Bucket B (2026-05-01)
+
+D11 violations reduced from the Phase 1 baseline of 56 to **21** (Bucket C only):
+
+- Bucket A (20 false positives) — suppressed by `audit-ignore-next-line` markers (PR #135).
+- Bucket B (15 sites) — routed through `readConnectorSecret` helper or added to the now-frozen 5-entry allow-list (this PR).
+- Bucket C (21 sites in `lazy-mesh.ts` + `connector-rpc-handlers.ts`) — deferred; tracked in [`deferred-backlog.md`](./deferred-backlog.md).
+
 ## Provenance
 
 - `count-any-usage` script: `scripts/structure-audit/count-any-usage.ts` @ `a3f327be871c810ff7c86690bb059fa381d85a6e`

--- a/docs/structure-audit/file-loc.json
+++ b/docs/structure-audit/file-loc.json
@@ -1,7 +1,7 @@
 [
   {
     "file": "packages/gateway/src/connectors/lazy-mesh.ts",
-    "loc": 1401
+    "loc": 1408
   },
   {
     "file": "packages/gateway/src/ipc/server.ts",
@@ -33,7 +33,7 @@
   },
   {
     "file": "packages/gateway/src/connectors/gitlab-sync.ts",
-    "loc": 638
+    "loc": 639
   },
   {
     "file": "packages/gateway/src/index/migrations/runner.ts",
@@ -69,7 +69,7 @@
   },
   {
     "file": "packages/gateway/src/connectors/filesystem-v2-sync.ts",
-    "loc": 489
+    "loc": 492
   },
   {
     "file": "packages/gateway/src/connectors/google-drive-sync.ts",
@@ -77,7 +77,7 @@
   },
   {
     "file": "packages/gateway/src/connectors/slack-sync.ts",
-    "loc": 475
+    "loc": 476
   },
   {
     "file": "packages/gateway/src/engine/agent.ts",
@@ -97,7 +97,7 @@
   },
   {
     "file": "packages/mcp-connectors/outlook/src/server.ts",
-    "loc": 404
+    "loc": 405
   },
   {
     "file": "packages/gateway/src/vault/win32.ts",
@@ -112,12 +112,12 @@
     "loc": 371
   },
   {
-    "file": "packages/gateway/src/extensions/install-from-local.ts",
-    "loc": 347
+    "file": "packages/gateway/src/platform/assemble.ts",
+    "loc": 349
   },
   {
-    "file": "packages/gateway/src/platform/assemble.ts",
-    "loc": 346
+    "file": "packages/gateway/src/extensions/install-from-local.ts",
+    "loc": 347
   },
   {
     "file": "packages/gateway/src/perf/bench-cli.ts",
@@ -125,7 +125,7 @@
   },
   {
     "file": "packages/gateway/src/connectors/github-sync.ts",
-    "loc": 341
+    "loc": 342
   },
   {
     "file": "packages/gateway/src/people/person-store.ts",
@@ -169,7 +169,7 @@
   },
   {
     "file": "packages/gateway/src/connectors/notion-sync.ts",
-    "loc": 299
+    "loc": 300
   },
   {
     "file": "packages/mcp-connectors/jira/src/server.ts",
@@ -201,14 +201,14 @@
   },
   {
     "file": "packages/gateway/src/connectors/linear-sync.ts",
-    "loc": 276
-  },
-  {
-    "file": "packages/gateway/src/engine/executor.ts",
-    "loc": 273
+    "loc": 277
   },
   {
     "file": "packages/gateway/src/connectors/github-actions-sync.ts",
+    "loc": 274
+  },
+  {
+    "file": "packages/gateway/src/engine/executor.ts",
     "loc": 273
   },
   {
@@ -268,12 +268,12 @@
     "loc": 242
   },
   {
-    "file": "packages/mcp-connectors/bitbucket/src/server.ts",
+    "file": "packages/gateway/src/platform/gateway-log-file.ts",
     "loc": 241
   },
   {
-    "file": "packages/gateway/src/platform/gateway-log-file.ts",
-    "loc": 239
+    "file": "packages/mcp-connectors/bitbucket/src/server.ts",
+    "loc": 241
   },
   {
     "file": "packages/gateway/src/ipc/data-rpc.ts",
@@ -300,11 +300,11 @@
     "loc": 210
   },
   {
-    "file": "packages/gateway/src/perf/bench-ci-gh.ts",
-    "loc": 208
+    "file": "packages/gateway/src/connectors/registry.ts",
+    "loc": 209
   },
   {
-    "file": "packages/gateway/src/connectors/registry.ts",
+    "file": "packages/gateway/src/perf/bench-ci-gh.ts",
     "loc": 208
   },
   {
@@ -352,10 +352,6 @@
     "loc": 189
   },
   {
-    "file": "packages/gateway/src/db/health.ts",
-    "loc": 184
-  },
-  {
     "file": "packages/gateway/src/telemetry/flush-scheduler.ts",
     "loc": 180
   },
@@ -364,15 +360,15 @@
     "loc": 179
   },
   {
+    "file": "packages/gateway/src/connectors/aws-sync.ts",
+    "loc": 178
+  },
+  {
     "file": "packages/gateway/src/connectors/onedrive-sync.ts",
     "loc": 178
   },
   {
     "file": "packages/gateway/src/platform/assemble-sync-registrations.ts",
-    "loc": 177
-  },
-  {
-    "file": "packages/gateway/src/connectors/aws-sync.ts",
     "loc": 177
   },
   {
@@ -456,6 +452,10 @@
     "loc": 155
   },
   {
+    "file": "packages/gateway/src/connectors/connector-vault.ts",
+    "loc": 155
+  },
+  {
     "file": "packages/cli/src/commands/workflow.ts",
     "loc": 155
   },
@@ -480,23 +480,15 @@
     "loc": 148
   },
   {
-    "file": "packages/gateway/src/testing/bun-test-support.ts",
-    "loc": 147
-  },
-  {
     "file": "packages/gateway/src/ipc/connector-rpc-shared.ts",
     "loc": 147
   },
   {
-    "file": "packages/gateway/src/perf/index.ts",
-    "loc": 146
+    "file": "packages/gateway/src/connectors/kubernetes-sync.ts",
+    "loc": 147
   },
   {
     "file": "packages/gateway/src/embedding/pipeline.ts",
-    "loc": 146
-  },
-  {
-    "file": "packages/gateway/src/connectors/kubernetes-sync.ts",
     "loc": 146
   },
   {
@@ -517,7 +509,7 @@
   },
   {
     "file": "packages/gateway/src/auth/oauth-vault-tokens.ts",
-    "loc": 138
+    "loc": 139
   },
   {
     "file": "packages/gateway/src/telemetry/db-aggregates.ts",
@@ -545,7 +537,7 @@
   },
   {
     "file": "packages/gateway/src/connectors/datadog-sync.ts",
-    "loc": 131
+    "loc": 132
   },
   {
     "file": "packages/cli/src/commands/lan.ts",
@@ -620,10 +612,6 @@
     "loc": 119
   },
   {
-    "file": "packages/gateway/src/connectors/connector-vault.ts",
-    "loc": 118
-  },
-  {
     "file": "packages/gateway/src/db/write.ts",
     "loc": 117
   },
@@ -652,15 +640,15 @@
     "loc": 112
   },
   {
+    "file": "packages/gateway/src/commands/data-import.ts",
+    "loc": 111
+  },
+  {
     "file": "packages/mcp-connectors/iac/src/server.ts",
     "loc": 111
   },
   {
     "file": "packages/gateway/src/commands/data-export.ts",
-    "loc": 110
-  },
-  {
-    "file": "packages/gateway/src/commands/data-import.ts",
     "loc": 110
   },
   {
@@ -684,11 +672,11 @@
     "loc": 106
   },
   {
-    "file": "packages/gateway/src/connectors/azure-sync.ts",
-    "loc": 105
+    "file": "packages/gateway/src/sync/scheduler-state-repository.ts",
+    "loc": 104
   },
   {
-    "file": "packages/gateway/src/sync/scheduler-state-repository.ts",
+    "file": "packages/gateway/src/connectors/azure-sync.ts",
     "loc": 104
   },
   {
@@ -702,10 +690,6 @@
   {
     "file": "packages/cli/src/commands/ask.ts",
     "loc": 104
-  },
-  {
-    "file": "packages/gateway/src/connectors/gcp-sync.ts",
-    "loc": 103
   },
   {
     "file": "packages/gateway/src/embedding/create-embedding-runtime.ts",
@@ -724,15 +708,19 @@
     "loc": 100
   },
   {
+    "file": "packages/gateway/src/connectors/gcp-sync.ts",
+    "loc": 100
+  },
+  {
     "file": "packages/gateway/src/people/parse-from-header.ts",
     "loc": 99
   },
   {
-    "file": "packages/gateway/src/connectors/grafana-sync.ts",
-    "loc": 98
+    "file": "packages/gateway/src/connectors/newrelic-sync.ts",
+    "loc": 99
   },
   {
-    "file": "packages/gateway/src/connectors/newrelic-sync.ts",
+    "file": "packages/gateway/src/connectors/grafana-sync.ts",
     "loc": 98
   },
   {
@@ -1116,6 +1104,10 @@
     "loc": 53
   },
   {
+    "file": "packages/gateway/src/connectors/connector-secrets-manifest.ts",
+    "loc": 52
+  },
+  {
     "file": "packages/gateway/src/connectors/reindex.ts",
     "loc": 52
   },
@@ -1165,10 +1157,6 @@
   },
   {
     "file": "packages/gateway/src/perf/percentiles.ts",
-    "loc": 45
-  },
-  {
-    "file": "packages/gateway/src/connectors/connector-secrets-manifest.ts",
     "loc": 45
   },
   {
@@ -1288,16 +1276,16 @@
     "loc": 35
   },
   {
+    "file": "packages/gateway/src/auth/notion-access-token.ts",
+    "loc": 35
+  },
+  {
     "file": "packages/cli/src/lib/cli-logger.ts",
     "loc": 35
   },
   {
     "file": "packages/cli/src/commands/index.ts",
     "loc": 35
-  },
-  {
-    "file": "packages/gateway/src/auth/notion-access-token.ts",
-    "loc": 34
   },
   {
     "file": "packages/cli/src/commands/telemetry.ts",
@@ -1320,6 +1308,10 @@
     "loc": 32
   },
   {
+    "file": "packages/gateway/src/auth/slack-access-token.ts",
+    "loc": 32
+  },
+  {
     "file": "packages/cli/src/commands/stop.ts",
     "loc": 32
   },
@@ -1333,10 +1325,6 @@
   },
   {
     "file": "packages/gateway/src/engine/json-fence.ts",
-    "loc": 31
-  },
-  {
-    "file": "packages/gateway/src/auth/slack-access-token.ts",
     "loc": 31
   },
   {
@@ -1440,10 +1428,6 @@
     "loc": 23
   },
   {
-    "file": "packages/cli/src/lib/repo-root.ts",
-    "loc": 23
-  },
-  {
     "file": "packages/sdk/src/hitl-request.ts",
     "loc": 22
   },
@@ -1453,10 +1437,6 @@
   },
   {
     "file": "packages/gateway/src/perf/surfaces/bench-llm-roundtrip.ts",
-    "loc": 22
-  },
-  {
-    "file": "packages/gateway/src/extensions/index.ts",
     "loc": 22
   },
   {
@@ -1489,14 +1469,6 @@
   },
   {
     "file": "packages/ui/src/store/slices/telemetry.ts",
-    "loc": 18
-  },
-  {
-    "file": "packages/sdk/src/testing/index.ts",
-    "loc": 18
-  },
-  {
-    "file": "packages/gateway/src/sync/index.ts",
     "loc": 18
   },
   {
@@ -1556,10 +1528,6 @@
     "loc": 13
   },
   {
-    "file": "packages/gateway/src/index/index.ts",
-    "loc": 13
-  },
-  {
     "file": "packages/gateway/src/auth/microsoft-access-token.ts",
     "loc": 13
   },
@@ -1581,10 +1549,6 @@
   },
   {
     "file": "packages/gateway/src/engine/agent-request-context.ts",
-    "loc": 12
-  },
-  {
-    "file": "packages/gateway/src/auth/index.ts",
     "loc": 12
   },
   {

--- a/docs/structure-audit/risky-assertions.json
+++ b/docs/structure-audit/risky-assertions.json
@@ -156,7 +156,7 @@
   },
   {
     "file": "packages/gateway/src/auth/oauth-vault-tokens.ts",
-    "line": 129,
+    "line": 130,
     "snippet": "const scopes = (parsed as Record<string, unknown>)[\"scopes\"];"
   },
   {
@@ -271,18 +271,8 @@
   },
   {
     "file": "packages/gateway/src/connectors/aws-sync.ts",
-    "line": 28,
+    "line": 29,
     "snippet": "const rec = parsed as Record<string, unknown>;"
-  },
-  {
-    "file": "packages/gateway/src/connectors/aws-sync.ts",
-    "line": 45,
-    "snippet": "const e = { ...process.env } as Record<string, string | undefined>;"
-  },
-  {
-    "file": "packages/gateway/src/connectors/azure-sync.ts",
-    "line": 40,
-    "snippet": "} as Record<string, string | undefined>;"
   },
   {
     "file": "packages/gateway/src/connectors/bitbucket-sync.ts",
@@ -331,62 +321,57 @@
   },
   {
     "file": "packages/gateway/src/connectors/filesystem-v2-sync.ts",
-    "line": 33,
+    "line": 34,
     "snippet": "const rec = parsed as Record<string, unknown>;"
   },
   {
     "file": "packages/gateway/src/connectors/filesystem-v2-sync.ts",
-    "line": 37,
+    "line": 38,
     "snippet": "for (const [k, v] of Object.entries(tipsRaw as Record<string, unknown>)) {"
   },
   {
     "file": "packages/gateway/src/connectors/filesystem-v2-sync.ts",
-    "line": 113,
+    "line": 116,
     "snippet": "entries = readdirSync(dir, { withFileTypes: true }) as Dirent[];"
   },
   {
     "file": "packages/gateway/src/connectors/filesystem-v2-sync.ts",
-    "line": 157,
+    "line": 160,
     "snippet": "const rec = j as Record<string, unknown>;"
   },
   {
     "file": "packages/gateway/src/connectors/filesystem-v2-sync.ts",
-    "line": 165,
+    "line": 168,
     "snippet": "for (const [k, v] of Object.entries(o as Record<string, unknown>)) {"
   },
   {
     "file": "packages/gateway/src/connectors/filesystem-v2-sync.ts",
-    "line": 315,
+    "line": 318,
     "snippet": "return readdirSync(dir, { withFileTypes: true }) as Dirent[];"
   },
   {
-    "file": "packages/gateway/src/connectors/gcp-sync.ts",
-    "line": 36,
-    "snippet": "} as Record<string, string | undefined>;"
-  },
-  {
     "file": "packages/gateway/src/connectors/github-actions-sync.ts",
-    "line": 27,
+    "line": 28,
     "snippet": "const rec = parsed as Record<string, unknown>;"
   },
   {
     "file": "packages/gateway/src/connectors/github-actions-sync.ts",
-    "line": 33,
+    "line": 34,
     "snippet": "for (const [k, v] of Object.entries(reposRaw as Record<string, unknown>)) {"
   },
   {
     "file": "packages/gateway/src/connectors/github-sync.ts",
-    "line": 39,
+    "line": 40,
     "snippet": "const rec = parsed as Record<string, unknown>;"
   },
   {
     "file": "packages/gateway/src/connectors/gitlab-sync.ts",
-    "line": 27,
+    "line": 28,
     "snippet": "for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {"
   },
   {
     "file": "packages/gateway/src/connectors/gitlab-sync.ts",
-    "line": 50,
+    "line": 51,
     "snippet": "const rec = parsed as Record<string, unknown>;"
   },
   {
@@ -521,22 +506,22 @@
   },
   {
     "file": "packages/gateway/src/connectors/lazy-mesh.ts",
-    "line": 1256,
+    "line": 1263,
     "snippet": "const fsTools = (await this.filesystem.listTools()) as LazyMeshToolMap;"
   },
   {
     "file": "packages/gateway/src/connectors/lazy-mesh.ts",
-    "line": 1296,
+    "line": 1303,
     "snippet": "const tools = (await slot.client.listTools()) as LazyMeshToolMap;"
   },
   {
     "file": "packages/gateway/src/connectors/linear-sync.ts",
-    "line": 53,
+    "line": 54,
     "snippet": "const rec = parsed as Record<string, unknown>;"
   },
   {
     "file": "packages/gateway/src/connectors/linear-sync.ts",
-    "line": 85,
+    "line": 86,
     "snippet": "json = JSON.parse(text) as GqlEnvelope;"
   },
   {
@@ -571,17 +556,17 @@
   },
   {
     "file": "packages/gateway/src/connectors/slack-sync.ts",
-    "line": 32,
+    "line": 33,
     "snippet": "for (const [k, v] of Object.entries(hw as Record<string, unknown>)) {"
   },
   {
     "file": "packages/gateway/src/connectors/slack-sync.ts",
-    "line": 53,
+    "line": 54,
     "snippet": "const rec = parsed as Record<string, unknown>;"
   },
   {
     "file": "packages/gateway/src/connectors/slack-sync.ts",
-    "line": 112,
+    "line": 113,
     "snippet": "? (parsed as Record<string, unknown>)"
   },
   {
@@ -1325,36 +1310,6 @@
     "snippet": "}) as unknown as ProcSubset;"
   },
   {
-    "file": "packages/gateway/src/perf/index.ts",
-    "line": 79,
-    "snippet": "type IpcCallFn as RssHeavySyncIpcCallFn,"
-  },
-  {
-    "file": "packages/gateway/src/perf/index.ts",
-    "line": 97,
-    "snippet": "type IpcCallFn as SyncThroughputDriveIpcCallFn,"
-  },
-  {
-    "file": "packages/gateway/src/perf/index.ts",
-    "line": 102,
-    "snippet": "type IpcCallFn as SyncThroughputGithubIpcCallFn,"
-  },
-  {
-    "file": "packages/gateway/src/perf/index.ts",
-    "line": 107,
-    "snippet": "type IpcCallFn as SyncThroughputGmailIpcCallFn,"
-  },
-  {
-    "file": "packages/gateway/src/perf/index.ts",
-    "line": 116,
-    "snippet": "type ParentMsg as SqliteWorkerParentMsg,"
-  },
-  {
-    "file": "packages/gateway/src/perf/index.ts",
-    "line": 120,
-    "snippet": "type WorkerMsg as SqliteWorkerWorkerMsg,"
-  },
-  {
     "file": "packages/gateway/src/perf/pr-comment-formatter.ts",
     "line": 36,
     "snippet": "const surface = line.surfaces[surfaceId as keyof HistoryLine[\"surfaces\"]];"
@@ -1461,7 +1416,7 @@
   },
   {
     "file": "packages/gateway/src/platform/gateway-log-file.ts",
-    "line": 110,
+    "line": 112,
     "snippet": "const eObj = { ...(e as Record<string, unknown>) };"
   },
   {

--- a/docs/superpowers/plans/2026-05-01-d11-bucket-b-readConnectorSecret-review.md
+++ b/docs/superpowers/plans/2026-05-01-d11-bucket-b-readConnectorSecret-review.md
@@ -1,0 +1,47 @@
+# D11 Bucket B — `readConnectorSecret` Implementation Plan Review Feedback
+
+**Date:** 2026-05-01
+**Reviewer:** Gemini CLI
+**Target Plan:** [`2026-05-01-d11-bucket-b-readConnectorSecret.md`](./2026-05-01-d11-bucket-b-readConnectorSecret.md)
+
+---
+
+## 1 — Suggestions & Improvements
+
+### 1.1 — Verification Floor (Task 11)
+Task 11 Step 2 checks for a floor of 15 `readConnectorSecret` calls. 
+
+**Suggestion:** To be even more precise, the check could be:
+`git grep -E 'readConnectorSecret\(' packages/gateway/src/ --invert-match -l 'connector-vault\.ts' | wc -l`
+This excludes the definition site and the test file (if it's in a separate package or excluded by path), focusing only on the production call sites. The target count for production callers should be exactly **15** (per the table in §4.1 of the spec).
+
+### 1.2 — Audit Hardening (Task 12 Option)
+My design review suggested hardening the `VAULT_KEY_RE` post-migration. 
+
+**Suggestion:** While the plan currently deferrs this to Bucket C, adding it as a final sub-task in Task 12 would be a strong "definition of done" for Bucket B. By adding `app_key|api_token|site|account_id` to the regex, we immediately confirm that the migration was comprehensive and that no sibling keys were left behind.
+
+### 1.3 — Comment Style Consistency (Task 3)
+The design spec §4.2 and §7 mention "recorded inline". The plan in Task 3 uses block comments.
+
+**Technical Nitpick:** While block comments are generally better for long explanations, if the automated audit ever evolves to parse these comments (e.g., to generate reports), consistency matters. I recommend sticking to the inline style if that's what the "structural reasons" rule usually follows.
+
+## 2 — Questions
+
+### 2.1 — Biome and Type Imports
+In Task 2 Step 4, you run `bun run lint:fix`. 
+
+**Question:** Since `ConnectorSecretKeyOf` uses `ConnectorServiceId` and `readConnectorSecret` uses `NimbusVault`, will `lint:fix` automatically add these as **type-only** imports if they aren't already there?
+`import type { NimbusVault } from "../vault/nimbus-vault.ts";`
+`import type { ConnectorServiceId } from "./connector-catalog.ts";`
+The plan's code snippet in Step 3 doesn't show the type imports. Ensure they are present or added.
+
+### 2.2 — Task 12 and `risky-assertions.json`
+Task 12 Step 3 mentions checking for deltas in `risky-assertions.json`.
+
+**Observation:** Since the iterator now skips `/testing/`, I expect `risky-assertions.json` to shrink significantly if the test utilities use many type assertions (common in test setup). This is a positive change for the audit signal quality.
+
+---
+
+## 3 — Overall Assessment
+
+The plan is exceptionally detailed and provides clear, commit-by-commit instructions. The TDD approach in Task 1 and Task 2 ensures the foundational changes are verified before the bulk migration starts. The verification tasks (11, 14) provide a high degree of confidence in the final PR state.

--- a/docs/superpowers/plans/2026-05-01-d11-bucket-b-readConnectorSecret.md
+++ b/docs/superpowers/plans/2026-05-01-d11-bucket-b-readConnectorSecret.md
@@ -1,0 +1,1206 @@
+# D11 Bucket B — `readConnectorSecret` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate D11 Bucket B (11 vault-key construction sites in 11 production files) by routing them through a typed `readConnectorSecret(vault, serviceId, keyName)` helper co-located in `packages/gateway/src/connectors/connector-vault.ts`. After this PR, the live D11 violation count drops from 36 to 21 (Bucket C only), and `VAULT_KEY_ALLOW_LIST` is frozen at exactly 5 entries by a unit test.
+
+**Architecture:** A tiny generic helper in `connector-vault.ts` (already on the D11 allow-list) wraps `vault.get(`${serviceId}.${keyName}`)` with a `ConnectorSecretKeyOf<S>` mapped type derived from `CONNECTOR_VAULT_SECRET_KEYS`. Misspelled or non-manifested keys fail at compile time. Two structurally-distinct files (`oauth-vault-tokens.ts` for provider-shared Microsoft OAuth; `embedding/create-embedding-runtime.ts` for OpenAI) are added to the allow-list rather than migrated. The audit's source-file iterator is extended to skip `**/testing/**` so test fixtures are no longer false-flagged.
+
+**Tech Stack:** TypeScript 6.x strict, `bun test`, Bun.Glob, no new dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-design.md`](../specs/2026-05-01-d11-bucket-b-readConnectorSecret-design.md)
+
+---
+
+## Pre-flight checklist
+
+Before starting Task 1:
+
+- [ ] Working tree is clean except for the two untracked spec docs (`...-design.md`, `...-review.md`).
+- [ ] Current branch is `main`.
+- [ ] `bun install` is up to date.
+
+---
+
+### Task 0: Worktree, branch, and commit the spec
+
+**Files:**
+- Modify (commit): `docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-design.md`
+- Modify (commit): `docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-review.md`
+
+- [ ] **Step 1: Create worktree + branch**
+
+```bash
+git worktree add .worktrees/d11-bucket-b-readConnectorSecret -b dev/asafgolombek/d11-bucket-b-readConnectorSecret
+```
+
+- [ ] **Step 2: Switch to the worktree**
+
+All subsequent steps run in `.worktrees/d11-bucket-b-readConnectorSecret`.
+
+- [ ] **Step 3: Stage and commit the spec + review**
+
+```bash
+git add docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-design.md \
+        docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-review.md
+git commit -m "$(cat <<'EOF'
+docs(structure-audit): add D11 Bucket B readConnectorSecret design + review
+
+Spec for routing 11 production vault-key-construction sites through
+a typed readConnectorSecret helper in connector-vault.ts. Companion
+review (Gemini CLI) captures three accepted/deferred/rejected decisions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Verify commit**
+
+```bash
+git log --oneline -1
+```
+
+Expected: `<sha> docs(structure-audit): add D11 Bucket B readConnectorSecret design + review`
+
+---
+
+### Task 1: Extend `iterateGlob` to skip `/testing/`
+
+This task fixes the false-positive D11 hit on `packages/gateway/src/testing/bun-test-support.ts:80`.
+
+**Files:**
+- Modify: `scripts/structure-audit/lib.ts:149-153`
+- Test (new): `scripts/structure-audit/lib.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/structure-audit/lib.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { iterateSourceFiles } from "./lib.ts";
+
+describe("iterateSourceFiles", () => {
+  test("excludes paths under */testing/*", async () => {
+    const visited: string[] = [];
+    for await (const f of iterateSourceFiles()) {
+      visited.push(f.relPath);
+    }
+    const testingPaths = visited.filter((p) => p.includes("/testing/"));
+    expect(testingPaths).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+```bash
+bun test scripts/structure-audit/lib.test.ts
+```
+
+Expected: FAIL — `testingPaths` contains `packages/gateway/src/testing/bun-test-support.ts` and `packages/sdk/src/testing/index.ts`.
+
+- [ ] **Step 3: Add the iterator exclusion**
+
+In `scripts/structure-audit/lib.ts`, locate the existing exclusion block in `iterateGlob`:
+
+```ts
+    if (relPath.endsWith(".test.ts")) continue;
+    if (relPath.endsWith("-sql.ts")) continue;
+    if (relPath.endsWith(".d.ts")) continue;
+    if (relPath.includes("/__fixtures__/")) continue;
+    if (relPath.includes("/test/fixtures/")) continue;
+```
+
+Add one line directly below:
+
+```ts
+    if (relPath.includes("/testing/")) continue;
+```
+
+- [ ] **Step 4: Run the test — confirm it passes**
+
+```bash
+bun test scripts/structure-audit/lib.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/structure-audit/lib.ts scripts/structure-audit/lib.test.ts
+git commit -m "$(cat <<'EOF'
+chore(structure-audit): exclude /testing/ paths from iterateSourceFiles
+
+Brings D8/D9/D10/D11 audits in line with the existing /test/fixtures/
+and /__fixtures__/ rules: test-support modules are tooling, not
+runtime, and should not be audit-gated.
+
+Removes the false-positive D11 hit on packages/gateway/src/testing/
+bun-test-support.ts:80.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `ConnectorSecretKeyOf` type + `readConnectorSecret` helper (TDD)
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/connector-vault.ts` (append helper after the existing exports)
+- Test (new): `packages/gateway/src/connectors/connector-vault.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/gateway/src/connectors/connector-vault.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { createMemoryVault } from "../testing/bun-test-support.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
+
+describe("readConnectorSecret", () => {
+  test("returns the stored value when the key is set", async () => {
+    const vault = createMemoryVault();
+    await vault.set("github.pat", "ghp_test");
+    expect(await readConnectorSecret(vault, "github", "pat")).toBe("ghp_test");
+  });
+
+  test("returns null when the key is absent", async () => {
+    const vault = createMemoryVault();
+    expect(await readConnectorSecret(vault, "github", "pat")).toBeNull();
+  });
+
+  test("does not trim or coerce empty string", async () => {
+    const vault = createMemoryVault();
+    await vault.set("slack.oauth", "  raw value  ");
+    expect(await readConnectorSecret(vault, "slack", "oauth")).toBe("  raw value  ");
+
+    await vault.set("notion.oauth", "");
+    expect(await readConnectorSecret(vault, "notion", "oauth")).toBe("");
+  });
+
+  test("resolves api_key and app_key to distinct vault keys (datadog multi-key)", async () => {
+    const vault = createMemoryVault();
+    await vault.set("datadog.api_key", "API");
+    await vault.set("datadog.app_key", "APP");
+    expect(await readConnectorSecret(vault, "datadog", "api_key")).toBe("API");
+    expect(await readConnectorSecret(vault, "datadog", "app_key")).toBe("APP");
+  });
+
+  test("resolves non-credential-shaped keys (gitlab.api_base)", async () => {
+    const vault = createMemoryVault();
+    await vault.set("gitlab.api_base", "https://gitlab.example.com/api/v4");
+    expect(await readConnectorSecret(vault, "gitlab", "api_base")).toBe(
+      "https://gitlab.example.com/api/v4",
+    );
+  });
+
+  test("compile-time: rejects non-manifested keys", () => {
+    const vault = createMemoryVault();
+    // @ts-expect-error — manifest is ["github.pat"]; "oauth" is not a github key.
+    void readConnectorSecret(vault, "github", "oauth");
+
+    // @ts-expect-error — google_drive manifest is empty; ConnectorSecretKeyOf resolves to never.
+    void readConnectorSecret(vault, "google_drive", "oauth");
+
+    // The runtime expectation is irrelevant for these checks; the assertion
+    // is that the file typechecks only with the @ts-expect-error directives.
+    expect(true).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — confirm they fail**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: FAIL — `readConnectorSecret` is not exported.
+
+- [ ] **Step 3: Add the helper to `connector-vault.ts`**
+
+The file already imports `NimbusVault` (type) and `ConnectorServiceId` (type) at the top — those don't need to be added. The only new import is `CONNECTOR_VAULT_SECRET_KEYS` (value, not type) from the manifest module.
+
+Append at the end of `packages/gateway/src/connectors/connector-vault.ts` (after the existing `clearOAuthVaultIfProviderUnused` function):
+
+```ts
+// ─── Bucket-B helper: typed connector-secret reader ──────────────────────────
+
+import { CONNECTOR_VAULT_SECRET_KEYS } from "./connector-secrets-manifest.ts";
+
+/**
+ * Bare-key view derived from `CONNECTOR_VAULT_SECRET_KEYS`. For service `S`,
+ * extracts the suffix after the dot in each fully-qualified manifest entry.
+ *
+ * Services with an empty manifest array (e.g. `google_drive`) resolve to `never`,
+ * making `readConnectorSecret(vault, "google_drive", ...)` uncallable — those
+ * services use OAuth via auth/google-access-token.ts, not this helper.
+ */
+export type ConnectorSecretKeyOf<S extends ConnectorServiceId> =
+  (typeof CONNECTOR_VAULT_SECRET_KEYS)[S][number] extends `${S}.${infer K}`
+    ? K
+    : never;
+
+/**
+ * Reads a connector's secret from the Vault by structural key name. Returns
+ * the raw stored value (no trim, no default) — semantics match `vault.get`.
+ * Misspelled or non-manifested key names fail at compile time.
+ */
+export async function readConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+): Promise<string | null> {
+  const fullKey = `${serviceId}.${keyName}`;
+  return vault.get(fullKey);
+}
+```
+
+Note: the import statement at the top of this code block (`import { CONNECTOR_VAULT_SECRET_KEYS } …`) needs to be moved to the top of the file alongside the other imports. Biome will auto-format this on `bun run lint:fix` (Step 4).
+
+- [ ] **Step 4: Move the import to the top of the file (style)**
+
+Run:
+
+```bash
+bun run lint:fix
+```
+
+Verify the import block at the top of `connector-vault.ts` now includes:
+
+```ts
+import { CONNECTOR_VAULT_SECRET_KEYS } from "./connector-secrets-manifest.ts";
+```
+
+…and the `import` line at the bottom of the file is gone.
+
+- [ ] **Step 5: Run the tests — confirm they pass**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: PASS — all 6 tests.
+
+- [ ] **Step 6: Run typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: clean. The `@ts-expect-error` directives confirm `ConnectorSecretKeyOf` rejects unmanifested keys.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/connectors/connector-vault.ts \
+        packages/gateway/src/connectors/connector-vault.test.ts
+git commit -m "$(cat <<'EOF'
+feat(connectors): add readConnectorSecret helper for D11 Bucket B
+
+Typed wrapper around vault.get that derives valid key names from
+CONNECTOR_VAULT_SECRET_KEYS. ConnectorSecretKeyOf<S> resolves to the
+union of bare key suffixes for service S, or never for services with
+an empty manifest. Misspelled or non-manifested keys fail at compile
+time.
+
+No production caller yet — subsequent commits route the 11 Bucket B
+sites through this helper.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Export `VAULT_KEY_ALLOW_LIST`, add 2 structural entries, and freeze the count
+
+Single-commit shape — promote the constant, add the 2 entries, and add the assertion test all together so HEAD stays green at every commit.
+
+**Files:**
+- Modify: `scripts/structure-audit/check-nimbus-invariants.ts:16-20`
+- Modify: `scripts/structure-audit/check-nimbus-invariants.test.ts`
+
+- [ ] **Step 1: Promote the constant + add 2 entries**
+
+In `scripts/structure-audit/check-nimbus-invariants.ts`, replace the 3-entry private const:
+
+```ts
+const VAULT_KEY_ALLOW_LIST = [
+  "packages/gateway/src/connectors/connector-vault.ts",
+  "packages/gateway/src/auth/google-access-token.ts",
+  "packages/gateway/src/auth/pkce.ts",
+];
+```
+
+with the 5-entry export (comments must match verbatim — see spec § 4.2):
+
+```ts
+export const VAULT_KEY_ALLOW_LIST = [
+  "packages/gateway/src/connectors/connector-vault.ts",
+  "packages/gateway/src/auth/google-access-token.ts",
+  "packages/gateway/src/auth/pkce.ts",
+  // Provider-shared OAuth canonical reader (Microsoft); mirrors google-access-token.ts.
+  "packages/gateway/src/auth/oauth-vault-tokens.ts",
+  // OpenAI embedding provider — not a Nimbus connector; no ConnectorServiceId.
+  "packages/gateway/src/embedding/create-embedding-runtime.ts",
+];
+```
+
+- [ ] **Step 2: Add the frozen-count test**
+
+In `scripts/structure-audit/check-nimbus-invariants.test.ts`, extend the import block from:
+
+```ts
+import {
+  checkSpawnInvariant,
+  checkVaultKeyAllowList,
+  collectDbRunCensus,
+} from "./check-nimbus-invariants.ts";
+```
+
+to:
+
+```ts
+import {
+  VAULT_KEY_ALLOW_LIST,
+  checkSpawnInvariant,
+  checkVaultKeyAllowList,
+  collectDbRunCensus,
+} from "./check-nimbus-invariants.ts";
+```
+
+Append a new `describe` block (after the existing `describe("D11 — checkVaultKeyAllowList", …)` block):
+
+```ts
+describe("D11 — VAULT_KEY_ALLOW_LIST is frozen at structural entries", () => {
+  test("VAULT_KEY_ALLOW_LIST has exactly 5 entries", () => {
+    // Each entry has a documented structural reason in the design spec § 4.4
+    // (helper home, Google OAuth canonical reader, Google PKCE writer,
+    // Microsoft provider-shared OAuth, OpenAI embedding provider).
+    // Adding a 6th entry requires updating this test, forcing a PR-level
+    // discussion of why the new file legitimately constructs vault keys.
+    expect(VAULT_KEY_ALLOW_LIST).toHaveLength(5);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test — confirm it passes**
+
+```bash
+bun test scripts/structure-audit/check-nimbus-invariants.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the audit — confirm the two added files are no longer flagged**
+
+```bash
+bun run audit:invariants 2>&1 | grep -E "oauth-vault-tokens|create-embedding-runtime" || echo "OK — neither file appears"
+```
+
+Expected: `OK — neither file appears`. (The 11 Bucket B sites still fire — they're cleared in Tasks 4–10.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/structure-audit/check-nimbus-invariants.ts \
+        scripts/structure-audit/check-nimbus-invariants.test.ts
+git commit -m "$(cat <<'EOF'
+chore(structure-audit): freeze VAULT_KEY_ALLOW_LIST at 5 structural entries
+
+Promotes VAULT_KEY_ALLOW_LIST to an export, adds two structural
+entries, and asserts the count in a unit test.
+
+Added entries (each with a structural reason recorded inline):
+- auth/oauth-vault-tokens.ts — provider-shared Microsoft OAuth
+  canonical reader; mirrors google-access-token.ts.
+- embedding/create-embedding-runtime.ts — OpenAI is not a Nimbus
+  connector; openai.api_key has no ConnectorServiceId.
+
+The new test forces a PR-level discussion when anyone adds a 6th
+entry, preserving D11's "vault keys live in 5 named files" signal.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Migrate `auth/notion-access-token.ts` and `auth/slack-access-token.ts`
+
+These two files are tiny single-call readers — bundle them into one commit.
+
+**Files:**
+- Modify: `packages/gateway/src/auth/notion-access-token.ts:10`
+- Modify: `packages/gateway/src/auth/slack-access-token.ts:10`
+
+- [ ] **Step 1: Edit `auth/notion-access-token.ts`**
+
+Replace the `vault.get` call:
+
+```ts
+// before
+const raw = await vault.get("notion.oauth");
+```
+
+```ts
+// after
+const raw = await readConnectorSecret(vault, "notion", "oauth");
+```
+
+Add the import at the top of the file (alongside the existing `NimbusVault` import):
+
+```ts
+import { readConnectorSecret } from "../connectors/connector-vault.ts";
+```
+
+- [ ] **Step 2: Edit `auth/slack-access-token.ts`**
+
+Same shape — replace `vault.get("slack.oauth")` with `readConnectorSecret(vault, "slack", "oauth")` and add the import.
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Re-run the audit — confirm both files no longer fire D11**
+
+```bash
+bun run audit:invariants 2>&1 | grep -E "notion-access-token|slack-access-token" || echo "OK — neither file appears"
+```
+
+Expected: `OK — neither file appears`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/auth/notion-access-token.ts \
+        packages/gateway/src/auth/slack-access-token.ts
+git commit -m "$(cat <<'EOF'
+refactor(auth): route notion/slack token readers through readConnectorSecret
+
+D11 Bucket B migration — clears 2 violations.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Migrate `platform/assemble.ts`
+
+**Files:**
+- Modify: `packages/gateway/src/platform/assemble.ts:127,133`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `packages/gateway/src/platform/assemble.ts`, add (alongside existing imports):
+
+```ts
+import { readConnectorSecret } from "../connectors/connector-vault.ts";
+```
+
+- [ ] **Step 2: Replace line 127**
+
+```ts
+// before
+const pat = await vault.get("github.pat");
+```
+
+```ts
+// after
+const pat = await readConnectorSecret(vault, "github", "pat");
+```
+
+- [ ] **Step 3: Replace line 133**
+
+```ts
+// before
+const cciTok = await vault.get("circleci.api_token");
+```
+
+```ts
+// after
+const cciTok = await readConnectorSecret(vault, "circleci", "api_token");
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: clean. (The `circleci.api_token` call is currently unflagged by D11 but migrates for consistency.)
+
+- [ ] **Step 5: Re-run the audit**
+
+```bash
+bun run audit:invariants 2>&1 | grep "platform/assemble" || echo "OK — file no longer appears"
+```
+
+Expected: `OK — file no longer appears`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/platform/assemble.ts
+git commit -m "$(cat <<'EOF'
+refactor(platform): route assemble.ts vault reads through readConnectorSecret
+
+D11 Bucket B migration — clears 1 D11 violation; migrates the
+sibling circleci.api_token read alongside for consistency.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Migrate `connectors/datadog-sync.ts`
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/datadog-sync.ts:119,120,124`
+- Test (existing, must still pass): `packages/gateway/src/connectors/datadog-sync.test.ts`
+
+- [ ] **Step 1: Run existing tests as a baseline**
+
+```bash
+bun test packages/gateway/src/connectors/datadog-sync.test.ts
+```
+
+Expected: PASS. Note any pre-existing failures so you can distinguish them from regressions.
+
+- [ ] **Step 2: Add the import**
+
+At the top of `packages/gateway/src/connectors/datadog-sync.ts`, add:
+
+```ts
+import { readConnectorSecret } from "./connector-vault.ts";
+```
+
+- [ ] **Step 3: Replace the three reads**
+
+```ts
+// before (lines 119/120/124)
+const apiKey = (await ctx.vault.get("datadog.api_key"))?.trim() ?? "";
+const appKey = (await ctx.vault.get("datadog.app_key"))?.trim() ?? "";
+// (intervening lines unchanged)
+const siteRaw = await ctx.vault.get("datadog.site");
+```
+
+```ts
+// after
+const apiKey = (await readConnectorSecret(ctx.vault, "datadog", "api_key"))?.trim() ?? "";
+const appKey = (await readConnectorSecret(ctx.vault, "datadog", "app_key"))?.trim() ?? "";
+// (intervening lines unchanged)
+const siteRaw = await readConnectorSecret(ctx.vault, "datadog", "site");
+```
+
+- [ ] **Step 4: Run datadog-sync tests**
+
+```bash
+bun test packages/gateway/src/connectors/datadog-sync.test.ts
+```
+
+Expected: PASS — semantics are identical, so existing tests must still pass.
+
+- [ ] **Step 5: Re-run the audit**
+
+```bash
+bun run audit:invariants 2>&1 | grep "datadog-sync" || echo "OK — file no longer appears"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/connectors/datadog-sync.ts
+git commit -m "$(cat <<'EOF'
+refactor(connectors): route datadog-sync vault reads through readConnectorSecret
+
+D11 Bucket B migration — clears 1 D11 violation; migrates the two
+sibling datadog.app_key and datadog.site reads alongside for
+consistency (currently unflagged because the audit regex only matches
+.api_key / .pat / .oauth / .token suffixes).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Migrate `connectors/github-actions-sync.ts`
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/github-actions-sync.ts:219`
+
+- [ ] **Step 1: Baseline test run**
+
+```bash
+bun test packages/gateway/src/connectors/github-actions-sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Add import**
+
+```ts
+import { readConnectorSecret } from "./connector-vault.ts";
+```
+
+- [ ] **Step 3: Replace line 219**
+
+```ts
+// before
+const pat = await ctx.vault.get("github.pat");
+```
+
+```ts
+// after
+const pat = await readConnectorSecret(ctx.vault, "github", "pat");
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+bun test packages/gateway/src/connectors/github-actions-sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Audit check**
+
+```bash
+bun run audit:invariants 2>&1 | grep "github-actions-sync" || echo "OK"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/connectors/github-actions-sync.ts
+git commit -m "$(cat <<'EOF'
+refactor(connectors): route github-actions-sync vault read through readConnectorSecret
+
+D11 Bucket B migration — clears 1 violation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Migrate `connectors/github-sync.ts`
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/github-sync.ts:333`
+
+- [ ] **Step 1: Baseline test run**
+
+```bash
+bun test packages/gateway/src/connectors/github-sync.test.ts
+```
+
+- [ ] **Step 2: Add import**
+
+```ts
+import { readConnectorSecret } from "./connector-vault.ts";
+```
+
+- [ ] **Step 3: Replace line 333**
+
+```ts
+// before
+const pat = await ctx.vault.get("github.pat");
+```
+
+```ts
+// after
+const pat = await readConnectorSecret(ctx.vault, "github", "pat");
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+bun test packages/gateway/src/connectors/github-sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Audit check**
+
+```bash
+bun run audit:invariants 2>&1 | grep "connectors/github-sync" || echo "OK"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/connectors/github-sync.ts
+git commit -m "$(cat <<'EOF'
+refactor(connectors): route github-sync vault read through readConnectorSecret
+
+D11 Bucket B migration — clears 1 violation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Migrate `connectors/gitlab-sync.ts`
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/gitlab-sync.ts:593,598`
+
+- [ ] **Step 1: Baseline test run**
+
+```bash
+bun test packages/gateway/src/connectors/gitlab-sync.test.ts
+```
+
+- [ ] **Step 2: Add import**
+
+```ts
+import { readConnectorSecret } from "./connector-vault.ts";
+```
+
+- [ ] **Step 3: Replace line 593**
+
+```ts
+// before
+const pat = await ctx.vault.get("gitlab.pat");
+```
+
+```ts
+// after
+const pat = await readConnectorSecret(ctx.vault, "gitlab", "pat");
+```
+
+- [ ] **Step 4: Replace line 598**
+
+```ts
+// before
+const apiBase = normalisedApiBase(await ctx.vault.get("gitlab.api_base"));
+```
+
+```ts
+// after
+const apiBase = normalisedApiBase(await readConnectorSecret(ctx.vault, "gitlab", "api_base"));
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+bun test packages/gateway/src/connectors/gitlab-sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Audit check**
+
+```bash
+bun run audit:invariants 2>&1 | grep "gitlab-sync" || echo "OK"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/connectors/gitlab-sync.ts
+git commit -m "$(cat <<'EOF'
+refactor(connectors): route gitlab-sync vault reads through readConnectorSecret
+
+D11 Bucket B migration — clears 1 D11 violation; migrates the
+sibling gitlab.api_base read for consistency.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: Migrate the remaining 4 connector sync files
+
+Bundle the four single-key connector reads + `slack-sync` (also single-key) into one commit. Each is a single-line replacement plus an import.
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/linear-sync.ts:219`
+- Modify: `packages/gateway/src/connectors/newrelic-sync.ts:38`
+- Modify: `packages/gateway/src/connectors/notion-sync.ts:239`
+- Modify: `packages/gateway/src/connectors/slack-sync.ts:399`
+
+- [ ] **Step 1: Edit `linear-sync.ts`**
+
+Add import at the top:
+
+```ts
+import { readConnectorSecret } from "./connector-vault.ts";
+```
+
+Replace line 219:
+
+```ts
+// before
+const apiKey = await ctx.vault.get("linear.api_key");
+// after
+const apiKey = await readConnectorSecret(ctx.vault, "linear", "api_key");
+```
+
+- [ ] **Step 2: Edit `newrelic-sync.ts`**
+
+Add import. Replace line 38:
+
+```ts
+// before
+const key = (await ctx.vault.get("newrelic.api_key"))?.trim() ?? "";
+// after
+const key = (await readConnectorSecret(ctx.vault, "newrelic", "api_key"))?.trim() ?? "";
+```
+
+- [ ] **Step 3: Edit `notion-sync.ts`**
+
+Add import. Replace line 239:
+
+```ts
+// before
+const rawVault = await ctx.vault.get("notion.oauth");
+// after
+const rawVault = await readConnectorSecret(ctx.vault, "notion", "oauth");
+```
+
+- [ ] **Step 4: Edit `slack-sync.ts`**
+
+Add import. Replace line 399:
+
+```ts
+// before
+const rawVault = await ctx.vault.get("slack.oauth");
+// after
+const rawVault = await readConnectorSecret(ctx.vault, "slack", "oauth");
+```
+
+- [ ] **Step 5: Run all four sync test files**
+
+```bash
+bun test packages/gateway/src/connectors/linear-sync.test.ts \
+         packages/gateway/src/connectors/newrelic-sync.test.ts \
+         packages/gateway/src/connectors/notion-sync.test.ts \
+         packages/gateway/src/connectors/slack-sync.test.ts
+```
+
+Expected: PASS for all four files.
+
+- [ ] **Step 6: Audit check — should now show only Bucket C violations**
+
+```bash
+bun run audit:invariants 2>&1 | grep "D11" | wc -l
+```
+
+Expected: `21` (Bucket C only — `lazy-mesh.ts` × 12 + `connector-rpc-handlers.ts` × 9).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/connectors/linear-sync.ts \
+        packages/gateway/src/connectors/newrelic-sync.ts \
+        packages/gateway/src/connectors/notion-sync.ts \
+        packages/gateway/src/connectors/slack-sync.ts
+git commit -m "$(cat <<'EOF'
+refactor(connectors): route 4 sync files through readConnectorSecret
+
+D11 Bucket B migration — clears the final 4 violations
+(linear, newrelic, notion, slack sync readers).
+
+Bucket B is now empty. Live D11 violation count: 21 (Bucket C only).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: Verify all caller migration is complete
+
+A defensive grep to catch any missed call site.
+
+- [ ] **Step 1: Confirm zero `vault.get("<service>.<key>")` literals remain in the migrated files**
+
+```bash
+git grep -nE 'vault\.get\("[a-z_]+\.[a-z_]+"\)' \
+  -- packages/gateway/src/auth/notion-access-token.ts \
+     packages/gateway/src/auth/slack-access-token.ts \
+     packages/gateway/src/platform/assemble.ts \
+     packages/gateway/src/connectors/datadog-sync.ts \
+     packages/gateway/src/connectors/github-actions-sync.ts \
+     packages/gateway/src/connectors/github-sync.ts \
+     packages/gateway/src/connectors/gitlab-sync.ts \
+     packages/gateway/src/connectors/linear-sync.ts \
+     packages/gateway/src/connectors/newrelic-sync.ts \
+     packages/gateway/src/connectors/notion-sync.ts \
+     packages/gateway/src/connectors/slack-sync.ts
+```
+
+Expected: zero matches.
+
+- [ ] **Step 2: Confirm every migrated file calls `readConnectorSecret` at least once**
+
+```bash
+MISSING=0
+for f in packages/gateway/src/auth/notion-access-token.ts \
+         packages/gateway/src/auth/slack-access-token.ts \
+         packages/gateway/src/platform/assemble.ts \
+         packages/gateway/src/connectors/datadog-sync.ts \
+         packages/gateway/src/connectors/github-actions-sync.ts \
+         packages/gateway/src/connectors/github-sync.ts \
+         packages/gateway/src/connectors/gitlab-sync.ts \
+         packages/gateway/src/connectors/linear-sync.ts \
+         packages/gateway/src/connectors/newrelic-sync.ts \
+         packages/gateway/src/connectors/notion-sync.ts \
+         packages/gateway/src/connectors/slack-sync.ts; do
+  if ! grep -q 'readConnectorSecret(' "$f"; then
+    echo "MISSING: $f does not call readConnectorSecret"
+    MISSING=1
+  fi
+done
+[ "$MISSING" = "0" ] && echo "OK — all 11 files call readConnectorSecret"
+```
+
+Expected: `OK — all 11 files call readConnectorSecret`.
+
+If any file is missing, return to that file's migration task and verify the change was committed. Per-file presence is stronger than a global call-count floor — adding a 12th caller in the future does not regress this check.
+
+---
+
+### Task 12: Re-validate audit baselines and update `baseline.md`
+
+The iterator change (Task 1) widens D8/D9/D10/D11. This task captures any baseline shifts.
+
+**Files:**
+- Modify: `docs/structure-audit/baseline.md` (update D11 line, add post-Phase-2 note)
+- Possibly modify: `docs/structure-audit/{any-baseline.json,db-run-census.json,risky-assertions.json}` (if iterator change shifted counts)
+
+- [ ] **Step 1: Re-run all four audits**
+
+```bash
+bun run audit:invariants 2>&1 | tail -5
+bun scripts/structure-audit/count-any-usage.ts --check
+bun run audit:dead-code | tail -5
+bun scripts/structure-audit/list-risky-assertions.ts
+bun scripts/structure-audit/measure-file-loc.ts
+```
+
+Note any audit that fails or reports a count change vs. the committed baseline.
+
+- [ ] **Step 2: If `count-any-usage --check` fails**
+
+The iterator change excluded `bun-test-support.ts` and `sdk/src/testing/index.ts` from the `any` scan. If those files contain `any`, the baseline drops. Run:
+
+```bash
+bun scripts/structure-audit/count-any-usage.ts --update
+git diff docs/structure-audit/any-baseline.json
+```
+
+If the diff shows a reduction, the new baseline is correct — commit it. If it shows an increase, **stop and investigate** — that's a regression, not the iterator change.
+
+- [ ] **Step 3: Re-run `risky-assertions` and check for delta**
+
+```bash
+bun scripts/structure-audit/list-risky-assertions.ts
+git diff docs/structure-audit/risky-assertions.json
+```
+
+Document any line-count change in the PR description. The list is informational, so no gate fires — just commit the regenerated file.
+
+- [ ] **Step 4: Update `baseline.md` D11 row**
+
+Edit `docs/structure-audit/baseline.md`. Find the D11 row in the per-dimension table:
+
+```markdown
+| D11 | F | Vault-key construction outside allow-list | 56 violations | `bun run audit:invariants` (binary) |
+```
+
+Add a "Phase 2 follow-up" note immediately after the table (or as a new sub-section), reflecting the post-PR state:
+
+```markdown
+## Phase 2 follow-up — post Bucket B (2026-05-01)
+
+D11 violations reduced from the Phase 1 baseline of 56 to **21** (Bucket C only):
+- Bucket A (20 false positives) — suppressed by `audit-ignore-next-line` markers (PR #135).
+- Bucket B (15 sites) — routed through `readConnectorSecret` helper or added to the now-frozen 5-entry allow-list (this PR).
+- Bucket C (21 sites in `lazy-mesh.ts` + `connector-rpc-handlers.ts`) — deferred; tracked in [`deferred-backlog.md`](./deferred-backlog.md).
+```
+
+- [ ] **Step 5: Commit baseline + report regenerations**
+
+```bash
+git add docs/structure-audit/baseline.md
+# Only add regenerated reports if they actually changed:
+git add -u docs/structure-audit/risky-assertions.json docs/structure-audit/any-baseline.json 2>/dev/null
+git commit -m "$(cat <<'EOF'
+docs(structure-audit): record D11 → 21 post Bucket B; refresh baselines
+
+Updates baseline.md with the post-Bucket-B D11 count (21, Bucket C
+only). Regenerates other audit baselines if the /testing/ iterator
+change shifted them.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 13: CLAUDE.md / GEMINI.md key-file table update
+
+The new exports (`readConnectorSecret`, `ConnectorSecretKeyOf`) live in `connector-vault.ts`, which already has a row in the key-file table. Update its purpose blurb.
+
+**Files:**
+- Modify: `CLAUDE.md` (table row for `connector-vault.ts`)
+- Modify: `GEMINI.md` (same row — kept in sync per CLAUDE.md instructions)
+
+- [ ] **Step 1: Find and update the row in `CLAUDE.md`**
+
+The current row reads:
+
+```markdown
+| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()` (Phase 4) |
+```
+
+Update to:
+
+```markdown
+| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers + typed connector-secret reader — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()`, `readConnectorSecret()` (Phase 4 / D11 Bucket B) |
+```
+
+- [ ] **Step 2: Mirror the change in `GEMINI.md`**
+
+Find the same row and apply the identical edit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md GEMINI.md
+git commit -m "$(cat <<'EOF'
+docs: note readConnectorSecret in CLAUDE.md / GEMINI.md key-file table
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 14: Full CI-parity preflight
+
+Per the user's standing rule: run the full CI suite locally before pushing any PR.
+
+- [ ] **Step 1: Run the full CI suite**
+
+```bash
+bun run test:ci
+```
+
+Expected: all green. Note duration; if anything fails, fix before pushing.
+
+- [ ] **Step 2: Run the full structure-audit pack**
+
+```bash
+bun run audit:structure
+```
+
+Expected: exits 0 (no binary violations). The orchestrator writes a fresh `docs/structure-audit/run-<timestamp>.json` blob — do NOT commit it (those run blobs are not committed except by the audit publishing step).
+
+- [ ] **Step 3: Lint + typecheck final pass**
+
+```bash
+bun run lint && bun run typecheck
+```
+
+Expected: both pass.
+
+---
+
+### Task 15: Push branch and open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin dev/asafgolombek/d11-bucket-b-readConnectorSecret
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "refactor(structure-audit): D11 Bucket B — route 11 sites through readConnectorSecret" --body "$(cat <<'EOF'
+## Summary
+- Eliminates D11 Bucket B (11 vault-key construction sites in 11 production files) by routing them through a typed `readConnectorSecret(vault, serviceId, keyName)` helper in `connector-vault.ts`.
+- Adds 2 structurally-distinct files to the D11 allow-list (`oauth-vault-tokens.ts` for provider-shared Microsoft OAuth; `embedding/create-embedding-runtime.ts` for OpenAI). Allow-list is now frozen at 5 entries by a unit test.
+- Extends the structure-audit iterator to skip `**/testing/**` paths (mirrors existing `/test/fixtures/` rule).
+- D11 violation count: **36 → 21** (Bucket C only). Post-PR baseline recorded in `docs/structure-audit/baseline.md`.
+
+## Test plan
+- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — 6 tests pass (3 behavioural + 3 type-level)
+- [ ] `bun test scripts/structure-audit/check-nimbus-invariants.test.ts` — frozen-count test passes
+- [ ] `bun test scripts/structure-audit/lib.test.ts` — `/testing/` iterator exclusion verified
+- [ ] `bun run audit:invariants` exits 0
+- [ ] `bun run audit:invariants 2>&1 | grep -c D11` reports `21`
+- [ ] `bun run test:ci` clean (Ubuntu CI parity)
+- [ ] All 11 connector sync test suites still pass (`datadog`, `github-actions`, `github`, `gitlab`, `linear`, `newrelic`, `notion`, `slack`)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Capture PR URL**
+
+The `gh pr create` output prints the PR URL. Record it for follow-up.
+
+---
+
+## Self-review checklist (run after Task 15, before declaring done)
+
+- [ ] Spec coverage: every section of `2026-05-01-d11-bucket-b-readConnectorSecret-design.md` is implemented by a numbered task.
+  - §1 Goal — Tasks 4–10, 12
+  - §2 Non-goals — captured by what is NOT in the plan (no `writeConnectorSecret` work)
+  - §3 Helper API — Task 2
+  - §4.1 Migration table — Tasks 4–10
+  - §4.2 Allow-list additions — Task 3
+  - §4.3 Iterator extension — Task 1
+  - §4.4 Final allow-list — Task 3
+  - §5 CI gate (frozen-count test) — Task 3
+  - §6 Helper tests — Task 2
+  - §7 Acceptance criteria — verified across Tasks 11, 12, 14
+  - §8 Rollout (single PR) — single-branch plan; Task 0 sets up branch, Task 15 opens PR
+- [ ] Type consistency: `readConnectorSecret` signature matches across Task 2 (definition) and Tasks 4–10 (callers).
+- [ ] No placeholders: every step contains the exact code or command to run; no "TBD" / "TODO" / "similar to above".
+
+---
+
+## What this plan deliberately does NOT do
+
+- It does not introduce `writeConnectorSecret(serviceId, value)`. That helper lands with Bucket C.
+- It does not widen `VAULT_KEY_RE` to catch additional suffixes (`api_token` / `app_key` / `api_base` / `site` / `account_id` / etc.). That is sequenced after Bucket C — see spec §9.
+- It does not touch `lazy-mesh.ts` or `connector-rpc-handlers.ts`. Those are Bucket C and have their own deferred entry.
+- It does not change the `CONNECTOR_VAULT_SECRET_KEYS` manifest shape or any vault.set / vault.delete semantics.
+- It does not refactor any caller's null/empty/trim guard logic — those stay verbatim.

--- a/docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-design.md
+++ b/docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-design.md
@@ -1,0 +1,235 @@
+# D11 Bucket B — `readConnectorSecret` helper
+
+**Date:** 2026-05-01
+**Phase:** Phase 4 / B3 structure audit — Phase 2 follow-up
+**Source:** [`docs/structure-audit/missed.md`](../../structure-audit/missed.md) row "D11 Bucket B"; [`docs/structure-audit/deferred-backlog.md`](../../structure-audit/deferred-backlog.md) section "D11 — vault-key Bucket B"
+**Predecessor specs:** [`2026-04-30-structure-audit-design.md`](./2026-04-30-structure-audit-design.md)
+
+---
+
+## 1 — Goal
+
+Eliminate the Bucket-B vault-key-construction sites in production code by routing them through a typed `readConnectorSecret` helper co-located in `packages/gateway/src/connectors/connector-vault.ts` (already on the D11 allow-list).
+
+**Pre-PR audit count (verified live with `bun run audit:invariants`):** 36 D11 violations.
+- 11 sites flagged in 11 production files (Bucket B migration scope).
+- 3 sites in 2 files become allow-list additions (`auth/oauth-vault-tokens.ts` × 2 + `embedding/create-embedding-runtime.ts` × 1).
+- 1 site in `testing/bun-test-support.ts` (test infrastructure — fixed via iterator extension, not allow-list).
+- 21 sites in `lazy-mesh.ts` + `connector-rpc-handlers.ts` (Bucket C, deferred — out of scope).
+
+**Post-PR audit count target:** 21 (Bucket C only).
+
+After this PR, the D11 audit signal collapses to **two sources only**:
+
+1. The structurally-justified 5-entry `VAULT_KEY_ALLOW_LIST` (frozen at count 5 by a unit test).
+2. Bucket C — 21 sites in `lazy-mesh.ts` + `connector-rpc-handlers.ts` (deferred to its own spec).
+
+Adding a new connector to Nimbus no longer requires a `VAULT_KEY_ALLOW_LIST` bump — the new entry to `CONNECTOR_VAULT_SECRET_KEYS` is sufficient. This is the audit-signal-preservation outcome the deferred-backlog explicitly described.
+
+## 2 — Non-goals
+
+- **Bucket C** (21 sites in `lazy-mesh.ts` + `connector-rpc-handlers.ts`). Stays deferred. This PR introduces no `writeConnectorSecret` stub — adding a write helper without a production caller is YAGNI and forces test surface for unused code.
+- **Provider-shared OAuth reads** (`microsoft.oauth` in `oauth-vault-tokens.ts`). The file is added to the allow-list with a structural reason: it is the canonical reader for the provider-shared Microsoft OAuth payload, mirroring `auth/google-access-token.ts`. It does not fit the per-service helper signature.
+- **Embedding provider keys** (`openai.api_key` in `embedding/create-embedding-runtime.ts`). OpenAI is not a connector — there is no `ConnectorServiceId` for it, and the `CONNECTOR_VAULT_SECRET_KEYS` manifest does not (and should not) cover it. Add to allow-list.
+- **No change to `vault.set` / `vault.delete` semantics, the `CONNECTOR_VAULT_SECRET_KEYS` manifest shape, or any caller's surrounding null/empty/trim guard logic.**
+
+## 3 — Helper API
+
+Co-located in `packages/gateway/src/connectors/connector-vault.ts` (no new file, no new allow-list entry). Two exports:
+
+```ts
+/**
+ * Bare-key view derived from `CONNECTOR_VAULT_SECRET_KEYS`. For a service `S`,
+ * extracts the suffix after the dot in each fully-qualified manifest entry.
+ *
+ * Services with an empty manifest array (e.g. `google_drive`) resolve to `never`,
+ * which makes `readConnectorSecret(vault, "google_drive", ...)` uncallable —
+ * those services use OAuth via `auth/google-access-token.ts`, not this helper.
+ */
+export type ConnectorSecretKeyOf<S extends ConnectorServiceId> =
+  (typeof CONNECTOR_VAULT_SECRET_KEYS)[S][number] extends `${S}.${infer K}`
+    ? K
+    : never;
+
+/**
+ * Reads a connector's secret from the Vault by structural key name.
+ * Returns the raw stored value (no trim, no default) — semantics match `vault.get`.
+ * Misspelled or non-manifested key names fail at compile time.
+ */
+export async function readConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+): Promise<string | null> {
+  const fullKey = `${serviceId}.${keyName}`;
+  return vault.get(fullKey);
+}
+```
+
+**Three guarantees:**
+
+1. **Type-safe.** `readConnectorSecret(vault, "github", "oauth")` is a compile error (manifest has `github.pat`, not `github.oauth`). `readConnectorSecret(vault, "datadog", "api_key" | "app_key" | "site")` all typecheck.
+2. **No semantic drift.** Returns `string | null` exactly like `vault.get`. Callers keep their existing `if (raw === null || raw === "")` and `?.trim() ?? ""` guards verbatim.
+3. **Allow-list neutral.** The `${serviceId}.${keyName}` template literal lives inside `connector-vault.ts`, which is already entry #1 of the allow-list. No D11 violation introduced.
+
+## 4 — Migration plan
+
+### 4.1 Production files to migrate (11 files, 15 vault calls)
+
+D11's regex `/['"`][a-z0-9_]*\.(oauth|token|pat|api_key)['"`]/` only flags four exact suffixes. Several files read additional secret keys whose suffixes (e.g., `app_key`, `api_token`, `api_base`, `site`) the regex does not match — those reads are not D11 violations today but **should still migrate** for code consistency: a function that calls `readConnectorSecret(...)` once and `vault.get("...")` once for sibling keys is worse code than today.
+
+The migration target is **every `vault.get` / `ctx.vault.get` call in the listed files that reads a key declared in `CONNECTOR_VAULT_SECRET_KEYS`**. The D11-flagged column shows which call(s) currently fire the audit.
+
+| # | File | All vault.get calls (post-migration target) | D11-flagged today |
+|---|---|---|---|
+| 1 | `packages/gateway/src/auth/notion-access-token.ts` | `notion.oauth` | yes (1) |
+| 2 | `packages/gateway/src/auth/slack-access-token.ts` | `slack.oauth` | yes (1) |
+| 3 | `packages/gateway/src/platform/assemble.ts` | `github.pat`, `circleci.api_token` | partial (only `.pat` matches regex) |
+| 4 | `packages/gateway/src/connectors/datadog-sync.ts` | `datadog.api_key`, `datadog.app_key`, `datadog.site` | partial (only `.api_key` matches regex) |
+| 5 | `packages/gateway/src/connectors/github-actions-sync.ts` | `github.pat` | yes (1) |
+| 6 | `packages/gateway/src/connectors/github-sync.ts` | `github.pat` | yes (1) |
+| 7 | `packages/gateway/src/connectors/gitlab-sync.ts` | `gitlab.pat`, `gitlab.api_base` | partial (only `.pat` matches regex) |
+| 8 | `packages/gateway/src/connectors/linear-sync.ts` | `linear.api_key` | yes (1) |
+| 9 | `packages/gateway/src/connectors/newrelic-sync.ts` | `newrelic.api_key` | yes (1) |
+| 10 | `packages/gateway/src/connectors/notion-sync.ts` | `notion.oauth` | yes (1) |
+| 11 | `packages/gateway/src/connectors/slack-sync.ts` | `slack.oauth` | yes (1) |
+
+Migration shape per file: `await vault.get("github.pat")` becomes `await readConnectorSecret(vault, "github", "pat")`. Surrounding `if (raw === null || raw === "")`, `?.trim() ?? ""`, and noop-result branches are preserved verbatim — the helper has identical `string | null` semantics.
+
+**Total D11 violations cleared from this section: 11** (the partial-fire files contribute one D11 site each; their unflagged sibling reads migrate alongside but don't count toward the audit reduction).
+
+### 4.2 Allow-list additions (2)
+
+These two files do **not** migrate to `readConnectorSecret`. They are added to `VAULT_KEY_ALLOW_LIST` with a structural reason recorded inline as a `// ` comment on the same line as the allow-list entry. Use **exactly** these comment strings to keep the wording stable across PR review:
+
+```ts
+const VAULT_KEY_ALLOW_LIST = [
+  "packages/gateway/src/connectors/connector-vault.ts",
+  "packages/gateway/src/auth/google-access-token.ts",
+  "packages/gateway/src/auth/pkce.ts",
+  // Provider-shared OAuth canonical reader (Microsoft); mirrors google-access-token.ts.
+  "packages/gateway/src/auth/oauth-vault-tokens.ts",
+  // OpenAI embedding provider — not a Nimbus connector; no ConnectorServiceId.
+  "packages/gateway/src/embedding/create-embedding-runtime.ts",
+];
+```
+
+### 4.3 Test infrastructure (extend iterator, do not migrate, do not allow-list)
+
+`packages/gateway/src/testing/bun-test-support.ts:80` writes `google.oauth` / `microsoft.oauth` to a test fixture vault. **Currently flagged by D11** because `iterateSourceFiles()` in `scripts/structure-audit/lib.ts` does not exclude `/testing/` paths (it only excludes `.test.ts`, `-sql.ts`, `.d.ts`, `/__fixtures__/`, `/test/fixtures/`).
+
+**Fix:** Add one line to `iterateGlob()` in `scripts/structure-audit/lib.ts`:
+
+```ts
+if (relPath.includes("/testing/")) continue;
+```
+
+This is consistent with the existing `/test/fixtures/` and `/__fixtures__/` rules and matches Nimbus's convention of putting shared test utilities under `*/src/testing/`. Affected files (verified):
+- `packages/gateway/src/testing/bun-test-support.ts` — gateway test support (currently flagged)
+- `packages/sdk/src/testing/index.ts` — SDK test helpers (public API for extension authors writing tests; appropriately excluded — extension test helpers should not be D11-gated)
+
+**Why iterator extension over allow-list:** the audit's purpose is catching production runtime code that constructs vault keys. Test-support modules are tooling, not runtime. Extending the iterator preserves D11's strict "vault keys live in 5 named files" signal; adding test-support files to the allow-list would dilute that signal as more test utilities accumulate.
+
+This iterator change also widens **all** structure audits (D8 any-count, D9 risky-assertions, D10 spawn). That widening is correct — none of those should gate on test tooling either. Implementation must re-run all audits after the change to capture any baseline shifts (`docs/structure-audit/{any-baseline.json,db-run-census.json,risky-assertions.json}` — record any deltas in the PR description).
+
+### 4.4 Final allow-list (5 entries)
+
+```ts
+const VAULT_KEY_ALLOW_LIST = [
+  "packages/gateway/src/connectors/connector-vault.ts",            // helper home + per-service OAuth helpers
+  "packages/gateway/src/auth/google-access-token.ts",              // provider OAuth canonical reader (Google)
+  "packages/gateway/src/auth/pkce.ts",                             // PKCE flow writer (provider OAuth)
+  "packages/gateway/src/auth/oauth-vault-tokens.ts",               // provider-shared OAuth canonical reader (Microsoft)
+  "packages/gateway/src/embedding/create-embedding-runtime.ts",    // OpenAI embedding provider (not a connector)
+];
+```
+
+## 5 — CI gate
+
+Add a unit test in `scripts/structure-audit/check-nimbus-invariants.test.ts`:
+
+```ts
+import { VAULT_KEY_ALLOW_LIST } from "./check-nimbus-invariants.ts";
+
+test("VAULT_KEY_ALLOW_LIST is frozen at 5 structural entries", () => {
+  // Each entry has a documented structural reason (see spec § 4.4).
+  // Adding a 6th entry forces a PR-level discussion via this test edit.
+  expect(VAULT_KEY_ALLOW_LIST).toHaveLength(5);
+});
+```
+
+Requires changing `VAULT_KEY_ALLOW_LIST` in `check-nimbus-invariants.ts` from a module-private `const` to an `export const`. The existing `checkVaultKeyAllowList()` function already accepts an `allowList` parameter, so no production caller imports the constant — the export is for tests only.
+
+**Why a count and not a string-equality snapshot.** The count is the durable invariant. If the helper file is renamed or `oauth-vault-tokens.ts` moves under a different folder, the test still passes. A string-equality snapshot would force every refactor to touch the test for no security benefit. The lightweight bar matches `any-baseline.json`'s single-number ratchet.
+
+## 6 — Tests for the helper
+
+New test cases in `packages/gateway/src/connectors/connector-vault.test.ts` (extend if it already exists; otherwise create). Three groups:
+
+### 6.1 Behavioural parity with `vault.get`
+
+- Returns the stored string when the key is set.
+- Returns `null` when the key is absent.
+- Does not trim, does not coerce empty string, does not throw — semantics are identical to `vault.get`.
+
+### 6.2 Manifest-driven key resolution
+
+- `readConnectorSecret(vault, "github", "pat")` reads `github.pat`.
+- `readConnectorSecret(vault, "datadog", "api_key")` and `("datadog", "app_key")` resolve to distinct vault keys (proving the multi-key case is correct).
+- `readConnectorSecret(vault, "gitlab", "api_base")` resolves to `gitlab.api_base` (covers the non-`pat`-shaped key on a service that also has `gitlab.pat`).
+
+### 6.3 Type-level rejection (`@ts-expect-error`)
+
+- `readConnectorSecret(vault, "github", "oauth")` is a compile error (github manifest is `["github.pat"]`).
+- `readConnectorSecret(vault, "google_drive", "oauth")` is a compile error — `ConnectorSecretKeyOf<"google_drive">` resolves to `never` because the manifest array is empty.
+
+Coverage: `connector-vault.ts` is already inside the gateway core covered by `bun run test:coverage:engine` (≥ 85%). No new coverage gate row needed.
+
+## 7 — Acceptance criteria
+
+All required:
+
+- [ ] `readConnectorSecret` and `ConnectorSecretKeyOf` exist in `connector-vault.ts` with the signatures in §3.
+- [ ] Every `vault.get` / `ctx.vault.get` call in the 11 files in §4.1 reads through `readConnectorSecret` (full file scope, including currently-unflagged sibling keys like `datadog.app_key`, `datadog.site`, `gitlab.api_base`, `circleci.api_token`). Verified by `git grep -n 'vault\.get\(' packages/gateway/src/{auth,connectors,platform}/` showing only `readConnectorSecret`-routed calls in the migrated files.
+- [ ] `oauth-vault-tokens.ts` and `embedding/create-embedding-runtime.ts` are added to `VAULT_KEY_ALLOW_LIST` with their structural reasons recorded as inline comments in `check-nimbus-invariants.ts`.
+- [ ] `iterateGlob()` in `scripts/structure-audit/lib.ts` excludes `/testing/` paths (one-line addition per §4.3).
+- [ ] `bun run audit:invariants` exits 0. (Bucket A's 20 false-positives stay suppressed via existing `audit-ignore-next-line` markers; Bucket C's 21 sites remain — they are deferred and do not gate this PR. Bucket C site-counts are unaffected.)
+- [ ] D11 violation count drops from **36 → 21** (Bucket C only). Recorded as a post-Phase-2 update line in `docs/structure-audit/baseline.md` with the new figure.
+- [ ] The `VAULT_KEY_ALLOW_LIST.length === 5` test passes.
+- [ ] All §6 tests pass: behavioural parity (3), manifest resolution (3), `@ts-expect-error` (2).
+- [ ] Other audit baselines (`any-baseline.json`, `db-run-census.json`, `risky-assertions.json`) re-validated after the iterator change; any deltas are documented in the PR description (expected: zero or near-zero, since `bun-test-support.ts` is small and `sdk/src/testing/index.ts` is a thin re-export — but verify rather than assume).
+- [ ] `bun run test:ci` clean on Ubuntu before pushing the PR (CI-parity preflight per the user's standing rule).
+- [ ] `git diff` for each migrated file shows only the call shape changed; surrounding `if (raw === null || raw === "")`, `?.trim() ?? ""`, and noop-result branches are preserved verbatim.
+
+## 8 — Rollout
+
+Single PR. Estimated cost is the deferred-backlog's "~3" estimate plus a small bump for the iterator change:
+- Helper + types in `connector-vault.ts`.
+- 11 callers updated (15 vault.get calls across them).
+- 2 allow-list additions in `check-nimbus-invariants.ts`.
+- 1 frozen-count test in `check-nimbus-invariants.test.ts`.
+- 1 iterator line in `scripts/structure-audit/lib.ts`.
+- Helper tests in `connector-vault.test.ts`.
+- Re-validation of other audit baselines (mechanical, may be a no-op).
+
+Splitting per file would create churn without isolation benefit — the helper has no caller until the first migration site lands, so a stub-then-migrate split would mean the stub PR ships dead code.
+
+**Branch name:** `dev/asafgolombek/d11-bucket-b-readConnectorSecret`
+
+**PR title:** `refactor(structure-audit): D11 Bucket B — route 11 sites through readConnectorSecret`
+
+## 9 — Out of scope, captured for future specs
+
+- **Bucket C** (`lazy-mesh.ts` + `connector-rpc-handlers.ts`, 21 sites). Expected to extend the same `connector-vault.ts` module with `writeConnectorSecret(serviceId, value)` and `sharedOAuthKey(provider)` helpers. Will not require any further `VAULT_KEY_ALLOW_LIST` additions if the design holds.
+- **`VAULT_KEY_RE` widening.** The current regex only matches four exact suffixes (`oauth|token|pat|api_key`). After Bucket B + Bucket C clear, the natural follow-up is to either extend the alternation to cover every secret-key suffix in the manifest (`app_key|api_token|api_base|site|account_id|client_secret|…`) or — better — derive the regex from `CONNECTOR_VAULT_SECRET_KEYS` at runtime so a new connector auto-extends the audit. **Out of scope here:** widening the regex while Bucket C still has live violations would re-fire D11 on lines that pass today (e.g., `lazy-mesh.ts:1238` reads `microsoft.oauth` and others), forcing more allow-list discussion mid-PR. Sequence it after Bucket C lands.
+- **D5 (cognitive complexity)** is unaffected — no function in this PR exceeds the 15-threshold.
+- **D7 (orphan files)** is unaffected — every export added has a caller.
+- **D8 (any count)** is unaffected — no `any` introduced; baseline stays at 2.
+
+## 10 — Provenance
+
+- Phase 2 ranking: [`docs/structure-audit/missed.md`](../../structure-audit/missed.md) row "D11 Bucket B canonical-reader sites" (cost 2, score 1.5).
+- Site list: [`docs/structure-audit/deferred-backlog.md`](../../structure-audit/deferred-backlog.md) "D11 — vault-key Bucket B".
+- Existing helpers: `packages/gateway/src/connectors/connector-vault.ts` (`perServiceOAuthVaultKey`, `writePerServiceOAuthKey`, `clearOAuthVaultIfProviderUnused`, `migrateToPerServiceOAuthKeys`).
+- Manifest: `packages/gateway/src/connectors/connector-secrets-manifest.ts` (`CONNECTOR_VAULT_SECRET_KEYS`).
+- Audit script: `scripts/structure-audit/check-nimbus-invariants.ts` (`VAULT_KEY_ALLOW_LIST`, `checkVaultKeyAllowList`).

--- a/docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-review.md
+++ b/docs/superpowers/specs/2026-05-01-d11-bucket-b-readConnectorSecret-review.md
@@ -1,0 +1,54 @@
+# D11 Bucket B — `readConnectorSecret` Design Review Feedback
+
+**Date:** 2026-05-01
+**Reviewer:** Gemini CLI
+**Target Spec:** [`2026-05-01-d11-bucket-b-readConnectorSecret-design.md`](./2026-05-01-d11-bucket-b-readConnectorSecret-design.md)
+
+---
+
+## 1 — Suggestions & Improvements
+
+### 1.1 — Regex Hardening (Post-Migration)
+The current `VAULT_KEY_RE` in `check-nimbus-invariants.ts` only flags four suffixes (`oauth|token|pat|api_key`). The spec correctly identifies that sibling keys like `app_key`, `api_token`, `api_base`, and `site` currently bypass the audit.
+
+**Suggestion:** Once the migration is complete and these 11 files are "clean," we should update the regex to catch these additional suffixes. This prevents future regressions where someone might use `vault.get("datadog.app_key")` instead of the helper. Since all valid construction sites will be inside `connector-vault.ts` (which is allow-listed), a stricter regex won't cause false positives in production code.
+
+### 1.2 — Optional Defaulting/Trimming
+Many `vault.get` callers immediately follow with `?.trim() ?? ""`.
+
+**Question:** Would adding an optional options object to `readConnectorSecret` improve call-site ergonomics without violating the "no semantic drift" goal?
+```ts
+export async function readConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+  options?: { trim?: boolean; fallback?: string }
+): Promise<string | null> {
+  let val = await vault.get(`${serviceId}.${keyName}`);
+  if (options?.trim) val = val?.trim() ?? null;
+  return val ?? options?.fallback ?? null;
+}
+```
+If the user prefers strict parity, the current design is fine, but it forces every caller to repeat the same boilerplate.
+
+### 1.3 — Audit Iterator Broadening
+The decision to exclude `/testing/` from `iterateGlob` (§4.3) is noted as widening all structure audits (D8, D9, D10). 
+
+**Observation:** While correct for D10 (spawns in tests are often necessary and don't need `extensionProcessEnv`), ensure that we don't accidentally lose visibility into "risky" patterns in test utilities if those utilities are ever used in a way that impacts production (unlikely in Nimbus given the package rules). The trade-off for a cleaner D11 signal seems worth it.
+
+## 2 — Questions
+
+### 2.1 — Handling of non-string values
+`readConnectorSecret` returns `Promise<string | null>`. 
+**Question:** Are there any connector secrets that are stored as JSON strings that need parsing, or are they all raw strings? `discord.enabled` in the manifest suggests a boolean-like string. If they are all strings, `string | null` is sufficient.
+
+### 2.2 — Compile-time check for `google_drive`
+The spec mentions `ConnectorSecretKeyOf<"google_drive">` resolves to `never`. 
+**Verification:** Does `readConnectorSecret(vault, "google_drive", someVar)` fail gracefully if `someVar` is typed as `never`? Yes, but explicitly testing this in §6.3 is a good idea to ensure no one accidentally "satisfies" `never`.
+
+---
+
+## 3 — Technical Nitpicks
+
+- **Type Helper:** The `infer K` logic is robust against union types in the manifest (e.g., `bitbucket`). 
+- **Allow-list Comments:** Ensure the structural reasons in §4.2 are worded exactly as they should appear in the code to minimize "review-the-reviewer" churn during implementation.

--- a/packages/gateway/src/auth/notion-access-token.ts
+++ b/packages/gateway/src/auth/notion-access-token.ts
@@ -1,4 +1,5 @@
 import { Config } from "../config.ts";
+import { readConnectorSecret } from "../connectors/connector-vault.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
 import { parseStoredOAuthTokens } from "./oauth-vault-tokens.ts";
 import { refreshNotionToken } from "./pkce.ts";
@@ -7,7 +8,7 @@ import { refreshNotionToken } from "./pkce.ts";
  * Returns a valid Notion integration access token, refreshing when the synthetic vault expiry is near.
  */
 export async function getValidNotionAccessToken(vault: NimbusVault): Promise<string> {
-  const raw = await vault.get("notion.oauth");
+  const raw = await readConnectorSecret(vault, "notion", "oauth");
   if (raw === null || raw === "") {
     throw new Error("Notion OAuth not configured; run: nimbus connector auth notion");
   }

--- a/packages/gateway/src/auth/slack-access-token.ts
+++ b/packages/gateway/src/auth/slack-access-token.ts
@@ -1,4 +1,5 @@
 import { Config } from "../config.ts";
+import { readConnectorSecret } from "../connectors/connector-vault.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
 import { parseStoredOAuthTokens } from "./oauth-vault-tokens.ts";
 import { refreshSlackUserToken } from "./pkce.ts";
@@ -7,7 +8,7 @@ import { refreshSlackUserToken } from "./pkce.ts";
  * Returns a valid Slack user access token, refreshing via `oauth.v2.access` when near expiry.
  */
 export async function getValidSlackAccessToken(vault: NimbusVault): Promise<string> {
-  const raw = await vault.get("slack.oauth");
+  const raw = await readConnectorSecret(vault, "slack", "oauth");
   if (raw === null || raw === "") {
     throw new Error("Slack OAuth not configured; run: nimbus connector auth slack");
   }

--- a/packages/gateway/src/connectors/connector-secrets-manifest.ts
+++ b/packages/gateway/src/connectors/connector-secrets-manifest.ts
@@ -2,9 +2,7 @@ import type { NimbusVault } from "../vault/nimbus-vault.ts";
 import type { ConnectorServiceId } from "./connector-catalog.ts";
 
 /** PAT / API keys cleared when removing a connector (OAuth keys use provider-wide clear elsewhere). */
-export const CONNECTOR_VAULT_SECRET_KEYS: {
-  readonly [K in ConnectorServiceId]: readonly string[];
-} = {
+export const CONNECTOR_VAULT_SECRET_KEYS = {
   google_drive: [],
   gmail: [],
   google_photos: [],
@@ -40,6 +38,8 @@ export const CONNECTOR_VAULT_SECRET_KEYS: {
   newrelic: ["newrelic.api_key", "newrelic.account_id"],
   // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   datadog: ["datadog.api_key", "datadog.app_key", "datadog.site"],
+} as const satisfies {
+  readonly [K in ConnectorServiceId]: readonly string[];
 };
 
 export async function clearConnectorVaultSecretKeys(

--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { createMemoryVault } from "../testing/bun-test-support.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
+
+describe("readConnectorSecret", () => {
+  test("returns the stored value when the key is set", async () => {
+    const vault = createMemoryVault();
+    await vault.set("github.pat", "ghp_test");
+    expect(await readConnectorSecret(vault, "github", "pat")).toBe("ghp_test");
+  });
+
+  test("returns null when the key is absent", async () => {
+    const vault = createMemoryVault();
+    expect(await readConnectorSecret(vault, "github", "pat")).toBeNull();
+  });
+
+  test("does not trim or coerce empty string", async () => {
+    const vault = createMemoryVault();
+    await vault.set("slack.oauth", "  raw value  ");
+    expect(await readConnectorSecret(vault, "slack", "oauth")).toBe("  raw value  ");
+
+    await vault.set("notion.oauth", "");
+    expect(await readConnectorSecret(vault, "notion", "oauth")).toBe("");
+  });
+
+  test("resolves api_key and app_key to distinct vault keys (datadog multi-key)", async () => {
+    const vault = createMemoryVault();
+    await vault.set("datadog.api_key", "API");
+    await vault.set("datadog.app_key", "APP");
+    expect(await readConnectorSecret(vault, "datadog", "api_key")).toBe("API");
+    expect(await readConnectorSecret(vault, "datadog", "app_key")).toBe("APP");
+  });
+
+  test("resolves non-credential-shaped keys (gitlab.api_base)", async () => {
+    const vault = createMemoryVault();
+    await vault.set("gitlab.api_base", "https://gitlab.example.com/api/v4");
+    expect(await readConnectorSecret(vault, "gitlab", "api_base")).toBe(
+      "https://gitlab.example.com/api/v4",
+    );
+  });
+
+  test("compile-time: rejects non-manifested keys", () => {
+    const vault = createMemoryVault();
+    // @ts-expect-error — manifest is ["github.pat"]; "oauth" is not a github key.
+    void readConnectorSecret(vault, "github", "oauth");
+
+    // @ts-expect-error — google_drive manifest is empty; ConnectorSecretKeyOf resolves to never.
+    void readConnectorSecret(vault, "google_drive", "oauth");
+
+    // The runtime expectation is irrelevant for these checks; the assertion
+    // is that the file typechecks only with the @ts-expect-error directives.
+    expect(true).toBe(true);
+  });
+});

--- a/packages/gateway/src/connectors/connector-vault.ts
+++ b/packages/gateway/src/connectors/connector-vault.ts
@@ -7,6 +7,7 @@ import {
   GOOGLE_CONNECTOR_SERVICES,
   MICROSOFT_CONNECTOR_SERVICES,
 } from "./connector-catalog.ts";
+import type { CONNECTOR_VAULT_SECRET_KEYS } from "./connector-secrets-manifest.ts";
 
 const GOOGLE_SERVICES = [...GOOGLE_CONNECTOR_SERVICES];
 const MICROSOFT_SERVICES = [...MICROSOFT_CONNECTOR_SERVICES];
@@ -115,4 +116,40 @@ export async function clearOAuthVaultIfProviderUnused(
     }
   }
   return cleared;
+}
+
+// ─── Bucket-B helper: typed connector-secret reader ──────────────────────────
+
+/**
+ * Bare-key view derived from `CONNECTOR_VAULT_SECRET_KEYS`. For service `S`,
+ * extracts the suffix after the dot in each fully-qualified manifest entry.
+ *
+ * Services with an empty manifest array (e.g. `google_drive`) resolve to `never`,
+ * making `readConnectorSecret(vault, "google_drive", ...)` uncallable — those
+ * services use OAuth via auth/google-access-token.ts, not this helper.
+ *
+ * The `[T] extends [never]` non-distributive guard short-circuits the empty-tuple
+ * case before the template-literal `infer K` runs — without it, `never extends ...`
+ * distribution would let `infer K` bind to its default constraint (`string`).
+ */
+export type ConnectorSecretKeyOf<S extends ConnectorServiceId> = [
+  (typeof CONNECTOR_VAULT_SECRET_KEYS)[S][number],
+] extends [never]
+  ? never
+  : (typeof CONNECTOR_VAULT_SECRET_KEYS)[S][number] extends `${S}.${infer K}`
+    ? K
+    : never;
+
+/**
+ * Reads a connector's secret from the Vault by structural key name. Returns
+ * the raw stored value (no trim, no default) — semantics match `vault.get`.
+ * Misspelled or non-manifested key names fail at compile time.
+ */
+export async function readConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+): Promise<string | null> {
+  const fullKey = `${serviceId}.${keyName}`;
+  return vault.get(fullKey);
 }

--- a/packages/gateway/src/connectors/datadog-sync.ts
+++ b/packages/gateway/src/connectors/datadog-sync.ts
@@ -6,6 +6,7 @@ import {
   syncPassCursorSuccess,
 } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord } from "./unknown-record.ts";
 
@@ -116,12 +117,12 @@ export function createDatadogSyncable(options: DatadogSyncableOptions): Syncable
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureDatadogMcpRunning();
-      const apiKey = (await ctx.vault.get("datadog.api_key"))?.trim() ?? "";
-      const appKey = (await ctx.vault.get("datadog.app_key"))?.trim() ?? "";
+      const apiKey = (await readConnectorSecret(ctx.vault, "datadog", "api_key"))?.trim() ?? "";
+      const appKey = (await readConnectorSecret(ctx.vault, "datadog", "app_key"))?.trim() ?? "";
       if (apiKey === "" || appKey === "") {
         return syncNoopResult(cursor, t0);
       }
-      const siteRaw = await ctx.vault.get("datadog.site");
+      const siteRaw = await readConnectorSecret(ctx.vault, "datadog", "site");
       const site = siteRaw !== null && siteRaw.trim() !== "" ? siteRaw.trim() : "datadoghq.com";
 
       await ctx.rateLimiter.acquire("datadog");

--- a/packages/gateway/src/connectors/github-actions-sync.ts
+++ b/packages/gateway/src/connectors/github-actions-sync.ts
@@ -1,5 +1,6 @@
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { listGithubReposFromIndex } from "./github-index-repos.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
@@ -216,7 +217,7 @@ export function createGithubActionsSyncable(options: GithubActionsSyncableOption
       const t0 = performance.now();
       await options.ensureGithubMcpRunning();
 
-      const pat = await ctx.vault.get("github.pat");
+      const pat = await readConnectorSecret(ctx.vault, "github", "pat");
       if (pat === null || pat.trim() === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -12,6 +12,7 @@ import {
   syncNoopResult,
   UnauthenticatedError,
 } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
@@ -330,7 +331,7 @@ export function createGithubSyncable(options: GithubSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureGithubMcpRunning();
-      const pat = await ctx.vault.get("github.pat");
+      const pat = await readConnectorSecret(ctx.vault, "github", "pat");
       if (pat === null || pat === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/gitlab-sync.ts
+++ b/packages/gateway/src/connectors/gitlab-sync.ts
@@ -2,6 +2,7 @@ import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { resolvePersonForSync } from "../people/linker.ts";
 import { stripTrailingSlashes } from "../string/strip-trailing-slashes.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
@@ -590,12 +591,12 @@ export function createGitlabSyncable(options: GitlabSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureGitlabMcpRunning();
-      const pat = await ctx.vault.get("gitlab.pat");
+      const pat = await readConnectorSecret(ctx.vault, "gitlab", "pat");
       if (pat === null || pat === "") {
         return syncNoopResult(cursor, t0);
       }
 
-      const apiBase = normalisedApiBase(await ctx.vault.get("gitlab.api_base"));
+      const apiBase = normalisedApiBase(await readConnectorSecret(ctx.vault, "gitlab", "api_base"));
       const webOrigin = webOriginFromApiBase(apiBase);
 
       const prev = decodeCursor(cursor);

--- a/packages/gateway/src/connectors/linear-sync.ts
+++ b/packages/gateway/src/connectors/linear-sync.ts
@@ -2,6 +2,7 @@ import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { resolvePersonForSync } from "../people/linker.ts";
 import type { PersonSyncHints } from "../people/person-types.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -216,7 +217,7 @@ export function createLinearSyncable(options: LinearSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureLinearMcpRunning();
-      const apiKey = await ctx.vault.get("linear.api_key");
+      const apiKey = await readConnectorSecret(ctx.vault, "linear", "api_key");
       if (apiKey === null || apiKey === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/newrelic-sync.ts
+++ b/packages/gateway/src/connectors/newrelic-sync.ts
@@ -6,6 +6,7 @@ import {
   syncPassCursorSuccess,
 } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -35,7 +36,7 @@ export function createNewrelicSyncable(options: NewrelicSyncableOptions): Syncab
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureNewrelicMcpRunning();
-      const key = (await ctx.vault.get("newrelic.api_key"))?.trim() ?? "";
+      const key = (await readConnectorSecret(ctx.vault, "newrelic", "api_key"))?.trim() ?? "";
       if (key === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/notion-sync.ts
+++ b/packages/gateway/src/connectors/notion-sync.ts
@@ -2,6 +2,7 @@ import { getValidNotionAccessToken } from "../auth/notion-access-token.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { resolvePersonForSync } from "../people/linker.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { isoMs, maxIso } from "./sync-iso-helpers.ts";
 import {
   decodeWatermarkCursorV1,
@@ -236,7 +237,7 @@ export function createNotionSyncable(options: NotionSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureNotionMcpRunning();
-      const rawVault = await ctx.vault.get("notion.oauth");
+      const rawVault = await readConnectorSecret(ctx.vault, "notion", "oauth");
       if (rawVault === null || rawVault === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/slack-sync.ts
+++ b/packages/gateway/src/connectors/slack-sync.ts
@@ -2,6 +2,7 @@ import { getValidSlackAccessToken } from "../auth/slack-access-token.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { resolvePersonForSync } from "../people/linker.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { shortIndexedMessageTitleFromPreview } from "./sync-message-preview-title.ts";
 import { asRecord } from "./unknown-record.ts";
@@ -396,7 +397,7 @@ export function createSlackSyncable(options: SlackSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureSlackMcpRunning();
-      const rawVault = await ctx.vault.get("slack.oauth");
+      const rawVault = await readConnectorSecret(ctx.vault, "slack", "oauth");
       if (rawVault === null || rawVault === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -14,7 +14,10 @@ import {
 import { loadNimbusSessionFromPath } from "../config/session-toml.ts";
 import { Config } from "../config.ts";
 import { defaultSyncIntervalMsForService } from "../connectors/connector-catalog.ts";
-import { migrateToPerServiceOAuthKeys } from "../connectors/connector-vault.ts";
+import {
+  migrateToPerServiceOAuthKeys,
+  readConnectorSecret,
+} from "../connectors/connector-vault.ts";
 import { createFilesystemV2Syncable } from "../connectors/filesystem-v2-sync.ts";
 import { createLazyConnectorMesh, type LazyConnectorMesh } from "../connectors/lazy-mesh.ts";
 import { listUserMcpConnectors } from "../connectors/user-mcp-store.ts";
@@ -124,13 +127,13 @@ async function ensureGithubCircleCiSchedulerCompanions(
   localIndex: LocalIndex,
   vault: NimbusVault,
 ): Promise<void> {
-  const pat = await vault.get("github.pat");
+  const pat = await readConnectorSecret(vault, "github", "pat");
   localIndex.ensureGithubActionsSchedulerCompanionIfNeeded({
     githubPatPresent: pat !== null && pat !== "",
     now: Date.now(),
     intervalMs: defaultSyncIntervalMsForService("github_actions"),
   });
-  const cciTok = await vault.get("circleci.api_token");
+  const cciTok = await readConnectorSecret(vault, "circleci", "api_token");
   localIndex.ensureCircleciSchedulerCompanionIfNeeded({
     circleciTokenPresent: cciTok !== null && cciTok !== "",
     now: Date.now(),

--- a/scripts/structure-audit/check-nimbus-invariants.test.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  VAULT_KEY_ALLOW_LIST,
   checkSpawnInvariant,
   checkVaultKeyAllowList,
   collectDbRunCensus,
@@ -98,6 +99,17 @@ describe("D11 — checkVaultKeyAllowList", () => {
       ALLOW_LIST,
     );
     expect(violations).toHaveLength(1);
+  });
+});
+
+describe("D11 — VAULT_KEY_ALLOW_LIST is frozen at structural entries", () => {
+  test("VAULT_KEY_ALLOW_LIST has exactly 5 entries", () => {
+    // Each entry has a documented structural reason in the design spec § 4.4
+    // (helper home, Google OAuth canonical reader, Google PKCE writer,
+    // Microsoft provider-shared OAuth, OpenAI embedding provider).
+    // Adding a 6th entry requires updating this test, forcing a PR-level
+    // discussion of why the new file legitimately constructs vault keys.
+    expect(VAULT_KEY_ALLOW_LIST).toHaveLength(5);
   });
 });
 

--- a/scripts/structure-audit/check-nimbus-invariants.test.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
-  VAULT_KEY_ALLOW_LIST,
   checkSpawnInvariant,
   checkVaultKeyAllowList,
   collectDbRunCensus,
+  VAULT_KEY_ALLOW_LIST,
 } from "./check-nimbus-invariants.ts";
 
 describe("D10 — checkSpawnInvariant (under connectors/)", () => {

--- a/scripts/structure-audit/check-nimbus-invariants.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.ts
@@ -13,10 +13,14 @@ import { auditOutputPath, iterateSourceFiles } from "./lib.ts";
 export type FileEntry = { relPath: string; contents: string };
 export type Violation = { rule: string; file: string; line: number; snippet: string };
 
-const VAULT_KEY_ALLOW_LIST = [
+export const VAULT_KEY_ALLOW_LIST = [
   "packages/gateway/src/connectors/connector-vault.ts",
   "packages/gateway/src/auth/google-access-token.ts",
   "packages/gateway/src/auth/pkce.ts",
+  // Provider-shared OAuth canonical reader (Microsoft); mirrors google-access-token.ts.
+  "packages/gateway/src/auth/oauth-vault-tokens.ts",
+  // OpenAI embedding provider — not a Nimbus connector; no ConnectorServiceId.
+  "packages/gateway/src/embedding/create-embedding-runtime.ts",
 ];
 
 // Match a Bun.spawn or child_process spawn call.

--- a/scripts/structure-audit/lib.test.ts
+++ b/scripts/structure-audit/lib.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { iterateSourceFiles } from "./lib.ts";
+
+describe("iterateSourceFiles", () => {
+  test("excludes paths under */testing/*", async () => {
+    const visited: string[] = [];
+    for await (const f of iterateSourceFiles()) {
+      visited.push(f.relPath);
+    }
+    const testingPaths = visited.filter((p) => p.includes("/testing/"));
+    expect(testingPaths).toEqual([]);
+  });
+});

--- a/scripts/structure-audit/lib.ts
+++ b/scripts/structure-audit/lib.ts
@@ -151,6 +151,7 @@ async function* iterateGlob(
     if (relPath.endsWith(".d.ts")) continue;
     if (relPath.includes("/__fixtures__/")) continue;
     if (relPath.includes("/test/fixtures/")) continue;
+    if (relPath.includes("/testing/")) continue;
     const path = join(REPO_ROOT, relPath);
     const contents = await Bun.file(path).text();
     yield { path, relPath, contents };


### PR DESCRIPTION
## Summary
- Eliminates D11 Bucket B (11 vault-key construction sites in 11 production files) by routing them through a typed `readConnectorSecret(vault, serviceId, keyName)` helper in `connector-vault.ts`.
- Adds 2 structurally-distinct files to the D11 allow-list (`oauth-vault-tokens.ts` for provider-shared Microsoft OAuth; `embedding/create-embedding-runtime.ts` for OpenAI). Allow-list is now frozen at 5 entries by a unit test.
- Extends the structure-audit iterator to skip `**/testing/**` paths (mirrors existing `/test/fixtures/` rule).
- D11 violation count: **36 → 21** (Bucket C only). Post-PR baseline recorded in `docs/structure-audit/baseline.md`.

## Test plan
- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — 6 tests pass (3 behavioural + 3 type-level)
- [ ] `bun test scripts/structure-audit/check-nimbus-invariants.test.ts` — frozen-count test passes
- [ ] `bun test scripts/structure-audit/lib.test.ts` — \`/testing/\` iterator exclusion verified
- [ ] \`bun run audit:invariants\` exits 0
- [ ] \`bun run audit:invariants 2>&1 | grep -c D11\` reports \`21\`
- [ ] \`bun run test:ci\` clean (Ubuntu CI parity)
- [ ] All 11 connector sync test suites still pass (\`datadog\`, \`github-actions\`, \`github\`, \`gitlab\`, \`linear\`, \`newrelic\`, \`notion\`, \`slack\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)