### PR TITLE
test(connectors): pin ConnectorSecretKeyOf<S> to manifest-derived unions

### DIFF
--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
 import { createMemoryVault } from "../testing/bun-test-support.ts";
-import { readConnectorSecret } from "./connector-vault.ts";
+import { type ConnectorSecretKeyOf, readConnectorSecret } from "./connector-vault.ts";
+
+// Type-equality probe (Hilger). Two type parameters are equal iff both are
+// assignable in both directions when wrapped in identity-typed arrow functions.
+// Used below to pin `ConnectorSecretKeyOf<S>` to specific union literals so
+// that any silent widening (e.g. to `string`) fails compile, not just runtime.
+type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+function assertEq<_A, _B>(_: Eq<_A, _B>): void {}
 
 describe("readConnectorSecret", () => {
   test("returns the stored value when the key is set", async () => {
@@ -50,6 +60,42 @@ describe("readConnectorSecret", () => {
 
     // The runtime expectation is irrelevant for these checks; the assertion
     // is that the file typechecks only with the @ts-expect-error directives.
+    expect(true).toBe(true);
+  });
+});
+
+describe("ConnectorSecretKeyOf — type pins", () => {
+  // These pins fail at compile time if `ConnectorSecretKeyOf<S>` ever silently
+  // widens to `string` or drifts from the manifest's bare-key suffix union.
+  // The earlier `@ts-expect-error` directives only assert that bad inputs are
+  // rejected; they would still pass if the type were `string` (which accepts
+  // every literal including the misspelled ones, plus everything else).
+  test("pins to manifest-derived bare-key suffixes (compile-time)", () => {
+    assertEq<ConnectorSecretKeyOf<"github">, "pat">(true);
+    assertEq<ConnectorSecretKeyOf<"slack">, "oauth">(true);
+    assertEq<ConnectorSecretKeyOf<"linear">, "api_key">(true);
+    assertEq<ConnectorSecretKeyOf<"gitlab">, "pat" | "api_base">(true);
+    assertEq<ConnectorSecretKeyOf<"datadog">, "api_key" | "app_key" | "site">(true);
+    assertEq<ConnectorSecretKeyOf<"bitbucket">, "username" | "app_password">(true);
+
+    // Empty-manifest services must resolve to `never`, not `string`. This is
+    // the main defence the `[T] extends [never]` non-distributive guard in
+    // ConnectorSecretKeyOf was added for.
+    assertEq<ConnectorSecretKeyOf<"google_drive">, never>(true);
+    assertEq<ConnectorSecretKeyOf<"gmail">, never>(true);
+    assertEq<ConnectorSecretKeyOf<"google_photos">, never>(true);
+    assertEq<ConnectorSecretKeyOf<"onedrive">, never>(true);
+    assertEq<ConnectorSecretKeyOf<"outlook">, never>(true);
+    assertEq<ConnectorSecretKeyOf<"teams">, never>(true);
+    assertEq<ConnectorSecretKeyOf<"github_actions">, never>(true);
+
+    // Negative pins prove the equality probe distinguishes the cases above
+    // from the most plausible regression (silent widening to `string`).
+    // @ts-expect-error — `ConnectorSecretKeyOf<"github">` is `"pat"`, not `string`.
+    assertEq<ConnectorSecretKeyOf<"github">, string>(true);
+    // @ts-expect-error — `ConnectorSecretKeyOf<"google_drive">` is `never`, not `string`.
+    assertEq<ConnectorSecretKeyOf<"google_drive">, string>(true);
+
     expect(true).toBe(true);
   });
 });

--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -7,9 +7,7 @@ import { type ConnectorSecretKeyOf, readConnectorSecret } from "./connector-vaul
 // assignable in both directions when wrapped in identity-typed arrow functions.
 // Used below to pin `ConnectorSecretKeyOf<S>` to specific union literals so
 // that any silent widening (e.g. to `string`) fails compile, not just runtime.
-type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
-  ? true
-  : false;
+type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 function assertEq<_A, _B>(_: Eq<_A, _B>): void {}
 


### PR DESCRIPTION
## Summary
- Adds type-equality assertions that fail at compile time if `ConnectorSecretKeyOf<S>` ever silently widens to `string` or drifts from the manifest-derived bare-key suffix union.
- Pins six representative services (github, slack, linear, gitlab, datadog, bitbucket) to their exact unions, plus all seven empty-manifest services to `never` (the case the `[T] extends [never]` non-distributive guard was added for).
- Two negative pins (`@ts-expect-error`) prove the equality probe distinguishes the correct unions from `string` — they would fail compile if the type drifted.

## Why
Recommended by the Task 2 code reviewer during D11 Bucket B (#145) as defensive insurance for the helper foundation Bucket C will build on. The existing `@ts-expect-error` directives catch misspelled keys, but they would still pass if the type were `string` (which accepts everything). The new pins close that silent-widening gap.

No production code changes — test file only.

## Test plan
- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — 7 tests pass (was 6; +1 type-pin test)
- [ ] `bun run typecheck` clean (proves all `@ts-expect-error` directives are load-bearing under TypeScript strict-mode unused-directive enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)