### PR TITLE
test(connectors): annotate empty assertEq body to satisfy SonarCloud

### DIFF
--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -9,7 +9,9 @@ import { type ConnectorSecretKeyOf, readConnectorSecret } from "./connector-vaul
 // that any silent widening (e.g. to `string`) fails compile, not just runtime.
 type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
-function assertEq<_A, _B>(_: Eq<_A, _B>): void {}
+function assertEq<_A, _B>(_: Eq<_A, _B>): void {
+  // Intentionally empty: assertion happens at the type-checker, not at runtime.
+}
 
 describe("readConnectorSecret", () => {
   test("returns the stored value when the key is set", async () => {


### PR DESCRIPTION
## Summary
Tiny follow-up to #146. The `assertEq` helper is a compile-time type-equality probe — its body is intentionally empty because the assertion happens at the type-checker, not at runtime. SonarCloud's empty-function rule fired on it after #146 merged.

Adds a one-line body comment so the rule passes without changing behavior.

## Test plan
- [x] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — 7 pass.
- [x] `bun run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)