### PR TITLE
docs(structure-audit): D11 Bucket C — design spec + implementation plan + reviews

### DIFF
--- a/docs/superpowers/plans/2026-05-02-d11-bucket-c-review.md
+++ b/docs/superpowers/plans/2026-05-02-d11-bucket-c-review.md
@@ -1,0 +1,98 @@
+# D11 Bucket C — Implementation Plan Review
+
+**Reviewer:** Gemini CLI
+**Date:** 2026-05-02
+**Status:** ✅ Approved with minor suggestions for encapsulation and verification
+
+---
+
+## 1 — Executive Summary
+
+The implementation plan at `docs/superpowers/plans/2026-05-02-d11-bucket-c.md` is detailed, well-structured, and correctly maps out the 21 violation sites. The TDD approach and the use of git worktrees ensure a safe and verifiable rollout.
+
+## 2 — Suggestions for Improvement
+
+### 2.1 Encapsulation of Shared OAuth Access
+
+In line with my design review, I suggest incorporating `readSharedOAuth` and `writeSharedOAuth` helpers. This would change Tasks 3, 4, 11, and 12.
+
+**Update to Task 3 (Task 3.1 Step 1):**
+Include `readSharedOAuth` and `writeSharedOAuth` in `connector-vault.ts`.
+
+```ts
+/** Reads a provider-shared OAuth token (e.g. google.oauth). */
+export async function readSharedOAuth(
+  vault: NimbusVault,
+  provider: SharedOAuthProvider
+): Promise<string | null> {
+  return vault.get(sharedOAuthKey(provider));
+}
+
+/** Writes a provider-shared OAuth token. */
+export async function writeSharedOAuth(
+  vault: NimbusVault,
+  provider: SharedOAuthProvider,
+  value: string
+): Promise<void> {
+  return vault.set(sharedOAuthKey(provider), value);
+}
+```
+
+**Update to Task 4 (Step 2):**
+`ensureIfProviderOAuthSet` should use `readSharedOAuth`.
+
+```ts
+  private async ensureIfProviderOAuthSet(
+    provider: SharedOAuthProvider,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    const v = await readSharedOAuth(this.vault, provider);
+    if (v !== null && v !== "") {
+      await run();
+    }
+  }
+```
+
+**Update to Task 12 (Steps 2 & 3):**
+Use the new helpers in `connector-rpc-handlers.ts`.
+
+```ts
+// Step 2
+return await readSharedOAuth(vault, "microsoft");
+
+// Step 3
+await writeSharedOAuth(vault, "microsoft", microsoftOAuthBackup);
+```
+
+### 2.2 Task 15 — Baseline Update Guidance
+
+To ensure consistency in `docs/structure-audit/baseline.md`, use this exact replacement for the D11 line in the "Per-dimension baselines" table:
+
+```markdown
+| D11 | F | Vault-key construction outside allow-list | 0 violations | `bun run audit:invariants` (binary) |
+```
+
+And update the "Phase 2 follow-up" section to:
+
+```markdown
+## Phase 2 follow-up — Bucket C (2026-05-02)
+
+D11 violations reduced from the Phase 1 baseline of 56 to **0**. **D11 closed.**
+
+- Bucket A (20 false positives) — suppressed by `audit-ignore-next-line` markers (PR #135).
+- Bucket B (15 sites) — routed through `readConnectorSecret` helper or added to the allow-list (PR #145).
+- Bucket C (21 sites) — routed through `readConnectorSecret`, `writeConnectorSecret`, and `sharedOAuthKey` (PR <PR-2-number>).
+```
+
+### 2.3 Minor Logic Optimization (Task 12 Step 9)
+
+While the explicit `if/else if` is correct, since the `sharedOAuthKey` signature is restricted to `SharedOAuthProvider`, you could technically use the variable if the type system allows, but keeping it explicit as proposed is safer and follows the existing pattern.
+
+## 3 — Questions
+
+- **Q:** Does `sharedOAuthKey` need to be exported if we provide `readSharedOAuth` and `writeSharedOAuth`?
+  - **A:** Yes, it is still needed for the `sharedKey` assignment in `connector-rpc-handlers.ts` (Task 12 Step 9) because that key is passed to `writePerServiceOAuthKey`.
+
+## 4 — Conclusion
+
+The plan is excellent. Incorporating the suggested helpers will finalize the centralization of vault access patterns, making the codebase more resilient to future regressions.

--- a/docs/superpowers/plans/2026-05-02-d11-bucket-c.md
+++ b/docs/superpowers/plans/2026-05-02-d11-bucket-c.md
@@ -1,0 +1,1210 @@
+# D11 Bucket C — Close D11 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the remaining 21 D11 vault-key-construction violations in two atomic PRs and close D11 entirely.
+
+**Architecture:** PR 1 adds `SharedOAuthProvider` + `sharedOAuthKey()` to the allow-listed `connector-vault.ts`, replaces the untyped private helper `LazyMcpMesh.ensureIfVaultKeyNonEmpty` with two typed variants (`ensureIfConnectorSecretSet<S>` for per-service keys, `ensureIfProviderOAuthSet` for shared OAuth keys), and migrates 12 read sites in `lazy-mesh.ts`. PR 2 adds the typed `writeConnectorSecret<S>()` helper and migrates the remaining 9 sites in `connector-rpc-handlers.ts`. The frozen 5-entry `VAULT_KEY_ALLOW_LIST` stays at exactly 5 throughout.
+
+**Tech Stack:** TypeScript 6.x strict / Bun v1.2 / `bun:test` / Biome lint / project-local `.worktrees/` for isolation.
+
+**Spec:** [`docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md`](../specs/2026-05-02-d11-bucket-c-design.md)
+
+**Preconditions:**
+- PR 1 branches from `main`. No external dependency.
+- PR 2 branches from `main` *after PR 1 merges*. PR 2's tests in Task 14 extend the `ConnectorSecretKeyOf — type pins` describe block + `assertEq` helper added by **PR #146** (type pinning), so PR #146 must also be merged to `main` before PR 2 is started. Verify with `git grep -n "function assertEq" packages/gateway/src/connectors/connector-vault.test.ts` returning a hit on `main`.
+- The two PRs are **not stacked**. PR 2 picks up `sharedOAuthKey` + `SharedOAuthProvider` from PR 1's merged state.
+
+**Pre-PR-1 baseline (verified live with `bun run audit:invariants`):** 21 D11 violations.
+- 12 in `packages/gateway/src/connectors/lazy-mesh.ts` — all reads (PR 1)
+- 9 in `packages/gateway/src/ipc/connector-rpc-handlers.ts` — 6 writes + 1 read + 2 sharedKey assignments (PR 2)
+
+Post-PR-1 target: 9. Post-PR-2 target: **0**.
+
+---
+
+## File Structure
+
+### PR 1 — lazy-mesh reads
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/gateway/src/connectors/connector-vault.ts` | Allow-listed home of vault-key construction. Add `SharedOAuthProvider` type + `sharedOAuthKey()` helper alongside the existing `readConnectorSecret`/`ConnectorSecretKeyOf` Bucket-B helpers. | Modify |
+| `packages/gateway/src/connectors/lazy-mesh.ts` | MCP connector mesh. Delete the untyped private helper `ensureIfVaultKeyNonEmpty`, replace with `ensureIfConnectorSecretSet<S>` + `ensureIfProviderOAuthSet`, and migrate 12 read sites. | Modify |
+| `packages/gateway/src/connectors/connector-vault.test.ts` | Existing helper-test home. Append a `sharedOAuthKey` describe block (3 cases). | Modify |
+
+### PR 2 — rpc-handlers writes + close D11
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/gateway/src/connectors/connector-vault.ts` | Add `writeConnectorSecret<S>()` helper below `readConnectorSecret`. | Modify |
+| `packages/gateway/src/ipc/connector-rpc-handlers.ts` | Connector auth/remove RPC handlers. Migrate 9 sites + add imports. | Modify |
+| `packages/gateway/src/connectors/connector-vault.test.ts` | Append `writeConnectorSecret` describe block (5 cases) + extend the existing `ConnectorSecretKeyOf — type pins` block (4 new pins). | Modify |
+| `docs/structure-audit/baseline.md` | Phase-2 audit baseline. Record D11 = 0 / Bucket C closed. | Modify |
+
+---
+
+## PR 1 — lazy-mesh reads + sharedOAuthKey
+
+**Branch:** `dev/asafgolombek/d11-bucket-c-lazy-mesh` (from `main`)
+**Worktree:** `.worktrees/d11-bucket-c-lazy-mesh`
+**Commit count:** 1 (atomic)
+
+### Task 1: Set up the PR 1 worktree
+
+**Files:** none (workspace setup)
+
+- [ ] **Step 1: Verify `main` is current**
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+```
+
+Expected: `Already up to date.` or fast-forward.
+
+- [ ] **Step 2: Create the worktree**
+
+```bash
+git worktree add -b dev/asafgolombek/d11-bucket-c-lazy-mesh .worktrees/d11-bucket-c-lazy-mesh main
+```
+
+Expected: `Preparing worktree (new branch ...)`.
+
+- [ ] **Step 3: Verify the pre-migration audit baseline**
+
+```bash
+cd .worktrees/d11-bucket-c-lazy-mesh
+bun run audit:invariants 2>&1 | grep "D11" | wc -l
+```
+
+Expected: `21` (count of D11 violation lines). If the number differs, stop and investigate before continuing — the migration tables in this plan reference 21 violations and exact line numbers.
+
+- [ ] **Step 4: Verify the lazy-mesh-only count**
+
+```bash
+bun run audit:invariants 2>&1 | grep "lazy-mesh" | wc -l
+```
+
+Expected: `12`.
+
+### Task 2: Write the failing `sharedOAuthKey` test (TDD red)
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/connector-vault.test.ts` (append a new `describe` block; the existing `readConnectorSecret` block is left untouched)
+
+- [ ] **Step 1: Append the new describe block at the end of the file (after the closing `});` of the existing `readConnectorSecret` block)**
+
+```ts
+describe("sharedOAuthKey", () => {
+  test("returns google.oauth for google", () => {
+    expect(sharedOAuthKey("google")).toBe("google.oauth");
+  });
+
+  test("returns microsoft.oauth for microsoft", () => {
+    expect(sharedOAuthKey("microsoft")).toBe("microsoft.oauth");
+  });
+
+  test("compile-time: rejects non-provider strings", () => {
+    // @ts-expect-error — SharedOAuthProvider is "google" | "microsoft" only.
+    void sharedOAuthKey("github");
+    expect(true).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Update the import line at the top of the file**
+
+Find:
+
+```ts
+import { readConnectorSecret } from "./connector-vault.ts";
+```
+
+Replace with:
+
+```ts
+import { readConnectorSecret, sharedOAuthKey } from "./connector-vault.ts";
+```
+
+- [ ] **Step 3: Run the test — expect a typecheck/import failure**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: failure citing `sharedOAuthKey` is not exported from `./connector-vault.ts` (or a TS error to that effect). This proves the test would actually catch a missing implementation.
+
+### Task 3: Implement `sharedOAuthKey` (TDD green)
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/connector-vault.ts` (append below the existing `readConnectorSecret` function — the file currently ends at line 155; insert after that)
+
+- [ ] **Step 1: Append the new export at the bottom of `connector-vault.ts`**
+
+```ts
+
+// ─── Bucket-C helper: provider-shared OAuth key constructor ──────────────────
+
+export type SharedOAuthProvider = "google" | "microsoft";
+
+/**
+ * Returns the provider-shared OAuth vault key (`google.oauth` or `microsoft.oauth`).
+ * Used when the caller is operating on the provider-wide token rather than a
+ * per-service token. The literal lives inside this allow-listed file, so D11
+ * does not fire at the call site.
+ *
+ * Return type is the literal union `"google.oauth" | "microsoft.oauth"` (resolved
+ * by TS template-literal inference) — implicitly assignable to `string` at the
+ * `vault.get`/`vault.set` boundary, so no widening cast is required at any caller.
+ */
+export function sharedOAuthKey(
+  provider: SharedOAuthProvider,
+): `${SharedOAuthProvider}.oauth` {
+  return `${provider}.oauth`;
+}
+```
+
+- [ ] **Step 2: Run the test — expect green**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: 8 pass / 0 fail (5 existing `readConnectorSecret` cases + 3 new `sharedOAuthKey` cases). 11 `expect()` calls.
+
+- [ ] **Step 3: Whole-repo typecheck (the new return type must not regress anything)**
+
+```bash
+bun run typecheck
+```
+
+Expected: clean.
+
+### Task 4: Replace the untyped helper method with two typed variants
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/lazy-mesh.ts` (lines 1151–1156 — remove and replace; this is in PR-1 worktree)
+
+- [ ] **Step 1: Audit the call sites before deletion**
+
+```bash
+git grep -n "ensureIfVaultKeyNonEmpty" -- packages/
+```
+
+Expected output (7 hits):
+
+```
+packages/gateway/src/connectors/lazy-mesh.ts:1151:  private async ensureIfVaultKeyNonEmpty(key: string, run: () => Promise<void>): Promise<void> {
+packages/gateway/src/connectors/lazy-mesh.ts:1238:    await this.ensureIfVaultKeyNonEmpty("microsoft.oauth", () =>
+packages/gateway/src/connectors/lazy-mesh.ts:1241:    await this.ensureIfVaultKeyNonEmpty("github.pat", () => this.ensureGithubRunning());
+packages/gateway/src/connectors/lazy-mesh.ts:1242:    await this.ensureIfVaultKeyNonEmpty("gitlab.pat", () => this.ensureGitlabRunning());
+packages/gateway/src/connectors/lazy-mesh.ts:1244:    await this.ensureIfVaultKeyNonEmpty("slack.oauth", () => this.ensureSlackRunning());
+packages/gateway/src/connectors/lazy-mesh.ts:1245:    await this.ensureIfVaultKeyNonEmpty("linear.api_key", () => this.ensureLinearRunning());
+packages/gateway/src/connectors/lazy-mesh.ts:1247:    await this.ensureIfVaultKeyNonEmpty("notion.oauth", () => this.ensureNotionRunning());
+```
+
+If the output diverges (counts, file, line numbers off by ≥3), stop — the plan's line-number table is stale.
+
+- [ ] **Step 2: Replace the method body in `lazy-mesh.ts`**
+
+Find (currently lines 1151–1156):
+
+```ts
+  private async ensureIfVaultKeyNonEmpty(key: string, run: () => Promise<void>): Promise<void> {
+    const v = await this.vault.get(key);
+    if (v !== null && v !== "") {
+      await run();
+    }
+  }
+```
+
+Replace with:
+
+```ts
+  private async ensureIfConnectorSecretSet<S extends ConnectorServiceId>(
+    serviceId: S,
+    keyName: ConnectorSecretKeyOf<S>,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    const v = await readConnectorSecret(this.vault, serviceId, keyName);
+    if (v !== null && v !== "") {
+      await run();
+    }
+  }
+
+  private async ensureIfProviderOAuthSet(
+    provider: SharedOAuthProvider,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    const v = await this.vault.get(sharedOAuthKey(provider));
+    if (v !== null && v !== "") {
+      await run();
+    }
+  }
+```
+
+(Local parameter/variable naming `run`/`v` matches the surrounding file style; do not rename.)
+
+- [ ] **Step 3: Update the imports at the top of `lazy-mesh.ts`**
+
+The current import block contains:
+
+```ts
+import { transitionHealth } from "./health.ts";
+import type { UserMcpConnectorRow } from "./user-mcp-store.ts";
+```
+
+Add a new import line for the helpers + types from `connector-vault.ts`. The grouping convention in this file is alphabetical-by-path within each group. Place the new line in the same group as `./health.ts`:
+
+```ts
+import { readConnectorSecret, sharedOAuthKey, type SharedOAuthProvider } from "./connector-vault.ts";
+import { transitionHealth } from "./health.ts";
+import type { UserMcpConnectorRow } from "./user-mcp-store.ts";
+```
+
+Then verify whether `ConnectorSecretKeyOf` and `ConnectorServiceId` are already imported (they may be re-exported via existing imports). Check with:
+
+```bash
+git grep -n "ConnectorServiceId\|ConnectorSecretKeyOf" packages/gateway/src/connectors/lazy-mesh.ts
+```
+
+If neither is imported in `lazy-mesh.ts`, add a type import beside the helpers import:
+
+```ts
+import { readConnectorSecret, sharedOAuthKey, type SharedOAuthProvider } from "./connector-vault.ts";
+import type { ConnectorSecretKeyOf } from "./connector-vault.ts";
+import type { ConnectorServiceId } from "./connector-catalog.ts";
+```
+
+(Combine into one `import type { ConnectorSecretKeyOf } from "./connector-vault.ts"` line if `connector-vault.ts` is already imported only as a `type` import elsewhere — but the runtime helpers above are value imports, so keep the `type` import on its own line per Biome's convention in this file.)
+
+### Task 5: Migrate the 6 helper-method call sites in `ensureCredentialConnectorsRunning`
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/lazy-mesh.ts` (lines 1238–1247 — within the `ensureCredentialConnectorsRunning` method body)
+
+- [ ] **Step 1: Migrate line 1238 (microsoft shared OAuth → typed shared helper)**
+
+Find:
+
+```ts
+    await this.ensureIfVaultKeyNonEmpty("microsoft.oauth", () =>
+      this.ensureMicrosoftBundleRunning(),
+    );
+```
+
+Replace with:
+
+```ts
+    await this.ensureIfProviderOAuthSet("microsoft", () =>
+      this.ensureMicrosoftBundleRunning(),
+    );
+```
+
+- [ ] **Step 2: Migrate line 1241 (github.pat → typed connector-secret helper)**
+
+Find:
+
+```ts
+    await this.ensureIfVaultKeyNonEmpty("github.pat", () => this.ensureGithubRunning());
+```
+
+Replace with:
+
+```ts
+    await this.ensureIfConnectorSecretSet("github", "pat", () => this.ensureGithubRunning());
+```
+
+- [ ] **Step 3: Migrate line 1242 (gitlab.pat)**
+
+Find:
+
+```ts
+    await this.ensureIfVaultKeyNonEmpty("gitlab.pat", () => this.ensureGitlabRunning());
+```
+
+Replace with:
+
+```ts
+    await this.ensureIfConnectorSecretSet("gitlab", "pat", () => this.ensureGitlabRunning());
+```
+
+- [ ] **Step 4: Migrate line 1244 (slack.oauth)**
+
+Find:
+
+```ts
+    await this.ensureIfVaultKeyNonEmpty("slack.oauth", () => this.ensureSlackRunning());
+```
+
+Replace with:
+
+```ts
+    await this.ensureIfConnectorSecretSet("slack", "oauth", () => this.ensureSlackRunning());
+```
+
+- [ ] **Step 5: Migrate line 1245 (linear.api_key)**
+
+Find:
+
+```ts
+    await this.ensureIfVaultKeyNonEmpty("linear.api_key", () => this.ensureLinearRunning());
+```
+
+Replace with:
+
+```ts
+    await this.ensureIfConnectorSecretSet("linear", "api_key", () => this.ensureLinearRunning());
+```
+
+- [ ] **Step 6: Migrate line 1247 (notion.oauth)**
+
+Find:
+
+```ts
+    await this.ensureIfVaultKeyNonEmpty("notion.oauth", () => this.ensureNotionRunning());
+```
+
+Replace with:
+
+```ts
+    await this.ensureIfConnectorSecretSet("notion", "oauth", () => this.ensureNotionRunning());
+```
+
+- [ ] **Step 7: Confirm zero residual references**
+
+```bash
+git grep -n "ensureIfVaultKeyNonEmpty" -- packages/
+```
+
+Expected: empty output (no hits).
+
+### Task 6: Migrate the 6 direct `vault.get` read sites
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/lazy-mesh.ts` (lines 488, 502, 677, 714, 826, 902)
+
+- [ ] **Step 1: Migrate line 488 (newrelic.api_key — preserves `?.trim() ?? ""`)**
+
+Find:
+
+```ts
+    const nrKey = (await this.vault.get("newrelic.api_key"))?.trim() ?? "";
+```
+
+Replace with:
+
+```ts
+    const nrKey = (await readConnectorSecret(this.vault, "newrelic", "api_key"))?.trim() ?? "";
+```
+
+- [ ] **Step 2: Migrate line 502 (datadog.api_key — preserves `?.trim() ?? ""`)**
+
+Find:
+
+```ts
+    const ddKey = (await this.vault.get("datadog.api_key"))?.trim() ?? "";
+```
+
+Replace with:
+
+```ts
+    const ddKey = (await readConnectorSecret(this.vault, "datadog", "api_key"))?.trim() ?? "";
+```
+
+(Note: line 503 — `datadog.app_key` — is **not** flagged by D11's regex and is **not** in scope for Bucket C. Do not touch it.)
+
+- [ ] **Step 3: Migrate line 677 (github.pat)**
+
+Find:
+
+```ts
+    const pat = await this.vault.get("github.pat");
+```
+
+Replace with:
+
+```ts
+    const pat = await readConnectorSecret(this.vault, "github", "pat");
+```
+
+- [ ] **Step 4: Migrate line 714 (gitlab.pat)**
+
+Find:
+
+```ts
+    const pat = await this.vault.get("gitlab.pat");
+```
+
+Replace with:
+
+```ts
+    const pat = await readConnectorSecret(this.vault, "gitlab", "pat");
+```
+
+- [ ] **Step 5: Migrate line 826 (linear.api_key)**
+
+Find:
+
+```ts
+    const apiKey = await this.vault.get("linear.api_key");
+```
+
+Replace with:
+
+```ts
+    const apiKey = await readConnectorSecret(this.vault, "linear", "api_key");
+```
+
+- [ ] **Step 6: Migrate line 902 (notion.oauth)**
+
+Find:
+
+```ts
+    const raw = await this.vault.get("notion.oauth");
+```
+
+Replace with:
+
+```ts
+    const raw = await readConnectorSecret(this.vault, "notion", "oauth");
+```
+
+### Task 7: Verify PR 1 acceptance criteria
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Audit count must drop to 9 (rpc-handlers only)**
+
+```bash
+bun run audit:invariants 2>&1 | grep "D11" | wc -l
+```
+
+Expected: `9`.
+
+- [ ] **Step 2: No D11 hits in lazy-mesh.ts**
+
+```bash
+bun run audit:invariants 2>&1 | grep "lazy-mesh"
+```
+
+Expected: empty output.
+
+- [ ] **Step 3: Frozen-count test still green**
+
+```bash
+bun test scripts/structure-audit/check-nimbus-invariants.test.ts
+```
+
+Expected: pass — `VAULT_KEY_ALLOW_LIST has exactly 5 entries` confirms.
+
+- [ ] **Step 4: Connector-vault tests pass (8 cases)**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: 8 pass / 0 fail / 11 expect() calls.
+
+- [ ] **Step 5: Lazy-mesh regression suite passes**
+
+```bash
+bun test packages/gateway/src/connectors/lazy-mesh.test.ts
+```
+
+Expected: existing pass count unchanged.
+
+- [ ] **Step 6: Whole-repo typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Lint**
+
+```bash
+bun run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 8: CI parity (the user's enforced pre-push check)**
+
+```bash
+bun run test:ci
+```
+
+Expected: all green. This is the final gate before pushing.
+
+### Task 8: Commit + push + open PR 1
+
+**Files:** none (git ops)
+
+- [ ] **Step 1: Stage the changes**
+
+```bash
+git add packages/gateway/src/connectors/connector-vault.ts \
+        packages/gateway/src/connectors/connector-vault.test.ts \
+        packages/gateway/src/connectors/lazy-mesh.ts
+```
+
+- [ ] **Step 2: Verify nothing else is staged**
+
+```bash
+git status
+```
+
+Expected: only the three files above are staged. No untracked or unrelated changes.
+
+- [ ] **Step 3: Commit (single atomic commit per spec § 3.5)**
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(connectors): D11 Bucket C — route lazy-mesh reads through readConnectorSecret + sharedOAuthKey
+
+Adds sharedOAuthKey() to the allow-listed connector-vault.ts and replaces
+LazyMcpMesh.ensureIfVaultKeyNonEmpty with two typed variants. Migrates 12
+read sites in lazy-mesh.ts. D11 count: 21 -> 9 (rpc-handlers only). The
+frozen 5-entry VAULT_KEY_ALLOW_LIST stays at 5.
+
+Spec: docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md
+Plan: docs/superpowers/plans/2026-05-02-d11-bucket-c.md (PR 1)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin dev/asafgolombek/d11-bucket-c-lazy-mesh
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --base main --title "refactor(connectors): D11 Bucket C — route lazy-mesh reads through readConnectorSecret + sharedOAuthKey" --body "$(cat <<'EOF'
+## Summary
+- Adds `sharedOAuthKey(provider)` + `SharedOAuthProvider` to allow-listed `connector-vault.ts`.
+- Replaces `LazyMcpMesh.ensureIfVaultKeyNonEmpty` (untyped) with `ensureIfConnectorSecretSet<S>` + `ensureIfProviderOAuthSet`.
+- Migrates 12 read sites in `lazy-mesh.ts`. D11 count drops 21 → 9 (rpc-handlers only).
+
+Bucket C closes in PR 2 (rpc-handlers writes). The frozen 5-entry `VAULT_KEY_ALLOW_LIST` is unchanged.
+
+## Test plan
+- [ ] `bun run audit:invariants` reports exactly 9 D11 hits, all in `connector-rpc-handlers.ts`.
+- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — 8 pass.
+- [ ] `bun test packages/gateway/src/connectors/lazy-mesh.test.ts` — regression check.
+- [ ] `bun run typecheck` clean.
+- [ ] `bun run lint` clean.
+- [ ] `bun run test:ci` clean.
+- [ ] `VAULT_KEY_ALLOW_LIST.length === 5` test still green.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 6: Wait for CI to go green, request review, merge.**
+
+Hand off to user / reviewer. Do not start PR 2 until PR 1 is merged to `main`.
+
+---
+
+## PR 2 — rpc-handlers writes + close D11
+
+**Branch:** `dev/asafgolombek/d11-bucket-c-rpc-handlers` (from `main`, **after PR 1 merges**)
+**Worktree:** `.worktrees/d11-bucket-c-rpc-handlers`
+**Commit count:** 1 (atomic)
+
+### Task 9: Set up the PR 2 worktree
+
+**Files:** none (workspace setup)
+
+- [ ] **Step 1: Confirm preconditions on `main`**
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# PR 1 merged: sharedOAuthKey is exported from connector-vault.ts
+git grep -n "export function sharedOAuthKey" packages/gateway/src/connectors/connector-vault.ts
+
+# PR #146 merged: assertEq + type pins exist in the test file
+git grep -n "function assertEq" packages/gateway/src/connectors/connector-vault.test.ts
+git grep -n "ConnectorSecretKeyOf — type pins" packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: each `git grep` returns at least one hit. If any returns empty, **stop** — a precondition is missing. Do not start PR 2 until both PR 1 and PR #146 are merged.
+
+- [ ] **Step 2: Create the worktree**
+
+```bash
+git worktree add -b dev/asafgolombek/d11-bucket-c-rpc-handlers .worktrees/d11-bucket-c-rpc-handlers main
+```
+
+- [ ] **Step 3: Verify the rpc-handlers-only count**
+
+```bash
+cd .worktrees/d11-bucket-c-rpc-handlers
+bun run audit:invariants 2>&1 | grep "D11" | wc -l
+```
+
+Expected: `9`. If the number is not 9, the plan's line-number table is stale.
+
+- [ ] **Step 4: Spot-check the 9 expected lines**
+
+```bash
+bun run audit:invariants 2>&1 | grep "connector-rpc-handlers" | awk -F'line=' '{print $2}' | awk -F: '{print $1}' | sort -n
+```
+
+Expected: `365 401 510 529 551 809 837 1020 1022` (whitespace-separated, sorted ascending).
+
+### Task 10: Write the failing `writeConnectorSecret` test (TDD red)
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/connector-vault.test.ts` (append a new describe block after the existing `sharedOAuthKey` block from PR 1; the existing `ConnectorSecretKeyOf — type pins` block stays where it is — extension happens in Task 14)
+
+- [ ] **Step 1: Update the import line at the top of the file**
+
+Find:
+
+```ts
+import { readConnectorSecret, sharedOAuthKey } from "./connector-vault.ts";
+```
+
+Replace with (note: `type ConnectorSecretKeyOf` may already be imported because PR #146 added it — check first; if so, just add `writeConnectorSecret`):
+
+```ts
+import {
+  type ConnectorSecretKeyOf,
+  readConnectorSecret,
+  sharedOAuthKey,
+  writeConnectorSecret,
+} from "./connector-vault.ts";
+```
+
+- [ ] **Step 2: Append the new describe block at the end of the file**
+
+```ts
+describe("writeConnectorSecret", () => {
+  test("writes the value under the constructed key", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "github", "pat", "ghp_test");
+    expect(await vault.get("github.pat")).toBe("ghp_test");
+  });
+
+  test("overwrites an existing value at the same key", async () => {
+    const vault = createMemoryVault();
+    await vault.set("github.pat", "old");
+    await writeConnectorSecret(vault, "github", "pat", "new");
+    expect(await vault.get("github.pat")).toBe("new");
+  });
+
+  test("stores empty string and whitespace verbatim (no validation)", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "slack", "oauth", "");
+    expect(await vault.get("slack.oauth")).toBe("");
+    await writeConnectorSecret(vault, "slack", "oauth", "  raw  ");
+    expect(await vault.get("slack.oauth")).toBe("  raw  ");
+  });
+
+  test("multi-key services write to distinct vault keys", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "datadog", "api_key", "API");
+    await writeConnectorSecret(vault, "datadog", "app_key", "APP");
+    expect(await vault.get("datadog.api_key")).toBe("API");
+    expect(await vault.get("datadog.app_key")).toBe("APP");
+  });
+
+  test("compile-time: rejects non-manifested keys", () => {
+    const vault = createMemoryVault();
+    // @ts-expect-error — github manifest is ["github.pat"].
+    void writeConnectorSecret(vault, "github", "oauth", "x");
+    // @ts-expect-error — google_drive manifest is empty.
+    void writeConnectorSecret(vault, "google_drive", "oauth", "x");
+    expect(true).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test — expect failure**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: failure citing `writeConnectorSecret` is not exported from `./connector-vault.ts`.
+
+### Task 11: Implement `writeConnectorSecret` (TDD green)
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/connector-vault.ts` (append below `readConnectorSecret`, above the Bucket-C `sharedOAuthKey` section that PR 1 added — keeping the typed read/write helpers adjacent)
+
+- [ ] **Step 1: Append the new export**
+
+Insert immediately after the `readConnectorSecret` function (which currently ends with the closing brace of the function body) and before the `// ─── Bucket-C helper: provider-shared OAuth key constructor ───` section header from PR 1:
+
+```ts
+
+/**
+ * Writes a connector's secret to the Vault by structural key name. Mirrors
+ * `readConnectorSecret`'s typing — `keyName` is constrained to
+ * `ConnectorSecretKeyOf<S>`, so misspelled or non-manifested keys fail at
+ * compile time. Returns `void` (mirrors `vault.set`).
+ */
+export async function writeConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+  value: string,
+): Promise<void> {
+  const fullKey = `${serviceId}.${keyName}`;
+  return vault.set(fullKey, value);
+}
+```
+
+- [ ] **Step 2: Run the test — expect green**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: 13 pass / 0 fail (5 readConnectorSecret + 3 sharedOAuthKey + 5 writeConnectorSecret). Type-pins block from PR #146 contributes 1 pass on top of those.
+
+- [ ] **Step 3: Whole-repo typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: clean.
+
+### Task 12: Migrate the 9 `connector-rpc-handlers.ts` sites
+
+**Files:**
+- Modify: `packages/gateway/src/ipc/connector-rpc-handlers.ts` (import block at line 20, plus 9 site changes at lines 365, 401, 510, 529, 551, 809, 837, 1020, 1022)
+
+- [ ] **Step 1: Update the import block**
+
+Find (currently lines 20–24):
+
+```ts
+import {
+  ALL_GOOGLE_OAUTH_VAULT_KEYS,
+  clearOAuthVaultIfProviderUnused,
+  writePerServiceOAuthKey,
+} from "../connectors/connector-vault.ts";
+```
+
+Replace with (alphabetical):
+
+```ts
+import {
+  ALL_GOOGLE_OAUTH_VAULT_KEYS,
+  clearOAuthVaultIfProviderUnused,
+  sharedOAuthKey,
+  writeConnectorSecret,
+  writePerServiceOAuthKey,
+} from "../connectors/connector-vault.ts";
+```
+
+- [ ] **Step 2: Migrate line 365 (microsoft shared OAuth read)**
+
+Find:
+
+```ts
+  return await vault.get("microsoft.oauth");
+```
+
+Replace with:
+
+```ts
+  return await vault.get(sharedOAuthKey("microsoft"));
+```
+
+- [ ] **Step 3: Migrate line 401 (microsoft shared OAuth restore on remove)**
+
+Find:
+
+```ts
+    await vault.set("microsoft.oauth", microsoftOAuthBackup);
+```
+
+Replace with:
+
+```ts
+    await vault.set(sharedOAuthKey("microsoft"), microsoftOAuthBackup);
+```
+
+- [ ] **Step 4: Migrate line 510 (github.pat write)**
+
+Find:
+
+```ts
+  await vault.set("github.pat", token);
+```
+
+Replace with:
+
+```ts
+  await writeConnectorSecret(vault, "github", "pat", token);
+```
+
+- [ ] **Step 5: Migrate line 529 (gitlab.pat write)**
+
+Find:
+
+```ts
+  await vault.set("gitlab.pat", token);
+```
+
+Replace with:
+
+```ts
+  await writeConnectorSecret(vault, "gitlab", "pat", token);
+```
+
+(Note: line 532 — `gitlab.api_base` — is **not** flagged by the D11 regex and is **not** in scope. Do not touch it.)
+
+- [ ] **Step 6: Migrate line 551 (linear.api_key write)**
+
+Find:
+
+```ts
+  await vault.set("linear.api_key", token);
+```
+
+Replace with:
+
+```ts
+  await writeConnectorSecret(vault, "linear", "api_key", token);
+```
+
+- [ ] **Step 7: Migrate line 809 (newrelic.api_key write)**
+
+Find:
+
+```ts
+  await vault.set("newrelic.api_key", token);
+```
+
+Replace with:
+
+```ts
+  await writeConnectorSecret(vault, "newrelic", "api_key", token);
+```
+
+(Note: line 813/815 — `newrelic.account_id` — is **not** in scope.)
+
+- [ ] **Step 8: Migrate line 837 (datadog.api_key write)**
+
+Find:
+
+```ts
+  await vault.set("datadog.api_key", api);
+```
+
+Replace with:
+
+```ts
+  await writeConnectorSecret(vault, "datadog", "api_key", api);
+```
+
+(Note: line 838 — `datadog.app_key` — and lines 842/844 — `datadog.site` — are **not** in scope.)
+
+- [ ] **Step 9: Migrate lines 1020 / 1022 (sharedKey assignments)**
+
+Find:
+
+```ts
+  let sharedKey: string | undefined;
+  if (profile.provider === "google") {
+    sharedKey = "google.oauth";
+  } else if (profile.provider === "microsoft") {
+    sharedKey = "microsoft.oauth";
+  }
+```
+
+Replace with:
+
+```ts
+  let sharedKey: string | undefined;
+  if (profile.provider === "google") {
+    sharedKey = sharedOAuthKey("google");
+  } else if (profile.provider === "microsoft") {
+    sharedKey = sharedOAuthKey("microsoft");
+  }
+```
+
+(`sharedOAuthKey(...)` returns `"google.oauth" | "microsoft.oauth"`, assignable to `string | undefined` — no widening cast needed. Verified in spec § 4.4.)
+
+### Task 13: Verify PR 2 audit-level acceptance criteria
+
+**Files:** none (verification)
+
+- [ ] **Step 1: D11 count is now 0**
+
+```bash
+bun run audit:invariants 2>&1 | grep "D11" | wc -l
+```
+
+Expected: `0`.
+
+- [ ] **Step 2: Audit script exits 0**
+
+```bash
+bun run audit:invariants
+echo "exit=$?"
+```
+
+Expected: `exit=0`. **D11 closed.**
+
+- [ ] **Step 3: Frozen-count test still green**
+
+```bash
+bun test scripts/structure-audit/check-nimbus-invariants.test.ts
+```
+
+Expected: pass — allow-list is still exactly 5.
+
+### Task 14: Extend the type-pin block
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/connector-vault.test.ts` (the existing `ConnectorSecretKeyOf — type pins` describe block added by PR #146)
+
+- [ ] **Step 1: Locate the existing pin block**
+
+```bash
+git grep -n "ConnectorSecretKeyOf — type pins" packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: one hit on the line that opens the describe block (e.g. `describe("ConnectorSecretKeyOf — type pins", () => {`).
+
+- [ ] **Step 2: Inside that block's existing `test("pins to manifest-derived bare-key suffixes (compile-time)", () => {` body, immediately after the existing assertEq lines for read-side pinning and before the closing `expect(true).toBe(true);` line, append**
+
+```ts
+    // writeConnectorSecret keyName must accept the same union as readConnectorSecret.
+    assertEq<Parameters<typeof writeConnectorSecret<"github">>[2], "pat">(true);
+    assertEq<
+      Parameters<typeof writeConnectorSecret<"datadog">>[2],
+      "api_key" | "app_key" | "site"
+    >(true);
+
+    // sharedOAuthKey signature pins.
+    assertEq<Parameters<typeof sharedOAuthKey>[0], "google" | "microsoft">(true);
+    assertEq<ReturnType<typeof sharedOAuthKey>, "google.oauth" | "microsoft.oauth">(true);
+```
+
+- [ ] **Step 3: Run the test file**
+
+```bash
+bun test packages/gateway/src/connectors/connector-vault.test.ts
+```
+
+Expected: 14 pass / 0 fail (1 type-pin test, 5 read, 3 sharedOAuthKey, 5 write — total tests count varies by how `bun:test` reports describe-grouped tests; the important assertion is "0 fail").
+
+### Task 15: Refresh the audit baseline
+
+**Files:**
+- Modify: `docs/structure-audit/baseline.md` (update the D11 table row + append a dated Phase-2 follow-up section)
+
+- [ ] **Step 1: Update the D11 row in the "Per-dimension baselines" table**
+
+Find:
+
+```markdown
+| D11 | F | Vault-key construction outside allow-list | 56 violations | `bun run audit:invariants` (binary) |
+```
+
+Replace with:
+
+```markdown
+| D11 | F | Vault-key construction outside allow-list | 0 violations (D11 closed 2026-05-02) | `bun run audit:invariants` (binary) |
+```
+
+(The `56 violations` figure was the Phase 1 frozen baseline. Closing D11 supersedes it; the in-table value tracks the current state, while incremental ratchet history lives in the "Phase 2 follow-up" sections below.)
+
+- [ ] **Step 2: Append a new follow-up section recording the closure**
+
+The existing "## Phase 2 follow-up — post Bucket B (2026-05-01)" section is a 2026-05-01 historical record of the Bucket-B ratchet. Leave it untouched (do **not** edit the "deferred" wording or the headline number — that section is a snapshot of what was true on that date).
+
+Insert a new section immediately after the existing post-Bucket-B section and before the `## Provenance` heading:
+
+```markdown
+## Phase 2 follow-up — post Bucket C (2026-05-02)
+
+D11 violations reduced from the post-Bucket-B count of 21 to **0**. **D11 closed.**
+
+- Bucket C (21 sites in `lazy-mesh.ts` + `connector-rpc-handlers.ts`) — routed through `readConnectorSecret`, `writeConnectorSecret`, and `sharedOAuthKey` (PR <PR-2-number>).
+
+The frozen 5-entry `VAULT_KEY_ALLOW_LIST` was unchanged across Buckets B and C.
+```
+
+Replace `<PR-2-number>` with the actual PR number once `gh pr create` returns it (Task 17 Step 5).
+
+- [ ] **Step 3: Verify the diff is the two edits above and nothing else**
+
+```bash
+git diff docs/structure-audit/baseline.md
+```
+
+Expected: one row changed in the table, one new H2 section appended; no edits to the Bucket-B section, the Provenance section, or the thresholds section.
+
+### Task 16: Final whole-repo verification
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Whole-repo typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 2: Lint**
+
+```bash
+bun run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 3: rpc-handlers / connector regression tests**
+
+Locate which test file(s) cover `connector-rpc-handlers.ts` and run them:
+
+```bash
+git grep -l "connector-rpc-handlers\|connectorAuthGithub\|connectorAuthDatadog" -- packages/gateway/src/ | grep -E "\.test\.ts$"
+```
+
+Then run each hit:
+
+```bash
+bun test <each-test-path>
+```
+
+Expected: existing pass count unchanged (zero new regressions).
+
+- [ ] **Step 4: CI parity (the user's enforced pre-push check per memory `feedback_preflight_before_pr.md`)**
+
+```bash
+bun run test:ci
+```
+
+Expected: all green.
+
+### Task 17: Commit + push + open PR 2
+
+**Files:** none (git ops)
+
+- [ ] **Step 1: Stage the changes**
+
+```bash
+git add packages/gateway/src/connectors/connector-vault.ts \
+        packages/gateway/src/connectors/connector-vault.test.ts \
+        packages/gateway/src/ipc/connector-rpc-handlers.ts \
+        docs/structure-audit/baseline.md
+```
+
+- [ ] **Step 2: Verify nothing else is staged**
+
+```bash
+git status
+```
+
+Expected: only the four files above are staged.
+
+- [ ] **Step 3: Single atomic commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(ipc): D11 Bucket C — add writeConnectorSecret + close D11 (0 violations)
+
+Adds writeConnectorSecret<S> to connector-vault.ts and migrates 9 sites in
+connector-rpc-handlers.ts (6 writes via writeConnectorSecret, 1 read + 2
+sharedKey assignments via sharedOAuthKey). D11 count: 9 -> 0. The frozen
+5-entry VAULT_KEY_ALLOW_LIST stays at 5. Updates audit baseline to record
+Bucket C closure.
+
+Spec: docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md
+Plan: docs/superpowers/plans/2026-05-02-d11-bucket-c.md (PR 2)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin dev/asafgolombek/d11-bucket-c-rpc-handlers
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --base main --title "refactor(ipc): D11 Bucket C — add writeConnectorSecret + close D11 (0 violations)" --body "$(cat <<'EOF'
+## Summary
+- Adds `writeConnectorSecret<S>(vault, serviceId, keyName, value)` to `connector-vault.ts` (mirrors `readConnectorSecret` typing).
+- Migrates 9 sites in `connector-rpc-handlers.ts` (6 writes via `writeConnectorSecret`, 2 sharedKey assignments + 1 read via `sharedOAuthKey`).
+- D11 count: 9 → **0**. **Bucket C closed.**
+- Updates `docs/structure-audit/baseline.md` to record the closure.
+
+The frozen 5-entry `VAULT_KEY_ALLOW_LIST` is unchanged.
+
+## Test plan
+- [ ] `bun run audit:invariants` exits 0; reports 0 D11 hits.
+- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — all green (read + sharedOAuthKey + write + type pins extended).
+- [ ] `connector-rpc-handlers` regression tests still green.
+- [ ] `bun run typecheck` clean.
+- [ ] `bun run lint` clean.
+- [ ] `bun run test:ci` clean.
+- [ ] `VAULT_KEY_ALLOW_LIST.length === 5` test still green.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 6: Wait for CI to go green, request review, merge.**
+
+After merge: D11 is closed. Optionally clean up worktrees:
+
+```bash
+git worktree remove .worktrees/d11-bucket-c-lazy-mesh
+git worktree remove .worktrees/d11-bucket-c-rpc-handlers
+git push origin --delete dev/asafgolombek/d11-bucket-c-lazy-mesh
+git push origin --delete dev/asafgolombek/d11-bucket-c-rpc-handlers
+```
+
+(Worktree cleanup is a courtesy step; some users prefer to keep merged branches locally.)
+
+---
+
+## Review dispositions (2026-05-02 Gemini CLI review)
+
+Recorded for traceability. Source: [`2026-05-02-d11-bucket-c-review.md`](./2026-05-02-d11-bucket-c-review.md).
+
+- **§ 2.1 — Add `readSharedOAuth` / `writeSharedOAuth` wrapper helpers → DEFER (decline).** This contradicts the spec's § 2 Non-goals, which explicitly rejects these wrappers as YAGNI ("would be one-line passthroughs to `vault.get(sharedOAuthKey(provider))` / `vault.set(sharedOAuthKey(provider), value)`"). The plan executes the spec; it cannot adopt a non-goal the spec excluded by name. Revisiting would require a spec amendment first, not a plan edit. Re-open if a future caller surfaces a shape these wrappers would simplify (none currently exists — the only shared-OAuth read/write sites are Tasks 12 Steps 2/3, both single-line).
+- **§ 2.2 — Concrete baseline edit text → ACCEPT (with correction).** Task 15 was previously hand-wavy because I had not read `baseline.md`. Now applied verbatim **except** for the section-replacement vs. section-append decision: the reviewer's draft replaces the existing 2026-05-01 post-Bucket-B section, which would erase a dated historical record. The accepted edit instead leaves the post-Bucket-B section intact and appends a new dated post-Bucket-C section recording D11 = 0. Same end-state, preserved provenance. See Task 15 Steps 1–3.
+- **§ 2.3 — Inline `sharedOAuthKey(profile.provider)` at Task 12 Step 9 → NO CHANGE.** The reviewer self-cancels: "keeping it explicit as proposed is safer and follows the existing pattern." The plan's `if/else if` form stays.
+- **§ 3 Q&A — Does `sharedOAuthKey` still need export? → MOOT.** The question is conditional on accepting § 2.1. Since § 2.1 is declined, the export is unambiguously required by Task 12 Step 9 regardless. No change.
+
+## Self-review notes
+
+- **Spec coverage:** every spec section has a task. § 3.1 → Task 3. § 3.2 → Task 4. § 3.3 (12 sites) → Tasks 5+6 (6 helper + 6 direct reads). § 3.4 (imports) → Task 4 step 3. § 3.5 (single commit) → Task 8. § 4.1 → Task 11. § 4.2 (9 sites) → Task 12. § 4.3 (imports) → Task 12 step 1. § 4.4 (sharedKey type compatibility) → Task 12 step 9 inline note. § 4.5 (single commit) → Task 17. § 5.1 (3 cases) → Task 2. § 5.2 (regression check) → Task 7 step 5. § 5.3 (5 cases) → Task 10. § 5.4 (type pins extension) → Task 14. § 5.5 (coverage) — implicit; no new gate row needed. § 6 (acceptance) → Tasks 7 and 13/16. § 7 (rollout) → Tasks 1 and 9. § 8 (out of scope) — explicit non-instructions in Tasks 6 step 2, 12 steps 5/7/8.
+- **Out-of-scope guardrails:** The spec calls out three items — `datadog.app_key` (line 503 read, 838 write), `gitlab.api_base` (line 532 write), `newrelic.account_id` (lines 813/815). Each gets an explicit "do not touch" note at the corresponding migration step.
+- **Type compatibility callouts:** `sharedOAuthKey` returns `"google.oauth" | "microsoft.oauth"`, assignable to `string | undefined` (Task 12 step 9) and to `string` at the `vault.get`/`vault.set` boundary. No widening casts required anywhere.
+- **PR ordering precondition:** PR 2's Task 14 reuses the `assertEq` helper from PR #146 — Task 9 step 1 explicitly verifies that helper exists on `main` before allowing PR 2 to start.

--- a/docs/superpowers/specs/2026-05-02-d11-bucket-c-design-review.md
+++ b/docs/superpowers/specs/2026-05-02-d11-bucket-c-design-review.md
@@ -1,0 +1,74 @@
+# D11 Bucket C — `writeConnectorSecret` + `sharedOAuthKey` — Design Review
+
+**Reviewer:** Gemini CLI
+**Date:** 2026-05-02
+**Status:** ✅ Approved with minor suggestions
+
+---
+
+## 1 — Executive Summary
+
+The proposed design for D11 Bucket C is technically sound and follows the established patterns from Bucket B ([#145](https://github.com/asafgolombek/Nimbus/pull/145)). It correctly identifies all remaining 21 D11 violation sites and provides a robust path to closing the D11 invariant entirely (0 violations).
+
+## 2 — Strengths
+
+- **Symmetry:** `writeConnectorSecret` perfectly mirrors `readConnectorSecret`, including the recursive `ConnectorSecretKeyOf<S>` type pinning.
+- **Refinement in `LazyMcpMesh`:** Replacing the generic `ensureIfVaultKeyNonEmpty(string)` with typed `ensureIfConnectorSecretSet` and `ensureIfProviderOAuthSet` significantly improves type safety in one of the gateway's most sensitive components.
+- **Atomic Rollout:** The two-PR strategy minimizes the "interim" state where the audit count is non-zero, and the post-PR-2 target of 0 is clear and verifiable.
+
+## 3 — Suggestions & Improvements
+
+### 3.1 Symmetry: `readSharedOAuth` and `writeSharedOAuth`
+
+The spec currently leaves callers to compose `vault.get(sharedOAuthKey(provider))`. While functional, I suggest adding explicit reader/writer helpers for shared keys for better encapsulation:
+
+```ts
+/** Reads a provider-shared OAuth token (e.g. google.oauth). */
+export async function readSharedOAuth(
+  vault: NimbusVault,
+  provider: SharedOAuthProvider
+): Promise<string | null> {
+  return vault.get(sharedOAuthKey(provider));
+}
+
+/** Writes a provider-shared OAuth token. */
+export async function writeSharedOAuth(
+  vault: NimbusVault,
+  provider: SharedOAuthProvider,
+  value: string
+): Promise<void> {
+  return vault.set(sharedOAuthKey(provider), value);
+}
+```
+
+This prevents callers from needing to know which `vault` method to use and keeps the string construction entirely internal to `connector-vault.ts`.
+
+### 3.2 Tighter Return Type for `sharedOAuthKey`
+
+The spec proposes returning `string`. I suggest returning the literal union:
+
+```ts
+export function sharedOAuthKey(provider: SharedOAuthProvider): `${SharedOAuthProvider}.oauth` {
+  return `${provider}.oauth` as `${SharedOAuthProvider}.oauth`;
+}
+```
+
+Since `vault.get`/`set` take `string`, no widening cast is required at the call site, but this provides better type information for any internal logic that might inspect these keys.
+
+## 4 — Verification of Violation Sites
+
+I have verified the sites mentioned in the spec against the current codebase:
+
+- **`lazy-mesh.ts` (12 sites):** Confirmed 6 direct `vault.get` calls and 6 `ensureIfVaultKeyNonEmpty` calls (which themselves pass raw strings). Total 12 matches.
+- **`connector-rpc-handlers.ts` (9 sites):** Confirmed 7 `vault.get/set` calls and 2 assignments to `sharedKey` (lines 1020, 1022). Total 9 matches.
+
+The `sharedKey` local at `connector-rpc-handlers.ts:1018` is typed as `string | undefined`, so the proposed assignment `sharedKey = sharedOAuthKey("google");` is perfectly compatible.
+
+## 5 — Questions
+
+- **Q:** Should `SharedOAuthProvider` eventually be derived from the `CONNECTOR_VAULT_SECRET_KEYS` manifest?
+  - **A:** Probably not, as `google.oauth` and `microsoft.oauth` are "provider-level" and the manifest is "service-level". The current manual enum in `connector-vault.ts` is the correct home for these.
+
+## 6 — Conclusion
+
+The design is ready for implementation. Closing D11 will be a major milestone for the B3 structure audit.

--- a/docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md
+++ b/docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md
@@ -1,0 +1,330 @@
+# D11 Bucket C — `writeConnectorSecret` + `sharedOAuthKey`
+
+**Date:** 2026-05-02
+**Phase:** Phase 4 / B3 structure audit — Phase 2 follow-up (Bucket C)
+**Source:** [`docs/structure-audit/missed.md`](../../structure-audit/missed.md) "D11 Bucket C" rows; [`docs/structure-audit/deferred-backlog.md`](../../structure-audit/deferred-backlog.md) "D11 — vault-key centralization (Bucket C)"
+**Predecessor specs:**
+- [`2026-04-30-structure-audit-design.md`](./2026-04-30-structure-audit-design.md)
+- [`2026-05-01-d11-bucket-b-readConnectorSecret-design.md`](./2026-05-01-d11-bucket-b-readConnectorSecret-design.md)
+**Predecessor PRs:** [#145](https://github.com/asafgolombek/Nimbus/pull/145) (Bucket B), [#146](https://github.com/asafgolombek/Nimbus/pull/146) (type pinning)
+
+---
+
+## 1 — Goal
+
+Eliminate the remaining 21 D11 violations (Bucket C) in two PRs, closing D11 entirely.
+
+**Pre-PR audit count (verified live with `bun run audit:invariants`):** 21 D11 violations, all in Bucket C.
+- 12 sites in `packages/gateway/src/connectors/lazy-mesh.ts` — all reads.
+- 9 sites in `packages/gateway/src/ipc/connector-rpc-handlers.ts` — 6 writes + 1 read + 2 sharedKey assignments.
+
+**Post-PR-2 audit count target:** **0**. D11 closed.
+
+After both PRs:
+- All vault-key construction lives inside `connector-vault.ts` (entry #1 of the frozen 5-entry `VAULT_KEY_ALLOW_LIST`).
+- Per-service reads + writes flow through typed `readConnectorSecret` / `writeConnectorSecret` helpers.
+- Provider-shared OAuth keys flow through `sharedOAuthKey(provider)`.
+- The frozen-count test stays green (no allow-list entries added).
+
+## 2 — Non-goals
+
+- **Widening `VAULT_KEY_RE` or making it manifest-derived.** Deferred to its own follow-up spec after Bucket C closes (per Bucket B spec § 9). The regex change has independent design dimensions (which key suffixes count as "secret"? manifest-derived vs. enumerated?) that warrant a separate brainstorm. Bundling here would risk re-firing on Bucket C lines mid-implementation.
+- **No new allow-list entries.** The frozen 5-entry list stays at 5; the Task-3 length-assertion test stays green throughout.
+- **No `readSharedOAuth(vault, provider)` / `writeSharedOAuth(vault, provider, value)` wrappers.** Just `sharedOAuthKey(provider)` — callers compose with `vault.get` / `vault.set` directly. The wrapper-helper variant would be one-line passthroughs to those expressions; YAGNI.
+- **No change to `vault.delete` semantics, the `CONNECTOR_VAULT_SECRET_KEYS` manifest shape, or any caller's surrounding null/empty/trim guard logic.**
+- **No structural refactor of `lazy-mesh.ts` or `connector-rpc-handlers.ts`.** Both are large hot files (1408 / 1103 LOC) flagged for D4 split. Targeted Bucket C migration only; the splits are separate refactor candidates tracked in `deferred-backlog.md`.
+
+## 3 — PR 1: lazy-mesh reads
+
+### 3.1 New export from `connector-vault.ts`
+
+```ts
+export type SharedOAuthProvider = "google" | "microsoft";
+
+/**
+ * Returns the provider-shared OAuth vault key (`google.oauth` or `microsoft.oauth`).
+ * Used when the caller is operating on the provider-wide token rather than
+ * a per-service token. The literal lives inside this allow-listed file,
+ * so D11 doesn't fire at the call site.
+ */
+export function sharedOAuthKey(
+  provider: SharedOAuthProvider,
+): `${SharedOAuthProvider}.oauth` {
+  return `${provider}.oauth`;
+}
+```
+
+Returns the literal union `` `${SharedOAuthProvider}.oauth` `` (i.e. `"google.oauth" | "microsoft.oauth"`) — TypeScript's template-literal inference resolves the body's `` `${provider}.oauth` `` to that exact union. The narrower return type matches the pattern set by `readConnectorSecret`/`writeConnectorSecret` (helpers return what their underlying op produces) and is implicitly assignable to `string` at the `vault.get`/`vault.set` boundary, so no widening cast is required at any call site.
+
+### 3.2 Two new typed methods on `LazyMcpMesh`
+
+The existing private method:
+
+```ts
+private async ensureIfVaultKeyNonEmpty(key: string, runner: () => Promise<void>): Promise<void> {
+  const value = await this.vault.get(key);
+  if (value !== null && value !== "") await runner();
+}
+```
+
+…is removed and replaced by two typed methods:
+
+```ts
+private async ensureIfConnectorSecretSet<S extends ConnectorServiceId>(
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+  runner: () => Promise<void>,
+): Promise<void> {
+  const value = await readConnectorSecret(this.vault, serviceId, keyName);
+  if (value !== null && value !== "") await runner();
+}
+
+private async ensureIfProviderOAuthSet(
+  provider: SharedOAuthProvider,
+  runner: () => Promise<void>,
+): Promise<void> {
+  const value = await this.vault.get(sharedOAuthKey(provider));
+  if (value !== null && value !== "") await runner();
+}
+```
+
+Implementer must `git grep ensureIfVaultKeyNonEmpty -- packages/` before deletion to confirm the 6 call sites in §3.3 are the only callers.
+
+### 3.3 Migration table (12 sites in `lazy-mesh.ts`)
+
+| Lines | Before | After |
+|---|---|---|
+| 488 | `(await this.vault.get("newrelic.api_key"))?.trim() ?? ""` | `(await readConnectorSecret(this.vault, "newrelic", "api_key"))?.trim() ?? ""` |
+| 502 | `(await this.vault.get("datadog.api_key"))?.trim() ?? ""` | `(await readConnectorSecret(this.vault, "datadog", "api_key"))?.trim() ?? ""` |
+| 677 | `await this.vault.get("github.pat")` | `await readConnectorSecret(this.vault, "github", "pat")` |
+| 714 | `await this.vault.get("gitlab.pat")` | `await readConnectorSecret(this.vault, "gitlab", "pat")` |
+| 826 | `await this.vault.get("linear.api_key")` | `await readConnectorSecret(this.vault, "linear", "api_key")` |
+| 902 | `await this.vault.get("notion.oauth")` | `await readConnectorSecret(this.vault, "notion", "oauth")` |
+| 1238 | `this.ensureIfVaultKeyNonEmpty("microsoft.oauth", () => …)` | `this.ensureIfProviderOAuthSet("microsoft", () => …)` |
+| 1241 | `this.ensureIfVaultKeyNonEmpty("github.pat", () => this.ensureGithubRunning())` | `this.ensureIfConnectorSecretSet("github", "pat", () => this.ensureGithubRunning())` |
+| 1242 | `this.ensureIfVaultKeyNonEmpty("gitlab.pat", …)` | `this.ensureIfConnectorSecretSet("gitlab", "pat", …)` |
+| 1244 | `this.ensureIfVaultKeyNonEmpty("slack.oauth", …)` | `this.ensureIfConnectorSecretSet("slack", "oauth", …)` |
+| 1245 | `this.ensureIfVaultKeyNonEmpty("linear.api_key", …)` | `this.ensureIfConnectorSecretSet("linear", "api_key", …)` |
+| 1247 | `this.ensureIfVaultKeyNonEmpty("notion.oauth", …)` | `this.ensureIfConnectorSecretSet("notion", "oauth", …)` |
+
+Surrounding `(await ...)?.trim() ?? ""` parenthesisation, null/empty checks, and call-runner control flow stay byte-identical.
+
+### 3.4 Imports in `lazy-mesh.ts`
+
+```ts
+import { readConnectorSecret, sharedOAuthKey } from "./connector-vault.ts";
+```
+
+Plus the type import for the new method signatures (may already exist):
+
+```ts
+import type { ConnectorSecretKeyOf } from "./connector-vault.ts";
+import type { ConnectorServiceId } from "./connector-catalog.ts";
+```
+
+Verify the existing imports during implementation; only add what's missing.
+
+### 3.5 Single PR-1 commit
+
+All 12 sites + the two new methods + the helper-method removal land in one commit so HEAD stays green.
+
+**Post-PR-1 D11 count:** 21 − 12 = **9** (rpc-handlers only).
+
+## 4 — PR 2: rpc-handlers writes
+
+### 4.1 New export from `connector-vault.ts`
+
+```ts
+/**
+ * Writes a connector's secret to the Vault by structural key name.
+ * Mirrors `readConnectorSecret`'s typing — `keyName` is constrained to
+ * `ConnectorSecretKeyOf<S>`, so misspelled or non-manifested keys fail
+ * at compile time. Returns `void` (mirrors `vault.set`).
+ */
+export async function writeConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+  value: string,
+): Promise<void> {
+  const fullKey = `${serviceId}.${keyName}`;
+  return vault.set(fullKey, value);
+}
+```
+
+`sharedOAuthKey` is reused from PR 1.
+
+### 4.2 Migration table (9 sites in `connector-rpc-handlers.ts`)
+
+| Line | Before | After |
+|---|---|---|
+| 365 | `return await vault.get("microsoft.oauth")` | `return await vault.get(sharedOAuthKey("microsoft"))` |
+| 401 | `await vault.set("microsoft.oauth", microsoftOAuthBackup)` | `await vault.set(sharedOAuthKey("microsoft"), microsoftOAuthBackup)` |
+| 510 | `await vault.set("github.pat", token)` | `await writeConnectorSecret(vault, "github", "pat", token)` |
+| 529 | `await vault.set("gitlab.pat", token)` | `await writeConnectorSecret(vault, "gitlab", "pat", token)` |
+| 551 | `await vault.set("linear.api_key", token)` | `await writeConnectorSecret(vault, "linear", "api_key", token)` |
+| 809 | `await vault.set("newrelic.api_key", token)` | `await writeConnectorSecret(vault, "newrelic", "api_key", token)` |
+| 837 | `await vault.set("datadog.api_key", api)` | `await writeConnectorSecret(vault, "datadog", "api_key", api)` |
+| 1020 | `sharedKey = "google.oauth";` | `sharedKey = sharedOAuthKey("google");` |
+| 1022 | `sharedKey = "microsoft.oauth";` | `sharedKey = sharedOAuthKey("microsoft");` |
+
+### 4.3 Imports in `connector-rpc-handlers.ts`
+
+```ts
+import { sharedOAuthKey, writeConnectorSecret } from "../connectors/connector-vault.ts";
+```
+
+### 4.4 `sharedKey` variable type compatibility
+
+Lines 1020/1022 assign to a local variable `sharedKey`, declared at line 1018 as `string | undefined` (verified by review). `sharedOAuthKey(...)` returns `"google.oauth" | "microsoft.oauth"`, which is assignable to `string | undefined` — no typecheck friction. No widening cast or local-type change required.
+
+### 4.5 Single PR-2 commit
+
+All 9 sites + `writeConnectorSecret` helper land in one commit.
+
+**Post-PR-2 D11 count:** 9 − 9 = **0**. Bucket C closed.
+
+## 5 — Tests
+
+Add to `packages/gateway/src/connectors/connector-vault.test.ts` (which already covers `readConnectorSecret` + `ConnectorSecretKeyOf` pinning from PR #146).
+
+### 5.1 PR 1: `sharedOAuthKey` (3 cases)
+
+```ts
+describe("sharedOAuthKey", () => {
+  test("returns google.oauth for google", () => {
+    expect(sharedOAuthKey("google")).toBe("google.oauth");
+  });
+
+  test("returns microsoft.oauth for microsoft", () => {
+    expect(sharedOAuthKey("microsoft")).toBe("microsoft.oauth");
+  });
+
+  test("compile-time: rejects non-provider strings", () => {
+    // @ts-expect-error — SharedOAuthProvider is "google" | "microsoft" only.
+    void sharedOAuthKey("github");
+    expect(true).toBe(true);
+  });
+});
+```
+
+### 5.2 PR 1: lazy-mesh regression check
+
+The existing `packages/gateway/src/connectors/lazy-mesh.test.ts` suite must pass unchanged. The two new typed methods are private and exercised through the existing public test paths. No new direct unit tests for the methods themselves — adding them would be YAGNI given they each wrap a `vault.get` + null-check.
+
+### 5.3 PR 2: `writeConnectorSecret` (5 cases)
+
+```ts
+describe("writeConnectorSecret", () => {
+  test("writes the value under the constructed key", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "github", "pat", "ghp_test");
+    expect(await vault.get("github.pat")).toBe("ghp_test");
+  });
+
+  test("overwrites an existing value at the same key", async () => {
+    const vault = createMemoryVault();
+    await vault.set("github.pat", "old");
+    await writeConnectorSecret(vault, "github", "pat", "new");
+    expect(await vault.get("github.pat")).toBe("new");
+  });
+
+  test("stores empty string and whitespace verbatim (no validation)", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "slack", "oauth", "");
+    expect(await vault.get("slack.oauth")).toBe("");
+    await writeConnectorSecret(vault, "slack", "oauth", "  raw  ");
+    expect(await vault.get("slack.oauth")).toBe("  raw  ");
+  });
+
+  test("multi-key services write to distinct vault keys", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "datadog", "api_key", "API");
+    await writeConnectorSecret(vault, "datadog", "app_key", "APP");
+    expect(await vault.get("datadog.api_key")).toBe("API");
+    expect(await vault.get("datadog.app_key")).toBe("APP");
+  });
+
+  test("compile-time: rejects non-manifested keys", () => {
+    const vault = createMemoryVault();
+    // @ts-expect-error — github manifest is ["github.pat"].
+    void writeConnectorSecret(vault, "github", "oauth", "x");
+    // @ts-expect-error — google_drive manifest is empty.
+    void writeConnectorSecret(vault, "google_drive", "oauth", "x");
+    expect(true).toBe(true);
+  });
+});
+```
+
+### 5.4 PR 2: type pins extension
+
+Extend the `ConnectorSecretKeyOf — type pins` block (added in PR #146) with pins for `writeConnectorSecret`:
+
+```ts
+// writeConnectorSecret keyName must accept the same union as readConnectorSecret.
+assertEq<Parameters<typeof writeConnectorSecret<"github">>[2], "pat">(true);
+assertEq<Parameters<typeof writeConnectorSecret<"datadog">>[2], "api_key" | "app_key" | "site">(true);
+
+// sharedOAuthKey signature pins.
+assertEq<Parameters<typeof sharedOAuthKey>[0], "google" | "microsoft">(true);
+assertEq<ReturnType<typeof sharedOAuthKey>, "google.oauth" | "microsoft.oauth">(true);
+```
+
+### 5.5 Coverage
+
+`connector-vault.ts` is in the `engine` coverage gate (≥85%). New helpers are simple passthroughs; coverage stays above threshold without new gate rows.
+
+## 6 — Acceptance criteria
+
+### PR 1 (lazy-mesh reads)
+
+- [ ] `sharedOAuthKey` and `SharedOAuthProvider` exported from `connector-vault.ts`.
+- [ ] `LazyMcpMesh.ensureIfVaultKeyNonEmpty` removed; replaced by `ensureIfConnectorSecretSet<S>` and `ensureIfProviderOAuthSet`.
+- [ ] `git grep ensureIfVaultKeyNonEmpty -- packages/` returns zero hits.
+- [ ] All 12 sites in §3.3 routed through the new helpers/methods.
+- [ ] `bun run audit:invariants 2>&1 | grep -c "D11"` reports **9** (Bucket C rpc-handlers only).
+- [ ] `bun run audit:invariants 2>&1 | grep "lazy-mesh"` returns no output.
+- [ ] `bun test packages/gateway/src/connectors/lazy-mesh.test.ts` passes (regression check).
+- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` passes (sharedOAuthKey tests added).
+- [ ] Whole-repo `bun run typecheck` clean.
+- [ ] `bun run lint` clean.
+- [ ] `bun run test:ci` clean (Ubuntu CI parity).
+- [ ] `VAULT_KEY_ALLOW_LIST.length === 5` test still passes.
+
+### PR 2 (rpc-handlers writes)
+
+- [ ] `writeConnectorSecret` exported from `connector-vault.ts` with the typed signature in §4.1.
+- [ ] All 9 sites in §4.2 routed through the new helpers.
+- [ ] `bun run audit:invariants 2>&1 | grep -c "D11"` reports **0**.
+- [ ] `bun run audit:invariants` exits 0. **D11 closed.**
+- [ ] `connector-rpc-handlers` regression tests still pass (whatever the existing coverage path is — verify in implementation).
+- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` passes (writeConnectorSecret tests added).
+- [ ] Whole-repo `bun run typecheck` clean.
+- [ ] `bun run lint` clean.
+- [ ] `bun run test:ci` clean.
+- [ ] `VAULT_KEY_ALLOW_LIST.length === 5` test still passes.
+- [ ] Post-PR baseline update in `docs/structure-audit/baseline.md` recording D11 = 0.
+
+## 7 — Rollout
+
+**PR 1 first.** Smaller blast radius (lazy-mesh-only), all reads, no new write helpers. Branch: `dev/asafgolombek/d11-bucket-c-lazy-mesh`. PR title: `refactor(connectors): D11 Bucket C — route lazy-mesh reads through readConnectorSecret + sharedOAuthKey`.
+
+**PR 2 after PR 1 merges.** Branch: `dev/asafgolombek/d11-bucket-c-rpc-handlers` opened against `main` (not stacked on PR 1's branch). PR title: `refactor(ipc): D11 Bucket C — add writeConnectorSecret + close D11 (0 violations)`. PR 2 depends on PR 1's `sharedOAuthKey` export landing on `main`.
+
+Each PR is single-commit (atomic acceptance state) plus a follow-up baseline-refresh commit if `baseline.md` shifts from the migration. The baseline update for D11 = 0 lands in PR 2 (deferred from PR 1 because PR 1 ends at D11 = 9, an interim state).
+
+## 8 — Out of scope, captured for future specs
+
+- **`VAULT_KEY_RE` widening / manifest-derived audit pattern.** Lands as a separate spec → plan → PR after Bucket C closes. Open design dimensions: which suffixes count as "secret" (current regex omits `app_key`, `api_token`, `api_base`, `site`, `account_id`, `client_secret`, `email`, `base_url`, `username`, `app_password`, `kubeconfig`, `tenant_id`, etc.); manifest-derived (auto-extends per new connector) vs. enumerated (explicit list); should non-secret keys like `email` / `base_url` / `username` gate at all.
+- **D4 splits of `lazy-mesh.ts` and `connector-rpc-handlers.ts`.** Both files exceed the 800-LOC threshold. Tracked as separate refactor candidates in `deferred-backlog.md`. Bucket C deliberately does not touch their structure.
+- **Migration of `oauth-vault-tokens.ts` to use `sharedOAuthKey`.** That file is allow-listed (entry #4) for being the provider-shared OAuth canonical reader; routing its internal reads through `sharedOAuthKey` would be cosmetic. Not a Bucket C concern.
+
+## 9 — Provenance
+
+- Phase 2 ranking: [`docs/structure-audit/missed.md`](../../structure-audit/missed.md) "D11 Bucket C" rows (cost 3 each, score 1.33).
+- Site list: [`docs/structure-audit/deferred-backlog.md`](../../structure-audit/deferred-backlog.md) "D11 — vault-key centralization (Bucket C)".
+- Existing helpers (Bucket B): `readConnectorSecret`, `ConnectorSecretKeyOf`, `perServiceOAuthVaultKey`, `writePerServiceOAuthKey`, `clearOAuthVaultIfProviderUnused`, `migrateToPerServiceOAuthKeys` — all in `packages/gateway/src/connectors/connector-vault.ts`.
+- Manifest: `packages/gateway/src/connectors/connector-secrets-manifest.ts` (`CONNECTOR_VAULT_SECRET_KEYS`).
+- Audit script: `scripts/structure-audit/check-nimbus-invariants.ts` (`VAULT_KEY_ALLOW_LIST`, `checkVaultKeyAllowList`).
+- Frozen-count test: `scripts/structure-audit/check-nimbus-invariants.test.ts`.
+- Type-pinning suite: `packages/gateway/src/connectors/connector-vault.test.ts` (PR #146 — type pins describe block).


### PR DESCRIPTION
## Summary
Two doc-only commits, no source changes:

1. **D11 Bucket C design spec** + Gemini CLI review of the spec.
2. **Implementation plan** (17 tasks across two PRs that close D11 entirely: 21 → 9 → 0) + Gemini CLI review of the plan, with dispositions recorded inline.

The plan executes against the spec without code edits in this PR.

Plan dispositions for the plan-review:
- Wrapper helpers `readSharedOAuth` / `writeSharedOAuth` — declined per spec § 2 Non-goals (YAGNI).
- Concrete baseline edit text — accepted with correction (append a dated post-Bucket-C section instead of rewriting post-Bucket-B history).
- Inline-optimize sharedKey assignment at Task 12 Step 9 — no change (reviewer self-cancels).

## Test plan
- [x] No code changes — review-only PR.
- [ ] Reviewer skims the spec, plan, and Gemini reviews to ratify the disposition table before Bucket C PR-1 is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)