### PR TITLE
refactor(connectors): D11 Bucket C — route lazy-mesh reads through readConnectorSecret + sharedOAuthKey

### DIFF
--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { createMemoryVault } from "../testing/bun-test-support.ts";
-import { type ConnectorSecretKeyOf, readConnectorSecret } from "./connector-vault.ts";
+import {
+  type ConnectorSecretKeyOf,
+  readConnectorSecret,
+  sharedOAuthKey,
+} from "./connector-vault.ts";
 
 // Type-equality probe (Hilger). Two type parameters are equal iff both are
 // assignable in both directions when wrapped in identity-typed arrow functions.
@@ -96,6 +100,22 @@ describe("ConnectorSecretKeyOf — type pins", () => {
     // @ts-expect-error — `ConnectorSecretKeyOf<"google_drive">` is `never`, not `string`.
     assertEq<ConnectorSecretKeyOf<"google_drive">, string>(true);
 
+    expect(true).toBe(true);
+  });
+});
+
+describe("sharedOAuthKey", () => {
+  test("returns google.oauth for google", () => {
+    expect(sharedOAuthKey("google")).toBe("google.oauth");
+  });
+
+  test("returns microsoft.oauth for microsoft", () => {
+    expect(sharedOAuthKey("microsoft")).toBe("microsoft.oauth");
+  });
+
+  test("compile-time: rejects non-provider strings", () => {
+    // @ts-expect-error — SharedOAuthProvider is "google" | "microsoft" only.
+    void sharedOAuthKey("github");
     expect(true).toBe(true);
   });
 });

--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -115,7 +115,7 @@ describe("sharedOAuthKey", () => {
 
   test("compile-time: rejects non-provider strings", () => {
     // @ts-expect-error — SharedOAuthProvider is "google" | "microsoft" only.
-    void sharedOAuthKey("github");
+    assertEq<Parameters<typeof sharedOAuthKey>[0], "github">(true);
     expect(true).toBe(true);
   });
 });

--- a/packages/gateway/src/connectors/connector-vault.ts
+++ b/packages/gateway/src/connectors/connector-vault.ts
@@ -153,3 +153,21 @@ export async function readConnectorSecret<S extends ConnectorServiceId>(
   const fullKey = `${serviceId}.${keyName}`;
   return vault.get(fullKey);
 }
+
+// ─── Bucket-C helper: provider-shared OAuth key constructor ──────────────────
+
+export type SharedOAuthProvider = "google" | "microsoft";
+
+/**
+ * Returns the provider-shared OAuth vault key (`google.oauth` or `microsoft.oauth`).
+ * Used when the caller is operating on the provider-wide token rather than a
+ * per-service token. The literal lives inside this allow-listed file, so D11
+ * does not fire at the call site.
+ *
+ * Return type is the literal union `"google.oauth" | "microsoft.oauth"` (resolved
+ * by TS template-literal inference) — implicitly assignable to `string` at the
+ * `vault.get`/`vault.set` boundary, so no widening cast is required at any caller.
+ */
+export function sharedOAuthKey(provider: SharedOAuthProvider): `${SharedOAuthProvider}.oauth` {
+  return `${provider}.oauth`;
+}

--- a/packages/gateway/src/connectors/lazy-mesh.ts
+++ b/packages/gateway/src/connectors/lazy-mesh.ts
@@ -19,6 +19,13 @@ import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import type { PlatformPaths } from "../platform/paths.ts";
 import { stripTrailingSlashes } from "../string/strip-trailing-slashes.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import type { ConnectorServiceId } from "./connector-catalog.ts";
+import {
+  type ConnectorSecretKeyOf,
+  readConnectorSecret,
+  type SharedOAuthProvider,
+  sharedOAuthKey,
+} from "./connector-vault.ts";
 import { transitionHealth } from "./health.ts";
 import type { UserMcpConnectorRow } from "./user-mcp-store.ts";
 
@@ -485,7 +492,7 @@ export class LazyConnectorMesh {
   private async phase3AddNewrelicMcp(
     servers: Record<string, { command: string; args: string[]; env: Record<string, string> }>,
   ): Promise<void> {
-    const nrKey = (await this.vault.get("newrelic.api_key"))?.trim() ?? "";
+    const nrKey = (await readConnectorSecret(this.vault, "newrelic", "api_key"))?.trim() ?? "";
     if (nrKey === "") {
       return;
     }
@@ -499,7 +506,7 @@ export class LazyConnectorMesh {
   private async phase3AddDatadogMcp(
     servers: Record<string, { command: string; args: string[]; env: Record<string, string> }>,
   ): Promise<void> {
-    const ddKey = (await this.vault.get("datadog.api_key"))?.trim() ?? "";
+    const ddKey = (await readConnectorSecret(this.vault, "datadog", "api_key"))?.trim() ?? "";
     const ddApp = (await this.vault.get("datadog.app_key"))?.trim() ?? "";
     if (ddKey === "" || ddApp === "") {
       return;
@@ -674,7 +681,7 @@ export class LazyConnectorMesh {
       this.scheduleLazyDisconnect(slotKey);
       return;
     }
-    const pat = await this.vault.get("github.pat");
+    const pat = await readConnectorSecret(this.vault, "github", "pat");
     if (pat === null || pat === "") {
       return;
     }
@@ -711,7 +718,7 @@ export class LazyConnectorMesh {
       this.scheduleLazyDisconnect(slotKey);
       return;
     }
-    const pat = await this.vault.get("gitlab.pat");
+    const pat = await readConnectorSecret(this.vault, "gitlab", "pat");
     if (pat === null || pat === "") {
       return;
     }
@@ -823,7 +830,7 @@ export class LazyConnectorMesh {
       this.scheduleLazyDisconnect(slotKey);
       return;
     }
-    const apiKey = await this.vault.get("linear.api_key");
+    const apiKey = await readConnectorSecret(this.vault, "linear", "api_key");
     if (apiKey === null || apiKey === "") {
       return;
     }
@@ -899,7 +906,7 @@ export class LazyConnectorMesh {
       this.scheduleLazyDisconnect(slotKey);
       return;
     }
-    const raw = await this.vault.get("notion.oauth");
+    const raw = await readConnectorSecret(this.vault, "notion", "oauth");
     if (raw === null || raw === "") {
       return;
     }
@@ -1148,8 +1155,22 @@ export class LazyConnectorMesh {
     this.scheduleLazyDisconnect(slotKey);
   }
 
-  private async ensureIfVaultKeyNonEmpty(key: string, run: () => Promise<void>): Promise<void> {
-    const v = await this.vault.get(key);
+  private async ensureIfConnectorSecretSet<S extends ConnectorServiceId>(
+    serviceId: S,
+    keyName: ConnectorSecretKeyOf<S>,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    const v = await readConnectorSecret(this.vault, serviceId, keyName);
+    if (v !== null && v !== "") {
+      await run();
+    }
+  }
+
+  private async ensureIfProviderOAuthSet(
+    provider: SharedOAuthProvider,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    const v = await this.vault.get(sharedOAuthKey(provider));
     if (v !== null && v !== "") {
       await run();
     }
@@ -1235,16 +1256,14 @@ export class LazyConnectorMesh {
   /** Spawns connector MCP children when matching vault keys are present (used before aggregating tools). */
   private async ensureCredentialConnectorsRunning(): Promise<void> {
     await this.ensureIfGoogleOAuthPresent();
-    await this.ensureIfVaultKeyNonEmpty("microsoft.oauth", () =>
-      this.ensureMicrosoftBundleRunning(),
-    );
-    await this.ensureIfVaultKeyNonEmpty("github.pat", () => this.ensureGithubRunning());
-    await this.ensureIfVaultKeyNonEmpty("gitlab.pat", () => this.ensureGitlabRunning());
+    await this.ensureIfProviderOAuthSet("microsoft", () => this.ensureMicrosoftBundleRunning());
+    await this.ensureIfConnectorSecretSet("github", "pat", () => this.ensureGithubRunning());
+    await this.ensureIfConnectorSecretSet("gitlab", "pat", () => this.ensureGitlabRunning());
     await this.ensureBitbucketIfVaultCreds();
-    await this.ensureIfVaultKeyNonEmpty("slack.oauth", () => this.ensureSlackRunning());
-    await this.ensureIfVaultKeyNonEmpty("linear.api_key", () => this.ensureLinearRunning());
+    await this.ensureIfConnectorSecretSet("slack", "oauth", () => this.ensureSlackRunning());
+    await this.ensureIfConnectorSecretSet("linear", "api_key", () => this.ensureLinearRunning());
     await this.ensureJiraIfVaultCreds();
-    await this.ensureIfVaultKeyNonEmpty("notion.oauth", () => this.ensureNotionRunning());
+    await this.ensureIfConnectorSecretSet("notion", "oauth", () => this.ensureNotionRunning());
     await this.ensureConfluenceIfVaultCreds();
     await this.ensureDiscordIfOptIn();
     await this.ensureJenkinsIfVaultCreds();


### PR DESCRIPTION
## Summary
- Adds `sharedOAuthKey(provider)` + `SharedOAuthProvider` type to allow-listed `connector-vault.ts`.
- Replaces `LazyMcpMesh.ensureIfVaultKeyNonEmpty` (untyped) with `ensureIfConnectorSecretSet<S>` + `ensureIfProviderOAuthSet`.
- Migrates 12 read sites in `lazy-mesh.ts`. D11 count drops 21 → 9 (rpc-handlers only).

PR 2 (D11 → 0, Bucket C closed) follows after this merges. The frozen 5-entry `VAULT_KEY_ALLOW_LIST` is unchanged.

## Test plan
- [x] ` bun run audit:invariants` reports exactly 9 D11 hits, all in `connector-rpc-handlers.ts`; zero in `lazy-mesh.ts`.
- [x] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — 10 pass (5 read + 1 type-pin + 3 sharedOAuthKey + the type-pins block from PR #146; 0 fail).
- [x] `bun test packages/gateway/src/connectors/lazy-mesh.test.ts` — pass count unchanged.
- [x] `bun test scripts/structure-audit/check-nimbus-invariants.test.ts` — `VAULT_KEY_ALLOW_LIST.length === 5` still green.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean.
- [x] `bun run test:ci` — all gateway/script suites pass. (Local UI vitest V8 coverage step has a pre-existing Windows-Bun-inspector race when run parallel with bun-test coverage; passes alone at 90.26%, identical to clean main. Linux GHA CI is unaffected.)

## Spec / Plan
- Spec: [`docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md)
- Plan: [`docs/superpowers/plans/2026-05-02-d11-bucket-c.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/plans/2026-05-02-d11-bucket-c.md) (PR 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)