### PR TITLE
test(release): bump nimbus-verify.ps1 test timeout to 30s for cold pwsh

### DIFF
--- a/scripts/release/nimbus-verify-ps1.test.ts
+++ b/scripts/release/nimbus-verify-ps1.test.ts
@@ -100,28 +100,48 @@ afterEach(() => {
   if (work) rmSync(work, { recursive: true, force: true });
 });
 
-test.skipIf(!HAS_PWSH)("ps1: exits 0 for valid chain with -NoFetch", () => {
-  const r = run(["-NoFetch"]);
-  expect(r.status).toBe(0);
-  expect(r.stdout).toContain("✅");
-});
+// Per-test timeout: pwsh cold-start + GPG chain verification can take 6–10s on
+// Windows GHA runners; the 5000ms default produced flakes.
+const PWSH_TEST_TIMEOUT_MS = 30000;
 
-test.skipIf(!HAS_PWSH)("ps1: exits 1 for tampered manifest", () => {
-  const manifest = readFileSync(join(cwd, "SHA256SUMS"), "utf8");
-  const tampered = manifest.replace(/^[0-9a-f]/, (c) => (c === "a" ? "b" : "a"));
-  writeFileSync(join(cwd, "SHA256SUMS"), tampered, "utf8");
-  const r = run(["-NoFetch"]);
-  expect(r.status).toBe(1);
-});
+test.skipIf(!HAS_PWSH)(
+  "ps1: exits 0 for valid chain with -NoFetch",
+  () => {
+    const r = run(["-NoFetch"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("✅");
+  },
+  PWSH_TEST_TIMEOUT_MS,
+);
 
-test.skipIf(!HAS_PWSH)("ps1: exits 2 when SHA256SUMS missing with -NoFetch", () => {
-  rmSync(join(cwd, "SHA256SUMS"));
-  const r = run(["-NoFetch"]);
-  expect(r.status).toBe(2);
-});
+test.skipIf(!HAS_PWSH)(
+  "ps1: exits 1 for tampered manifest",
+  () => {
+    const manifest = readFileSync(join(cwd, "SHA256SUMS"), "utf8");
+    const tampered = manifest.replace(/^[0-9a-f]/, (c) => (c === "a" ? "b" : "a"));
+    writeFileSync(join(cwd, "SHA256SUMS"), tampered, "utf8");
+    const r = run(["-NoFetch"]);
+    expect(r.status).toBe(1);
+  },
+  PWSH_TEST_TIMEOUT_MS,
+);
 
-test.skipIf(!HAS_PWSH)("ps1: prints imported fingerprint for bootstrap trust", () => {
-  const r = run(["-NoFetch"]);
-  expect(r.status).toBe(0);
-  expect(r.stdout).toContain(fingerprint);
-});
+test.skipIf(!HAS_PWSH)(
+  "ps1: exits 2 when SHA256SUMS missing with -NoFetch",
+  () => {
+    rmSync(join(cwd, "SHA256SUMS"));
+    const r = run(["-NoFetch"]);
+    expect(r.status).toBe(2);
+  },
+  PWSH_TEST_TIMEOUT_MS,
+);
+
+test.skipIf(!HAS_PWSH)(
+  "ps1: prints imported fingerprint for bootstrap trust",
+  () => {
+    const r = run(["-NoFetch"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(fingerprint);
+  },
+  PWSH_TEST_TIMEOUT_MS,
+);


### PR DESCRIPTION
## Summary
Tiny follow-up to #149. Two of the four PS1 verifier tests in `scripts/release/nimbus-verify-ps1.test.ts` timed out on this branch's Windows CI run:

- `ps1: exits 0 for valid chain with -NoFetch` — took 9370ms (timeout: 5000ms)
- `ps1: exits 2 when SHA256SUMS missing with -NoFetch` — took 6715ms (timeout: 5000ms)

Both spawn pwsh + run `nimbus-verify.ps1`, which performs SHA-256 + GPG chain verification. Cold pwsh + GPG startup on a Windows GHA runner exceeds the 5000ms Bun-test default. Sets a 30s per-test timeout on all four tests that spawn pwsh (any of them can hit the cold-start path on a fresh runner).

Unrelated to the D11 Bucket C migration — pure CI-flake fix.

## Test plan
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean.
- [ ] CI on this PR shows the four `ps1:` tests pass without timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)