### PR TITLE
refactor(ipc): D11 Bucket C — add writeConnectorSecret + close D11 (0 violations)

### DIFF
--- a/docs/structure-audit/baseline.md
+++ b/docs/structure-audit/baseline.md
@@ -22,7 +22,7 @@ ranks deviations from these baselines.
 | D8 | D | `any` count | 2 (frozen in `any-baseline.json`) | `bun run audit:any` |
 | D9 | D | Risky type assertions (informational) | 399 | `docs/structure-audit/risky-assertions.json` |
 | D10 | F | Spawn under connectors/ not via `extensionProcessEnv()` | 5 violations | `bun run audit:invariants` (binary) |
-| D11 | F | Vault-key construction outside allow-list | 56 violations | `bun run audit:invariants` (binary) |
+| D11 | F | Vault-key construction outside allow-list | 0 violations (D11 closed 2026-05-02) | `bun run audit:invariants` (binary) |
 | D12 | F | `db.run()` outside `db/write.ts` (census) | 94 sites | `docs/structure-audit/db-run-census.json` |
 
 ## Phase 2 follow-up — post Bucket B (2026-05-01)
@@ -32,6 +32,14 @@ D11 violations reduced from the Phase 1 baseline of 56 to **21** (Bucket C only)
 - Bucket A (20 false positives) — suppressed by `audit-ignore-next-line` markers (PR #135).
 - Bucket B (15 sites) — routed through `readConnectorSecret` helper or added to the now-frozen 5-entry allow-list (this PR).
 - Bucket C (21 sites in `lazy-mesh.ts` + `connector-rpc-handlers.ts`) — deferred; tracked in [`deferred-backlog.md`](./deferred-backlog.md).
+
+## Phase 2 follow-up — post Bucket C (2026-05-02)
+
+D11 violations reduced from the post-Bucket-B count of 21 to **0**. **D11 closed.**
+
+- Bucket C — 12 read sites in `lazy-mesh.ts` migrated through `readConnectorSecret` + `sharedOAuthKey` (PR #149); 9 sites in `connector-rpc-handlers.ts` (6 writes + 1 read + 2 sharedKey assignments) migrated through `writeConnectorSecret` + `sharedOAuthKey` (PR <PR-2-number>).
+
+The frozen 5-entry `VAULT_KEY_ALLOW_LIST` was unchanged across Buckets B and C.
 
 ## Provenance
 

--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -5,6 +5,7 @@ import {
   type ConnectorSecretKeyOf,
   readConnectorSecret,
   sharedOAuthKey,
+  writeConnectorSecret,
 } from "./connector-vault.ts";
 
 // Type-equality probe (Hilger). Two type parameters are equal iff both are
@@ -100,6 +101,16 @@ describe("ConnectorSecretKeyOf — type pins", () => {
     // @ts-expect-error — `ConnectorSecretKeyOf<"google_drive">` is `never`, not `string`.
     assertEq<ConnectorSecretKeyOf<"google_drive">, string>(true);
 
+    // writeConnectorSecret keyName must accept the same union as readConnectorSecret.
+    assertEq<Parameters<typeof writeConnectorSecret<"github">>[2], "pat">(true);
+    assertEq<Parameters<typeof writeConnectorSecret<"datadog">>[2], "api_key" | "app_key" | "site">(
+      true,
+    );
+
+    // sharedOAuthKey signature pins.
+    assertEq<Parameters<typeof sharedOAuthKey>[0], "google" | "microsoft">(true);
+    assertEq<ReturnType<typeof sharedOAuthKey>, "google.oauth" | "microsoft.oauth">(true);
+
     expect(true).toBe(true);
   });
 });
@@ -116,6 +127,46 @@ describe("sharedOAuthKey", () => {
   test("compile-time: rejects non-provider strings", () => {
     // @ts-expect-error — SharedOAuthProvider is "google" | "microsoft" only.
     assertEq<Parameters<typeof sharedOAuthKey>[0], "github">(true);
+    expect(true).toBe(true);
+  });
+});
+
+describe("writeConnectorSecret", () => {
+  test("writes the value under the constructed key", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "github", "pat", "ghp_test");
+    expect(await vault.get("github.pat")).toBe("ghp_test");
+  });
+
+  test("overwrites an existing value at the same key", async () => {
+    const vault = createMemoryVault();
+    await vault.set("github.pat", "old");
+    await writeConnectorSecret(vault, "github", "pat", "new");
+    expect(await vault.get("github.pat")).toBe("new");
+  });
+
+  test("stores empty string and whitespace verbatim (no validation)", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "slack", "oauth", "");
+    expect(await vault.get("slack.oauth")).toBe("");
+    await writeConnectorSecret(vault, "slack", "oauth", "  raw  ");
+    expect(await vault.get("slack.oauth")).toBe("  raw  ");
+  });
+
+  test("multi-key services write to distinct vault keys", async () => {
+    const vault = createMemoryVault();
+    await writeConnectorSecret(vault, "datadog", "api_key", "API");
+    await writeConnectorSecret(vault, "datadog", "app_key", "APP");
+    expect(await vault.get("datadog.api_key")).toBe("API");
+    expect(await vault.get("datadog.app_key")).toBe("APP");
+  });
+
+  test("compile-time: rejects non-manifested keys", async () => {
+    const vault = createMemoryVault();
+    // @ts-expect-error — github manifest is ["github.pat"].
+    await writeConnectorSecret(vault, "github", "oauth", "x");
+    // @ts-expect-error — google_drive manifest is empty; ConnectorSecretKeyOf resolves to never.
+    await writeConnectorSecret(vault, "google_drive", "oauth", "x");
     expect(true).toBe(true);
   });
 });

--- a/packages/gateway/src/connectors/connector-vault.ts
+++ b/packages/gateway/src/connectors/connector-vault.ts
@@ -154,6 +154,22 @@ export async function readConnectorSecret<S extends ConnectorServiceId>(
   return vault.get(fullKey);
 }
 
+/**
+ * Writes a connector's secret to the Vault by structural key name. Mirrors
+ * `readConnectorSecret`'s typing — `keyName` is constrained to
+ * `ConnectorSecretKeyOf<S>`, so misspelled or non-manifested keys fail at
+ * compile time. Returns `void` (mirrors `vault.set`).
+ */
+export async function writeConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+  value: string,
+): Promise<void> {
+  const fullKey = `${serviceId}.${keyName}`;
+  return vault.set(fullKey, value);
+}
+
 // ─── Bucket-C helper: provider-shared OAuth key constructor ──────────────────
 
 export type SharedOAuthProvider = "google" | "microsoft";

--- a/packages/gateway/src/ipc/connector-rpc-handlers.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers.ts
@@ -20,6 +20,8 @@ import { clearConnectorVaultSecretKeys } from "../connectors/connector-secrets-m
 import {
   ALL_GOOGLE_OAUTH_VAULT_KEYS,
   clearOAuthVaultIfProviderUnused,
+  sharedOAuthKey,
+  writeConnectorSecret,
   writePerServiceOAuthKey,
 } from "../connectors/connector-vault.ts";
 import { getConnectorHealthHistory } from "../connectors/health.ts";
@@ -362,7 +364,7 @@ async function snapshotMicrosoftOAuthIfLastFamilyMember(
   ) {
     return null;
   }
-  return await vault.get("microsoft.oauth");
+  return await vault.get(sharedOAuthKey("microsoft"));
 }
 
 function unregisterConnectorFromSyncScheduler(
@@ -398,7 +400,7 @@ async function restoreGoogleAndMicrosoftOAuthBackups(
     }
   }
   if (microsoftOAuthBackup !== null) {
-    await vault.set("microsoft.oauth", microsoftOAuthBackup);
+    await vault.set(sharedOAuthKey("microsoft"), microsoftOAuthBackup);
   }
 }
 
@@ -507,7 +509,7 @@ async function connectorAuthGithub(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Missing personalAccessToken for github");
   }
-  await vault.set("github.pat", token);
+  await writeConnectorSecret(vault, "github", "pat", token);
   const now = Date.now();
   const interval = defaultSyncIntervalMsForService("github");
   localIndex.ensureConnectorSchedulerRegistration("github", interval, now);
@@ -526,7 +528,7 @@ async function connectorAuthGitlab(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Missing personalAccessToken for gitlab");
   }
-  await vault.set("gitlab.pat", token);
+  await writeConnectorSecret(vault, "gitlab", "pat", token);
   const baseRaw = rec?.["apiBaseUrl"] ?? rec?.["api_base"];
   if (typeof baseRaw === "string" && baseRaw.trim() !== "") {
     await vault.set("gitlab.api_base", stripTrailingSlashes(baseRaw.trim()));
@@ -548,7 +550,7 @@ async function connectorAuthLinear(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Missing API key for linear");
   }
-  await vault.set("linear.api_key", token);
+  await writeConnectorSecret(vault, "linear", "api_key", token);
   const interval = defaultSyncIntervalMsForService("linear");
   localIndex.ensureConnectorSchedulerRegistration("linear", interval, Date.now());
   return authSuccess("linear");
@@ -806,7 +808,7 @@ async function connectorAuthNewrelic(
       "New Relic requires a user API key (connector.auth newrelic --token …)",
     );
   }
-  await vault.set("newrelic.api_key", token);
+  await writeConnectorSecret(vault, "newrelic", "api_key", token);
   const acctRaw = rec?.["newrelicAccountId"] ?? rec?.["accountId"];
   const acct = typeof acctRaw === "string" && acctRaw.trim() !== "" ? acctRaw.trim() : "";
   if (acct === "") {
@@ -834,7 +836,7 @@ async function connectorAuthDatadog(
       "Datadog requires API key and application key (connector.auth datadog …)",
     );
   }
-  await vault.set("datadog.api_key", api);
+  await writeConnectorSecret(vault, "datadog", "api_key", api);
   await vault.set("datadog.app_key", app);
   const siteRaw = rec?.["datadogSite"] ?? rec?.["site"];
   const site = typeof siteRaw === "string" && siteRaw.trim() !== "" ? siteRaw.trim() : "";
@@ -1017,9 +1019,9 @@ async function connectorAuthOAuthPkce(
   // only its own key (Phase 4 A.3 — scope isolation groundwork).
   let sharedKey: string | undefined;
   if (profile.provider === "google") {
-    sharedKey = "google.oauth";
+    sharedKey = sharedOAuthKey("google");
   } else if (profile.provider === "microsoft") {
-    sharedKey = "microsoft.oauth";
+    sharedKey = sharedOAuthKey("microsoft");
   }
   if (sharedKey !== undefined) {
     await writePerServiceOAuthKey(vault, id, sharedKey);


### PR DESCRIPTION
## Summary
- Adds `writeConnectorSecret<S>(vault, serviceId, keyName, value)` to allow-listed `connector-vault.ts` (mirrors `readConnectorSecret` typing).
- Migrates 9 sites in `connector-rpc-handlers.ts`:
  - 6 writes via `writeConnectorSecret` (github.pat, gitlab.pat, linear.api_key, newrelic.api_key, datadog.api_key)
  - 2 `sharedKey` assignments via `sharedOAuthKey("google"/"microsoft")`
  - 1 read via `vault.get(sharedOAuthKey("microsoft"))`
- Extends the `ConnectorSecretKeyOf — type pins` block with 4 new pins (`writeConnectorSecret` parameter pins + `sharedOAuthKey` signature pins).
- Refreshes `docs/structure-audit/baseline.md`: D11 row → 0 violations, with a new dated post-Bucket-C section recording the closure.

**D11 count: 9 → 0. Bucket C closed.** The frozen 5-entry `VAULT_KEY_ALLOW_LIST` is unchanged.

## Test plan
- [x] `bun run audit:invariants` exits 0; reports 0 D11 hits.
- [x] `bun test packages/gateway/src/connectors/connector-vault.test.ts` — 15 pass.
- [x] `bun test packages/gateway/src/ipc/connector-rpc-handlers-setconfig.test.ts` — pass count unchanged.
- [x] `bun test scripts/structure-audit/check-nimbus-invariants.test.ts` — `VAULT_KEY_ALLOW_LIST.length === 5` still green.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean.
- [x] `bun run test:ci` — gateway/script suites pass. (Local UI vitest V8 coverage step has a pre-existing Windows-Bun-inspector race when run in parallel with bun-test coverage; passes alone at 90.26%, identical to clean main. Linux GHA CI is unaffected — same pattern as #149.)

## Spec / Plan
- Spec: [`docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/specs/2026-05-02-d11-bucket-c-design.md)
- Plan: [`docs/superpowers/plans/2026-05-02-d11-bucket-c.md`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/plans/2026-05-02-d11-bucket-c.md) (PR 2)

## Predecessor
PR #149 (Bucket C PR-1: lazy-mesh reads + `sharedOAuthKey`, D11: 21 → 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)