### PR TITLE
refactor(ipc): D11 widen — route 44 manifest-shaped vault-keys through helpers + add deleteConnectorSecret

### DIFF
--- a/packages/gateway/src/connectors/connector-vault.test.ts
+++ b/packages/gateway/src/connectors/connector-vault.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { createMemoryVault } from "../testing/bun-test-support.ts";
 import {
   type ConnectorSecretKeyOf,
+  deleteConnectorSecret,
   readConnectorSecret,
   sharedOAuthKey,
   writeConnectorSecret,
@@ -111,6 +112,10 @@ describe("ConnectorSecretKeyOf — type pins", () => {
     assertEq<Parameters<typeof sharedOAuthKey>[0], "google" | "microsoft">(true);
     assertEq<ReturnType<typeof sharedOAuthKey>, "google.oauth" | "microsoft.oauth">(true);
 
+    // deleteConnectorSecret signature pins (parameter + return type).
+    assertEq<Parameters<typeof deleteConnectorSecret<"github">>[2], "pat">(true);
+    assertEq<ReturnType<typeof deleteConnectorSecret>, Promise<void>>(true);
+
     expect(true).toBe(true);
   });
 });
@@ -167,6 +172,48 @@ describe("writeConnectorSecret", () => {
     await writeConnectorSecret(vault, "github", "oauth", "x");
     // @ts-expect-error — google_drive manifest is empty; ConnectorSecretKeyOf resolves to never.
     await writeConnectorSecret(vault, "google_drive", "oauth", "x");
+    expect(true).toBe(true);
+  });
+});
+
+describe("deleteConnectorSecret", () => {
+  test("deletes the value at the constructed key", async () => {
+    const vault = createMemoryVault();
+    await vault.set("github.pat", "ghp_test");
+    await deleteConnectorSecret(vault, "github", "pat");
+    expect(await vault.get("github.pat")).toBeNull();
+  });
+
+  test("is a no-op when the key is absent", async () => {
+    const vault = createMemoryVault();
+    await deleteConnectorSecret(vault, "github", "pat");
+    expect(await vault.get("github.pat")).toBeNull();
+  });
+
+  test("does not affect sibling keys on the same service", async () => {
+    const vault = createMemoryVault();
+    await vault.set("datadog.api_key", "API");
+    await vault.set("datadog.app_key", "APP");
+    await deleteConnectorSecret(vault, "datadog", "api_key");
+    expect(await vault.get("datadog.api_key")).toBeNull();
+    expect(await vault.get("datadog.app_key")).toBe("APP");
+  });
+
+  test("does not affect other services' keys", async () => {
+    const vault = createMemoryVault();
+    await vault.set("github.pat", "ghp");
+    await vault.set("gitlab.pat", "glpat");
+    await deleteConnectorSecret(vault, "github", "pat");
+    expect(await vault.get("github.pat")).toBeNull();
+    expect(await vault.get("gitlab.pat")).toBe("glpat");
+  });
+
+  test("compile-time: rejects non-manifested keys", async () => {
+    const vault = createMemoryVault();
+    // @ts-expect-error — github manifest is ["github.pat"].
+    await deleteConnectorSecret(vault, "github", "oauth");
+    // @ts-expect-error — google_drive manifest is empty; ConnectorSecretKeyOf resolves to never.
+    await deleteConnectorSecret(vault, "google_drive", "oauth");
     expect(true).toBe(true);
   });
 });

--- a/packages/gateway/src/connectors/connector-vault.ts
+++ b/packages/gateway/src/connectors/connector-vault.ts
@@ -170,6 +170,21 @@ export async function writeConnectorSecret<S extends ConnectorServiceId>(
   return vault.set(fullKey, value);
 }
 
+/**
+ * Deletes a connector's secret from the Vault by structural key name.
+ * Mirrors `readConnectorSecret`/`writeConnectorSecret` typing — `keyName` is
+ * constrained to `ConnectorSecretKeyOf<S>`, so misspelled or non-manifested
+ * keys fail at compile time. Returns `void` (mirrors `vault.delete`).
+ */
+export async function deleteConnectorSecret<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  serviceId: S,
+  keyName: ConnectorSecretKeyOf<S>,
+): Promise<void> {
+  const fullKey = `${serviceId}.${keyName}`;
+  return vault.delete(fullKey);
+}
+
 // ─── Bucket-C helper: provider-shared OAuth key constructor ──────────────────
 
 export type SharedOAuthProvider = "google" | "microsoft";

--- a/packages/gateway/src/ipc/connector-rpc-handlers.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers.ts
@@ -20,6 +20,7 @@ import { clearConnectorVaultSecretKeys } from "../connectors/connector-secrets-m
 import {
   ALL_GOOGLE_OAUTH_VAULT_KEYS,
   clearOAuthVaultIfProviderUnused,
+  deleteConnectorSecret,
   sharedOAuthKey,
   writeConnectorSecret,
   writePerServiceOAuthKey,
@@ -531,9 +532,9 @@ async function connectorAuthGitlab(
   await writeConnectorSecret(vault, "gitlab", "pat", token);
   const baseRaw = rec?.["apiBaseUrl"] ?? rec?.["api_base"];
   if (typeof baseRaw === "string" && baseRaw.trim() !== "") {
-    await vault.set("gitlab.api_base", stripTrailingSlashes(baseRaw.trim()));
+    await writeConnectorSecret(vault, "gitlab", "api_base", stripTrailingSlashes(baseRaw.trim()));
   } else {
-    await vault.delete("gitlab.api_base");
+    await deleteConnectorSecret(vault, "gitlab", "api_base");
   }
   const interval = defaultSyncIntervalMsForService("gitlab");
   localIndex.ensureConnectorSchedulerRegistration("gitlab", interval, Date.now());
@@ -576,8 +577,8 @@ async function connectorAuthDiscord(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Missing bot token for discord");
   }
-  await vault.set("discord.bot_token", token);
-  await vault.set("discord.enabled", "1");
+  await writeConnectorSecret(vault, "discord", "bot_token", token);
+  await writeConnectorSecret(vault, "discord", "enabled", "1");
   const interval = defaultSyncIntervalMsForService("discord");
   localIndex.ensureConnectorSchedulerRegistration("discord", interval, Date.now());
   return authSuccess("discord");
@@ -593,7 +594,7 @@ async function connectorAuthCircleci(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Missing API token for circleci");
   }
-  await vault.set("circleci.api_token", token);
+  await writeConnectorSecret(vault, "circleci", "api_token", token);
   const interval = defaultSyncIntervalMsForService("circleci");
   localIndex.ensureConnectorSchedulerRegistration("circleci", interval, Date.now());
   return authSuccess("circleci");
@@ -612,25 +613,25 @@ async function persistAwsAccessKeyPair(
       "AWS key pair requires a default region or profile (connector.auth aws --region … or --profile …)",
     );
   }
-  await vault.set("aws.access_key_id", ak);
-  await vault.set("aws.secret_access_key", sk);
+  await writeConnectorSecret(vault, "aws", "access_key_id", ak);
+  await writeConnectorSecret(vault, "aws", "secret_access_key", sk);
   if (reg === "") {
-    await vault.delete("aws.default_region");
+    await deleteConnectorSecret(vault, "aws", "default_region");
   } else {
-    await vault.set("aws.default_region", reg);
+    await writeConnectorSecret(vault, "aws", "default_region", reg);
   }
   if (prof === "") {
-    await vault.delete("aws.profile");
+    await deleteConnectorSecret(vault, "aws", "profile");
   } else {
-    await vault.set("aws.profile", prof);
+    await writeConnectorSecret(vault, "aws", "profile", prof);
   }
 }
 
 async function persistAwsProfileOnly(vault: NimbusVault, prof: string): Promise<void> {
-  await vault.delete("aws.access_key_id");
-  await vault.delete("aws.secret_access_key");
-  await vault.delete("aws.default_region");
-  await vault.set("aws.profile", prof);
+  await deleteConnectorSecret(vault, "aws", "access_key_id");
+  await deleteConnectorSecret(vault, "aws", "secret_access_key");
+  await deleteConnectorSecret(vault, "aws", "default_region");
+  await writeConnectorSecret(vault, "aws", "profile", prof);
 }
 
 async function connectorAuthAws(
@@ -681,9 +682,9 @@ async function connectorAuthAzure(
       "Azure requires tenant id, client id, and client secret (connector.auth azure …)",
     );
   }
-  await vault.set("azure.tenant_id", tenant);
-  await vault.set("azure.client_id", clientId);
-  await vault.set("azure.client_secret", secret);
+  await writeConnectorSecret(vault, "azure", "tenant_id", tenant);
+  await writeConnectorSecret(vault, "azure", "client_id", clientId);
+  await writeConnectorSecret(vault, "azure", "client_secret", secret);
   const interval = defaultSyncIntervalMsForService("azure");
   localIndex.ensureConnectorSchedulerRegistration("azure", interval, Date.now());
   return authSuccess("azure");
@@ -702,13 +703,13 @@ async function connectorAuthGcp(
       "GCP requires a service account JSON key path (connector.auth gcp --credentials-json <path>)",
     );
   }
-  await vault.set("gcp.credentials_json_path", path);
+  await writeConnectorSecret(vault, "gcp", "credentials_json_path", path);
   const projRaw = rec?.["gcpProjectId"] ?? rec?.["projectId"];
   const proj = typeof projRaw === "string" && projRaw.trim() !== "" ? projRaw.trim() : "";
   if (proj === "") {
-    await vault.delete("gcp.project_id");
+    await deleteConnectorSecret(vault, "gcp", "project_id");
   } else {
-    await vault.set("gcp.project_id", proj);
+    await writeConnectorSecret(vault, "gcp", "project_id", proj);
   }
   const interval = defaultSyncIntervalMsForService("gcp");
   localIndex.ensureConnectorSchedulerRegistration("gcp", interval, Date.now());
@@ -728,7 +729,7 @@ async function connectorAuthIac(
       "IaC connector is opt-in: nimbus connector auth iac --enable",
     );
   }
-  await vault.set("iac.enabled", "1");
+  await writeConnectorSecret(vault, "iac", "enabled", "1");
   const interval = defaultSyncIntervalMsForService("iac");
   localIndex.ensureConnectorSchedulerRegistration("iac", interval, Date.now());
   return authSuccess("iac");
@@ -758,8 +759,8 @@ async function connectorAuthGrafana(
       "Grafana requires an API token (connector.auth grafana --token …)",
     );
   }
-  await vault.set("grafana.url", base);
-  await vault.set("grafana.api_token", token);
+  await writeConnectorSecret(vault, "grafana", "url", base);
+  await writeConnectorSecret(vault, "grafana", "api_token", token);
   const interval = defaultSyncIntervalMsForService("grafana");
   localIndex.ensureConnectorSchedulerRegistration("grafana", interval, Date.now());
   return authSuccess("grafana");
@@ -780,15 +781,15 @@ async function connectorAuthSentry(
       "Sentry requires auth token and org slug (connector.auth sentry --token … --org …)",
     );
   }
-  await vault.set("sentry.auth_token", token);
-  await vault.set("sentry.org_slug", org);
+  await writeConnectorSecret(vault, "sentry", "auth_token", token);
+  await writeConnectorSecret(vault, "sentry", "org_slug", org);
   const urlRaw = rec?.["sentryUrl"] ?? rec?.["apiBaseUrl"];
   const surl =
     typeof urlRaw === "string" && urlRaw.trim() !== "" ? stripTrailingSlashes(urlRaw.trim()) : "";
   if (surl === "") {
-    await vault.delete("sentry.url");
+    await deleteConnectorSecret(vault, "sentry", "url");
   } else {
-    await vault.set("sentry.url", surl);
+    await writeConnectorSecret(vault, "sentry", "url", surl);
   }
   const interval = defaultSyncIntervalMsForService("sentry");
   localIndex.ensureConnectorSchedulerRegistration("sentry", interval, Date.now());
@@ -812,9 +813,9 @@ async function connectorAuthNewrelic(
   const acctRaw = rec?.["newrelicAccountId"] ?? rec?.["accountId"];
   const acct = typeof acctRaw === "string" && acctRaw.trim() !== "" ? acctRaw.trim() : "";
   if (acct === "") {
-    await vault.delete("newrelic.account_id");
+    await deleteConnectorSecret(vault, "newrelic", "account_id");
   } else {
-    await vault.set("newrelic.account_id", acct);
+    await writeConnectorSecret(vault, "newrelic", "account_id", acct);
   }
   const interval = defaultSyncIntervalMsForService("newrelic");
   localIndex.ensureConnectorSchedulerRegistration("newrelic", interval, Date.now());
@@ -837,13 +838,13 @@ async function connectorAuthDatadog(
     );
   }
   await writeConnectorSecret(vault, "datadog", "api_key", api);
-  await vault.set("datadog.app_key", app);
+  await writeConnectorSecret(vault, "datadog", "app_key", app);
   const siteRaw = rec?.["datadogSite"] ?? rec?.["site"];
   const site = typeof siteRaw === "string" && siteRaw.trim() !== "" ? siteRaw.trim() : "";
   if (site === "") {
-    await vault.delete("datadog.site");
+    await deleteConnectorSecret(vault, "datadog", "site");
   } else {
-    await vault.set("datadog.site", site);
+    await writeConnectorSecret(vault, "datadog", "site", site);
   }
   const interval = defaultSyncIntervalMsForService("datadog");
   localIndex.ensureConnectorSchedulerRegistration("datadog", interval, Date.now());
@@ -863,12 +864,12 @@ async function connectorAuthKubernetes(
       "Kubernetes requires kubeconfig path: connector.auth kubernetes --kubeconfig <path>",
     );
   }
-  await vault.set("kubernetes.kubeconfig", kubePath);
+  await writeConnectorSecret(vault, "kubernetes", "kubeconfig", kubePath);
   const ctxRaw = rec?.["context"];
   if (typeof ctxRaw === "string" && ctxRaw.trim() !== "") {
-    await vault.set("kubernetes.context", ctxRaw.trim());
+    await writeConnectorSecret(vault, "kubernetes", "context", ctxRaw.trim());
   } else {
-    await vault.delete("kubernetes.context");
+    await deleteConnectorSecret(vault, "kubernetes", "context");
   }
   const interval = defaultSyncIntervalMsForService("kubernetes");
   localIndex.ensureConnectorSchedulerRegistration("kubernetes", interval, Date.now());
@@ -885,7 +886,7 @@ async function connectorAuthPagerduty(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Missing API token for pagerduty");
   }
-  await vault.set("pagerduty.api_token", token);
+  await writeConnectorSecret(vault, "pagerduty", "api_token", token);
   const interval = defaultSyncIntervalMsForService("pagerduty");
   localIndex.ensureConnectorSchedulerRegistration("pagerduty", interval, Date.now());
   return authSuccess("pagerduty");
@@ -917,9 +918,9 @@ async function connectorAuthJenkins(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Jenkins requires --token <api_token>");
   }
-  await vault.set("jenkins.base_url", base);
-  await vault.set("jenkins.username", user);
-  await vault.set("jenkins.api_token", token);
+  await writeConnectorSecret(vault, "jenkins", "base_url", base);
+  await writeConnectorSecret(vault, "jenkins", "username", user);
+  await writeConnectorSecret(vault, "jenkins", "api_token", token);
   const interval = defaultSyncIntervalMsForService("jenkins");
   localIndex.ensureConnectorSchedulerRegistration("jenkins", interval, Date.now());
   return authSuccess("jenkins");
@@ -940,8 +941,8 @@ async function connectorAuthBitbucket(
   if (token === "") {
     throw new ConnectorRpcError(-32602, "Missing app password for bitbucket (use token field)");
   }
-  await vault.set("bitbucket.username", user);
-  await vault.set("bitbucket.app_password", token);
+  await writeConnectorSecret(vault, "bitbucket", "username", user);
+  await writeConnectorSecret(vault, "bitbucket", "app_password", token);
   const interval = defaultSyncIntervalMsForService("bitbucket");
   localIndex.ensureConnectorSchedulerRegistration("bitbucket", interval, Date.now());
   return authSuccess("bitbucket");


### PR DESCRIPTION
## Summary

- Adds `deleteConnectorSecret<S>(vault, serviceId, keyName)` to `connector-vault.ts` — mirrors `readConnectorSecret`/`writeConnectorSecret` typing; `keyName` is `ConnectorSecretKeyOf<S>`, so non-manifested keys fail at compile time.
- Migrates 42 `vault.get`/`vault.set`/`vault.delete` sites in `connector-rpc-handlers.ts` to the typed helpers (`readConnectorSecret`/`writeConnectorSecret`/`deleteConnectorSecret`), eliminating all manifest-shaped string literals from that file.
- Extends the `ConnectorSecretKeyOf — type pins` describe block with compile-time signature pins for `deleteConnectorSecret`.
- Adds 5 new runtime tests for `deleteConnectorSecret` (delete, no-op, sibling isolation, cross-service isolation, compile-time rejection). Test count: 15 → 20.

## Files changed

- `packages/gateway/src/connectors/connector-vault.ts` — new `deleteConnectorSecret` export
- `packages/gateway/src/connectors/connector-vault.test.ts` — 5 new tests + 2 type-pin assertions
- `packages/gateway/src/ipc/connector-rpc-handlers.ts` — 42 vault.{get,set,delete} sites migrated to typed helpers

## Notes

- Discovery grep found 42 manifest-shaped literals (not 44 as in the plan; 2 were already migrated in Bucket C / sharedOAuthKey wrapping).
- `readConnectorSecret` was added to the import defensively per the plan then removed after confirming it was unused in the migration (Biome lint confirmed clean).
- The 2 remaining pre-existing wrapped-OAuth lines at ~365/401 use `sharedOAuthKey("microsoft")` and do not appear as manifest-shaped string literals — confirmed correct.

## Test plan

- [ ] `bun test packages/gateway/src/connectors/connector-vault.test.ts` → 20 pass / 0 fail
- [ ] `bun test packages/gateway/src/ipc/connector-rpc-handlers-setconfig.test.ts` → 18 pass / 0 fail
- [ ] `bun test scripts/structure-audit/check-nimbus-invariants.test.ts` → 10 pass / 0 fail
- [ ] `bun run audit:invariants` → 0 D11 hits
- [ ] `bun run typecheck` → clean
- [ ] `bun run lint` → clean
- [ ] `bun run test:ci` → gateway/script suites 1505 pass / 0 fail (UI V8 coverage known flake acceptable)

Spec: `docs/superpowers/specs/2026-05-02-d11-manifest-derived-audit-design.md`
Plan: `docs/superpowers/plans/2026-05-02-d11-manifest-derived-audit.md` (PR A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)