### PR TITLE
refactor(connectors): D11 widen — route per-connector sync-file vault-keys through helpers (PR C)

### DIFF
--- a/packages/gateway/src/connectors/aws-sync.ts
+++ b/packages/gateway/src/connectors/aws-sync.ts
@@ -2,6 +2,7 @@ import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { clampSyncTitle, syncPassCursorParseEmpty } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -35,10 +36,10 @@ function decodeCursor(raw: string | null): AwsCursorV1 | null {
 }
 
 async function awsCredentialsExtra(ctx: SyncContext): Promise<Record<string, string> | null> {
-  const ak = (await ctx.vault.get("aws.access_key_id"))?.trim() ?? "";
-  const sk = (await ctx.vault.get("aws.secret_access_key"))?.trim() ?? "";
-  const reg = (await ctx.vault.get("aws.default_region"))?.trim() ?? "";
-  const prof = (await ctx.vault.get("aws.profile"))?.trim() ?? "";
+  const ak = (await readConnectorSecret(ctx.vault, "aws", "access_key_id"))?.trim() ?? "";
+  const sk = (await readConnectorSecret(ctx.vault, "aws", "secret_access_key"))?.trim() ?? "";
+  const reg = (await readConnectorSecret(ctx.vault, "aws", "default_region"))?.trim() ?? "";
+  const prof = (await readConnectorSecret(ctx.vault, "aws", "profile"))?.trim() ?? "";
   const ok = (ak !== "" && sk !== "" && (reg !== "" || prof !== "")) || (prof !== "" && ak === "");
   if (!ok) {
     return null;

--- a/packages/gateway/src/connectors/azure-sync.ts
+++ b/packages/gateway/src/connectors/azure-sync.ts
@@ -7,6 +7,7 @@ import {
   syncPassCursorSuccess,
 } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -27,9 +28,9 @@ async function azureCliJson(
   ctx: SyncContext,
   args: string[],
 ): Promise<{ ok: boolean; text: string }> {
-  const tenant = (await ctx.vault.get("azure.tenant_id"))?.trim() ?? "";
-  const clientId = (await ctx.vault.get("azure.client_id"))?.trim() ?? "";
-  const secret = (await ctx.vault.get("azure.client_secret"))?.trim() ?? "";
+  const tenant = (await readConnectorSecret(ctx.vault, "azure", "tenant_id"))?.trim() ?? "";
+  const clientId = (await readConnectorSecret(ctx.vault, "azure", "client_id"))?.trim() ?? "";
+  const secret = (await readConnectorSecret(ctx.vault, "azure", "client_secret"))?.trim() ?? "";
   if (tenant === "" || clientId === "" || secret === "") {
     return { ok: false, text: "" };
   }
@@ -60,7 +61,7 @@ export function createAzureSyncable(options: AzureSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureAzureMcpRunning();
-      const tenant = await ctx.vault.get("azure.tenant_id");
+      const tenant = await readConnectorSecret(ctx.vault, "azure", "tenant_id");
       if (tenant === null || tenant.trim() === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/bitbucket-sync.ts
+++ b/packages/gateway/src/connectors/bitbucket-sync.ts
@@ -2,6 +2,7 @@ import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { resolvePersonForSync } from "../people/linker.ts";
 import { plainTextPreviewFromHtml } from "../string/html-plain-text.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
@@ -218,8 +219,8 @@ export function createBitbucketSyncable(options: BitbucketSyncableOptions): Sync
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureBitbucketMcpRunning();
-      const user = await ctx.vault.get("bitbucket.username");
-      const pass = await ctx.vault.get("bitbucket.app_password");
+      const user = await readConnectorSecret(ctx.vault, "bitbucket", "username");
+      const pass = await readConnectorSecret(ctx.vault, "bitbucket", "app_password");
       if (user === null || user === "" || pass === null || pass === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/circleci-sync.ts
+++ b/packages/gateway/src/connectors/circleci-sync.ts
@@ -1,6 +1,7 @@
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { clampSyncTitle } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { listGithubReposFromIndex } from "./github-index-repos.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
@@ -213,7 +214,7 @@ export function createCircleciSyncable(options: CircleciSyncableOptions): Syncab
       const t0 = performance.now();
       await options.ensureCircleciMcpRunning();
 
-      const apiTok = await ctx.vault.get("circleci.api_token");
+      const apiTok = await readConnectorSecret(ctx.vault, "circleci", "api_token");
       if (apiTok === null || apiTok.trim() === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/confluence-sync.ts
+++ b/packages/gateway/src/connectors/confluence-sync.ts
@@ -7,6 +7,7 @@ import {
   normalizeAtlassianSiteBaseUrl,
   stringField,
 } from "./atlassian-api-sync-helpers.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { isoMs, maxIso } from "./sync-iso-helpers.ts";
 import {
   decodeWatermarkCursorV1,
@@ -259,9 +260,9 @@ export function createConfluenceSyncable(options: ConfluenceSyncableOptions): Sy
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureConfluenceMcpRunning();
-      const token = await ctx.vault.get("confluence.api_token");
-      const email = await ctx.vault.get("confluence.email");
-      const baseRaw = await ctx.vault.get("confluence.base_url");
+      const token = await readConnectorSecret(ctx.vault, "confluence", "api_token");
+      const email = await readConnectorSecret(ctx.vault, "confluence", "email");
+      const baseRaw = await readConnectorSecret(ctx.vault, "confluence", "base_url");
       if (
         token === null ||
         token === "" ||

--- a/packages/gateway/src/connectors/discord-sync.ts
+++ b/packages/gateway/src/connectors/discord-sync.ts
@@ -1,6 +1,7 @@
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { resolvePersonForSync } from "../people/linker.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -442,8 +443,8 @@ export function createDiscordSyncable(options: DiscordSyncableOptions): Syncable
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureDiscordMcpRunning();
-      const enabled = await ctx.vault.get("discord.enabled");
-      const token = await ctx.vault.get("discord.bot_token");
+      const enabled = await readConnectorSecret(ctx.vault, "discord", "enabled");
+      const token = await readConnectorSecret(ctx.vault, "discord", "bot_token");
       if (enabled !== "1" || token === null || token === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/gcp-sync.ts
+++ b/packages/gateway/src/connectors/gcp-sync.ts
@@ -7,6 +7,7 @@ import {
   syncPassCursorSuccess,
 } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -27,7 +28,8 @@ async function gcloudJson(
   ctx: SyncContext,
   args: string[],
 ): Promise<{ ok: boolean; text: string }> {
-  const credPath = (await ctx.vault.get("gcp.credentials_json_path"))?.trim() ?? "";
+  const credPath =
+    (await readConnectorSecret(ctx.vault, "gcp", "credentials_json_path"))?.trim() ?? "";
   if (credPath === "") {
     return { ok: false, text: "" };
   }
@@ -54,11 +56,11 @@ export function createGcpSyncable(options: GcpSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureGcpMcpRunning();
-      const credPath = await ctx.vault.get("gcp.credentials_json_path");
+      const credPath = await readConnectorSecret(ctx.vault, "gcp", "credentials_json_path");
       if (credPath === null || credPath.trim() === "") {
         return syncNoopResult(cursor, t0);
       }
-      const projectRaw = await ctx.vault.get("gcp.project_id");
+      const projectRaw = await readConnectorSecret(ctx.vault, "gcp", "project_id");
       const projectId = projectRaw !== null && projectRaw.trim() !== "" ? projectRaw.trim() : null;
       if (projectId === null) {
         return syncNoopResult(cursor, t0);

--- a/packages/gateway/src/connectors/grafana-sync.ts
+++ b/packages/gateway/src/connectors/grafana-sync.ts
@@ -6,6 +6,7 @@ import {
   syncPassCursorSuccess,
 } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord } from "./unknown-record.ts";
 
@@ -35,8 +36,8 @@ export function createGrafanaSyncable(options: GrafanaSyncableOptions): Syncable
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureGrafanaMcpRunning();
-      const base = (await ctx.vault.get("grafana.url"))?.trim() ?? "";
-      const tok = (await ctx.vault.get("grafana.api_token"))?.trim() ?? "";
+      const base = (await readConnectorSecret(ctx.vault, "grafana", "url"))?.trim() ?? "";
+      const tok = (await readConnectorSecret(ctx.vault, "grafana", "api_token"))?.trim() ?? "";
       if (base === "" || tok === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/iac-sync.ts
+++ b/packages/gateway/src/connectors/iac-sync.ts
@@ -1,5 +1,6 @@
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 
 const SERVICE_ID = "iac";
@@ -28,7 +29,7 @@ export function createIacSyncable(options: IacSyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureIacMcpRunning();
-      const en = await ctx.vault.get("iac.enabled");
+      const en = await readConnectorSecret(ctx.vault, "iac", "enabled");
       if (en !== "1") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/jenkins-sync.ts
+++ b/packages/gateway/src/connectors/jenkins-sync.ts
@@ -2,6 +2,7 @@ import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { stripTrailingSlashes } from "../string/strip-trailing-slashes.ts";
 import { clampSyncTitle } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import {
   flattenJenkinsApiJobs,
   JENKINS_JOBS_API_TREE,
@@ -259,9 +260,9 @@ export function createJenkinsSyncable(options: JenkinsSyncableOptions): Syncable
       const t0 = performance.now();
       await options.ensureJenkinsMcpRunning();
 
-      const baseRaw = await ctx.vault.get("jenkins.base_url");
-      const user = await ctx.vault.get("jenkins.username");
-      const token = await ctx.vault.get("jenkins.api_token");
+      const baseRaw = await readConnectorSecret(ctx.vault, "jenkins", "base_url");
+      const user = await readConnectorSecret(ctx.vault, "jenkins", "username");
+      const token = await readConnectorSecret(ctx.vault, "jenkins", "api_token");
       if (
         baseRaw === null ||
         baseRaw.trim() === "" ||

--- a/packages/gateway/src/connectors/jira-sync.ts
+++ b/packages/gateway/src/connectors/jira-sync.ts
@@ -15,6 +15,7 @@ import {
   normalizeAtlassianSiteBaseUrl,
   stringField,
 } from "./atlassian-api-sync-helpers.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 
 const SERVICE_ID = "jira";
@@ -92,9 +93,9 @@ type SearchEnvelope = {
 type JiraVaultCreds = { token: string; email: string; baseUrl: string };
 
 async function loadJiraVaultCreds(ctx: SyncContext): Promise<JiraVaultCreds | null> {
-  const token = await ctx.vault.get("jira.api_token");
-  const email = await ctx.vault.get("jira.email");
-  const baseRaw = await ctx.vault.get("jira.base_url");
+  const token = await readConnectorSecret(ctx.vault, "jira", "api_token");
+  const email = await readConnectorSecret(ctx.vault, "jira", "email");
+  const baseRaw = await readConnectorSecret(ctx.vault, "jira", "base_url");
   if (
     token === null ||
     token === "" ||

--- a/packages/gateway/src/connectors/kubernetes-sync.ts
+++ b/packages/gateway/src/connectors/kubernetes-sync.ts
@@ -2,6 +2,7 @@ import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { syncPassCursorParseEmpty } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -132,12 +133,12 @@ export function createKubernetesSyncable(options: KubernetesSyncableOptions): Sy
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureKubernetesMcpRunning();
-      const kubePath = await ctx.vault.get("kubernetes.kubeconfig");
+      const kubePath = await readConnectorSecret(ctx.vault, "kubernetes", "kubeconfig");
       if (kubePath === null || kubePath.trim() === "") {
         return syncNoopResult(cursor, t0);
       }
       const kc = kubePath.trim();
-      const ctxNameRaw = await ctx.vault.get("kubernetes.context");
+      const ctxNameRaw = await readConnectorSecret(ctx.vault, "kubernetes", "context");
       const kctx = ctxNameRaw !== null && ctxNameRaw.trim() !== "" ? ctxNameRaw.trim() : null;
 
       await ctx.rateLimiter.acquire("kubernetes");

--- a/packages/gateway/src/connectors/pagerduty-sync.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.ts
@@ -1,5 +1,6 @@
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -119,7 +120,7 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensurePagerdutyMcpRunning();
-      const token = await ctx.vault.get("pagerduty.api_token");
+      const token = await readConnectorSecret(ctx.vault, "pagerduty", "api_token");
       if (token === null || token.trim() === "") {
         return syncNoopResult(cursor, t0);
       }

--- a/packages/gateway/src/connectors/sentry-sync.ts
+++ b/packages/gateway/src/connectors/sentry-sync.ts
@@ -7,6 +7,7 @@ import {
   syncPassCursorSuccess,
 } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
@@ -36,12 +37,12 @@ export function createSentrySyncable(options: SentrySyncableOptions): Syncable {
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();
       await options.ensureSentryMcpRunning();
-      const token = (await ctx.vault.get("sentry.auth_token"))?.trim() ?? "";
-      const org = (await ctx.vault.get("sentry.org_slug"))?.trim() ?? "";
+      const token = (await readConnectorSecret(ctx.vault, "sentry", "auth_token"))?.trim() ?? "";
+      const org = (await readConnectorSecret(ctx.vault, "sentry", "org_slug"))?.trim() ?? "";
       if (token === "" || org === "") {
         return syncNoopResult(cursor, t0);
       }
-      const baseRaw = await ctx.vault.get("sentry.url");
+      const baseRaw = await readConnectorSecret(ctx.vault, "sentry", "url");
       const apiRoot =
         baseRaw !== null && baseRaw.trim() !== ""
           ? `${stripTrailingSlashes(baseRaw.trim())}/api/0`

--- a/packages/gateway/src/index/drift-hints.ts
+++ b/packages/gateway/src/index/drift-hints.ts
@@ -54,6 +54,7 @@ export function driftHintsFromIndex(db: Database): string[] {
 
   if (hb === undefined || hb === null) {
     lines.push(
+      // audit-ignore-next-line D11-vault-key (diagnostic prose, not vault-key construction)
       "IaC heartbeat: not yet written (enable `iac.enabled` in Vault and run an IaC sync to snapshot indexed cloud counts).",
     );
   } else {

--- a/packages/gateway/src/ipc/connector-rpc-shared.ts
+++ b/packages/gateway/src/ipc/connector-rpc-shared.ts
@@ -3,6 +3,7 @@ import {
   defaultSyncIntervalMsForService,
   normalizeConnectorServiceId,
 } from "../connectors/connector-catalog.ts";
+import { writeConnectorSecret } from "../connectors/connector-vault.ts";
 import { USER_MCP_SERVICE_ID_PATTERN } from "../connectors/user-mcp-store.ts";
 import type { LocalIndex } from "../index/local-index.ts";
 import { stripTrailingSlashes } from "../string/strip-trailing-slashes.ts";
@@ -134,9 +135,9 @@ export async function registerAtlassianApiConnectorAuth(options: {
   creds: { email: string; apiToken: string; baseNormalized: string };
 }): Promise<{ ok: true; serviceId: ConnectorServiceId; scopesGranted: string[] }> {
   const { vault, localIndex, serviceId, creds } = options;
-  await vault.set(`${serviceId}.email`, creds.email);
-  await vault.set(`${serviceId}.api_token`, creds.apiToken);
-  await vault.set(`${serviceId}.base_url`, creds.baseNormalized);
+  await writeConnectorSecret(vault, serviceId, "email", creds.email);
+  await writeConnectorSecret(vault, serviceId, "api_token", creds.apiToken);
+  await writeConnectorSecret(vault, serviceId, "base_url", creds.baseNormalized);
   const interval = defaultSyncIntervalMsForService(serviceId);
   localIndex.ensureConnectorSchedulerRegistration(serviceId, interval, Date.now());
   return {


### PR DESCRIPTION
## Summary
Migrates 37 manifest-shaped vault-key sites + adds 1 audit-ignore marker:
- **34 reads** across 14 per-connector sync files (aws / azure / bitbucket / circleci / confluence / discord / gcp / grafana / iac / jenkins / jira / kubernetes / pagerduty / sentry) → `readConnectorSecret`.
- **3 writes** in `connector-rpc-shared.ts` (`registerAtlassianApiConnectorAuth`'s template-literal `vault.set(\`${serviceId}.X\`, ...)` calls) → `writeConnectorSecret(vault, serviceId, "X", ...)`. The typed `serviceId: "jira" | "confluence"` flows through; both services have the same key set in the manifest.
- **1 \`audit-ignore-next-line\` marker** in \`drift-hints.ts\` for a diagnostic prose mention of \`\\`iac.enabled\\`\` in a user-facing message — defensive for after PR D widens the regex (currently a no-op against the existing 4-suffix regex).

D11 audit count under the current regex is unchanged (0). The widening lands in PR D.

## Test plan
- [x] \`bun test packages/gateway/src/connectors/\` — 121 pass / 0 fail (unchanged from main).
- [x] \`bun run audit:invariants\` reports 0 D11 hits (unchanged).
- [x] \`bun run typecheck\` clean.
- [x] \`bun run lint\` clean (one Biome line-length auto-wrap in \`gcp-sync.ts\`).
- [x] \`bun run test:ci\` clean (modulo the known UI vitest V8 coverage parallel-run flake; same as PRs #149/#151/#154/#155).

## Spec / Plan
- Spec: [\`docs/superpowers/specs/2026-05-02-d11-manifest-derived-audit-design.md\`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/specs/2026-05-02-d11-manifest-derived-audit-design.md)
- Plan: [\`docs/superpowers/plans/2026-05-02-d11-manifest-derived-audit.md\`](https://github.com/asafgolombek/Nimbus/blob/main/docs/superpowers/plans/2026-05-02-d11-manifest-derived-audit.md) (PR C)

## Predecessors
- PR #154 (PR A — D11 widen — rpc-handlers + deleteConnectorSecret).
- PR #155 (PR B — D11 widen — lazy-mesh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)