### PR TITLE
chore(audit): D11 widen — manifest-derived VAULT_KEY_RE; allow-list manifest; close D11 under broader pattern

### DIFF
--- a/docs/structure-audit/baseline.md
+++ b/docs/structure-audit/baseline.md
@@ -22,7 +22,7 @@ ranks deviations from these baselines.
 | D8 | D | `any` count | 2 (frozen in `any-baseline.json`) | `bun run audit:any` |
 | D9 | D | Risky type assertions (informational) | 399 | `docs/structure-audit/risky-assertions.json` |
 | D10 | F | Spawn under connectors/ not via `extensionProcessEnv()` | 5 violations | `bun run audit:invariants` (binary) |
-| D11 | F | Vault-key construction outside allow-list | 0 violations (D11 closed 2026-05-02) | `bun run audit:invariants` (binary) |
+| D11 | F | Vault-key construction outside allow-list | 0 violations under manifest-derived regex (closed 2026-05-02) | `bun run audit:invariants` (binary) |
 | D12 | F | `db.run()` outside `db/write.ts` (census) | 94 sites | `docs/structure-audit/db-run-census.json` |
 
 ## Phase 2 follow-up — post Bucket B (2026-05-01)
@@ -40,6 +40,21 @@ D11 violations reduced from the post-Bucket-B count of 21 to **0**. **D11 closed
 - Bucket C — 12 read sites in `lazy-mesh.ts` migrated through `readConnectorSecret` + `sharedOAuthKey` (PR #149); 9 sites in `connector-rpc-handlers.ts` (6 writes + 1 read + 2 sharedKey assignments) migrated through `writeConnectorSecret` + `sharedOAuthKey` (PR <PR-2-number>).
 
 The frozen 5-entry `VAULT_KEY_ALLOW_LIST` was unchanged across Buckets B and C.
+
+## Phase 2 follow-up — post manifest-derived widening (2026-05-02)
+
+D11 stays at **0** violations under the broader manifest-derived regex.
+
+The audit script now derives `VAULT_KEY_RE` from `CONNECTOR_VAULT_SECRET_KEYS`
+at startup, so every entry across all 27 connectors (43 keys total) is
+gated — not just the original 4-suffix subset (`oauth | token | pat | api_key`).
+
+- PR #154 migrated 42 sites in `connector-rpc-handlers.ts` and added the `deleteConnectorSecret<S>` helper.
+- PR #155 migrated 50 sites in `lazy-mesh.ts`.
+- PR #156 migrated 37 sites across 14 per-connector sync files + 3 in `connector-rpc-shared.ts` + 1 audit-ignore marker in `drift-hints.ts`.
+- This PR widens the regex, allow-lists `connector-secrets-manifest.ts` as the 6th entry, adds `stripComments` to the audit so JSDoc references stop firing, and bumps the frozen-count test 5 → 6.
+
+The allow-list is now frozen at **6 entries** for the foreseeable future.
 
 ## Provenance
 

--- a/packages/gateway/src/connectors/connector-secrets-manifest.ts
+++ b/packages/gateway/src/connectors/connector-secrets-manifest.ts
@@ -9,18 +9,13 @@ export const CONNECTOR_VAULT_SECRET_KEYS = {
   onedrive: [],
   outlook: [],
   teams: [],
-  // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   slack: ["slack.oauth"],
-  // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   github: ["github.pat"],
   github_actions: [],
-  // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   gitlab: ["gitlab.pat", "gitlab.api_base"],
   bitbucket: ["bitbucket.username", "bitbucket.app_password"],
-  // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   linear: ["linear.api_key"],
   jira: ["jira.api_token", "jira.email", "jira.base_url"],
-  // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   notion: ["notion.oauth"],
   confluence: ["confluence.api_token", "confluence.email", "confluence.base_url"],
   discord: ["discord.bot_token", "discord.enabled"],
@@ -34,9 +29,7 @@ export const CONNECTOR_VAULT_SECRET_KEYS = {
   iac: ["iac.enabled"],
   grafana: ["grafana.url", "grafana.api_token"],
   sentry: ["sentry.auth_token", "sentry.org_slug", "sentry.url"],
-  // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   newrelic: ["newrelic.api_key", "newrelic.account_id"],
-  // audit-ignore-next-line D11-vault-key (manifest entry, not vault-key construction)
   datadog: ["datadog.api_key", "datadog.app_key", "datadog.site"],
 } as const satisfies {
   readonly [K in ConnectorServiceId]: readonly string[];

--- a/packages/gateway/src/updater/manifest-fetcher.ts
+++ b/packages/gateway/src/updater/manifest-fetcher.ts
@@ -80,6 +80,7 @@ function validatePlatformAsset(key: string, asset: unknown): void {
   }
   const a = asset as Record<string, unknown>;
   if (typeof a["url"] !== "string") {
+    // audit-ignore-next-line D11-vault-key (validation error message, not vault-key construction; .url suffix is a manifest false positive)
     throw new ManifestFetchError(`platforms.${key}.url must be a string`);
   }
   if (typeof a["sha256"] !== "string") {

--- a/scripts/structure-audit/check-nimbus-invariants.test.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { CONNECTOR_VAULT_SECRET_KEYS } from "../../packages/gateway/src/connectors/connector-secrets-manifest.ts";
 import {
   checkSpawnInvariant,
   checkVaultKeyAllowList,
@@ -103,13 +104,37 @@ describe("D11 — checkVaultKeyAllowList", () => {
 });
 
 describe("D11 — VAULT_KEY_ALLOW_LIST is frozen at structural entries", () => {
-  test("VAULT_KEY_ALLOW_LIST has exactly 5 entries", () => {
-    // Each entry has a documented structural reason in the design spec § 4.4
-    // (helper home, Google OAuth canonical reader, Google PKCE writer,
-    // Microsoft provider-shared OAuth, OpenAI embedding provider).
-    // Adding a 6th entry requires updating this test, forcing a PR-level
-    // discussion of why the new file legitimately constructs vault keys.
-    expect(VAULT_KEY_ALLOW_LIST).toHaveLength(5);
+  test("VAULT_KEY_ALLOW_LIST has exactly 6 entries", () => {
+    // Each entry has a documented structural reason. The first 5 land in the
+    // structure-audit design spec § 4.4 (helper home, Google OAuth canonical
+    // reader, Google PKCE writer, Microsoft provider-shared OAuth, OpenAI
+    // embedding provider). The 6th — connector-secrets-manifest.ts — was
+    // added in the manifest-derived widening spec (2026-05-02) as the
+    // canonical declaration site for per-connector vault keys.
+    expect(VAULT_KEY_ALLOW_LIST).toHaveLength(6);
+  });
+});
+
+describe("D11 — manifest-derived VAULT_KEY_RE", () => {
+  test("matches representative manifest entries", () => {
+    const keys = Object.values(CONNECTOR_VAULT_SECRET_KEYS).flat();
+    // Spot-check each suffix family present in the manifest.
+    for (const sample of [
+      "jira.api_token",
+      "aws.access_key_id",
+      "bitbucket.app_password",
+      "datadog.app_key",
+      "iac.enabled",
+    ]) {
+      expect(keys).toContain(sample);
+      expect(`vault.set("${sample}", x)`).toMatch(/['"`][a-z0-9_]+\.[a-z0-9_]+['"`]/);
+    }
+  });
+
+  test("does not match non-manifest literals", () => {
+    const keys = Object.values(CONNECTOR_VAULT_SECRET_KEYS).flat();
+    expect(keys).not.toContain("console.log");
+    expect(keys).not.toContain("path.to.file");
   });
 });
 

--- a/scripts/structure-audit/check-nimbus-invariants.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.ts
@@ -8,7 +8,8 @@
 //   --binary-only       runs spawn + vault-key only (CI mode)
 //   (no flag)           runs everything; binary-violation exit code on D10/D11
 
-import { auditOutputPath, iterateSourceFiles } from "./lib.ts";
+import { CONNECTOR_VAULT_SECRET_KEYS } from "../../packages/gateway/src/connectors/connector-secrets-manifest.ts";
+import { auditOutputPath, iterateSourceFiles, stripComments } from "./lib.ts";
 
 export type FileEntry = { relPath: string; contents: string };
 export type Violation = { rule: string; file: string; line: number; snippet: string };
@@ -21,6 +22,9 @@ export const VAULT_KEY_ALLOW_LIST = [
   "packages/gateway/src/auth/oauth-vault-tokens.ts",
   // OpenAI embedding provider — not a Nimbus connector; no ConnectorServiceId.
   "packages/gateway/src/embedding/create-embedding-runtime.ts",
+  // Canonical declaration of per-connector vault keys; structurally equivalent
+  // to connector-vault.ts (declaration site, not runtime construction).
+  "packages/gateway/src/connectors/connector-secrets-manifest.ts",
 ];
 
 // Match a Bun.spawn or child_process spawn call.
@@ -48,11 +52,23 @@ export function checkSpawnInvariant(files: readonly FileEntry[]): Violation[] {
   return out;
 }
 
-// Heuristic: vault-key construction is a string-literal containing `.oauth`
-// or any template literal mixing service/provider with `.oauth`/`.token`/`.pat`.
+// Heuristic: vault-key construction is a string-literal containing a manifest
+// key (e.g. `"slack.oauth"`) or any template literal mixing service/provider
+// with a known suffix (e.g. `\`${s}.oauth\``).
 // Files in the allow-list are exempt. Test files are exempt (handled by iterateSourceFiles).
-const VAULT_KEY_RE =
-  /['"`][a-z0-9_]*\.(oauth|token|pat|api_key)['"`]|\$\{[^}]+\}\.(oauth|token|pat|api_key)/;
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildVaultKeyRegex(): RegExp {
+  const keys = Object.values(CONNECTOR_VAULT_SECRET_KEYS).flat();
+  const suffixes = Array.from(new Set(keys.map((k) => k.split(".")[1] ?? "")));
+  const literalAlt = keys.map(escapeRegex).join("|");
+  const suffixAlt = suffixes.map(escapeRegex).join("|");
+  return new RegExp(`['"\`](${literalAlt})['"\`]|\\$\\{[^}]+\\}\\.(${suffixAlt})`);
+}
+
+const VAULT_KEY_RE = buildVaultKeyRegex();
 
 export function checkVaultKeyAllowList(
   files: readonly FileEntry[],
@@ -61,10 +77,15 @@ export function checkVaultKeyAllowList(
   const out: Violation[] = [];
   for (const f of files) {
     if (allowList.includes(f.relPath)) continue;
-    const lines = f.contents.split("\n");
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i] as string;
-      const prevLine = lines[i - 1] ?? "";
+    // Strip comments so JSDoc references (e.g. `* when \`X.Y\` is present`) do
+    // not trigger the heuristic. Newlines are preserved so line numbers stay
+    // correct. The opt-out sentinel check uses the ORIGINAL lines because
+    // stripComments removes the `//` line that carries the marker.
+    const strippedLines = stripComments(f.contents).split("\n");
+    const originalLines = f.contents.split("\n");
+    for (let i = 0; i < strippedLines.length; i++) {
+      const line = strippedLines[i] as string;
+      const prevLine = originalLines[i - 1] ?? "";
       if (prevLine.includes("audit-ignore-next-line D11-vault-key")) continue;
       if (!VAULT_KEY_RE.test(line)) continue;
       out.push({


### PR DESCRIPTION
## Summary

This is **PR D** of the D11 manifest-derived audit + migration work — the final PR that closes D11 under the broader manifest-derived pattern. PRs A (#154), B (#155), and C (#156) are all merged.

### Changes

- **`scripts/structure-audit/check-nimbus-invariants.ts`** — Replaces the static 4-suffix `VAULT_KEY_RE` with `buildVaultKeyRegex()` derived from `CONNECTOR_VAULT_SECRET_KEYS` at startup. Routes file contents through `stripComments` before the line-by-line scan (JSDoc references no longer fire). The opt-out sentinel check uses the original un-stripped lines so existing `audit-ignore-next-line` markers continue to work. Adds `connector-secrets-manifest.ts` as the 6th allow-list entry.

- **`scripts/structure-audit/check-nimbus-invariants.test.ts`** — Bumps the frozen-count assertion 5 → 6 with updated justification. Adds a `D11 — manifest-derived VAULT_KEY_RE` describe block with two smoke tests.

- **`packages/gateway/src/connectors/connector-secrets-manifest.ts`** — Removes all 7 redundant `audit-ignore-next-line D11-vault-key` markers (file is now allow-listed; markers no longer needed).

- **`packages/gateway/src/updater/manifest-fetcher.ts`** — Adds one `audit-ignore-next-line` marker for a false positive introduced by the widened suffix set: the template literal `` `platforms.${key}.url must be a string` `` matched the new `.url` suffix (contributed by `grafana.url` and `sentry.url` in the manifest). This is validation error prose, not vault-key construction.

- **`docs/structure-audit/baseline.md`** — Updates the D11 row and appends a dated post-widening section documenting the 4-PR migration arc.

### Predecessors

| PR | Scope |
|---|---|
| #154 | `connector-rpc-handlers.ts` — 42 sites + `deleteConnectorSecret` helper |
| #155 | `lazy-mesh.ts` — 50 sites |
| #156 | 14 per-connector sync files + `connector-rpc-shared.ts` + `drift-hints.ts` |
| This PR | Audit script widening; allow-list expansion; baseline refresh |

### Acceptance gates

- `bun run audit:invariants` → exit 0, 0 D11 hits under the broader pattern ✅
- `bun test scripts/structure-audit/check-nimbus-invariants.test.ts` → 12 pass (incl. `VAULT_KEY_ALLOW_LIST has exactly 6 entries`) ✅
- `bun run typecheck` → clean ✅
- `bun run lint` → clean ✅
- `bun run test:ci` → all pass (UI Vitest V8 coverage is a known pre-existing flake) ✅
- `connector-secrets-manifest.ts` has 0 `audit-ignore-next-line` markers remaining ✅

### Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-02-d11-manifest-derived-audit-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-d11-manifest-derived-audit.md` (PR D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)