### PR TITLE
docs(structure-audit): correct connector count 27 → 28 in post-widening section

### DIFF
--- a/docs/structure-audit/baseline.md
+++ b/docs/structure-audit/baseline.md
@@ -46,7 +46,7 @@ The frozen 5-entry `VAULT_KEY_ALLOW_LIST` was unchanged across Buckets B and C.
 D11 stays at **0** violations under the broader manifest-derived regex.
 
 The audit script now derives `VAULT_KEY_RE` from `CONNECTOR_VAULT_SECRET_KEYS`
-at startup, so every entry across all 27 connectors (43 keys total) is
+at startup, so every entry across all 28 connectors (43 keys total) is
 gated — not just the original 4-suffix subset (`oauth | token | pat | api_key`).
 
 - PR #154 migrated 42 sites in `connector-rpc-handlers.ts` and added the `deleteConnectorSecret<S>` helper.


### PR DESCRIPTION
## Summary
Tiny follow-up to #157. The new \`Phase 2 follow-up — post manifest-derived widening (2026-05-02)\` section in \`docs/structure-audit/baseline.md\` said the manifest covers \"27 connectors\" but the manifest actually has 28 connector entries (43 keys total). Code review on #157 caught this; this PR fixes the typo.

## Test plan
- [x] No code changes — doc-only PR.
- [x] No CI gates affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)