### PR TITLE
docs(structure-audit): mark connector-rpc-handlers.ts D4 row as landed in PR #160

### DIFF
--- a/docs/structure-audit/deferred-backlog.md
+++ b/docs/structure-audit/deferred-backlog.md
@@ -28,7 +28,7 @@ prioritisation.
 | `packages/gateway/src/connectors/lazy-mesh.ts` | 1401 | 37 (p80+) | Refactor candidate: split MCP-spawn-config from server-record state machine — by-concern preserves single export surface; own design spec | High |
 | `packages/gateway/src/ipc/server.ts` | 1239 | 56 (p80+) | Refactor candidate: extract per-namespace handler registries; dispatcher stays thin — own design spec | High |
 | `packages/cli/src/commands/connector.ts` | 1238 | 32 (p80+) | Refactor candidate: split per-subcommand modules under `cli/commands/connector/` — own design spec | High |
-| `packages/gateway/src/ipc/connector-rpc-handlers.ts` | 1103 | 30 (p80+) | Refactor candidate: split by namespace (status / config / oauth / removal) — own design spec | High |
+| ~~`packages/gateway/src/ipc/connector-rpc-handlers.ts`~~ | ~~1103~~ | ~~30 (p80+)~~ | ✅ **Landed in PR #160 (2026-05-02)** — split into `connector-rpc-handlers/` directory with 7 sibling files (auth/config/context/index/lifecycle/removal/status). Largest resulting file: `auth.ts` at 676 LOC. | — |
 | `packages/gateway/src/index/local-index.ts` | 987 | 45 (p80+) | Refactor candidate: extract write/read/migration concerns into sibling modules — own design spec | High |
 | `packages/gateway/src/auth/pkce.ts` | 886 | 12 (p80+) | Refactor candidate: split by OAuth provider flow (Google / Microsoft / generic core) — own design spec | High |
 


### PR DESCRIPTION
## Summary
Tiny follow-up to #160. The deferred-backlog file had an active D4 row tracking the very work that PR #160 just delivered. Marks the row as ✅ landed with a reference to #160 so future structure-audit runs don't misdirect.

Code review on #160 caught this; this PR closes the loop.

## Test plan
- [x] No code changes — doc-only PR.
- [x] No CI gates affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)