### PR TITLE
refactor(connectors): apply spec-review §2.2 — move MeshLogger to slot.ts

### DIFF
--- a/packages/gateway/src/connectors/lazy-mesh/index.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/index.ts
@@ -1,3 +1,4 @@
 export { LazyDrainTracker } from "./drain.ts";
 export { createLazyConnectorMesh, LazyConnectorMesh } from "./mesh.ts";
-export { type MeshLogger, mergeToolMapsOrThrow } from "./tool-map.ts";
+export type { MeshLogger } from "./slot.ts";
+export { mergeToolMapsOrThrow } from "./tool-map.ts";

--- a/packages/gateway/src/connectors/lazy-mesh/mesh.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/mesh.ts
@@ -26,13 +26,8 @@ import {
 import { ensureCredentialConnectorsRunning } from "./credential-orchestration.ts";
 import { LazyDrainTracker } from "./drain.ts";
 import { LAZY_MESH, USER_MESH_PREFIX, userMcpMeshKey } from "./keys.ts";
-import type { LazyMcpSlot, MeshSpawnContext } from "./slot.ts";
-import {
-  type LazyMeshToolMap,
-  listLazyMeshClientTools,
-  type MeshLogger,
-  mergeToolMapsOrThrow,
-} from "./tool-map.ts";
+import type { LazyMcpSlot, MeshLogger, MeshSpawnContext } from "./slot.ts";
+import { type LazyMeshToolMap, listLazyMeshClientTools, mergeToolMapsOrThrow } from "./tool-map.ts";
 import { ensureUserMcpClient } from "./user-mcp.ts";
 
 /**

--- a/packages/gateway/src/connectors/lazy-mesh/slot.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/slot.ts
@@ -2,7 +2,6 @@ import type { MCPClient } from "@mastra/mcp";
 
 import type { NimbusVault } from "../../vault/nimbus-vault.ts";
 import type { LazyDrainTracker } from "./drain.ts";
-import type { MeshLogger } from "./tool-map.ts";
 
 export type LazyMcpSlot = {
   client: MCPClient | undefined;
@@ -16,6 +15,11 @@ export type ServerSpec = {
   args: string[];
   env: Record<string, string>;
 };
+
+/** Minimal logger shape — accepts the pino `(bindings, msg)` form. */
+export interface MeshLogger {
+  warn(bindings: Record<string, unknown>, msg?: string): void;
+}
 
 /**
  * Internal collaborator interface — wraps the slot state-machine on

--- a/packages/gateway/src/connectors/lazy-mesh/tool-map.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/tool-map.ts
@@ -38,8 +38,3 @@ export async function listLazyMeshClientTools(
   }
   return (await client.listTools()) as LazyMeshToolMap;
 }
-
-/** Minimal logger shape — accepts the pino `(bindings, msg)` form. */
-export interface MeshLogger {
-  warn(bindings: Record<string, unknown>, msg?: string): void;
-}


### PR DESCRIPTION
## Summary
Spec-review disposition follow-up to PR #163 (the lazy-mesh.ts split, already merged). PR #162 (the spec/plan PR) accepted §2.2 of the Gemini spec review: move \`MeshLogger\` from \`tool-map.ts\` to \`slot.ts\`, where its primary consumer \`MeshSpawnContext\` lives.

## Changes
- \`tool-map.ts\` — remove the \`MeshLogger\` interface definition. File is now purely about tool-map types/helpers (\`LazyMeshToolMap\`, \`listLazyMeshClientTools\`, \`mergeToolMapsOrThrow\`).
- \`slot.ts\` — add the \`MeshLogger\` interface definition. Drops the \`import type { MeshLogger } from "./tool-map.ts"\` line — \`slot.ts\` no longer depends on \`tool-map.ts\`.
- \`mesh.ts\` — import \`MeshLogger\` from \`./slot.ts\` (was \`./tool-map.ts\`).
- \`index.ts\` — re-export \`MeshLogger\` from \`./slot.ts\` (was \`./tool-map.ts\`). Public surface unchanged.

Pure file-move refactor; **zero behavioral change**. Public surface identical — \`MeshLogger\` still re-exported from the package's \`index.ts\` shim, just sourced from a different sibling.

## Why
- Co-locates \`MeshLogger\` with its primary consumer \`MeshSpawnContext\`.
- Removes the \`slot.ts → tool-map.ts\` import edge.
- Keeps \`tool-map.ts\` purely about tool maps.

## Test plan
- [x] \`bun run audit:invariants\` exit 0.
- [x] \`bun run typecheck\` clean.
- [x] \`bun run lint\` clean (Biome, 958 files).
- [x] \`bun test\` lazy-mesh + lazy-mesh-args-json + security-invariants — 25/25 pass.

## Spec disposition
Lands on top of #162 (spec/plan PR). The \`§2.2 ACCEPT\` rationale is documented in the spec's \`§ 9 — Review dispositions\` section there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)