### PR TITLE
docs: Phase 4 v0.1.1 + Phase 5 Team Intelligence + Phase 7 point-in-time + 4 new Claude skills

### DIFF
--- a/.claude/commands/nimbus-agent-patterns.md
+++ b/.claude/commands/nimbus-agent-patterns.md
@@ -1,0 +1,104 @@
+---
+name: nimbus-agent-patterns
+description: >
+  Reference for authoring built-in Nimbus agents (meeting-prep, oncall-brief, expert,
+  standup, catchup, impact, etc.): file location, the read-only/HITL-free shape invariant,
+  parallel sub-agent decomposition via AgentCoordinator, tool-scope restriction, the
+  briefReady IPC notification contract, the matching CLI entry point, the e2e test
+  pattern, and the latency budget. Use this skill whenever you are adding a new built-in
+  agent, modifying an existing one, deciding how to decompose a multi-step task, wiring
+  a new CLI command for an agent, or asking why an agent's brief is slow or empty. Also
+  trigger for questions like "where does this agent live?", "should this be sequential
+  or parallel?", "what tool scope does my sub-agent need?", or "how do I test an agent?".
+  Consult before writing any new file under packages/gateway/src/agents/.
+---
+
+# Nimbus Built-in Agent Patterns
+
+## Built-in Agent Location
+
+All built-in agents live in `packages/gateway/src/agents/`. Each agent is a single file named after the command it serves: `meeting-prep.ts`, `oncall-brief.ts`, `expert.ts`, `standup.ts`, `catchup.ts`, `impact.ts`, etc.
+
+## Agent Shape Invariant
+
+Every built-in agent must be:
+
+- **Read-only** — no write tools in scope.
+- **Parallel where possible** — use `AgentCoordinator` with independent sub-agents.
+- **HITL-free** — if the coordinator encounters a HITL-required tool it skips it and notes the omission in output. Built-in agents never wait on consent.
+- **Notifying** — emits a `<agentName>.briefReady { sessionId, brief: string }` IPC notification on completion.
+
+## Sub-agent Decomposition Pattern
+
+Use `AgentCoordinator` to decompose into parallel sub-agents with isolated tool scopes:
+
+```typescript
+const plan = await coordinator.decompose(intent, {
+  subTasks: [
+    { id: "a", toolScope: ["github.pr.list", "github.issue.list"], description: "..." },
+    { id: "b", toolScope: ["slack.search"], description: "..." },
+    { id: "c", toolScope: ["searchLocalIndex"], description: "..." },
+  ]
+});
+const results = await coordinator.executeAll(plan); // runs in parallel
+```
+
+**Never use sequential tool calls where parallel sub-agents would work** — it defeats the latency purpose of decomposition.
+
+## Tool Scope Restriction
+
+Sub-agents receive only the tools listed in their `toolScope`. This is enforced at the dispatcher level. **Do not give a sub-agent a broad scope "for flexibility"** — scope it to exactly the tools it needs. Broad scopes break the principle of least privilege and make latency budgets unpredictable.
+
+## IPC Notification Contract
+
+Every agent emits a completion notification via the Gateway IPC server:
+
+```typescript
+ipcServer.notify(`${agentName}.briefReady`, { sessionId, brief });
+```
+
+- `brief` is **always a Markdown string**.
+- `sessionId` ties the notification to the originating `engine.askStream` call.
+- Notification name is always `<agentName>.briefReady` — the CLI subscribes to that exact name.
+
+## CLI Entry Point
+
+Each built-in agent gets a dedicated CLI command in `packages/cli/src/commands/`. The command:
+
+1. Calls the Gateway IPC method.
+2. Streams the `briefReady` notification.
+3. Renders the Markdown brief to stdout, **respecting `NO_COLOR`**.
+
+Add the command to the CLI's command registry in `packages/cli/src/index.ts`.
+
+## E2E Test Pattern
+
+Every agent requires an e2e test at `packages/gateway/test/e2e/scenarios/<agent-name>.e2e.test.ts` that:
+
+- Mocks all connector MCP servers.
+- Asserts the brief contains the expected sections (e.g., attendees, recent work, doc references for `meeting-prep`).
+- Asserts **zero HITL actions fired**.
+- Asserts the `briefReady` notification is emitted with a non-empty `brief`.
+
+Use the existing `meeting-prep.e2e.test.ts` as the reference implementation.
+
+## Coverage Gate
+
+`packages/gateway/src/agents/` ≥ **80% line coverage**.
+
+## Latency Expectation
+
+Built-in agents targeting interactive use (`oncall`, `expert`, `standup`) should complete in **under 15 seconds** on a mid-range laptop using local LLM routing. If sub-agent decomposition would exceed this, **reduce the number of parallel sub-agents** rather than increasing the timeout — fewer, more focused sub-agents are always preferable to a long fan-out.
+
+## Authoring Checklist
+
+- [ ] File created at `packages/gateway/src/agents/<agent-name>.ts`.
+- [ ] Agent is read-only — no write tools in scope.
+- [ ] Decomposed into parallel sub-agents via `AgentCoordinator` where independent steps exist.
+- [ ] Each sub-agent's `toolScope` lists exactly the tools it needs — nothing extra.
+- [ ] HITL-required tools are skipped and noted in output, never awaited.
+- [ ] Emits `<agentName>.briefReady { sessionId, brief }` on completion; `brief` is Markdown.
+- [ ] CLI command added under `packages/cli/src/commands/` and registered in `packages/cli/src/index.ts`; respects `NO_COLOR`.
+- [ ] E2E test added at `packages/gateway/test/e2e/scenarios/<agent-name>.e2e.test.ts` covering brief sections, zero HITL fires, and the `briefReady` notification.
+- [ ] Latency on a mid-range laptop with local LLM routing is under 15 s.
+- [ ] `packages/gateway/src/agents/` line coverage stays ≥ 80%.

--- a/.claude/commands/nimbus-connector-authoring.md
+++ b/.claude/commands/nimbus-connector-authoring.md
@@ -1,0 +1,131 @@
+---
+name: nimbus-connector-authoring
+description: >
+  Complete reference for authoring first-party MCP connectors in the Nimbus monorepo:
+  package layout, mandatory tool surface, manifest structure, credential injection,
+  the sync handler contract, item ID format, HITL declaration, contract tests, and
+  coverage gates. Use this skill whenever the user is creating a new connector,
+  modifying an existing one, asking what tools must be exposed, debugging a contract
+  test failure, or wiring a new MCP server into the connector registry. Also trigger
+  for questions like "where does the connector go?", "do I need a write tool here?",
+  "how do credentials get into the connector process?", or "what does my sync handler
+  need to return?". Consult before writing any connector code.
+---
+
+# Nimbus Connector Authoring
+
+## Package Location
+
+First-party connectors live in `packages/mcp-connectors/<name>/`. Each is a Bun workspace package with its own:
+
+- `package.json`
+- `src/server.ts` entry point
+- `nimbus.extension.json` manifest
+
+## Mandatory Tool Surface
+
+Every connector must expose **at minimum**:
+
+- `list` (no HITL)
+- `get` (no HITL)
+- `search` (no HITL)
+
+Write tools (`create`, `update`, `move`, `delete`) are conditional or always-HITL per the table in `docs/architecture.md`. **`move` and `delete` are always HITL.** Never omit a read tool to save time — the contract test will fail.
+
+## Manifest Structure
+
+`nimbus.extension.json` must include:
+
+| Field | Format | Notes |
+|---|---|---|
+| `id` | reverse-domain (e.g. `com.nimbus.github`) | stable across versions |
+| `displayName` | string | UI-facing |
+| `version` | semver | bumps on every release |
+| `entrypoint` | path | usually `dist/server.js` |
+| `runtime` | `"bun"` | only supported runtime today |
+| `permissions` | string array | enumerates capabilities |
+| `hitlRequired` | string array | every write permission listed here |
+| `syncInterval` | seconds | default sync cadence |
+| `minNimbusVersion` | semver | gating |
+
+The `hitlRequired` field is what causes the Gateway to gate those tools — **omitting it means write tools run without consent**.
+
+## Credential Injection Pattern
+
+**Credentials are never fetched from the Vault inside the connector.** They arrive as environment variables injected at spawn time by the Gateway. The connector reads them from `process.env` at startup. **Never call any Vault API from connector code** — the connector process has no Vault access by design.
+
+```typescript
+const token = process.env.GITHUB_TOKEN;
+if (!token) throw new Error("GITHUB_TOKEN not set");
+```
+
+## Sync Handler Contract
+
+Implement `ConnectorSyncHandler`:
+
+```typescript
+interface ConnectorSyncHandler {
+  connectorId: string;
+  syncInterval: number;
+  sync(db: Database, lastSyncToken: string | null): Promise<SyncResult>;
+}
+
+interface SyncResult {
+  upserted: IndexedItem[];
+  deleted: string[];
+  nextSyncToken: string;
+  hasMore?: boolean;
+}
+```
+
+- `hasMore: true` causes the scheduler to re-queue immediately.
+- Always return a `nextSyncToken` even on first sync — use a timestamp string if the API has no native token.
+
+## Item ID Format
+
+Always `"<service>:<native_id>"` — e.g. `"github:pr_12345"`.
+
+**Never use a UUID.** IDs must be stable across syncs so upserts work correctly.
+
+## HITL Tool Declaration
+
+Write tools in the MCP server must call `server.assertHitlRequired()` at the **top of their handler**. The Gateway enforces HITL regardless, but the assertion makes intent explicit and the contract test checks for it.
+
+## Contract Tests
+
+Run `nimbus test` from the connector directory before submitting. This executes `runContractTests()` from `@nimbus-dev/sdk` which checks:
+
+- Manifest schema validity.
+- Mandatory tool surface presence (`list`, `get`, `search`).
+- HITL declaration on write tools.
+- Item ID format on returned items.
+- `SyncResult` shape.
+
+**All must pass** before a PR is ready for review.
+
+## Coverage Gate
+
+MCP connectors: **≥ 70% line coverage**. Integration tests use a fresh temp dir and real SQLite — no mocking the DB layer.
+
+## Scaffold
+
+Always start from:
+
+```bash
+nimbus scaffold extension --name <name> --output ./packages/mcp-connectors/<name>
+```
+
+Then add the sync handler and register in the connector registry at `packages/gateway/src/connectors/registry.ts`.
+
+## Authoring Checklist
+
+- [ ] Package created under `packages/mcp-connectors/<name>/` via `nimbus scaffold extension`.
+- [ ] `nimbus.extension.json` populated with `id`, `displayName`, `version`, `entrypoint`, `runtime: "bun"`, `permissions`, `hitlRequired`, `syncInterval`, `minNimbusVersion`.
+- [ ] Mandatory `list`, `get`, `search` tools exposed.
+- [ ] Every write tool listed in `hitlRequired` and calls `server.assertHitlRequired()` at the top of its handler.
+- [ ] Credentials read from `process.env` only; no Vault API calls.
+- [ ] `ConnectorSyncHandler` implemented; `SyncResult.nextSyncToken` always populated.
+- [ ] Item IDs follow `"<service>:<native_id>"` — no UUIDs.
+- [ ] `nimbus test` passes (contract tests green).
+- [ ] Connector registered in `packages/gateway/src/connectors/registry.ts`.
+- [ ] Line coverage ≥ 70%.

--- a/.claude/commands/nimbus-db-migrations.md
+++ b/.claude/commands/nimbus-db-migrations.md
@@ -1,0 +1,141 @@
+---
+name: nimbus-db-migrations
+description: >
+  Reference for authoring SQLite migrations in the Nimbus Gateway: file location and
+  numbering, the runner contract (transaction wrapping, pre-migration backups, ledger
+  recording), the append-only schema rule, large-backfill batching, the _schema_migrations
+  ledger, the new-table checklist, and FTS5/vec0 virtual-table cautions. Use this skill
+  whenever the user is adding a schema migration, modifying an existing one, debugging
+  a failed migration, asking why a migration cannot be rolled back, or adding a new
+  table or column. Also trigger for questions like "what V<N> number do I use?", "can
+  I drop this column?", "how do I backfill safely?", or "where does the pre-migration
+  backup live?". Consult before creating any file under packages/gateway/src/db/migrations/.
+---
+
+# Nimbus DB Migrations
+
+## Migration Location
+
+All migrations live in `packages/gateway/src/db/migrations/`. Each migration is a numbered TypeScript file:
+
+```
+V<N>__<description>.ts
+```
+
+Example: `V23__add_api_endpoint_items.ts`.
+
+**Numbers are strictly sequential — never reuse or skip a number.**
+
+## Migration Runner Contract
+
+The runner in `packages/gateway/src/db/migrate.ts`:
+
+- Applies migrations in order.
+- Wraps each migration in **a single transaction**.
+- Writes a **pre-migration backup** before each migration runs.
+- Records each migration in `_schema_migrations` on success.
+- On a thrown migration: rolls back the transaction, restores the backup, marks the migration `failed` in the ledger, and exits with an error.
+
+**Never write a migration that cannot be safely rolled back within a transaction.**
+
+## Pre-migration Backup Rule
+
+The backup is written by the runner automatically before every migration. **Never skip it.** If the backup write fails, the migration is **aborted** — this is intentional.
+
+The backup lives at:
+
+```
+<dataDir>/backups/pre-migration-V<N>-<timestamp>.db
+```
+
+## Migration File Structure
+
+Every migration file must export exactly one function:
+
+```typescript
+export async function up(db: Database): Promise<void> {
+  // All SQL in one transaction — the runner wraps this call
+  db.run("CREATE TABLE ...");
+  db.run("CREATE INDEX ...");
+}
+```
+
+**No `down()` function** — Nimbus migrations are append-only and forward-only. If you need to undo a migration, write a new migration that reverses it.
+
+## Append-only Schema Rule
+
+**Never** drop a column, rename a column, or drop a table in a migration unless it was added in the same phase and has no data.
+
+Additive changes only:
+
+- `CREATE TABLE`
+- `CREATE INDEX`
+- `ALTER TABLE ADD COLUMN`
+- `CREATE VIRTUAL TABLE`
+
+If a column rename is truly necessary: add the new column, backfill it, and **leave the old column in place with a deprecation comment**.
+
+## Large Backfill Pattern
+
+Migrations that backfill existing rows must process in batches to avoid locking the DB for extended periods:
+
+```typescript
+const BATCH = 1000;
+let offset = 0;
+while (true) {
+  const rows = db.query("SELECT id FROM table LIMIT ? OFFSET ?").all(BATCH, offset);
+  if (rows.length === 0) break;
+  db.transaction(() => { /* update rows */ })();
+  offset += BATCH;
+}
+```
+
+**Never process an unbounded number of rows in a single statement inside a migration.**
+
+## `_schema_migrations` Ledger
+
+Columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `version` | integer | the `V<N>` number |
+| `description` | text | from the filename |
+| `applied_at` | integer | unix ms |
+| `status` | `applied` \| `failed` | runner-managed |
+
+The runner inserts a row with `status = 'applied'` after each successful migration. **Never write to this table manually.**
+
+## New Table Checklist
+
+When adding a new table, always include:
+
+- A primary key.
+- `created_at INTEGER NOT NULL` (unix ms).
+- Appropriate indexes for the expected query patterns.
+- A `CHECK` constraint on any enum-like column.
+- An entry in the schema reference in `docs/architecture.md` under "Local Database Schema".
+
+## Virtual Table Caution
+
+FTS5 and `vec0` virtual tables cannot be created inside a regular `ALTER TABLE` — they must be `CREATE VIRTUAL TABLE` statements.
+
+When deleting rows from a source table that has an FTS5 shadow:
+
+- **Delete from the FTS5 table first** using targeted row deletion: `DELETE FROM items_fts WHERE rowid = ?`.
+- **Never** issue `INSERT INTO items_fts(items_fts) VALUES('rebuild')` inside a migration — that rebuilds the entire index and blocks reads.
+
+## Coverage Gate
+
+`packages/gateway/src/db/` ≥ **85% line coverage**. Migration files are covered by the integration test suite which runs all migrations against a fresh in-memory SQLite instance on every CI run.
+
+## Authoring Checklist
+
+- [ ] File created at `packages/gateway/src/db/migrations/V<N>__<description>.ts` with the next sequential number — no reuse, no gaps.
+- [ ] Exports a single `up(db: Database): Promise<void>` function — no `down()`.
+- [ ] All schema changes are additive (`CREATE TABLE`, `CREATE INDEX`, `ALTER TABLE ADD COLUMN`, `CREATE VIRTUAL TABLE`); no drops or renames except for same-phase, no-data items.
+- [ ] Backfills process in 1 000-row batches inside `db.transaction()`.
+- [ ] No manual writes to `_schema_migrations`.
+- [ ] New tables include primary key, `created_at INTEGER NOT NULL`, query-pattern indexes, and `CHECK` constraints on enum columns.
+- [ ] FTS5 row deletes use targeted `DELETE FROM items_fts WHERE rowid = ?` — never the `'rebuild'` command.
+- [ ] Schema reference in `docs/architecture.md` updated for any new table.
+- [ ] Integration tests covering the migration are green; `packages/gateway/src/db/` line coverage stays ≥ 85%.

--- a/.claude/commands/nimbus-security-invariants.md
+++ b/.claude/commands/nimbus-security-invariants.md
@@ -1,0 +1,92 @@
+---
+name: nimbus-security-invariants
+description: >
+  Authoritative reference for the Nimbus invariant triple rule and the security-defense
+  lifecycle: production wiring + docs entry + enforcement test. Use this skill whenever
+  you are adding, modifying, or auditing a structural security defense — HITL action types,
+  extension integrity checks, Vault redaction rules, ALLOWED_METHODS bridge entries, or
+  any new gating mechanism. Also trigger for questions like "is this defense real?",
+  "how do I add a new HITL action?", "should this be in ALLOWED_METHODS?", or "why does
+  the security-invariants test fail?". Consult before claiming a defense is active —
+  the B1 audit found three defenses defined in code but never wired in production.
+---
+
+# Nimbus Security Invariants
+
+## The Invariant Triple Rule
+
+Every structural security defense in Nimbus must exist as **three things simultaneously** or it is not considered real:
+
+1. **Production wiring site** — an actual call site in production code, not just a function definition.
+2. **Entry in `docs/SECURITY-INVARIANTS.md`** — names the defense, its invariant ID (format `I<N>`), and the production wiring file and line.
+3. **Assertion in `packages/gateway/src/security-invariants.test.ts`** — fails if the wiring is removed.
+
+If any one of the three is missing, **do not claim the defense is active**. Search for all three before marking work done.
+
+## The B1 Audit Lesson
+
+The Phase 4 internal audit found three defenses (`extensionProcessEnv`, `checkLanMethodAllowed`, the `<tool_output>` envelope) that were **defined in code but had zero production callers**. The triple rule exists to prevent that failure mode. When adding a new defense, do all three of:
+
+- `grep` for the function name across `packages/gateway/src/` to confirm it has at least one production caller.
+- Add the `I<N>` row to `docs/SECURITY-INVARIANTS.md` with the wiring file:line.
+- Add a test in `security-invariants.test.ts` that fails if the wiring is removed (e.g., asserts a specific source file imports/calls the defense).
+
+## HITL Invariants
+
+`HITL_REQUIRED` in `packages/gateway/src/engine/executor.ts` is a **module-level `ReadonlySet` frozen with `Object.freeze`**. Rules:
+
+- Never populated from config files, IPC calls, or extension APIs at runtime.
+- New action types are added by editing the static source declaration only.
+- The corresponding test asserts that **every action type in the set triggers the consent channel** in `ToolExecutor.execute()`.
+- The gate consults `action.type` only — **not** `payload.mcpToolId` or `resolvedToolId` (the set holds logical types, not MCP ids — invariant `I3`).
+- `hitlStatus` is set only by the consent gate (invariant `I4`). Hardcoding `hitlStatus: "approved"` in any handler is a regression.
+
+## Extension Integrity Invariants
+
+Manifest SHA-256 is verified **twice**:
+
+1. At Gateway startup via `verifyExtensionsBestEffort`.
+2. **Immediately before each spawn** via `verifyOneExtensionStrict`.
+
+Both wiring sites must be present. A defense that only verifies at startup is insufficient — it does not catch mutations between startup and spawn. When auditing, check both call sites exist; deleting either breaks the invariant.
+
+## Vault Invariants
+
+**No code path may** write a credential value to disk in plaintext, include it in a log line, or return it in an IPC response.
+
+- The Pino logger `redact` config covers `*.token`, `*.secret`, and `oauth.*` patterns.
+- When adding a new credential type, verify the field name matches one of these patterns or **add it explicitly to the redact list**.
+- The structured logger redaction is enforced by a unit test that pipes a known-secret payload through the logger and asserts the secret never appears in output.
+
+## ALLOWED_METHODS Invariant
+
+The Rust bridge in `packages/ui/src-tauri/src/gateway_bridge.rs` maintains a **compile-time `ALLOWED_METHODS: &[&str]` array**. A `cargo test allowlist_exact_size` assertion verifies the count.
+
+When adding new IPC methods accessible from the UI:
+
+- Add them to `ALLOWED_METHODS` **alphabetically**.
+- **Update the count assertion** in the test.
+- Never expose `vault.*`, `db.*` writes, `updater.*`, or `lan.*` pairing methods through this surface — these are RCE-class or pairing-class methods that must remain Gateway-only.
+
+## When to Create a New Invariant Entry
+
+Add an invariant entry (`I<N>` row in `SECURITY-INVARIANTS.md` + test assertion) when you add:
+
+- A new HITL action type.
+- A new credential storage path.
+- A new extension verification step.
+- A new IPC method gating.
+- A new prompt injection defense.
+
+**Do not** add invariant entries for non-security behavior. The invariant table is a load-bearing contract, not a documentation index.
+
+## Workflow Checklist
+
+When introducing or modifying a structural defense:
+
+- [ ] Production wiring site exists and has a real caller (`grep` to confirm).
+- [ ] `docs/SECURITY-INVARIANTS.md` has an `I<N>` row naming the defense + wiring file:line.
+- [ ] `packages/gateway/src/security-invariants.test.ts` has an assertion that fails if the wiring is removed.
+- [ ] If the defense gates an IPC method exposed to the UI, the method is in `ALLOWED_METHODS` and the count assertion is updated.
+- [ ] If the defense affects credentials, the field name matches the Pino `redact` patterns or is added explicitly.
+- [ ] When changing a wiring site, update both the test and `SECURITY-INVARIANTS.md` in the same commit. When retiring an invariant, delete the row — never leave it as documentation drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,3 +472,12 @@ Verify the result before proposing the install. **Do not propose `bun add`** if 
 - The author/maintainer is unfamiliar for a name that resembles a well-known package (e.g. `expresss`, `lodahs`, `react-domm`)
 
 When all three checks pass, include the package's published age and maintainer in your suggestion so the user can confirm before installing.
+
+---
+
+## Skill References
+
+@.claude/commands/nimbus-agent-patterns.md
+@.claude/commands/nimbus-connector-authoring.md
+@.claude/commands/nimbus-db-migrations.md
+@.claude/commands/nimbus-security-invariants.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,18 @@ nimbus ask "What Terraform drift has been detected since last week's deployment?
 # Data lineage — answered from the local index, no warehouse query
 nimbus ask "The Q1 revenue dashboard shows zeroes — which upstream model broke?"
 
+# Expert routing — find who has the most context on a topic
+nimbus ask "who has the most context on the payment retry logic?"
+
+# Blast radius — answered from the relationship graph before you push
+nimbus impact src/billing/retry.ts
+
+# Personal standup — assembled from your activity across all connected services
+nimbus standup
+
+# Catch up after time away — prioritized by what you care about
+nimbus catchup --since 3d
+
 # Consent-gated automation — full plan preview before anything executes
 nimbus run ./incident-response.yml
 ```
@@ -107,6 +119,7 @@ Nimbus is built for engineers and operators who run systems in production. If yo
 | **Platform Engineer** | Drift detection, multi-cloud infra state, deployment correlation, consent-gated IaC apply and rollback |
 | **Security Engineer** | Alert-to-commit tracing, CVE-to-PR correlation, full audit log for every agent action, compliance posture queries |
 | **Senior Developer** | Cross-repo PR intelligence, release readiness checks, pipeline context, local-only credential storage |
+| **Team Lead / Engineering Manager** | Cross-service activity digest, changelog generation, expert routing, blast radius analysis — without asking anyone |
 | **Analytics Engineer / Data Scientist** | Cross-stack lineage from dashboard to dbt model to warehouse table to orchestration DAG — one local query instead of five consoles; metadata-only ingestion keeps row data on the warehouse |
 
 This is not a tool for everyone. There is no managed cloud service, no Nimbus account, and no relay server. If that's what you need, look elsewhere.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -406,6 +406,10 @@ These items have no external blocker; they slip out of `v0.1.0` to keep the rele
 | **Workflow branching / conditionals (`if` / `else` / `switch`)** | engineering work only |
 | **Built-in `nimbus prep` (Meeting preparation agent)** | WS6 streaming surface (`engine.askStream`) battle-tested in the wild |
 | **5 seed community extensions in the registry** | `registry.nimbus.dev` host live (see [`v0.1.0-prerequisites.md`](./release/v0.1.0-prerequisites.md) §5) |
+| **`nimbus explain last` (X-ray of the most recent `nimbus ask`)** — prints what data the agent loaded into its context window, how each item was ranked and why, what was discarded and the reason (connector rate-limited, below relevance threshold, context window full), and which connectors were queried vs answered from cache. Helps users understand weak or wrong answers and tune their index accordingly. No new Gateway APIs required — the agent already tracks this metadata internally during query execution; this command surfaces it. Output: plain text by default; `--json` for machine-readable. Read-only, no HITL. | engineering work only — surfaces metadata the agent already records |
+| **`nimbus changelog` (Markdown changelog assembled from the local index)** — generates a human-readable changelog for a service or across all connected services by assembling everything that moved in the indexed data over a time window: PRs merged, deployments ran, incidents opened and resolved, dependency updates, config changes. Formatted as a Markdown document suitable for release notes, weekly engineering updates, or onboarding new team members. Flags: `--service <name>` to scope to one service, `--since <duration>` (default: `7d`), `--format <markdown\|slack\|plain>`. Zero new connectors required. Read-only, no HITL. | engineering work only — uses existing indexed data |
+| **`nimbus standup` (personal standup update from indexed activity)** — assembles everything the authenticated user did across all connected services in the last 24 hours (configurable via `--since`): PRs opened, reviewed, and merged; tickets moved or commented on; incidents responded to; deployments triggered; Slack threads participated in. Output is copy-pasteable Markdown. Scoped to the current user's identity as resolved by the people graph. `--format <markdown\|slack\|plain>` flag. Read-only, no HITL. Entirely local — nothing is posted anywhere without a separate explicit command. | engineering work only — uses existing people graph |
+| **`nimbus index health` (index quality report beyond raw item counts)** — embedding coverage percentage per connector, connectors contributing stale data (last synced more than a configurable threshold ago), item types with sparse metadata (missing `url`, `modified_at`, or `raw_meta` fields), and an overall query confidence score (0–100) derived from coverage and freshness. Helps users understand why they're getting weak query results before giving up on Nimbus. Integrates with `nimbus doctor` — a confidence score below 60 prints a warning in `nimbus doctor` output. Read-only, no HITL. `--json` flag for machine-readable output. | engineering work only — index metrics already collected |
 
 ### Maintenance-initiative follow-ups (B-series)
 
@@ -424,6 +428,10 @@ The B1 security audit and the B2 perf audit completed in Phase 4. Two more initi
 - Five community extensions available in the Marketplace at `v0.1.0` launch *(seed plan: publish first-party connectors as community packages and engage early adopters via `docs/contributors/extension-author-walkthrough.md`)*
 - VS Code extension installs from Open VSX and connects to a running Gateway without any manual configuration
 - Voice query completes end-to-end (speech → Whisper.cpp transcription → Gateway → TTS playback) on all three platforms; audio never leaves the machine — verified by network inspection in CI
+- `nimbus changelog --service payment-service --since 7d` produces a Markdown document containing at least PRs merged and incidents resolved for that service, assembled entirely from the local index without a live API call
+- `nimbus standup` produces a Markdown summary of the authenticated user's activity across at least GitHub and Linear in the last 24 hours, resolved via the people graph from the local index
+- `nimbus explain last` after a recent `nimbus ask` lists the indexed items loaded into context with their relevance scores and the reason any candidate items were discarded, and identifies which connectors were queried vs answered from cache
+- `nimbus index health` reports per-connector embedding coverage and a 0–100 confidence score derived from coverage and freshness; a confidence score below 60 surfaces in `nimbus doctor` output as a warning
 
 ---
 
@@ -532,6 +540,12 @@ The B1 security audit and the B2 perf audit completed in Phase 4. Two more initi
 - [ ] **Wiz** — cloud security posture findings, misconfigurations, toxic combinations, asset inventory; API token; read-only index; `cloud_finding` item type; enables "show me all critical Wiz findings for the services that paged last week" queries
 - [ ] **SBOM / supply chain tracking** — ingests CycloneDX or SPDX SBOMs from CI artefacts or GitHub Dependency Graph; indexes component → repo → version relationships; enables queries like "which of my services ship lodash <4.17.21?" without touching each repo; no auth required beyond existing GitHub/GitLab connectors
 
+### Team Intelligence
+
+- [ ] **`nimbus expert <topic-or-file>`** — answers "who on my team has the most context on this?" by querying the relationship graph and indexed metadata: git blame history for the file or topic (via indexed code symbols and PR authorship), PR review participation patterns, Slack thread activity mentioning the topic, and Linear/Jira ticket assignments. Returns a ranked list of people with a confidence score and the evidence behind each ranking (e.g. "authored 4 of the last 6 PRs touching this file, resolved 2 incidents tagged `payment-retry`"). Uses the existing people graph — no new connectors required. Read-only, no HITL.
+- [ ] **`nimbus catchup --since <duration>`** — retrospective digest of everything that happened across connected services while the user was away, prioritized by relevance to their recent work history. Unlike `nimbus changelog` (which is service-scoped and uniform), `nimbus catchup` is personalized — it weights activity by the user's historical involvement: services they own, repos they contribute to, incidents they've responded to, people they collaborate with frequently. Default window: `3d`. Output: structured Markdown with sections per service, prioritized by relevance score. Read-only, no HITL.
+- [ ] **`nimbus impact <file-or-PR-url>`** — answers "if I change this, what breaks?" by running a reverse dependency query across the relationship graph: which services import the affected module (via indexed code symbols and `depends_on` graph edges), which pipelines would rebuild (via `pipeline_run` items linked to the repo), which dashboards pull from affected data models (via `upstream_refs` graph edges), and which on-call rotations own the affected services (via PagerDuty schedule index). Returns a structured impact report with blast radius by category. Built entirely on the Phase 3 relationship graph substrate — no new connectors required. Read-only, no HITL. `--json` flag for CI integration.
+
 ### Nimbus as a CI/CD Data Layer
 
 The local HTTP API and `@nimbus-dev/client` (Phase 3.5) unlock Nimbus as a data source for CI pipelines and external tooling. This section makes that story explicit with first-class integration points.
@@ -580,6 +594,9 @@ Items deferred from the [Phase 4 security audit (B1)](./superpowers/specs/2026-0
 - **Downstream Impact Analysis** — `nimbus ask "if I change the revenue calc in this PR, which Looker dashboards break?"` resolves via `traverseGraph` over `code_symbol` → `data_model` → `dashboard` relations in the Phase 3 relationship graph; returns affected dashboards in under 500 ms from the local index
 - Local data-file profiling indexes column names + types + row-count estimates from `.parquet`, `.csv`, `.jsonl`, `.json`, and `.orc` files under configured filesystem roots; contract test asserts the connector surface exposes no row-sample or cell-read tool; manual audit confirms only file footers / header lines / line counts are read — never row contents
 - MLflow / SageMaker / Vertex AI experiments and models are indexed with framework, metric snapshots, and stage transitions; `ml.model.promote` triggers HITL before a registered model is moved to Production on any of the three providers
+- `nimbus expert src/billing/retry.ts` returns a ranked list of team members with evidence drawn from indexed PR authorship, review history, and incident involvement — answered from the local index without a live API call
+- `nimbus catchup --since 3d` returns a digest prioritized by the authenticated user's historical involvement, with higher-ranked items matching services and repos the user has recently contributed to — verified by seeding two connectors with different activity levels and confirming the more-relevant one ranks first
+- `nimbus impact src/billing/retry.ts` returns at minimum the set of services that depend on the file and the pipelines that would be affected, resolved from the local relationship graph without a live API call
 
 ---
 
@@ -692,6 +709,7 @@ Depends on Team Vault (above) so service-account / SSO credentials can be shared
 - [ ] **Personalization layer** — agent adapts communication style and tool selection priority based on observed user preferences; preferences are explicit (configurable), not inferred silently
 - [ ] **Automated PR pre-review** — agent performs "lint-plus" review based on team's historical review patterns (e.g., "In this repo, we usually ask for Y when X is changed")
 - [ ] **Decision pattern recognition** — agent identifies repeated HITL decision patterns across history; surfaces them as standing rule candidates
+- [ ] **Point-in-time index queries** — ability to reconstruct the state of the indexed data at a specific historical timestamp using sync history and item `modified_at` metadata already stored in the index. Enables queries like `nimbus ask "what was the deployment state of payment-service at 14:32 last Tuesday?"` for post-incident analysis. Implementation: the query layer filters indexed items to their state at the requested timestamp using `modified_at` and sync cycle timestamps already recorded in `sync_state`; no new data collection required. Exposed via `--at <ISO8601-or-relative-time>` flag on `nimbus ask` and `nimbus query`. Read-only, no HITL.
 
 ### Core — LAN Hardening (deferred from Phase 4 B1 audit)
 
@@ -722,6 +740,7 @@ Depends on Team Vault (above) so service-account / SSO credentials can be shared
 - A morning briefing workflow runs fully unattended; any write step without a standing rule sends a notification and blocks rather than executing silently
 - `nimbus ask "who's on call for payment-service right now?"` returns the correct engineer from the indexed PagerDuty schedule without a live API call
 - A post-mortem draft for a resolved incident is generated from the incident record and surfaced for review; the HITL-gated push to Notion succeeds only after the user explicitly approves
+- `nimbus ask "what PRs were open for payment-service at 09:00 yesterday?" --at yesterday-09:00` returns results consistent with the indexed sync history for that timestamp, verified by seeding the index with timestamped items and confirming the filter excludes items modified after the requested time
 
 ---
 


### PR DESCRIPTION
## Summary

Roadmap, README, and Claude Code skill additions — pure docs, no code changes.

### `docs/roadmap.md`
- **Phase 4 v0.1.1 batch** — 4 new commands: `nimbus explain last`, `nimbus changelog`, `nimbus standup`, `nimbus index health`. Each gets a Phase 4 acceptance criterion.
- **Phase 5 Team Intelligence** (new sub-section) — `nimbus expert`, `nimbus catchup`, `nimbus impact`. Each gets a Phase 5 acceptance criterion.
- **Phase 7 Agent Memory & Personalization** — added Point-in-time index queries (`--at <timestamp>` on `nimbus ask` / `nimbus query`) with a Phase 7 acceptance criterion.

### `docs/README.md`
- Added 4 new CLI examples to the "What It Does" block: expert (via `nimbus ask`), `nimbus impact`, `nimbus standup`, `nimbus catchup` — each one comment line + one command line.
- Added a new "Team Lead / Engineering Manager" row to the "Who It's For" table.

### `.claude/commands/` — 4 new skill files
- `nimbus-security-invariants.md` — the invariant triple rule (wiring + docs entry + enforcement test), B1 audit lesson, HITL/extension/Vault/ALLOWED_METHODS rules.
- `nimbus-connector-authoring.md` — package layout, mandatory tool surface, manifest structure, credential injection, sync handler contract, item ID format, contract tests.
- `nimbus-agent-patterns.md` — built-in agent shape invariant (read-only, parallel, HITL-free), `AgentCoordinator` decomposition, tool-scope restriction, `briefReady` notification contract, e2e test pattern, 15s latency budget.
- `nimbus-db-migrations.md` — file numbering, runner contract, append-only schema rule, batched-backfill pattern, `_schema_migrations` ledger, FTS5/vec0 cautions.

### `CLAUDE.md`
- New "Skill References" block at the bottom with the four `@.claude/commands/...` imports in alphabetical order.

## Test plan
- [ ] Roadmap renders correctly on GitHub — Phase 4 v0.1.1 table, Phase 5 Team Intelligence sub-section, Phase 7 point-in-time entry all present
- [ ] README "What It Does" block stays concise — each new entry is exactly one comment line + one command line
- [ ] Each new feature has at least one acceptance criterion in the corresponding phase
- [ ] No new feature is placed in a completed phase (1, 2, 3, 3.5)
- [ ] All 4 skill files load via the Skill tool (visible in available-skills list)
- [ ] `@.claude/commands/...` imports in CLAUDE.md resolve correctly when CLAUDE.md is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)