### PR TITLE
fix(test): stabilize migration-rollback tests + refresh docs status

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.8
 **Runtime:** Bun v1.2+ / TypeScript 6.x (strict)
-**Status:** Active Design — reflects `main` as of Phase 3.5 (Observability) complete; **Phase 4 (Presence) active** (WS1–WS6 + S2 + B2-P1 complete)
+Status: Active Design — reflects `main` as of Phase 3.5 (Observability) complete; **Phase 4 (Presence) active** (WS1–WS6 + S2 + B2-P1 + B3-P1/2 complete)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.8
 **Runtime:** Bun v1.2+ / TypeScript 6.x (strict)
-Status: Active Design — reflects `main` as of Phase 3.5 (Observability) complete; **Phase 4 (Presence) active** (WS1–WS6 + S2 + B2-P1 + B3-P1/2 complete)
+**Status:** Active Design — reflects `main` as of Phase 3.5 (Observability) complete; **Phase 4 (Presence) active** (WS1–WS6 + S2 + B2-P1 + B3-P1/2 complete)
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -305,6 +305,10 @@ Commercial license also available now for organizations that need to embed Nimbu
 - [x] **System tray enhancements (WS5-B)** — aggregate-health icon (green → amber → red); pending-HITL badge; "Connectors ▸" submenu populated from `set_connectors_menu`; click navigates to Dashboard and flashes the matching tile
 - [x] **Dashboard (WS5-B)** — `IndexMetricsStrip` (items · embeddings · p95 · size), `ConnectorGrid` with live `connector://health-changed` patches + empty state, `AuditFeed` (last 25); `useIpcQuery` polling hook pauses on hidden / disconnected
 - [x] **HITL consent dialogs (WS5-B)** — dedicated frameless 480×360 always-on-top popup at `#/hitl-popup`; `StructuredPreview` renders details XSS-safely; destructive-action deny-list suppresses Approve `autoFocus`; Rust `pending_hitl` inbox + `consent://request`/`consent://resolved` classifier; diff view for file/code changes and optional edit-before-approve deferred to a later sub-project
+- [x] **Settings Shell (WS5-C)** — Profiles, Telemetry, Connectors, Model, Audit, Updates, and Data panels (including Export/Import/Delete wizards); per-service OAuth vault keys; re-attaches to in-flight pulls
+- [x] **Extension Marketplace panel (WS5-D)** — list, install-from-directory, enable/disable, remove; v0.1.0 MVP
+- [x] **Watcher management UI (WS5-D)** — create, pause, delete; graph-aware condition builder; history-of-fires drawer
+- [x] **Workflow pipeline editor (WS5-D)** — step list editor, run, dry-run toggle, delete; run history drawer with audit deep-link + "Run with params…" override
 
 #### WS5 Sub-project B acceptance
 
@@ -314,10 +318,6 @@ Commercial license also available now for organizations that need to embed Nimbu
 - Tray badge matches pending HITL count.
 - `ALLOWED_METHODS` grew by exactly four read-side methods; no `vault.*` or `db.*` writes.
 - `packages/ui` coverage ≥ 80 % lines / ≥ 75 % branches.
-- [x] **Extension Marketplace panel** (v0.1.0 MVP) — list, install-from-directory, enable/disable, remove. *Online browse, verified publisher, ratings, changelog, auto-update — deferred to Phase 5 "Marketplace v2".*
-- [x] **Watcher management UI** (v0.1.0) — create, pause, delete; graph-aware condition builder; **history-of-fires drawer** (WS5-D Polish).
-- [x] **Workflow pipeline editor** (v0.1.0) — step list editor, run, dry-run toggle, delete; **run history drawer with audit deep-link** + **"Run with params…" one-shot parameter override** (WS5-D Polish). *Re-run-failed-steps deferred to v0.1.1.*
-- [x] **Settings** — ~~model selection (cloud vs local)~~ ✅ (Plan 3) · ~~sync intervals per connector~~ ✅ (Plan 3) · ~~profile switcher~~ ✅ (Plan 2) · ~~audit log viewer + export~~ ✅ (Plan 4) · ~~data export/import~~ ✅ (Plan 5) · ~~telemetry toggle~~ ✅ (Plan 2) · ~~Updates panel~~ ✅ (Plan 4) · ~~Delete service data~~ ✅ (Plan 5) — Vault key listing deferred to Phase 5
 
 ### Local LLM & Multi-Agent
 
@@ -419,11 +419,12 @@ These items have no external blocker; they slip out of `v0.1.0` to keep the rele
 
 ### Maintenance-initiative follow-ups (B-series)
 
-The B1 security audit and the B2 perf audit completed in Phase 4. Two more initiatives are sequenced behind them; each will get its own design spec when picked up.
+The B1 security audit completed in Phase 4. Three more initiatives are active or sequenced; each gets its own design spec when picked up.
 
-- [ ] **B3 — SOLID / duplication / project-structure audit** — same three-phase shape as B1/B2 (design → measurement → fix-PR plans); scoped at the package and module boundary level
-- [ ] **B4 — Bug-hunt audit** — same shape; ranked by user-facing impact / engineering cost
-- [ ] **Third-party package upgrades** — npm + cargo crate upgrades **deferred from the toolchain refresh** (the refresh PR bumped runner OSes, Node, and Rust MSRV but left dependency upgrades for a focused follow-up); land before B3/B4 so the audits measure the upgraded baseline
+- [x] **B2 — Perf bench (Phase 1)** — S8/S9/S10 drivers implemented; reference-machine baseline established; wired into CI via `_perf.yml`.
+- [x] **B3 — Structure audit (Phases 1 & 2)** — Phase 1 tooling (`check-nimbus-invariants.ts`, `count-any-usage.ts`) implemented; Phase 2 ranking and findings documented in `docs/structure-audit/baseline.md`.
+- [ ] **B4 — Bug-hunt audit** — ranked by user-facing impact / engineering cost.
+- [ ] **Third-party package upgrades** — npm + cargo crate upgrades **deferred from the toolchain refresh** (the refresh PR bumped runner OSes, Node, and Rust MSRV but left dependency upgrades for a focused follow-up).
 
 ### Acceptance Criteria
 

--- a/packages/gateway/test/unit/db/migration-rollback.test.ts
+++ b/packages/gateway/test/unit/db/migration-rollback.test.ts
@@ -97,50 +97,48 @@ describe("runIndexedSchemaMigrations — with backup options", () => {
   });
 });
 
-describe("runIndexedSchemaMigrations — rollback on failure", () => {
-  test("throws MigrationRollbackError when a step throws, schema version unchanged", () => {
-    const tempDir = makeTempDir();
-    const dbPath = join(tempDir, "nimbus.db");
-    const _backupDir = join(tempDir, "backups");
+describe("runIndexedSchemaMigrations — unsupported target version", () => {
+  test("throws when target exceeds the highest known step; schema version unchanged", () => {
+    // No file-backed DB or backups needed — this only exercises the
+    // post-loop "Unsupported local index schema version" throw.
+    const db = new Database(":memory:");
 
-    // Create a DB already at version 11 so only one more step runs
-    const db = new Database(dbPath);
-    runIndexedSchemaMigrations(db, 11);
+    // Bring the DB up to the current schema so the next call has nothing to do.
+    runIndexedSchemaMigrations(db, LocalIndex.SCHEMA_VERSION);
     expect((db.query("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(
-      11,
+      LocalIndex.SCHEMA_VERSION,
     );
 
-    // Now inject a broken migration by patching the step list indirectly:
-    // We simulate failure by pointing to version 99 which has no step defined.
-    // The runner will throw "Unsupported local index schema version" — not a
-    // MigrationRollbackError. To test the rollback path properly, we need a
-    // step that throws mid-run. We test this by attempting to migrate to a
-    // non-existent target version greater than the max step.
-    expect(() => runIndexedSchemaMigrations(db, 99)).toThrow();
+    // Targeting one beyond the highest known step throws and leaves user_version intact.
+    expect(() => runIndexedSchemaMigrations(db, LocalIndex.SCHEMA_VERSION + 1)).toThrow(
+      /Unsupported local index schema version/,
+    );
 
-    // Schema version advances to the highest known step before the runner
-    // throws "Unsupported local index schema version" for the gap to 99.
     const row = db.query("PRAGMA user_version").get() as { user_version: number };
     expect(row.user_version).toBe(LocalIndex.SCHEMA_VERSION);
     db.close();
   });
+});
 
-  test("backup file exists after failed migration attempt", () => {
+describe("runIndexedSchemaMigrations — backup files per step", () => {
+  test("writes a non-empty .db.gz for each migration step", () => {
     const tempDir = makeTempDir();
     const dbPath = join(tempDir, "nimbus.db");
     const backupDir = join(tempDir, "backups");
 
     const db = new Database(dbPath);
-    // Migrate to v1 so we have a real file-backed DB with one schema applied
+    // Establish a real file-backed DB with one schema applied so VACUUM INTO
+    // has something to copy on the next call.
     runIndexedSchemaMigrations(db, 1);
 
-    // Now run from v1→v13 with backup options so backups are written
+    // Two backups are enough to prove the per-step contract; running the full
+    // schema range here is wall-clock heavy on Windows (Defender + journal fsync)
+    // and offers no extra coverage.
     const opts: MigrationBackupOptions = { backupDir, dbPath };
-    runIndexedSchemaMigrations(db, 13, opts);
+    runIndexedSchemaMigrations(db, 3, opts);
 
     const files = readdirSync(backupDir).filter((f) => f.endsWith(".db.gz"));
     expect(files.length).toBeGreaterThan(0);
-    // Verify files are non-empty (actual gzip data)
     for (const f of files) {
       const size = statSync(join(backupDir, f)).size;
       expect(size).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- **Stabilize two flaky migration-rollback tests** that timed out at the default 5 s on slow Windows disks. Both tests under \`describe(\"…rollback on failure\")\` were misnamed (neither exercised the rollback path) and over-scoped (one ran 23 file-backed migrations end-to-end as \`SCHEMA_VERSION\` grew; the other wrote 12 \`VACUUM INTO\` + gzip backups when two prove the per-step contract). Re-scope each test to the behaviour it actually asserts: the unsupported-target-version test now runs in \`:memory:\`, and the backup-per-step test stops at v3.
- **Refresh docs**: bump \`docs/architecture.md\` status line for B3-P1/2; promote WS5-C/D Settings, Marketplace, Watcher UI, and Workflow editor rows in \`docs/roadmap.md\` to delivered; mark B2-P1 and B3 Phases 1/2 complete in the maintenance-initiative section.

Test fix verified locally: \`bun test packages/gateway/test/unit/db/migration-rollback.test.ts --rerun-each=10\` → 80/80 in 1.68 s. Full \`bun run test:ci\` is green for every step except a known-flaky UI Vitest+V8 coverage step that passes when run on its own (the changes here don't touch \`packages/ui/\`).

## Test plan

- [ ] CI typecheck + lint + build green on Ubuntu / macOS / Windows
- [ ] \`packages/gateway\` unit test suite green; the two re-scoped tests in \`migration-rollback.test.ts\` pass
- [ ] \`packages/gateway/src/db/\` coverage gate (≥ 85 %) holds
- [ ] UI Vitest coverage green on the Linux runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)