### PR TITLE
feat(gateway): engine.cancelStream + engine.getSessionTranscript + V24 audit_log.session_id (WS7 PR2)

### DIFF
--- a/packages/gateway/src/db/audit-chain.ts
+++ b/packages/gateway/src/db/audit-chain.ts
@@ -34,6 +34,8 @@ export interface AppendAuditEntryFields {
   readonly hitlStatus: string;
   readonly actionJson: string;
   readonly timestamp: number;
+  /** Non-hashed metadata for transcript rehydration (Task 10). Not included in BLAKE3 chain. */
+  readonly sessionId?: string;
 }
 
 /**
@@ -56,8 +58,16 @@ export function appendAuditEntry(db: Database, fields: AppendAuditEntryFields): 
     timestamp: fields.timestamp,
   });
   db.run(
-    `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [fields.actionType, fields.hitlStatus, fields.actionJson, fields.timestamp, rowHash, prevHash],
+    `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash, session_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      fields.actionType,
+      fields.hitlStatus,
+      fields.actionJson,
+      fields.timestamp,
+      rowHash,
+      prevHash,
+      fields.sessionId ?? null,
+    ],
   );
 }

--- a/packages/gateway/src/engine/executor.ts
+++ b/packages/gateway/src/engine/executor.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { redactAuditPayload } from "../audit/format-audit-payload.ts";
 import type { ConsentCoordinator } from "../ipc/consent.ts";
 import { ConsentDisconnectedError } from "../ipc/consent.ts";
+import { getAgentRequestSessionId } from "./agent-request-context.ts";
 import type {
   ActionResult,
   AuditSink,
@@ -233,11 +234,13 @@ export class ToolExecutor {
     }
 
     // ALWAYS write audit record BEFORE any execution
+    const sessionId = getAgentRequestSessionId();
     this.audit.recordAudit({
       actionType: action.type,
       hitlStatus,
       actionJson: auditPayload(action, auditExtras),
       timestamp: Date.now(),
+      ...(sessionId !== undefined ? { sessionId } : {}),
     });
 
     if (hitlStatus === "rejected") {

--- a/packages/gateway/src/engine/types.ts
+++ b/packages/gateway/src/engine/types.ts
@@ -26,6 +26,8 @@ export interface AuditSink {
     hitlStatus: "approved" | "rejected" | "not_required";
     actionJson: string;
     timestamp: number;
+    /** Non-hashed session identifier for transcript rehydration (Task 10). */
+    sessionId?: string;
   }): void;
 }
 

--- a/packages/gateway/src/index/audit-session-v24-sql.ts
+++ b/packages/gateway/src/index/audit-session-v24-sql.ts
@@ -1,0 +1,16 @@
+/**
+ * V24 migration — adds `session_id` column to `audit_log` and a supporting
+ * index so Task 10 (`engine.getSessionTranscript`) can efficiently filter
+ * audit rows by session.
+ *
+ * `session_id` is intentionally NOT included in the BLAKE3 audit-chain hash
+ * (`computeAuditRowHash`). It is metadata for rehydration; including it
+ * would invalidate every historical row and break `nimbus audit verify`.
+ *
+ * Purely additive — no backfill required. Existing rows get `session_id = NULL`.
+ */
+
+export const AUDIT_SESSION_V24_SCHEMA_SQL = `
+ALTER TABLE audit_log ADD COLUMN session_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_audit_log_session_id ON audit_log(session_id);
+`;

--- a/packages/gateway/src/index/local-index.ts
+++ b/packages/gateway/src/index/local-index.ts
@@ -264,7 +264,7 @@ export interface LanPeerRow {
 }
 
 /** Current indexed DB schema version — also accessible as `LocalIndex.SCHEMA_VERSION`. */
-export const CURRENT_SCHEMA_VERSION = 23;
+export const CURRENT_SCHEMA_VERSION = 24;
 
 /**
  * S4-F1 — explicit allowlist for `LocalIndex.getMeta` / `setMeta`. The `_meta`
@@ -764,6 +764,7 @@ export class LocalIndex {
     hitlStatus: AuditEntry["hitlStatus"];
     actionJson: string;
     timestamp: number;
+    sessionId?: string;
   }): void {
     appendAuditEntry(this.db, entry);
   }

--- a/packages/gateway/src/index/migrations/runner-v24.test.ts
+++ b/packages/gateway/src/index/migrations/runner-v24.test.ts
@@ -1,0 +1,71 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { runIndexedSchemaMigrations } from "./runner.ts";
+
+describe("V24 migration — audit_log.session_id", () => {
+  test("adds session_id column to audit_log", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 24);
+
+    const cols = db.query("PRAGMA table_info(audit_log)").all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("session_id");
+  });
+
+  test("creates idx_audit_log_session_id index", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 24);
+
+    const idx = db
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_audit_log_session_id'`,
+      )
+      .get();
+    expect(idx).not.toBeNull();
+  });
+
+  test("old rows inserted before migration have NULL session_id", () => {
+    const db = new Database(":memory:");
+    // Bootstrap to V23 so audit_log exists without session_id
+    runIndexedSchemaMigrations(db, 23);
+
+    // Insert a legacy row (no session_id column yet)
+    db.run(
+      `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      ["test.legacy", "not_required", "{}", 1000, "a".repeat(64), "0".repeat(64)],
+    );
+
+    // Now apply V24
+    runIndexedSchemaMigrations(db, 24);
+
+    const row = db
+      .query(`SELECT session_id FROM audit_log WHERE action_type = 'test.legacy'`)
+      .get() as { session_id: string | null } | undefined;
+    expect(row?.session_id).toBeNull();
+  });
+
+  test("new rows can be inserted with a session_id value", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 24);
+
+    db.run(
+      `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, row_hash, prev_hash, session_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ["test.new", "approved", "{}", 2000, "b".repeat(64), "0".repeat(64), "sess-abc-123"],
+    );
+
+    const row = db.query(`SELECT session_id FROM audit_log WHERE action_type = 'test.new'`).get() as
+      | { session_id: string }
+      | undefined;
+    expect(row?.session_id).toBe("sess-abc-123");
+  });
+
+  test("user_version is set to 24 after migration", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 24);
+
+    const row = db.query("PRAGMA user_version").get() as { user_version: number } | undefined;
+    expect(row?.user_version).toBe(24);
+  });
+});

--- a/packages/gateway/src/index/migrations/runner.ts
+++ b/packages/gateway/src/index/migrations/runner.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import { CONNECTOR_REMOVE_INTENT_V15_SQL } from "../../connectors/remove-intent.ts";
 import { computeAuditRowHash } from "../../db/audit-chain.ts";
 import { AUDIT_CHAIN_V18_SCHEMA_SQL } from "../audit-chain-v18-sql.ts";
+import { AUDIT_SESSION_V24_SCHEMA_SQL } from "../audit-session-v24-sql.ts";
 import { CONNECTOR_DEPTH_V21_SQL } from "../connector-depth-v21-sql.ts";
 import { CONNECTOR_HEALTH_V13_SQL } from "../connector-health-v13-sql.ts";
 import {
@@ -335,6 +336,14 @@ function migrateIndexedV22ToV23(db: Database, now: number): void {
   })();
 }
 
+function migrateIndexedV23ToV24(db: Database, now: number): void {
+  db.transaction(() => {
+    db.exec(AUDIT_SESSION_V24_SCHEMA_SQL);
+    db.exec("PRAGMA user_version = 24");
+    recordMigration(db, 24, "audit_log.session_id (transcript rehydration support)", now);
+  })();
+}
+
 const INDEXED_SCHEMA_STEPS: readonly IndexedSchemaStep[] = [
   { fromVersion: 0, toVersion: 1, apply: migrateIndexedV0ToV1 },
   { fromVersion: 1, toVersion: 2, apply: migrateIndexedV1ToV2 },
@@ -359,6 +368,7 @@ const INDEXED_SCHEMA_STEPS: readonly IndexedSchemaStep[] = [
   { fromVersion: 20, toVersion: 21, apply: migrateIndexedV20ToV21 },
   { fromVersion: 21, toVersion: 22, apply: migrateIndexedV21ToV22 },
   { fromVersion: 22, toVersion: 23, apply: migrateIndexedV22ToV23 },
+  { fromVersion: 23, toVersion: 24, apply: migrateIndexedV23ToV24 },
 ];
 
 const BACKFILL_LABELS: readonly string[] = [
@@ -385,6 +395,7 @@ const BACKFILL_LABELS: readonly string[] = [
   "sync_state.depth (per-connector reindex depth) (backfilled)",
   "watcher.graph_predicate_json (graph-aware conditions) (backfilled)",
   "workflow_run.dry_run + workflow_run.params_override_json (WS5-D Polish) (backfilled)",
+  "audit_log.session_id (transcript rehydration support) (backfilled)",
 ];
 
 /**

--- a/packages/gateway/src/ipc/engine-ask-stream-handler.test.ts
+++ b/packages/gateway/src/ipc/engine-ask-stream-handler.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type AskStreamHandlerDeps,
+  createAskStreamHandler,
+  type StreamRegistry,
+} from "./engine-ask-stream.ts";
+
+function makeRegistry(): StreamRegistry {
+  const map = new Map<string, AbortController>();
+  return {
+    register: (id, ac) => {
+      map.set(id, ac);
+    },
+    cancel: (id) => {
+      const ac = map.get(id);
+      if (ac === undefined) return false;
+      ac.abort();
+      map.delete(id);
+      return true;
+    },
+    unregister: (id) => {
+      map.delete(id);
+    },
+    has: (id) => map.has(id),
+    size: () => map.size,
+  };
+}
+
+describe("createAskStreamHandler", () => {
+  test("returns streamId immediately and emits tokens via sendChunk", async () => {
+    const registry = makeRegistry();
+    const notifications: { method: string; params: Record<string, unknown> }[] = [];
+    const deps: AskStreamHandlerDeps = {
+      registry,
+      randomId: () => "stream-test-1",
+      sessionWriteNotification: (n) => notifications.push(n),
+      runWithRequestContext: async (_ctx, fn) => fn(),
+      agentInvokeHandler: async (ctx) => {
+        ctx.sendChunk?.("hello");
+        ctx.sendChunk?.(" world");
+      },
+    };
+    const handler = createAskStreamHandler(deps);
+    const result = await handler("client-1", { input: "say hi" });
+    expect(result).toEqual({ streamId: "stream-test-1" });
+    // Wait for the IIFE to flush
+    await new Promise((r) => setTimeout(r, 10));
+    const tokens = notifications.filter((n) => n.method === "engine.streamToken");
+    expect(tokens.length).toBe(2);
+    expect(tokens[0]?.params).toMatchObject({ streamId: "stream-test-1", text: "hello" });
+    const done = notifications.find((n) => n.method === "engine.streamDone");
+    expect(done).toBeDefined();
+  });
+
+  test("emits engine.streamError when handler throws", async () => {
+    const registry = makeRegistry();
+    const notifications: { method: string; params: Record<string, unknown> }[] = [];
+    const deps: AskStreamHandlerDeps = {
+      registry,
+      randomId: () => "stream-test-2",
+      sessionWriteNotification: (n) => notifications.push(n),
+      runWithRequestContext: async (_ctx, fn) => fn(),
+      agentInvokeHandler: async () => {
+        throw new Error("boom");
+      },
+    };
+    const handler = createAskStreamHandler(deps);
+    await handler("client-1", { input: "" });
+    await new Promise((r) => setTimeout(r, 10));
+    const err = notifications.find((n) => n.method === "engine.streamError");
+    expect(err?.params).toMatchObject({ streamId: "stream-test-2", error: "boom" });
+  });
+
+  test("cancellation aborts the stream and emits streamError with cancelled code", async () => {
+    const registry = makeRegistry();
+    const notifications: { method: string; params: Record<string, unknown> }[] = [];
+    let signalSeen: AbortSignal | undefined;
+    const deps: AskStreamHandlerDeps = {
+      registry,
+      randomId: () => "stream-cancel-1",
+      sessionWriteNotification: (n) => notifications.push(n),
+      runWithRequestContext: async (_ctx, fn) => fn(),
+      agentInvokeHandler: async (ctx) => {
+        signalSeen = ctx.signal;
+        // Simulate a long-running stream that checks signal cooperatively
+        for (let i = 0; i < 100; i += 1) {
+          if (ctx.signal?.aborted) {
+            throw new Error("cancelled");
+          }
+          await new Promise((r) => setTimeout(r, 1));
+        }
+      },
+    };
+    const handler = createAskStreamHandler(deps);
+    await handler("client-1", { input: "long" });
+    // Cancel quickly
+    await new Promise((r) => setTimeout(r, 5));
+    expect(registry.has("stream-cancel-1")).toBe(true);
+    expect(registry.cancel("stream-cancel-1")).toBe(true);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(signalSeen?.aborted).toBe(true);
+    const err = notifications.find((n) => n.method === "engine.streamError");
+    expect(err?.params).toMatchObject({ streamId: "stream-cancel-1", code: "cancelled" });
+  });
+
+  test("registry is cleared after stream completion", async () => {
+    const registry = makeRegistry();
+    const deps: AskStreamHandlerDeps = {
+      registry,
+      randomId: () => "stream-cleanup-1",
+      sessionWriteNotification: () => undefined,
+      runWithRequestContext: async (_c, fn) => fn(),
+      agentInvokeHandler: async () => undefined,
+    };
+    const handler = createAskStreamHandler(deps);
+    await handler("client-1", { input: "" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(registry.has("stream-cleanup-1")).toBe(false);
+  });
+});

--- a/packages/gateway/src/ipc/engine-ask-stream.ts
+++ b/packages/gateway/src/ipc/engine-ask-stream.ts
@@ -1,0 +1,135 @@
+/**
+ * Extracted handler for `engine.askStream`. Owns the stream's AbortController
+ * via the StreamRegistry so `engine.cancelStream` can cancel by streamId.
+ */
+
+export type StreamNotification = {
+  jsonrpc: "2.0";
+  method: string;
+  params: Record<string, unknown>;
+};
+
+export type AgentInvokeContextLike = {
+  clientId: string;
+  input: string;
+  stream: true;
+  sendChunk?: (text: string) => void;
+  sessionId?: string;
+  signal?: AbortSignal;
+};
+
+export type RequestContextLike = { sessionId?: string };
+
+export type StreamRegistry = {
+  register(streamId: string, ac: AbortController): void;
+  cancel(streamId: string): boolean;
+  unregister(streamId: string): void;
+  has(streamId: string): boolean;
+  size(): number;
+};
+
+export type AskStreamHandlerDeps = {
+  registry: StreamRegistry;
+  randomId: () => string;
+  sessionWriteNotification: (n: StreamNotification) => void;
+  runWithRequestContext: <T>(ctx: RequestContextLike, fn: () => Promise<T>) => Promise<T>;
+  agentInvokeHandler: (ctx: AgentInvokeContextLike) => Promise<unknown>;
+};
+
+export type AskStreamParams = {
+  input: string;
+  sessionId?: string;
+};
+
+export type AskStreamResult = { streamId: string };
+
+export function createAskStreamHandler(
+  deps: AskStreamHandlerDeps,
+): (clientId: string, params: AskStreamParams) => Promise<AskStreamResult> {
+  return async (clientId, params): Promise<AskStreamResult> => {
+    const streamId = deps.randomId();
+    const ac = new AbortController();
+    deps.registry.register(streamId, ac);
+
+    const sendChunk = (text: string): void => {
+      if (ac.signal.aborted) return;
+      deps.sessionWriteNotification({
+        jsonrpc: "2.0",
+        method: "engine.streamToken",
+        params: { streamId, text },
+      });
+    };
+
+    void (async (): Promise<void> => {
+      try {
+        const ctx: RequestContextLike = {};
+        if (params.sessionId !== undefined) ctx.sessionId = params.sessionId;
+        await deps.runWithRequestContext(ctx, async () => {
+          const payload: AgentInvokeContextLike = {
+            clientId,
+            input: params.input,
+            stream: true,
+            sendChunk,
+            signal: ac.signal,
+          };
+          if (params.sessionId !== undefined) payload.sessionId = params.sessionId;
+          await deps.agentInvokeHandler(payload);
+        });
+        if (ac.signal.aborted) {
+          deps.sessionWriteNotification({
+            jsonrpc: "2.0",
+            method: "engine.streamError",
+            params: { streamId, code: "cancelled", error: "Stream cancelled" },
+          });
+        } else {
+          deps.sessionWriteNotification({
+            jsonrpc: "2.0",
+            method: "engine.streamDone",
+            params: {
+              streamId,
+              meta: { modelUsed: "default", isLocal: false, provider: "remote" },
+            },
+          });
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Stream error";
+        const code = ac.signal.aborted ? "cancelled" : "stream_error";
+        deps.sessionWriteNotification({
+          jsonrpc: "2.0",
+          method: "engine.streamError",
+          params: { streamId, code, error: message },
+        });
+      } finally {
+        deps.registry.unregister(streamId);
+      }
+    })();
+
+    return { streamId };
+  };
+}
+
+/** Default in-memory implementation of StreamRegistry. */
+export function createStreamRegistry(): StreamRegistry {
+  const map = new Map<string, AbortController>();
+  return {
+    register(id, ac): void {
+      map.set(id, ac);
+    },
+    cancel(id): boolean {
+      const ac = map.get(id);
+      if (ac === undefined) return false;
+      ac.abort();
+      map.delete(id);
+      return true;
+    },
+    unregister(id): void {
+      map.delete(id);
+    },
+    has(id): boolean {
+      return map.has(id);
+    },
+    size(): number {
+      return map.size;
+    },
+  };
+}

--- a/packages/gateway/src/ipc/engine-cancel-stream.test.ts
+++ b/packages/gateway/src/ipc/engine-cancel-stream.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { createStreamRegistry } from "./engine-ask-stream.ts";
+import { createCancelStreamHandler } from "./engine-cancel-stream.ts";
+
+describe("createCancelStreamHandler", () => {
+  test("returns ok=true and aborts the controller for known streamId", () => {
+    const registry = createStreamRegistry();
+    const ac = new AbortController();
+    registry.register("s1", ac);
+    const handler = createCancelStreamHandler(registry);
+    const result = handler({ streamId: "s1" });
+    expect(result).toEqual({ ok: true });
+    expect(ac.signal.aborted).toBe(true);
+  });
+
+  test("returns ok=true (idempotent) for unknown streamId", () => {
+    const registry = createStreamRegistry();
+    const handler = createCancelStreamHandler(registry);
+    const result = handler({ streamId: "never-existed" });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("throws RpcMethodError when streamId is not a non-empty string", () => {
+    const registry = createStreamRegistry();
+    const handler = createCancelStreamHandler(registry);
+    expect(() => handler({ streamId: "" })).toThrow();
+    expect(() => handler({ streamId: 42 as unknown as string })).toThrow();
+  });
+});

--- a/packages/gateway/src/ipc/engine-cancel-stream.ts
+++ b/packages/gateway/src/ipc/engine-cancel-stream.ts
@@ -1,0 +1,22 @@
+import type { StreamRegistry } from "./engine-ask-stream.ts";
+import { RpcMethodError } from "./server/rpc-error.ts";
+
+export type CancelStreamParams = { readonly streamId: string };
+export type CancelStreamResult = { readonly ok: boolean };
+
+export function createCancelStreamHandler(
+  registry: StreamRegistry,
+): (params: unknown) => CancelStreamResult {
+  return (params): CancelStreamResult => {
+    if (typeof params !== "object" || params === null) {
+      throw new RpcMethodError(-32602, "engine.cancelStream requires { streamId: string }");
+    }
+    const sid = (params as { streamId?: unknown }).streamId;
+    if (typeof sid !== "string" || sid.length === 0) {
+      throw new RpcMethodError(-32602, "engine.cancelStream requires non-empty streamId");
+    }
+    // Cancellation is idempotent — unknown streams resolve as ok
+    registry.cancel(sid);
+    return { ok: true };
+  };
+}

--- a/packages/gateway/src/ipc/engine-get-session-transcript.test.ts
+++ b/packages/gateway/src/ipc/engine-get-session-transcript.test.ts
@@ -1,0 +1,96 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { createGetSessionTranscriptHandler } from "./engine-get-session-transcript.ts";
+
+function seedDb(): Database {
+  const db = new Database(":memory:");
+  // Schema mirrors the post-V24 production audit_log layout.
+  db.run(`
+    CREATE TABLE audit_log (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      action_type TEXT NOT NULL,
+      hitl_status TEXT NOT NULL,
+      action_json TEXT NOT NULL,
+      timestamp   INTEGER NOT NULL,
+      row_hash    TEXT,
+      prev_hash   TEXT,
+      session_id  TEXT
+    )
+  `);
+  const insert = db.prepare(
+    "INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+  );
+  insert.run("engine.askUser", "not_required", JSON.stringify({ text: "hello" }), 1000, "sess-1");
+  insert.run(
+    "engine.askAssistant",
+    "not_required",
+    JSON.stringify({ text: "hi there" }),
+    1100,
+    "sess-1",
+  );
+  insert.run(
+    "engine.askUser",
+    "not_required",
+    JSON.stringify({ text: "how are you" }),
+    2000,
+    "sess-1",
+  );
+  insert.run(
+    "engine.askAssistant",
+    "not_required",
+    JSON.stringify({ text: "fine" }),
+    2100,
+    "sess-1",
+  );
+  insert.run(
+    "engine.askUser",
+    "not_required",
+    JSON.stringify({ text: "noise" }),
+    3000,
+    "sess-OTHER",
+  );
+  return db;
+}
+
+describe("createGetSessionTranscriptHandler", () => {
+  test("returns ordered turns for the requested session", async () => {
+    const db = seedDb();
+    const handler = createGetSessionTranscriptHandler(db);
+    const result = await handler({ sessionId: "sess-1" });
+    expect(result.sessionId).toBe("sess-1");
+    expect(result.turns.length).toBe(4);
+    expect(result.turns[0]).toMatchObject({ role: "user", text: "hello", timestamp: 1000 });
+    expect(result.turns[1]).toMatchObject({ role: "assistant", text: "hi there" });
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("clamps limit to [1, 500] and reports hasMore", async () => {
+    const db = seedDb();
+    const handler = createGetSessionTranscriptHandler(db);
+    const r1 = await handler({ sessionId: "sess-1", limit: 2 });
+    expect(r1.turns.length).toBe(2);
+    expect(r1.hasMore).toBe(true);
+    const r2 = await handler({ sessionId: "sess-1", limit: 9999 });
+    expect(r2.turns.length).toBe(4);
+    expect(r2.hasMore).toBe(false);
+    const r3 = await handler({ sessionId: "sess-1", limit: 0 });
+    expect(r3.turns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("returns empty turns for unknown sessionId", async () => {
+    const db = seedDb();
+    const handler = createGetSessionTranscriptHandler(db);
+    const result = await handler({ sessionId: "never" });
+    expect(result.sessionId).toBe("never");
+    expect(result.turns).toEqual([]);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("rejects invalid params", async () => {
+    const db = seedDb();
+    const handler = createGetSessionTranscriptHandler(db);
+    await expect(handler({ sessionId: "" })).rejects.toThrow();
+    await expect(handler({} as { sessionId: string })).rejects.toThrow();
+  });
+});

--- a/packages/gateway/src/ipc/engine-get-session-transcript.ts
+++ b/packages/gateway/src/ipc/engine-get-session-transcript.ts
@@ -1,0 +1,102 @@
+import type { Database } from "bun:sqlite";
+
+import { RpcMethodError } from "./server/rpc-error.ts";
+
+export type GetSessionTranscriptParams = {
+  readonly sessionId: string;
+  readonly limit?: number;
+};
+
+export type TranscriptTurn = {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+  readonly timestamp: number;
+  readonly auditLogId?: number;
+};
+
+export type SessionTranscriptResult = {
+  readonly sessionId: string;
+  readonly turns: readonly TranscriptTurn[];
+  readonly hasMore: boolean;
+};
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 500;
+const DEFAULT_LIMIT = 100;
+
+function clampLimit(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return DEFAULT_LIMIT;
+  if (raw < MIN_LIMIT) return MIN_LIMIT;
+  if (raw > MAX_LIMIT) return MAX_LIMIT;
+  return Math.trunc(raw);
+}
+
+function actionToRole(actionType: string): "user" | "assistant" | undefined {
+  // Returns undefined for action types that aren't part of a chat exchange
+  // (e.g., agent.invoke, MCP tool dispatches, audit-only rows). Callers
+  // skip such rows entirely — they are not chat turns and must not appear
+  // in the rehydrated transcript at all.
+  if (actionType === "engine.askUser") return "user";
+  if (actionType === "engine.askAssistant") return "assistant";
+  return undefined;
+}
+
+function parseDetailsText(actionJson: string | null): string {
+  // For rows that ARE chat turns (actionToRole returned user/assistant)
+  // but whose text is missing/unparseable, return "[redacted]" so the
+  // turn count stays consistent in the UI even when content is absent.
+  if (actionJson === null) return "[redacted]";
+  try {
+    const parsed = JSON.parse(actionJson) as { text?: unknown };
+    if (typeof parsed.text === "string") return parsed.text;
+  } catch {
+    // fall through
+  }
+  return "[redacted]";
+}
+
+export function createGetSessionTranscriptHandler(
+  db: Database,
+): (params: unknown) => Promise<SessionTranscriptResult> {
+  return async (params): Promise<SessionTranscriptResult> => {
+    if (typeof params !== "object" || params === null) {
+      throw new RpcMethodError(-32602, "engine.getSessionTranscript requires params object");
+    }
+    const sid = (params as { sessionId?: unknown }).sessionId;
+    if (typeof sid !== "string" || sid.length === 0) {
+      throw new RpcMethodError(-32602, "engine.getSessionTranscript requires non-empty sessionId");
+    }
+    const limit = clampLimit((params as { limit?: unknown }).limit);
+
+    const stmt = db.prepare(
+      `SELECT id, action_type, timestamp, action_json
+       FROM audit_log
+       WHERE session_id = ?
+       ORDER BY timestamp ASC, id ASC
+       LIMIT ?`,
+    );
+    type Row = {
+      id: number;
+      action_type: string;
+      timestamp: number;
+      action_json: string | null;
+    };
+    const rows = stmt.all(sid, limit + 1) as Row[];
+
+    const hasMore = rows.length > limit;
+    const used = hasMore ? rows.slice(0, limit) : rows;
+
+    const turns: TranscriptTurn[] = [];
+    for (const r of used) {
+      const role = actionToRole(r.action_type);
+      if (role === undefined) continue;
+      turns.push({
+        role,
+        text: parseDetailsText(r.action_json),
+        timestamp: r.timestamp,
+        auditLogId: r.id,
+      });
+    }
+    return { sessionId: sid, turns, hasMore };
+  };
+}

--- a/packages/gateway/src/ipc/server/context.ts
+++ b/packages/gateway/src/ipc/server/context.ts
@@ -1,5 +1,6 @@
 import type { AgentInvokeHandler } from "../agent-invoke.ts";
 import type { ConsentCoordinatorImpl } from "../consent.ts";
+import type { StreamRegistry } from "../engine-ask-stream.ts";
 import type { WorkflowRunHandler } from "../workflow-invoke.ts";
 import type { CreateIpcServerOptions } from "./options.ts";
 
@@ -18,6 +19,7 @@ export interface ServerCtx {
   readonly options: CreateIpcServerOptions;
   readonly consentImpl: ConsentCoordinatorImpl;
   readonly startedAtMs: number;
+  readonly streamRegistry: StreamRegistry;
   broadcastNotification(method: string, params: Record<string, unknown>): void;
   getAgentInvokeHandler(): AgentInvokeHandler | undefined;
   getWorkflowRunHandler(): WorkflowRunHandler | undefined;

--- a/packages/gateway/src/ipc/server/inline-handlers.ts
+++ b/packages/gateway/src/ipc/server/inline-handlers.ts
@@ -10,6 +10,7 @@ import { GatewayAgentUnavailableError } from "../../engine/gateway-agent-error.t
 import { driftHintsFromIndex } from "../../index/drift-hints.ts";
 import type { IndexSearchQuery } from "../../index/local-index.ts";
 import type { AgentInvokeContext } from "../agent-invoke.ts";
+import { type AgentInvokeContextLike, createAskStreamHandler } from "../engine-ask-stream.ts";
 import type { ClientSession } from "../session.ts";
 import type { WorkflowRunContext } from "../workflow-invoke.ts";
 import type { ServerCtx } from "./context.ts";
@@ -263,7 +264,7 @@ export function dispatchEngineAskStream(
   session: ClientSession,
   clientId: string,
   params: unknown,
-): { streamId: string } {
+): Promise<{ streamId: string }> {
   const rec = asRecord(params);
   const input = rec !== undefined && typeof rec["input"] === "string" ? rec["input"] : "";
   const sessionIdRaw = rec?.["sessionId"];
@@ -271,54 +272,42 @@ export function dispatchEngineAskStream(
     typeof sessionIdRaw === "string" && sessionIdRaw.trim() !== ""
       ? sessionIdRaw.trim()
       : undefined;
-  const streamId = randomUUID();
 
-  // Capture-once (same rationale as dispatchAgentInvoke). The async IIFE below
-  // uses this captured local; never re-read the getter inside the IIFE.
+  // Capture-once (same rationale as dispatchAgentInvoke). The factory's
+  // agentInvokeHandler callback uses this captured local; never re-read the
+  // getter inside the async IIFE.
   const handler = ctx.getAgentInvokeHandler();
   if (handler === undefined) {
     throw new RpcMethodError(-32603, "No agent handler configured for engine.askStream");
   }
 
-  // Return streamId immediately so caller can track this stream
-  const sendChunk = (text: string) => {
-    session.writeNotification({
-      jsonrpc: "2.0",
-      method: "engine.streamToken",
-      params: { streamId, text },
-    });
-  };
-  void (async () => {
-    try {
+  const dispatch = createAskStreamHandler({
+    registry: ctx.streamRegistry,
+    randomId: () => randomUUID(),
+    sessionWriteNotification: (n) => session.writeNotification(n),
+    runWithRequestContext: (rc, fn) => {
       const requestStore: AgentRequestContext = {};
-      if (sessionId !== undefined) requestStore.sessionId = sessionId;
-      await agentRequestContext.run(requestStore, async () => {
-        const payload: AgentInvokeContext = {
-          clientId,
-          input,
-          stream: true,
-          sendChunk,
-        };
-        if (sessionId !== undefined) payload.sessionId = sessionId;
-        await handler(payload);
-      });
-      session.writeNotification({
-        jsonrpc: "2.0",
-        method: "engine.streamDone",
-        params: {
-          streamId,
-          meta: { modelUsed: "default", isLocal: false, provider: "remote" },
-        },
-      });
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Stream error";
-      session.writeNotification({
-        jsonrpc: "2.0",
-        method: "engine.streamError",
-        params: { streamId, error: message },
-      });
-    }
-  })();
+      if (rc.sessionId !== undefined) requestStore.sessionId = rc.sessionId;
+      return agentRequestContext.run(requestStore, fn);
+    },
+    agentInvokeHandler: async (innerCtx: AgentInvokeContextLike) => {
+      const payload: AgentInvokeContext = {
+        clientId: innerCtx.clientId,
+        input: innerCtx.input,
+        stream: innerCtx.stream,
+        sendChunk: innerCtx.sendChunk ?? (() => undefined),
+      };
+      if (innerCtx.sessionId !== undefined) payload.sessionId = innerCtx.sessionId;
+      // NOTE: signal is intentionally NOT plumbed into AgentInvokeContext yet because
+      // the existing AgentInvokeContext type doesn't support it. That plumbing is a
+      // future task; for now the AbortController only short-circuits sendChunk and
+      // the post-completion done/error notification, which is enough for cancelStream
+      // (Task 9) to terminate observable behaviour.
+      return await handler(payload);
+    },
+  });
 
-  return { streamId };
+  const askParams: { input: string; sessionId?: string } = { input };
+  if (sessionId !== undefined) askParams.sessionId = sessionId;
+  return dispatch(clientId, askParams);
 }

--- a/packages/gateway/src/ipc/server/server.ts
+++ b/packages/gateway/src/ipc/server/server.ts
@@ -5,6 +5,7 @@ import { platform } from "node:os";
 
 import type { AgentInvokeHandler } from "../agent-invoke.ts";
 import { ConsentCoordinatorImpl } from "../consent.ts";
+import { createStreamRegistry } from "../engine-ask-stream.ts";
 import {
   errorResponse,
   isRequest,
@@ -60,6 +61,8 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     return session === undefined ? undefined : (n) => session.writeNotification(n);
   });
 
+  const streamRegistry = createStreamRegistry();
+
   let bunListener: ReturnType<typeof Bun.listen<BunSessionData>> | undefined;
   let netServer: net.Server | undefined;
   let winSockets: Set<net.Socket> = new Set();
@@ -82,6 +85,7 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     options,
     consentImpl,
     startedAtMs,
+    streamRegistry,
     broadcastNotification,
     getAgentInvokeHandler: () => agentInvokeHandler,
     getWorkflowRunHandler: () => workflowRunHandler,

--- a/packages/gateway/src/ipc/server/server.ts
+++ b/packages/gateway/src/ipc/server/server.ts
@@ -7,6 +7,7 @@ import type { AgentInvokeHandler } from "../agent-invoke.ts";
 import { ConsentCoordinatorImpl } from "../consent.ts";
 import { createStreamRegistry } from "../engine-ask-stream.ts";
 import { createCancelStreamHandler } from "../engine-cancel-stream.ts";
+import { createGetSessionTranscriptHandler } from "../engine-get-session-transcript.ts";
 import {
   errorResponse,
   isRequest,
@@ -179,6 +180,16 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
         return dispatchEngineAskStream(ctx, session, clientId, params);
       case "engine.cancelStream":
         return createCancelStreamHandler(ctx.streamRegistry)(params);
+      case "engine.getSessionTranscript": {
+        const li = ctx.options.localIndex;
+        if (li === undefined) {
+          throw new RpcMethodError(
+            -32603,
+            "engine.getSessionTranscript requires a configured local index",
+          );
+        }
+        return await createGetSessionTranscriptHandler(li.rawDb)(params);
+      }
       default:
         return await rpcVaultOrMethodNotFound(ctx, method, params, clientId);
     }

--- a/packages/gateway/src/ipc/server/server.ts
+++ b/packages/gateway/src/ipc/server/server.ts
@@ -6,6 +6,7 @@ import { platform } from "node:os";
 import type { AgentInvokeHandler } from "../agent-invoke.ts";
 import { ConsentCoordinatorImpl } from "../consent.ts";
 import { createStreamRegistry } from "../engine-ask-stream.ts";
+import { createCancelStreamHandler } from "../engine-cancel-stream.ts";
 import {
   errorResponse,
   isRequest,
@@ -176,6 +177,8 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
         return rpcAuditList(ctx, params);
       case "engine.askStream":
         return dispatchEngineAskStream(ctx, session, clientId, params);
+      case "engine.cancelStream":
+        return createCancelStreamHandler(ctx.streamRegistry)(params);
       default:
         return await rpcVaultOrMethodNotFound(ctx, method, params, clientId);
     }

--- a/packages/ui/src-tauri/src/gateway_bridge.rs
+++ b/packages/ui/src-tauri/src/gateway_bridge.rs
@@ -80,6 +80,8 @@ pub const ALLOWED_METHODS: &[&str] = &[
     "diag.getVersion",
     "diag.snapshot",
     "engine.askStream",
+    "engine.cancelStream",
+    "engine.getSessionTranscript",
     "extension.disable",
     "extension.enable",
     "extension.list",
@@ -439,7 +441,7 @@ mod tests {
         // list,pause,resume} + workflow.{delete,list,run,save} → 14 new methods → 54 total.
         // WS5-D polish adds watcher.listHistory + workflow.listRuns → 2 new methods → 56 total.
         // Security fix: remove extension.install → 55 total.
-        assert_eq!(ALLOWED_METHODS.len(), 55);
+        assert_eq!(ALLOWED_METHODS.len(), 57);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR2 of 5 for WS7 (VS Code extension). Adds the gateway-side IPC plumbing the upcoming VS Code extension needs: AbortController-based stream cancellation, session-tagged audit rows, and a transcript rehydration endpoint. No client / extension changes — those depend on these surfaces and ship in PR1 (#169) and PR3 onward.

## What landed

- **`engine.askStream` refactored** into `packages/gateway/src/ipc/engine-ask-stream.ts` with a `createAskStreamHandler` factory and a `StreamRegistry` per-server. Each stream registers an `AbortController`; the existing `dispatchEngineAskStream` wraps the factory while preserving its export signature so `server.ts`'s switch case is unchanged. New `engine-ask-stream-handler.test.ts` covers token flow, error path, cooperative cancellation, and registry cleanup (4/4).
- **`engine.cancelStream` IPC method** in `engine-cancel-stream.ts` — idempotent (`{ ok: true }` for unknown ids), validates non-empty streamId, aborts the registered controller. 3/3 tests.
- **V24 schema migration** — additive \`ALTER TABLE audit_log ADD COLUMN session_id TEXT\` + \`idx_audit_log_session_id\`. \`runner-v24.test.ts\` covers column add, index, NULL for old rows, non-NULL insert, user_version=24. **Hash chain unchanged** — \`computeAuditRowHash\` does NOT include session_id; existing rows verify clean. 5/5 tests + 8/8 audit-chain regression.
- **Audit-chain wiring** — \`AppendAuditEntryFields.sessionId?\`, propagated through \`LocalIndex.recordAudit\` and the \`AuditSink\` interface. \`engine/executor.ts\` reads \`getAgentRequestSessionId()\` (from the AsyncLocalStorage already populated by Task 8) and conditionally writes session_id into the audit row.
- **\`engine.getSessionTranscript\` IPC method** in \`engine-get-session-transcript.ts\` — selects \`engine.askUser\` / \`engine.askAssistant\` rows by session_id, builds ordered \`{role, text, timestamp, auditLogId}\` turns with \`limit + 1\` pagination + \`hasMore\`, clamps limit to [1, 500] (default 100), \`[redacted]\` for missing/unparseable text. Until a future task adds chat-turn audit writes, this returns empty for current data — that's intentional per spec §13.1. 4/4 tests.
- **Tauri allowlist** in \`packages/ui/src-tauri/src/gateway_bridge.rs\` — added \`engine.cancelStream\` and \`engine.getSessionTranscript\` alphabetically; size assertion bumped 55 → 57. \`cargo test allowlist\` 17/17.

## Out of scope (intentional)

- Chat-turn audit writes (no current code emits \`engine.askUser\` / \`engine.askAssistant\`). The transcript handler will return empty for current data; future task adds the writers.
- Client-side wrappers (PR1 #169 already added them as \`NimbusClient.cancelStream\` / \`getSessionTranscript\`; this PR adds the gateway handlers they call).
- Plumbing \`AbortSignal\` into the actual agent invocation (\`AgentInvokeContext\`). Today the AbortController only short-circuits \`sendChunk\` and the post-completion done/error notification. Sufficient for cancelStream's observable contract; deeper signal propagation is a future task.

## Test plan

- [ ] \`bun test packages/gateway/src/ipc/\` — 184/184 pass
- [ ] \`bun test packages/gateway/src/index/migrations/\` — 33/33 pass (incl. runner-v24)
- [ ] \`bun test packages/gateway/src/db/audit-chain.test.ts\` — 8/8 pass (hash invariant unchanged)
- [ ] \`bun test packages/gateway/src/engine/\` — 133/133 pass (no executor regression)
- [ ] \`bun run typecheck\` — clean across all packages
- [ ] \`cd packages/ui/src-tauri && cargo test allowlist\` — 17/17 pass (size 57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)