### PR TITLE
feat(vscode-extension): chat webview UI + webview-routed inline HITL (WS7 PR5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ packages/gateway/src/nimbus-gateway.js
 packages/gateway/src/nimbus-gateway.js.map
 packages/mcp-connectors/*/src/nimbus-mcp-*.js
 packages/mcp-connectors/*/src/nimbus-mcp-*.js.map
+
+# vscode-extension webview bundle output (esbuild copies styles.css and emits
+# webview.js here; both are produced from src/chat/webview/* and never edited
+# by hand)
+packages/vscode-extension/media/webview.js
+packages/vscode-extension/media/webview.js.map
+packages/vscode-extension/media/webview.css
 .turbo/
 
 # --- TypeScript ---

--- a/bun.lock
+++ b/bun.lock
@@ -517,9 +517,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@nimbus-dev/client": "workspace:*",
+        "dompurify": "^3.2.0",
         "marked": "^14.0.0",
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.0",
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.90.0",
         "@vitest/coverage-v8": "^2.0.0",
@@ -1350,6 +1352,8 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -1407,6 +1411,8 @@
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
     "@types/tar": ["@types/tar@7.0.87", "", { "dependencies": { "tar": "*" } }, "sha512-3IxNBV8LeY5oi2ZFpvAhOtW1+mHswkzM7BuisVrwJgPv67GBO2rkLPQlEKtzfHuLdhDDczhkCZeT+RuizMay4A=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1777,6 +1783,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -156,9 +156,11 @@
   },
   "dependencies": {
     "@nimbus-dev/client": "workspace:*",
+    "dompurify": "^3.2.0",
     "marked": "^14.0.0"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.0",
     "@types/node": "^20.11.0",
     "@types/vscode": "^1.90.0",
     "@vitest/coverage-v8": "^2.0.0",

--- a/packages/vscode-extension/src/chat/webview/main.ts
+++ b/packages/vscode-extension/src/chat/webview/main.ts
@@ -286,7 +286,14 @@ function bootstrap(): void {
   });
 
   window.addEventListener("message", (ev) => {
-    if (!isFromExtensionHost(ev)) return;
+    // Origin verification (Sonar S2819 / CodeQL js/missing-origin-check):
+    // VS Code webviews receive messages from the extension host frame
+    // embedding this iframe. The host sets `event.source === window.parent`
+    // and uses a `vscode-webview://` origin scheme. Reject anything else.
+    // Empty origins are still accepted so legitimate webview test harnesses
+    // (jsdom, etc.) keep working.
+    if (ev.source !== window.parent) return;
+    if (ev.origin.length > 0 && !ev.origin.startsWith("vscode-webview")) return;
     const data = ev.data as ExtensionToWebview;
     if (data === null || typeof data !== "object" || typeof data.type !== "string") return;
     applyMessage(r, data);
@@ -334,21 +341,6 @@ function handleEmptyStateActionClick(target: HTMLElement): void {
   } else if (action === "startGateway") {
     vscode.postMessage({ type: "startGateway" });
   }
-}
-
-/**
- * VS Code webviews receive postMessage events from the extension host frame
- * embedding this iframe. The host sets `event.source === window.parent` and
- * uses an `vscode-webview://` origin (or a webview-prefixed scheme on web).
- * Any message that doesn't satisfy both is from a hostile injected frame
- * and must be dropped before its `data` is applied.
- */
-function isFromExtensionHost(ev: MessageEvent): boolean {
-  if (ev.source !== window.parent) return false;
-  // `event.origin` may be empty in test/sandbox environments; only reject
-  // explicit non-vscode origins so legitimate webview test harnesses still work.
-  if (ev.origin.length > 0 && !ev.origin.startsWith("vscode-webview")) return false;
-  return true;
 }
 
 if (document.readyState === "loading") {

--- a/packages/vscode-extension/src/chat/webview/main.ts
+++ b/packages/vscode-extension/src/chat/webview/main.ts
@@ -1,6 +1,330 @@
 /**
- * Placeholder webview entry. PR4 (Task 23) replaces this with the real
- * markdown renderer + HITL card + empty state. esbuild needs an entry to
- * bundle so the package builds during PR3 CI.
+ * Webview entry — bundled by esbuild to `media/webview.js` (browser IIFE,
+ * `globalName: "NimbusWebview"`). Loaded by the chat WebviewPanel constructed
+ * in `extension.ts`.
+ *
+ * Responsibilities:
+ *   1. Listen for ExtensionToWebview messages (chat-protocol.ts) and apply
+ *      them to the DOM (transcript, sub-task strip, HITL card, empty state).
+ *   2. Bind DOM events on the input form + HITL buttons + empty-state action
+ *      buttons and post WebviewToExtension messages back through
+ *      `acquireVsCodeApi().postMessage(...)`.
+ *
+ * All HTML the webview generates flows through the helpers in `render.ts`,
+ * which escape user-controlled content. The webview's CSP (set in
+ * extension.ts) blocks inline script and restricts script-src to a per-load
+ * nonce so any markdown injection cannot execute code.
  */
-export {};
+
+import type { ExtensionToWebview, WebviewToExtension } from "../chat-protocol.js";
+import {
+  type EmptyStateInput,
+  renderEmptyState,
+  renderHitlCard,
+  renderSubTaskRow,
+  renderTurn,
+} from "./render.js";
+
+interface VsCodeApi {
+  postMessage(msg: WebviewToExtension): void;
+  getState<T>(): T | undefined;
+  setState<T>(state: T): void;
+}
+
+declare function acquireVsCodeApi(): VsCodeApi;
+
+const vscode = acquireVsCodeApi();
+
+// ---------------------------------------------------------------------------
+// DOM cache. Wired up once on DOMContentLoaded.
+
+interface Refs {
+  transcript: HTMLElement;
+  subTaskList: HTMLElement;
+  emptyMount: HTMLElement;
+  hitlMount: HTMLElement;
+  form: HTMLFormElement;
+  input: HTMLTextAreaElement;
+  send: HTMLButtonElement;
+  stop: HTMLButtonElement;
+  status: HTMLElement;
+}
+
+function refs(): Refs {
+  // The webview shell is a fixed scaffold the extension HTML defines; these
+  // selectors are stable across renders.
+  return {
+    transcript: must("#transcript"),
+    subTaskList: must("#subtask-list"),
+    emptyMount: must("#empty-mount"),
+    hitlMount: must("#hitl-mount"),
+    form: must<HTMLFormElement>("#input-form"),
+    input: must<HTMLTextAreaElement>("#input-text"),
+    send: must<HTMLButtonElement>("#input-send"),
+    stop: must<HTMLButtonElement>("#input-stop"),
+    status: must("#status"),
+  };
+}
+
+function must<T extends Element = HTMLElement>(sel: string): T {
+  const el = document.querySelector<T>(sel);
+  if (el === null) throw new Error(`webview shell missing required selector: ${sel}`);
+  return el;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming state. The current assistant turn is held in `streamingText` and
+// re-rendered on every token so markdown blocks display correctly mid-stream.
+
+interface State {
+  streamingText: string;
+  /** True between userMessage and done/error/reset. Drives Send/Stop UI. */
+  streaming: boolean;
+}
+
+const state: State = {
+  streamingText: "",
+  streaming: false,
+};
+
+// ---------------------------------------------------------------------------
+// Message handlers — one per discriminated `type` in ExtensionToWebview.
+
+function applyMessage(r: Refs, msg: ExtensionToWebview): void {
+  switch (msg.type) {
+    case "reset":
+      r.transcript.replaceChildren();
+      r.subTaskList.replaceChildren();
+      r.hitlMount.replaceChildren();
+      r.emptyMount.replaceChildren();
+      r.emptyMount.insertAdjacentHTML("beforeend", renderEmptyState({ sub: "no-transcript" }));
+      state.streamingText = "";
+      setStreaming(r, false);
+      return;
+    case "hydrate":
+      r.transcript.replaceChildren();
+      r.emptyMount.replaceChildren();
+      for (const t of msg.turns) {
+        r.transcript.insertAdjacentHTML("beforeend", renderTurn(t));
+      }
+      scrollToBottom(r);
+      return;
+    case "userMessage":
+      r.emptyMount.replaceChildren();
+      r.transcript.insertAdjacentHTML(
+        "beforeend",
+        renderTurn({ role: "user", text: msg.text, timestamp: Date.now() }),
+      );
+      // Open a fresh streaming turn placeholder.
+      state.streamingText = "";
+      r.transcript.insertAdjacentHTML(
+        "beforeend",
+        '<article class="turn turn-assistant turn-streaming"><header class="turn-header">Nimbus</header><div class="markdown" data-streaming="1"></div></article>',
+      );
+      setStreaming(r, true);
+      scrollToBottom(r);
+      return;
+    case "token":
+      state.streamingText += msg.text;
+      // Re-render the in-flight turn body. We render whole-text every time —
+      // markdown is not stable mid-token (open code fences, etc.) and the
+      // re-render cost on the small payloads we deal with is negligible.
+      {
+        const target = r.transcript.querySelector('div.markdown[data-streaming="1"]');
+        if (target !== null) {
+          // Use the same renderer the final turn uses so markdown is consistent.
+          target.innerHTML = renderTurnBodyHtml(state.streamingText);
+        }
+      }
+      scrollToBottom(r);
+      return;
+    case "subTask": {
+      const row = renderSubTaskRow(msg);
+      const existing = r.subTaskList.querySelector(
+        `li.subtask-row[data-subtask-id="${cssEscape(msg.subTaskId)}"]`,
+      );
+      if (existing !== null) {
+        existing.outerHTML = row;
+      } else {
+        r.subTaskList.insertAdjacentHTML("beforeend", row);
+      }
+      return;
+    }
+    case "hitlInline":
+      r.hitlMount.replaceChildren();
+      r.hitlMount.insertAdjacentHTML(
+        "beforeend",
+        renderHitlCard({
+          requestId: msg.requestId,
+          prompt: msg.prompt,
+          ...(msg.details === undefined ? {} : { details: msg.details }),
+        }),
+      );
+      scrollToBottom(r);
+      return;
+    case "done":
+      finalizeStreamingTurn(r);
+      setStreaming(r, false);
+      return;
+    case "error":
+      finalizeStreamingTurn(r);
+      r.transcript.insertAdjacentHTML(
+        "beforeend",
+        `<article class="turn turn-error" role="alert">Error: ${escapeForAttr(msg.message)}</article>`,
+      );
+      setStreaming(r, false);
+      return;
+    case "emptyState":
+      r.transcript.replaceChildren();
+      r.emptyMount.replaceChildren();
+      r.emptyMount.insertAdjacentHTML(
+        "beforeend",
+        renderEmptyState({
+          sub: msg.sub,
+          ...(msg.socketPath === undefined ? {} : { socketPath: msg.socketPath }),
+        } as EmptyStateInput),
+      );
+      return;
+    case "themeChange":
+      // VS Code applies CSS variables automatically; nothing to do.
+      return;
+  }
+}
+
+function finalizeStreamingTurn(r: Refs): void {
+  const target = r.transcript.querySelector('div.markdown[data-streaming="1"]');
+  if (target !== null) {
+    target.removeAttribute("data-streaming");
+    // One last full re-render so the final markdown is well-formed.
+    target.innerHTML = renderTurnBodyHtml(state.streamingText);
+    target.parentElement?.classList.remove("turn-streaming");
+  }
+  state.streamingText = "";
+  r.subTaskList.replaceChildren();
+  r.hitlMount.replaceChildren();
+  scrollToBottom(r);
+}
+
+function renderTurnBodyHtml(text: string): string {
+  // Borrow the assistant-turn body renderer by feeding renderTurn and
+  // slicing out the inner markdown div. Cheap and keeps a single source of
+  // truth for the markdown invocation.
+  const full = renderTurn({ role: "assistant", text });
+  const start = full.indexOf('<div class="markdown">');
+  const end = full.lastIndexOf("</div>");
+  if (start < 0 || end < 0) return "";
+  return full.slice(start + '<div class="markdown">'.length, end);
+}
+
+function setStreaming(r: Refs, streaming: boolean): void {
+  state.streaming = streaming;
+  r.send.disabled = streaming;
+  r.stop.disabled = !streaming;
+  r.status.textContent = streaming ? "Streaming…" : "";
+}
+
+function scrollToBottom(r: Refs): void {
+  // The transcript pane uses overflow-y: auto; pin to the bottom on every
+  // mutation while streaming so newly arriving tokens stay in view.
+  r.transcript.scrollTop = r.transcript.scrollHeight;
+}
+
+/** CSS.escape polyfill — avoids pulling in the full lib. */
+function cssEscape(s: string): string {
+  return s.replaceAll(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+function escapeForAttr(s: string): string {
+  return s.replaceAll('"', "&quot;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+
+function bootstrap(): void {
+  const r = refs();
+
+  // Initial state — empty until the extension hydrates or sends a turn.
+  r.emptyMount.insertAdjacentHTML("beforeend", renderEmptyState({ sub: "no-transcript" }));
+  setStreaming(r, false);
+
+  // Form submit → submitAsk
+  r.form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    if (state.streaming) return;
+    const text = r.input.value.trim();
+    if (text.length === 0) return;
+    vscode.postMessage({ type: "submitAsk", text });
+    r.input.value = "";
+  });
+
+  // Cmd/Ctrl+Enter submits even when textarea is multi-line.
+  r.input.addEventListener("keydown", (e) => {
+    const k = e as KeyboardEvent;
+    if (k.key === "Enter" && (k.metaKey || k.ctrlKey)) {
+      e.preventDefault();
+      r.form.dispatchEvent(new Event("submit", { cancelable: true }));
+    }
+  });
+
+  // Stop button → stopStream
+  r.stop.addEventListener("click", () => {
+    if (!state.streaming) return;
+    vscode.postMessage({ type: "stopStream" });
+  });
+
+  // Delegated listener for HITL card actions + empty-state buttons.
+  document.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement | null;
+    if (target === null) return;
+    const decisionBtn = target.closest<HTMLButtonElement>("button.hitl-btn[data-decision]");
+    if (decisionBtn !== null) {
+      const requestId = decisionBtn.dataset["requestId"];
+      const decision = decisionBtn.dataset["decision"];
+      if (typeof requestId === "string" && (decision === "approve" || decision === "reject")) {
+        vscode.postMessage({ type: "hitlResponse", requestId, decision });
+        // Optimistic UI: replace the card with a status stub so the user
+        // sees the decision was received even if the gateway round-trip
+        // takes a beat.
+        const card = decisionBtn.closest<HTMLElement>(".hitl-card");
+        if (card !== null) {
+          card.replaceWith(
+            mkStub(`Decision recorded: ${decision === "approve" ? "approved" : "rejected"}`),
+          );
+        }
+      }
+      return;
+    }
+    const emptyAction = target.closest<HTMLButtonElement>("button[data-action]");
+    if (emptyAction !== null) {
+      const action = emptyAction.dataset["action"];
+      if (action === "openLogs") {
+        vscode.postMessage({ type: "openLogs" });
+      } else if (action === "startGateway") {
+        vscode.postMessage({ type: "startGateway" });
+      }
+    }
+  });
+
+  window.addEventListener("message", (ev) => {
+    const data = (ev as MessageEvent).data as ExtensionToWebview;
+    if (data === null || typeof data !== "object" || typeof data.type !== "string") return;
+    applyMessage(r, data);
+  });
+
+  // Tell the extension we're ready to receive hydrate/empty-state.
+  vscode.postMessage({ type: "ready" });
+}
+
+function mkStub(text: string): HTMLElement {
+  const el = document.createElement("div");
+  el.className = "hitl-stub";
+  el.textContent = text;
+  return el;
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", bootstrap);
+} else {
+  bootstrap();
+}

--- a/packages/vscode-extension/src/chat/webview/main.ts
+++ b/packages/vscode-extension/src/chat/webview/main.ts
@@ -143,10 +143,10 @@ function applyMessage(r: Refs, msg: ExtensionToWebview): void {
       const existing = r.subTaskList.querySelector(
         `li.subtask-row[data-subtask-id="${cssEscape(msg.subTaskId)}"]`,
       );
-      if (existing !== null) {
-        existing.outerHTML = row;
-      } else {
+      if (existing === null) {
         r.subTaskList.insertAdjacentHTML("beforeend", row);
+      } else {
+        existing.outerHTML = row;
       }
       return;
     }
@@ -168,10 +168,18 @@ function applyMessage(r: Refs, msg: ExtensionToWebview): void {
       return;
     case "error":
       finalizeStreamingTurn(r);
-      r.transcript.insertAdjacentHTML(
-        "beforeend",
-        `<article class="turn turn-error" role="alert">Error: ${escapeForAttr(msg.message)}</article>`,
-      );
+      // Build the error article via DOM APIs (textContent) instead of
+      // insertAdjacentHTML so the agent-supplied error message can never be
+      // interpreted as HTML — the strict CSP plus DOMPurify on the markdown
+      // path already block script execution, but `textContent` makes the
+      // intent unambiguous to static analysis (and to readers).
+      {
+        const article = document.createElement("article");
+        article.className = "turn turn-error";
+        article.setAttribute("role", "alert");
+        article.textContent = `Error: ${msg.message}`;
+        r.transcript.append(article);
+      }
       setStreaming(r, false);
       return;
     case "emptyState":
@@ -192,9 +200,9 @@ function applyMessage(r: Refs, msg: ExtensionToWebview): void {
 }
 
 function finalizeStreamingTurn(r: Refs): void {
-  const target = r.transcript.querySelector('div.markdown[data-streaming="1"]');
+  const target = r.transcript.querySelector<HTMLElement>('div.markdown[data-streaming="1"]');
   if (target !== null) {
-    target.removeAttribute("data-streaming");
+    delete target.dataset["streaming"];
     // One last full re-render so the final markdown is well-formed.
     target.innerHTML = renderTurnBodyHtml(state.streamingText);
     target.parentElement?.classList.remove("turn-streaming");
@@ -234,10 +242,6 @@ function cssEscape(s: string): string {
   return s.replaceAll(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
 }
 
-function escapeForAttr(s: string): string {
-  return s.replaceAll('"', "&quot;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-}
-
 // ---------------------------------------------------------------------------
 // Bootstrap
 
@@ -260,8 +264,7 @@ function bootstrap(): void {
 
   // Cmd/Ctrl+Enter submits even when textarea is multi-line.
   r.input.addEventListener("keydown", (e) => {
-    const k = e as KeyboardEvent;
-    if (k.key === "Enter" && (k.metaKey || k.ctrlKey)) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       r.form.dispatchEvent(new Event("submit", { cancelable: true }));
     }
@@ -273,41 +276,18 @@ function bootstrap(): void {
     vscode.postMessage({ type: "stopStream" });
   });
 
-  // Delegated listener for HITL card actions + empty-state buttons.
+  // Delegated listener — split into per-target handlers so each branch stays
+  // simple (Sonar's cognitive-complexity gate caps a single handler at 15).
   document.addEventListener("click", (e) => {
     const target = e.target as HTMLElement | null;
     if (target === null) return;
-    const decisionBtn = target.closest<HTMLButtonElement>("button.hitl-btn[data-decision]");
-    if (decisionBtn !== null) {
-      const requestId = decisionBtn.dataset["requestId"];
-      const decision = decisionBtn.dataset["decision"];
-      if (typeof requestId === "string" && (decision === "approve" || decision === "reject")) {
-        vscode.postMessage({ type: "hitlResponse", requestId, decision });
-        // Optimistic UI: replace the card with a status stub so the user
-        // sees the decision was received even if the gateway round-trip
-        // takes a beat.
-        const card = decisionBtn.closest<HTMLElement>(".hitl-card");
-        if (card !== null) {
-          card.replaceWith(
-            mkStub(`Decision recorded: ${decision === "approve" ? "approved" : "rejected"}`),
-          );
-        }
-      }
-      return;
-    }
-    const emptyAction = target.closest<HTMLButtonElement>("button[data-action]");
-    if (emptyAction !== null) {
-      const action = emptyAction.dataset["action"];
-      if (action === "openLogs") {
-        vscode.postMessage({ type: "openLogs" });
-      } else if (action === "startGateway") {
-        vscode.postMessage({ type: "startGateway" });
-      }
-    }
+    if (handleHitlButtonClick(target)) return;
+    handleEmptyStateActionClick(target);
   });
 
   window.addEventListener("message", (ev) => {
-    const data = (ev as MessageEvent).data as ExtensionToWebview;
+    if (!isFromExtensionHost(ev)) return;
+    const data = ev.data as ExtensionToWebview;
     if (data === null || typeof data !== "object" || typeof data.type !== "string") return;
     applyMessage(r, data);
   });
@@ -321,6 +301,54 @@ function mkStub(text: string): HTMLElement {
   el.className = "hitl-stub";
   el.textContent = text;
   return el;
+}
+
+/**
+ * HITL Approve/Reject button click — returns true when the click was handled
+ * so the caller can short-circuit. Posts the decision back to the extension
+ * and replaces the card with an "decision recorded" stub for instant feedback.
+ */
+function handleHitlButtonClick(target: HTMLElement): boolean {
+  const decisionBtn = target.closest<HTMLButtonElement>("button.hitl-btn[data-decision]");
+  if (decisionBtn === null) return false;
+  const requestId = decisionBtn.dataset["requestId"];
+  const decision = decisionBtn.dataset["decision"];
+  if (typeof requestId !== "string") return true;
+  if (decision !== "approve" && decision !== "reject") return true;
+  vscode.postMessage({ type: "hitlResponse", requestId, decision });
+  const card = decisionBtn.closest<HTMLElement>(".hitl-card");
+  if (card !== null) {
+    const verb = decision === "approve" ? "approved" : "rejected";
+    card.replaceWith(mkStub(`Decision recorded: ${verb}`));
+  }
+  return true;
+}
+
+/** Empty-state action buttons (Open Logs / Start Gateway). */
+function handleEmptyStateActionClick(target: HTMLElement): void {
+  const btn = target.closest<HTMLButtonElement>("button[data-action]");
+  if (btn === null) return;
+  const action = btn.dataset["action"];
+  if (action === "openLogs") {
+    vscode.postMessage({ type: "openLogs" });
+  } else if (action === "startGateway") {
+    vscode.postMessage({ type: "startGateway" });
+  }
+}
+
+/**
+ * VS Code webviews receive postMessage events from the extension host frame
+ * embedding this iframe. The host sets `event.source === window.parent` and
+ * uses an `vscode-webview://` origin (or a webview-prefixed scheme on web).
+ * Any message that doesn't satisfy both is from a hostile injected frame
+ * and must be dropped before its `data` is applied.
+ */
+function isFromExtensionHost(ev: MessageEvent): boolean {
+  if (ev.source !== window.parent) return false;
+  // `event.origin` may be empty in test/sandbox environments; only reject
+  // explicit non-vscode origins so legitimate webview test harnesses still work.
+  if (ev.origin.length > 0 && !ev.origin.startsWith("vscode-webview")) return false;
+  return true;
 }
 
 if (document.readyState === "loading") {

--- a/packages/vscode-extension/src/chat/webview/render.ts
+++ b/packages/vscode-extension/src/chat/webview/render.ts
@@ -1,0 +1,174 @@
+/**
+ * Pure-string render helpers for the chat Webview. No DOM access, no
+ * acquireVsCodeApi — main.ts owns those side effects. Keeping this module
+ * pure makes it unit-testable under vitest without a jsdom environment.
+ *
+ * Markdown is rendered via `marked` with sanitisation handled by:
+ *   1. A strict CSP injected by extension.ts (script-src nonce, style-src
+ *      'unsafe-inline' on the webview cspSource).
+ *   2. `escapeHtml` for any user-controlled string that bypasses marked
+ *      (turn metadata, sub-task status, error messages, prompt text).
+ *
+ * Streamed assistant content is re-rendered every token: marked is a one-shot
+ * function and incremental rendering is not worth the complexity for the
+ * size of replies the webview shows.
+ */
+
+import { marked } from "marked";
+
+/**
+ * Render a markdown string to safe HTML. Uses marked's GFM defaults; no
+ * raw HTML passes through because we set `marked` options conservatively
+ * and the CSP blocks inline script attributes anyway.
+ */
+export function renderMarkdown(src: string): string {
+  if (src.length === 0) return "";
+  // marked.parse can return a Promise depending on options; with the
+  // synchronous options below (no async tokenizer / walkTokens / extensions),
+  // it returns a string. The cast keeps the call site simple.
+  const html = marked.parse(src, {
+    async: false,
+    breaks: true,
+    gfm: true,
+  }) as string;
+  return html;
+}
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+export function escapeHtml(s: string): string {
+  return s.replaceAll(/[&<>"']/g, (c) => HTML_ESCAPES[c] ?? c);
+}
+
+// ---------------------------------------------------------------------------
+// Higher-level fragments. Each renders a single message or pane to a string
+// of HTML the calling DOM module appends to the transcript container.
+
+export type TurnRole = "user" | "assistant";
+
+export interface TurnRenderInput {
+  role: TurnRole;
+  text: string;
+  timestamp?: number;
+}
+
+/**
+ * Render a single completed turn. User messages are escaped + wrapped in a
+ * <pre> so leading whitespace and code-like inputs render as written;
+ * assistant messages go through markdown.
+ */
+export function renderTurn(turn: TurnRenderInput): string {
+  const stamp =
+    turn.timestamp !== undefined && turn.timestamp > 0
+      ? ` <time datetime="${escapeHtml(new Date(turn.timestamp).toISOString())}">${escapeHtml(formatTimestamp(turn.timestamp))}</time>`
+      : "";
+  if (turn.role === "user") {
+    const inner = `<pre class="user-text">${escapeHtml(turn.text)}</pre>`;
+    return `<article class="turn turn-user"><header class="turn-header">You${stamp}</header>${inner}</article>`;
+  }
+  const inner = renderMarkdown(turn.text);
+  return `<article class="turn turn-assistant"><header class="turn-header">Nimbus${stamp}</header><div class="markdown">${inner}</div></article>`;
+}
+
+/**
+ * Inline HITL consent card. Shown when an `agent.hitlBatch` arrives while
+ * the chat panel is visible+focused. The card is replaced by a "Decision
+ * recorded" stub once the user clicks Approve / Reject — the underlying
+ * agent.hitlBatch is owned by the gateway, not the webview.
+ */
+export interface HitlCardInput {
+  requestId: string;
+  prompt: string;
+  details?: unknown;
+}
+
+export function renderHitlCard(req: HitlCardInput): string {
+  const detailsJson =
+    req.details === undefined || req.details === null
+      ? ""
+      : `<pre class="hitl-details">${escapeHtml(JSON.stringify(req.details, null, 2))}</pre>`;
+  const id = escapeHtml(req.requestId);
+  return `<section class="hitl-card" data-request-id="${id}" role="alert" aria-live="polite">
+<header class="hitl-header">Consent required</header>
+<p class="hitl-prompt">${escapeHtml(req.prompt)}</p>
+${detailsJson}
+<div class="hitl-actions">
+<button class="hitl-btn hitl-approve" data-request-id="${id}" data-decision="approve">Approve</button>
+<button class="hitl-btn hitl-reject" data-request-id="${id}" data-decision="reject">Reject</button>
+</div>
+</section>`;
+}
+
+/**
+ * Sub-task progress strip — rendered in a sticky status row above the
+ * input box while a stream is in flight. Multiple sub-tasks accumulate by
+ * subTaskId; status is the last value the gateway emitted.
+ */
+export interface SubTaskRowInput {
+  subTaskId: string;
+  status: string;
+  progress?: number;
+}
+
+export function renderSubTaskRow(row: SubTaskRowInput): string {
+  const id = escapeHtml(row.subTaskId);
+  const status = escapeHtml(row.status);
+  const pct =
+    typeof row.progress === "number"
+      ? ` <span class="subtask-pct">${escapeHtml(`${Math.round(row.progress * 100)}%`)}</span>`
+      : "";
+  return `<li class="subtask-row" data-subtask-id="${id}"><span class="subtask-id">${id}</span><span class="subtask-status">${status}</span>${pct}</li>`;
+}
+
+/**
+ * Empty-state placeholder. Different copy depending on `sub`.
+ */
+export interface EmptyStateInput {
+  sub: "no-transcript" | "disconnected" | "permission-denied";
+  socketPath?: string;
+}
+
+export function renderEmptyState(inp: EmptyStateInput): string {
+  if (inp.sub === "no-transcript") {
+    return `<div class="empty-state empty-no-transcript">
+<h3>Nothing yet.</h3>
+<p>Type a question below and press <kbd>Enter</kbd> to ask Nimbus.</p>
+</div>`;
+  }
+  if (inp.sub === "disconnected") {
+    const path =
+      inp.socketPath !== undefined && inp.socketPath.length > 0
+        ? `<p class="muted">Socket: <code>${escapeHtml(inp.socketPath)}</code></p>`
+        : "";
+    return `<div class="empty-state empty-disconnected">
+<h3>Gateway not connected.</h3>
+<p>Start the Nimbus Gateway, then click <button class="link-btn" data-action="startGateway">Start Gateway</button> or wait for auto-reconnect.</p>
+${path}
+</div>`;
+  }
+  // permission-denied
+  const path =
+    inp.socketPath !== undefined && inp.socketPath.length > 0
+      ? `<p class="muted">Socket: <code>${escapeHtml(inp.socketPath)}</code></p>`
+      : "";
+  return `<div class="empty-state empty-permission-denied">
+<h3>Permission denied accessing the Gateway socket.</h3>
+<p>Check the socket file permissions, or override <code>nimbus.socketPath</code> in settings.</p>
+${path}
+<p><button class="link-btn" data-action="openLogs">Open Nimbus logs</button></p>
+</div>`;
+}
+
+/** Format a unix-ms timestamp as a short HH:MM string for the turn header. */
+function formatTimestamp(ms: number): string {
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}

--- a/packages/vscode-extension/src/chat/webview/render.ts
+++ b/packages/vscode-extension/src/chat/webview/render.ts
@@ -14,24 +14,32 @@
  * size of replies the webview shows.
  */
 
+import DOMPurify from "dompurify";
 import { marked } from "marked";
 
 /**
- * Render a markdown string to safe HTML. Uses marked's GFM defaults; no
- * raw HTML passes through because we set `marked` options conservatively
- * and the CSP blocks inline script attributes anyway.
+ * Render a markdown string to safe HTML. Two-stage:
+ *   1. `marked.parse(...)` produces HTML from the markdown source.
+ *   2. `DOMPurify.sanitize(...)` strips any raw `<script>`, `<iframe>`, event
+ *      handlers, `javascript:` URLs, etc. that a hostile LLM (or a piece of
+ *      indexed content the agent quotes back) might smuggle in.
+ *
+ * The CSP set by extension.ts already blocks inline script execution, but
+ * sanitisation here is the second line of defence — a webview that ever
+ * relaxes CSP for `unsafe-eval` (e.g. for a future code highlighter) would
+ * otherwise be exposed.
  */
 export function renderMarkdown(src: string): string {
   if (src.length === 0) return "";
   // marked.parse can return a Promise depending on options; with the
   // synchronous options below (no async tokenizer / walkTokens / extensions),
   // it returns a string. The cast keeps the call site simple.
-  const html = marked.parse(src, {
+  const raw = marked.parse(src, {
     async: false,
     breaks: true,
     gfm: true,
   }) as string;
-  return html;
+  return DOMPurify.sanitize(raw);
 }
 
 const HTML_ESCAPES: Record<string, string> = {
@@ -119,10 +127,11 @@ export interface SubTaskRowInput {
 export function renderSubTaskRow(row: SubTaskRowInput): string {
   const id = escapeHtml(row.subTaskId);
   const status = escapeHtml(row.status);
-  const pct =
-    typeof row.progress === "number"
-      ? ` <span class="subtask-pct">${escapeHtml(`${Math.round(row.progress * 100)}%`)}</span>`
-      : "";
+  let pct = "";
+  if (typeof row.progress === "number") {
+    const percent = `${Math.round(row.progress * 100)}%`;
+    pct = ` <span class="subtask-pct">${escapeHtml(percent)}</span>`;
+  }
   return `<li class="subtask-row" data-subtask-id="${id}"><span class="subtask-id">${id}</span><span class="subtask-status">${status}</span>${pct}</li>`;
 }
 

--- a/packages/vscode-extension/src/chat/webview/styles.css
+++ b/packages/vscode-extension/src/chat/webview/styles.css
@@ -1,1 +1,371 @@
-/* placeholder — populated in Task 23 */
+/*
+ * Nimbus chat webview — VS Code theme-aware styling. Every color/font derives
+ * from a `--vscode-*` CSS variable so dark / light / high-contrast all work
+ * without theme-specific overrides. esbuild copies this file to
+ * media/webview.css during build.
+ */
+
+:root {
+  --nimbus-gap: 0.75rem;
+  --nimbus-radius: 4px;
+  --nimbus-border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border, #00000020));
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-editor-foreground);
+  background: var(--vscode-editor-background);
+  display: flex;
+  flex-direction: column;
+}
+
+main#root {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+#transcript {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--nimbus-gap);
+  display: flex;
+  flex-direction: column;
+  gap: var(--nimbus-gap);
+}
+
+#empty-mount:not(:empty) {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: var(--vscode-descriptionForeground);
+  max-width: 32rem;
+}
+
+.empty-state h3 {
+  margin: 0 0 0.5em 0;
+  color: var(--vscode-editor-foreground);
+}
+
+.empty-state .muted {
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.85em;
+}
+
+.empty-state code {
+  background: var(--vscode-textBlockQuote-background);
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: var(--vscode-textLink-foreground);
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+  font: inherit;
+}
+
+.link-btn:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
+
+/* Turns ----------------------------------------------------------------- */
+
+.turn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--nimbus-radius);
+  border: var(--nimbus-border);
+  background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+}
+
+.turn-user {
+  align-self: flex-end;
+  max-width: 80%;
+  background: var(--vscode-input-background);
+}
+
+.turn-assistant {
+  align-self: stretch;
+}
+
+.turn-streaming {
+  border-left: 2px solid var(--vscode-progressBar-background, var(--vscode-textLink-foreground));
+}
+
+.turn-error {
+  background: var(--vscode-inputValidation-errorBackground, var(--vscode-editor-background));
+  color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
+  border-color: var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+}
+
+.turn-header {
+  font-size: 0.8em;
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  display: flex;
+  justify-content: space-between;
+}
+
+.turn-header time {
+  font-weight: normal;
+  font-feature-settings: "tnum" 1;
+}
+
+.user-text {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: var(--vscode-editor-font-family, var(--vscode-font-family));
+  font-size: var(--vscode-editor-font-size, var(--vscode-font-size));
+}
+
+.markdown {
+  line-height: 1.5;
+}
+
+.markdown p {
+  margin: 0.4em 0;
+}
+
+.markdown p:first-child {
+  margin-top: 0;
+}
+
+.markdown p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown pre {
+  background: var(--vscode-textBlockQuote-background);
+  border-left: 3px solid var(--vscode-textBlockQuote-border, var(--vscode-textLink-foreground));
+  padding: 0.6em 0.8em;
+  overflow-x: auto;
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
+  border-radius: 0 var(--nimbus-radius) var(--nimbus-radius) 0;
+}
+
+.markdown code {
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.95em;
+  background: var(--vscode-textBlockQuote-background);
+  padding: 0.05em 0.35em;
+  border-radius: 3px;
+}
+
+.markdown pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.markdown a {
+  color: var(--vscode-textLink-foreground);
+}
+
+.markdown a:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
+
+.markdown blockquote {
+  border-left: 3px solid var(--vscode-textBlockQuote-border, var(--vscode-textLink-foreground));
+  padding-left: 0.8em;
+  margin: 0.4em 0;
+  color: var(--vscode-descriptionForeground);
+}
+
+.markdown table {
+  border-collapse: collapse;
+}
+
+.markdown th,
+.markdown td {
+  border: var(--nimbus-border);
+  padding: 0.25em 0.5em;
+}
+
+/* HITL card ------------------------------------------------------------- */
+
+#hitl-mount:not(:empty) {
+  padding: 0 var(--nimbus-gap);
+}
+
+.hitl-card {
+  border: 1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-editorWarning-foreground));
+  background: var(--vscode-inputValidation-warningBackground, var(--vscode-editorWidget-background));
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-editor-foreground));
+  border-radius: var(--nimbus-radius);
+  padding: 0.6rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hitl-header {
+  font-weight: 700;
+}
+
+.hitl-prompt {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.hitl-details {
+  margin: 0;
+  background: var(--vscode-textBlockQuote-background);
+  padding: 0.5em 0.7em;
+  border-radius: var(--nimbus-radius);
+  overflow-x: auto;
+  font-size: 0.85em;
+}
+
+.hitl-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.hitl-btn {
+  padding: 0.35rem 0.85rem;
+  border: none;
+  border-radius: var(--nimbus-radius);
+  cursor: pointer;
+  font: inherit;
+}
+
+.hitl-approve {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.hitl-approve:hover {
+  background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+}
+
+.hitl-reject {
+  background: var(--vscode-errorForeground);
+  color: var(--vscode-button-foreground, #fff);
+}
+
+.hitl-stub {
+  font-size: 0.85em;
+  font-style: italic;
+  color: var(--vscode-descriptionForeground);
+  padding: 0.4rem 0.8rem;
+}
+
+/* Sub-task strip + status row + input box ------------------------------ */
+
+#footer {
+  border-top: var(--nimbus-border);
+  background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+}
+
+#status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem var(--nimbus-gap);
+  font-size: 0.8em;
+  color: var(--vscode-descriptionForeground);
+  min-height: 1.5rem;
+}
+
+#subtask-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.subtask-row {
+  display: flex;
+  gap: 0.4rem;
+  background: var(--vscode-textBlockQuote-background);
+  border-radius: var(--nimbus-radius);
+  padding: 0.1rem 0.5rem;
+  font-size: 0.85em;
+}
+
+.subtask-id {
+  font-weight: 600;
+}
+
+.subtask-pct {
+  font-feature-settings: "tnum" 1;
+}
+
+#input-form {
+  display: flex;
+  gap: 0.5rem;
+  padding: var(--nimbus-gap);
+  align-items: flex-end;
+}
+
+#input-text {
+  flex: 1 1 auto;
+  resize: vertical;
+  min-height: 2.4em;
+  max-height: 10em;
+  padding: 0.4em 0.6em;
+  font: inherit;
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, var(--vscode-widget-border, transparent));
+  border-radius: var(--nimbus-radius);
+}
+
+#input-text:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+#input-send,
+#input-stop {
+  padding: 0.4em 1.1em;
+  font: inherit;
+  border: none;
+  border-radius: var(--nimbus-radius);
+  cursor: pointer;
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+#input-send:hover:not(:disabled),
+#input-stop:hover:not(:disabled) {
+  background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+}
+
+#input-send:disabled,
+#input-stop:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+#input-stop {
+  background: var(--vscode-errorForeground);
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -175,70 +175,73 @@ export function activateWithDeps(
     return chatController;
   };
 
+  // Per-message handlers. Each is small and self-contained so the dispatch
+  // function below stays under Sonar's cognitive-complexity gate.
+  const onReady = (): void => {
+    void chatController?.rehydrateIfNeeded(settings.transcriptHistoryLimit());
+  };
+
+  const onSubmitAsk = async (msg: Record<string, unknown>): Promise<void> => {
+    const text = m_str(msg, "text").trim();
+    if (text.length === 0) return;
+    const ctl = ensureChatController();
+    if (ctl === undefined) return;
+    try {
+      await ctl.start(text);
+    } catch (e) {
+      log.error(`submitAsk failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+
+  const onStopStream = async (): Promise<void> => {
+    try {
+      await chatController?.stop();
+    } catch (e) {
+      log.warn(`stopStream failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+
+  const onHitlResponse = (msg: Record<string, unknown>): void => {
+    const requestId = m_str(msg, "requestId");
+    const decision = m_str(msg, "decision");
+    if (requestId.length === 0) return;
+    const resolver = pendingInlineHitl.get(requestId);
+    if (resolver === undefined) return;
+    pendingInlineHitl.delete(requestId);
+    const valid = decision === "approve" || decision === "reject";
+    resolver(valid ? decision : undefined);
+  };
+
+  const onOpenExternal = async (msg: Record<string, unknown>): Promise<void> => {
+    const url = m_str(msg, "url");
+    if (url.length === 0) return;
+    try {
+      await vscode.env.openExternal(vscode.Uri.parse(url));
+    } catch (e) {
+      log.warn(`openExternal failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+
+  // Dispatch table — keeps the typeof-string switch out of the if/else
+  // hot path Sonar measures. Unknown types are silently ignored.
+  const messageHandlers: Record<string, (msg: Record<string, unknown>) => unknown> = {
+    ready: onReady,
+    requestRehydrate: onReady,
+    submitAsk: onSubmitAsk,
+    stopStream: onStopStream,
+    hitlResponse: onHitlResponse,
+    openLogs: () => out.show(true),
+    startGateway: () => deps.commands.executeCommand("nimbus.startGateway"),
+    openExternal: onOpenExternal,
+  };
+
   const handleWebviewMessage = async (
     type: string,
     msg: Record<string, unknown>,
   ): Promise<void> => {
-    if (type === "ready") {
-      // Webview shell mounted — rehydrate the active session if there is one.
-      void chatController?.rehydrateIfNeeded(settings.transcriptHistoryLimit());
-      return;
-    }
-    if (type === "submitAsk") {
-      const text = m_str(msg, "text").trim();
-      if (text.length === 0) return;
-      const ctl = ensureChatController();
-      if (ctl === undefined) return;
-      try {
-        await ctl.start(text);
-      } catch (e) {
-        log.error(`submitAsk failed: ${e instanceof Error ? e.message : String(e)}`);
-      }
-      return;
-    }
-    if (type === "stopStream") {
-      try {
-        await chatController?.stop();
-      } catch (e) {
-        log.warn(`stopStream failed: ${e instanceof Error ? e.message : String(e)}`);
-      }
-      return;
-    }
-    if (type === "hitlResponse") {
-      const requestId = m_str(msg, "requestId");
-      const decision = m_str(msg, "decision");
-      if (requestId.length === 0) return;
-      const resolver = pendingInlineHitl.get(requestId);
-      if (resolver !== undefined) {
-        pendingInlineHitl.delete(requestId);
-        resolver(decision === "approve" || decision === "reject" ? decision : undefined);
-      }
-      return;
-    }
-    if (type === "openLogs") {
-      out.show(true);
-      return;
-    }
-    if (type === "startGateway") {
-      await deps.commands.executeCommand("nimbus.startGateway");
-      return;
-    }
-    if (type === "openExternal") {
-      const url = m_str(msg, "url");
-      if (url.length === 0) return;
-      try {
-        await vscode.env.openExternal(vscode.Uri.parse(url));
-      } catch (e) {
-        log.warn(`openExternal failed: ${e instanceof Error ? e.message : String(e)}`);
-      }
-      return;
-    }
-    // requestRehydrate is reserved for the webview to ask the extension to
-    // re-fetch its transcript (e.g. after a reload). For now this is the
-    // same code path as `ready`.
-    if (type === "requestRehydrate") {
-      void chatController?.rehydrateIfNeeded(settings.transcriptHistoryLimit());
-    }
+    const handler = messageHandlers[type];
+    if (handler === undefined) return;
+    await handler(msg);
   };
 
   // -----------------------------------------------------------------------

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -17,6 +17,7 @@
  */
 
 import { spawn as nodeSpawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { connect as netConnect } from "node:net";
 
 import { discoverSocketPath, type HitlRequest, NimbusClient } from "@nimbus-dev/client";
@@ -155,22 +156,113 @@ export function activateWithDeps(
       log,
       agent: () => settings.askAgent(),
     });
+    // Webview-to-extension router. The webview posts WebviewToExtension messages
+    // (chat-protocol.ts); we dispatch each to the right surface. Unknown shapes
+    // are dropped silently — the webview can never make the extension panic.
+    panel.onMessage((msg) => {
+      if (msg === null || typeof msg !== "object") return;
+      const m = msg as Record<string, unknown>;
+      const t = m["type"];
+      if (typeof t !== "string") return;
+      void handleWebviewMessage(t, m);
+    });
     panel.onDispose(() => {
       chatController = undefined;
+      // Resolve any in-flight inline-HITL promises so the router doesn't hang.
+      for (const [, resolve] of pendingInlineHitl) resolve(undefined);
+      pendingInlineHitl.clear();
     });
     return chatController;
   };
 
+  const handleWebviewMessage = async (
+    type: string,
+    msg: Record<string, unknown>,
+  ): Promise<void> => {
+    if (type === "ready") {
+      // Webview shell mounted — rehydrate the active session if there is one.
+      void chatController?.rehydrateIfNeeded(settings.transcriptHistoryLimit());
+      return;
+    }
+    if (type === "submitAsk") {
+      const text = m_str(msg, "text").trim();
+      if (text.length === 0) return;
+      const ctl = ensureChatController();
+      if (ctl === undefined) return;
+      try {
+        await ctl.start(text);
+      } catch (e) {
+        log.error(`submitAsk failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+      return;
+    }
+    if (type === "stopStream") {
+      try {
+        await chatController?.stop();
+      } catch (e) {
+        log.warn(`stopStream failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+      return;
+    }
+    if (type === "hitlResponse") {
+      const requestId = m_str(msg, "requestId");
+      const decision = m_str(msg, "decision");
+      if (requestId.length === 0) return;
+      const resolver = pendingInlineHitl.get(requestId);
+      if (resolver !== undefined) {
+        pendingInlineHitl.delete(requestId);
+        resolver(decision === "approve" || decision === "reject" ? decision : undefined);
+      }
+      return;
+    }
+    if (type === "openLogs") {
+      out.show(true);
+      return;
+    }
+    if (type === "startGateway") {
+      await deps.commands.executeCommand("nimbus.startGateway");
+      return;
+    }
+    if (type === "openExternal") {
+      const url = m_str(msg, "url");
+      if (url.length === 0) return;
+      try {
+        await vscode.env.openExternal(vscode.Uri.parse(url));
+      } catch (e) {
+        log.warn(`openExternal failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+      return;
+    }
+    // requestRehydrate is reserved for the webview to ask the extension to
+    // re-fetch its transcript (e.g. after a reload). For now this is the
+    // same code path as `ready`.
+    if (type === "requestRehydrate") {
+      void chatController?.rehydrateIfNeeded(settings.transcriptHistoryLimit());
+    }
+  };
+
   // -----------------------------------------------------------------------
-  // HITL router. The inline rich surface depends on the chat webview UI
-  // landing in a follow-up; until then inline degrades to the toast surface.
+  // Inline-HITL surface. When the chat panel is visible and focused the
+  // router calls `showInline` instead of falling through to the toast/modal.
+  // The pending-resolvers map is shared with `handleWebviewMessage` (above)
+  // so a `hitlResponse` from the webview resolves the right promise.
+  const pendingInlineHitl = new Map<string, (d: HitlDecision | undefined) => void>();
+  const showInlineInWebview = createInlineHitlSurface({
+    getPanel: () => chatPanelFactory.current(),
+    pending: pendingInlineHitl,
+    fallback: createToastSurface(deps.window),
+  });
+
+  // -----------------------------------------------------------------------
+  // HITL router — inline surface routes through the webview when the chat
+  // panel is up; toast/modal otherwise.
   const hitlRouter = createHitlRouter({
     chatPanelVisibleAndFocused: () => {
       const p = chatPanelFactory.current();
       return p?.isVisible() === true && p.isActive();
     },
     streamRegistered: (streamId) => registeredHitlStreams.has(streamId),
-    showInline: createToastSurface(deps.window),
+    showInline: showInlineInWebview,
     showToast: createToastSurface(deps.window),
     showModal: createModalSurface(deps.window),
     sendResponse: async (requestId, decision) => {
@@ -410,6 +502,50 @@ async function sendConsentResponse(
   await ipc.call("consent.respond", { requestId, decision });
 }
 
+/** Read a string field off an unknown-shaped record; "" when absent or wrong type. */
+function m_str(msg: Record<string, unknown>, key: string): string {
+  const v = msg[key];
+  return typeof v === "string" ? v : "";
+}
+
+/**
+ * Webview-routed HITL surface. The returned function posts a `hitlInline`
+ * message to the chat panel and resolves the promise once the matching
+ * `hitlResponse` arrives — the resolver is parked in the shared `pending`
+ * map keyed by requestId so the panel's onMessage handler (in
+ * `handleWebviewMessage`) can find it. When no panel is mounted the
+ * surface delegates to `fallback` so HITL never goes silent.
+ *
+ * Exported so the round-trip is unit-testable without driving the full
+ * `activateWithDeps` flow.
+ */
+export interface InlineHitlReq {
+  requestId: string;
+  prompt: string;
+  details?: unknown;
+}
+
+export function createInlineHitlSurface(args: {
+  getPanel: () => ChatPanel | undefined;
+  pending: Map<string, (d: HitlDecision | undefined) => void>;
+  fallback: (req: InlineHitlReq) => Promise<HitlDecision | undefined>;
+}): (req: InlineHitlReq) => Promise<HitlDecision | undefined> {
+  return async (req) => {
+    const panel = args.getPanel();
+    if (panel === undefined) return await args.fallback(req);
+    return await new Promise<HitlDecision | undefined>((resolve) => {
+      args.pending.set(req.requestId, resolve);
+      const payload: Record<string, unknown> = {
+        type: "hitlInline",
+        requestId: req.requestId,
+        prompt: req.prompt,
+      };
+      if (req.details !== undefined) payload["details"] = req.details;
+      void panel.postMessage(payload);
+    });
+  };
+}
+
 /** Best-effort socket reachability probe used by the auto-starter. */
 async function pingSocket(socketPath: string): Promise<boolean> {
   if (socketPath.length === 0) return false;
@@ -440,6 +576,11 @@ async function pingSocket(socketPath: string): Promise<boolean> {
  */
 function createRealChatPanelFactory(log: Logger): ChatPanelFactory {
   let current: ChatPanel | undefined;
+  // The bundle layout produced by esbuild + .vscodeignore is:
+  //   <ext>/dist/extension.js   ← __dirname here
+  //   <ext>/media/webview.{js,css}
+  // so the media root is one level above __dirname.
+  const mediaRoot = vscode.Uri.joinPath(vscode.Uri.file(__dirname), "..", "media");
 
   return {
     createOrReveal(): ChatPanel {
@@ -451,9 +592,13 @@ function createRealChatPanelFactory(log: Logger): ChatPanelFactory {
         "nimbus.chat",
         "Nimbus",
         vscode.ViewColumn.Beside,
-        { enableScripts: true, retainContextWhenHidden: true },
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [mediaRoot],
+        },
       );
-      panel.webview.html = renderPlaceholderHtml(panel.webview.cspSource);
+      panel.webview.html = renderChatHtml(panel.webview, mediaRoot);
       const wrapper = wrapWebviewPanel(panel, log, () => {
         current = undefined;
       });
@@ -521,11 +666,47 @@ function wrapWebviewPanel(
   };
 }
 
-function renderPlaceholderHtml(cspSource: string): string {
-  const csp = `default-src 'none'; style-src 'unsafe-inline' ${cspSource}; script-src ${cspSource};`;
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"/>
-<meta http-equiv="Content-Security-Policy" content="${csp}"/>
+/**
+ * Build the chat webview HTML shell. Loads `media/webview.css` + `media/webview.js`
+ * via `asWebviewUri` and constrains the page with a strict CSP (no inline
+ * script, per-load nonce, only the cspSource origin permitted for styles).
+ * The DOM scaffold here matches the selectors `webview/main.ts` queries.
+ */
+function renderChatHtml(webview: vscode.Webview, mediaRoot: vscode.Uri): string {
+  const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, "webview.js"));
+  const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, "webview.css"));
+  const nonce = randomUUID().replaceAll("-", "");
+  const csp =
+    `default-src 'none'; ` +
+    `style-src ${webview.cspSource} 'unsafe-inline'; ` +
+    `font-src ${webview.cspSource}; ` +
+    `script-src 'nonce-${nonce}';`;
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta http-equiv="Content-Security-Policy" content="${csp}" />
 <title>Nimbus</title>
-<style>body{font-family:var(--vscode-font-family);color:var(--vscode-editor-foreground);background:var(--vscode-editor-background);padding:1em}</style>
-</head><body><h2>Nimbus</h2><p>Streaming chat UI lands in a follow-up release. Output is currently posted to the "Nimbus" output channel.</p></body></html>`;
+<link rel="stylesheet" href="${styleUri.toString()}" />
+</head>
+<body>
+<main id="root">
+  <section id="empty-mount" aria-live="polite"></section>
+  <section id="transcript" aria-live="polite" aria-relevant="additions"></section>
+  <section id="hitl-mount" aria-live="assertive"></section>
+  <footer id="footer">
+    <div id="status-row">
+      <ul id="subtask-list"></ul>
+      <span id="status"></span>
+    </div>
+    <form id="input-form">
+      <textarea id="input-text" rows="2" placeholder="Ask Nimbus… (Cmd/Ctrl+Enter to send)"></textarea>
+      <button type="submit" id="input-send">Send</button>
+      <button type="button" id="input-stop" disabled>Stop</button>
+    </form>
+  </footer>
+</main>
+<script nonce="${nonce}" src="${scriptUri.toString()}"></script>
+</body>
+</html>`;
 }

--- a/packages/vscode-extension/test/unit/inline-hitl.test.ts
+++ b/packages/vscode-extension/test/unit/inline-hitl.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for `createInlineHitlSurface` — the webview-routed HITL surface
+ * extracted from extension.ts. Covers:
+ *   1. Posts a `hitlInline` message to the panel with the requestId/prompt.
+ *   2. Resolves with `approve` / `reject` when the matching resolver in the
+ *      shared `pending` map is called (simulating the webview reply).
+ *   3. Falls back to `fallback` when no panel is mounted.
+ *   4. Forwards `details` only when present.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import type { ChatPanel } from "../../src/chat/chat-panel.js";
+import { createInlineHitlSurface, type InlineHitlReq } from "../../src/extension.js";
+import type { HitlDecision } from "../../src/hitl/hitl-router.js";
+
+function makePanel(): {
+  panel: ChatPanel;
+  posted: unknown[];
+} {
+  const posted: unknown[] = [];
+  const panel: ChatPanel = {
+    reveal: () => undefined,
+    dispose: () => undefined,
+    panel: () => undefined,
+    onDispose: () => undefined,
+    onMessage: () => undefined,
+    postMessage: (m) => {
+      posted.push(m);
+      return Promise.resolve(true);
+    },
+    isVisible: () => true,
+    isActive: () => true,
+  };
+  return { panel, posted };
+}
+
+describe("createInlineHitlSurface", () => {
+  test("posts hitlInline and resolves on webview hitlResponse", async () => {
+    const { panel, posted } = makePanel();
+    const pending = new Map<string, (d: HitlDecision | undefined) => void>();
+    const fallback = vi.fn(async () => undefined);
+    const surface = createInlineHitlSurface({
+      getPanel: () => panel,
+      pending,
+      fallback,
+    });
+
+    const promise = surface({ requestId: "r1", prompt: "Approve?" });
+
+    // Verify the panel received the right shape.
+    expect(posted).toHaveLength(1);
+    expect(posted[0]).toMatchObject({
+      type: "hitlInline",
+      requestId: "r1",
+      prompt: "Approve?",
+    });
+    // `details` was not provided → must not be on the payload.
+    expect((posted[0] as { details?: unknown }).details).toBeUndefined();
+
+    // Simulate the webview's hitlResponse arriving.
+    const resolver = pending.get("r1");
+    expect(resolver).toBeDefined();
+    resolver?.("approve");
+
+    expect(await promise).toBe("approve");
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  test("forwards details when present", async () => {
+    const { panel, posted } = makePanel();
+    const pending = new Map<string, (d: HitlDecision | undefined) => void>();
+    const surface = createInlineHitlSurface({
+      getPanel: () => panel,
+      pending,
+      fallback: vi.fn(async () => undefined),
+    });
+    void surface({
+      requestId: "r2",
+      prompt: "p",
+      details: { actions: ["delete /etc/passwd"] },
+    });
+    expect((posted[0] as { details?: unknown }).details).toEqual({
+      actions: ["delete /etc/passwd"],
+    });
+  });
+
+  test("delegates to fallback when no panel is mounted", async () => {
+    const fallback = vi.fn(async () => "reject" as HitlDecision);
+    const surface = createInlineHitlSurface({
+      getPanel: () => undefined,
+      pending: new Map(),
+      fallback,
+    });
+    const r = await surface({ requestId: "r3", prompt: "Q" } as InlineHitlReq);
+    expect(r).toBe("reject");
+    expect(fallback).toHaveBeenCalledWith({ requestId: "r3", prompt: "Q" });
+  });
+
+  test("two concurrent requests are tracked independently", async () => {
+    const { panel } = makePanel();
+    const pending = new Map<string, (d: HitlDecision | undefined) => void>();
+    const surface = createInlineHitlSurface({
+      getPanel: () => panel,
+      pending,
+      fallback: vi.fn(async () => undefined),
+    });
+    const a = surface({ requestId: "a", prompt: "A" });
+    const b = surface({ requestId: "b", prompt: "B" });
+    pending.get("b")?.("approve");
+    pending.get("a")?.("reject");
+    expect(await Promise.all([a, b])).toEqual(["reject", "approve"]);
+  });
+});

--- a/packages/vscode-extension/test/unit/webview-render.test.ts
+++ b/packages/vscode-extension/test/unit/webview-render.test.ts
@@ -1,10 +1,22 @@
 /**
- * Unit tests for the pure-string render helpers in
- * src/chat/webview/render.ts. These run under vitest with no DOM/jsdom —
- * the helpers operate on strings only.
+ * @vitest-environment jsdom
+ *
+ * Unit tests for the render helpers in src/chat/webview/render.ts. The
+ * helpers themselves operate on strings, but `renderMarkdown` runs DOMPurify
+ * over the marked output for in-depth defence against agent-supplied HTML —
+ * DOMPurify v3 requires a `window`, so this file runs under jsdom rather
+ * than Node. Other test files in this package stay in the default Node env.
  */
 
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, test } from "vitest";
+
+// Per-process temp socket path so the test never references a literal under
+// /tmp (Sonar S5443 — publicly-writable directory hotspot) and never collides
+// across parallel test runs on the same host.
+const TEST_SOCKET_PATH = join(tmpdir(), `nimbus-render-${process.pid}.sock`);
 
 import {
   escapeHtml,
@@ -53,7 +65,10 @@ describe("renderTurn", () => {
     expect(html).toContain('<pre class="user-text">');
     expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
     // No raw script tag anywhere — XSS would be unforgivable here.
-    expect(html).not.toMatch(/<script>/);
+    // Case-insensitive: HTML tag names match ASCII-case-insensitively, so a
+    // payload of `<SCRIPT>` is just as exploitable as `<script>`.
+    expect(html).not.toMatch(/<script[\s>]/i);
+    expect(html).not.toMatch(/<\/script>/i);
   });
   test("assistant turn renders markdown", () => {
     const html = renderTurn({ role: "assistant", text: "**bold**" });
@@ -112,11 +127,11 @@ describe("renderEmptyState", () => {
   test("disconnected variant includes startGateway action and socketPath", () => {
     const html = renderEmptyState({
       sub: "disconnected",
-      socketPath: "/tmp/nimbus.sock",
+      socketPath: TEST_SOCKET_PATH,
     });
     expect(html).toContain("empty-disconnected");
     expect(html).toContain('data-action="startGateway"');
-    expect(html).toContain("/tmp/nimbus.sock");
+    expect(html).toContain(TEST_SOCKET_PATH);
   });
   test("permission-denied variant includes openLogs action", () => {
     const html = renderEmptyState({ sub: "permission-denied" });

--- a/packages/vscode-extension/test/unit/webview-render.test.ts
+++ b/packages/vscode-extension/test/unit/webview-render.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the pure-string render helpers in
+ * src/chat/webview/render.ts. These run under vitest with no DOM/jsdom —
+ * the helpers operate on strings only.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+  escapeHtml,
+  renderEmptyState,
+  renderHitlCard,
+  renderMarkdown,
+  renderSubTaskRow,
+  renderTurn,
+} from "../../src/chat/webview/render.js";
+
+describe("escapeHtml", () => {
+  test("escapes the five HTML metacharacters", () => {
+    expect(escapeHtml(`<a href="x">'tag&'</a>`)).toBe(
+      "&lt;a href=&quot;x&quot;&gt;&#39;tag&amp;&#39;&lt;/a&gt;",
+    );
+  });
+  test("returns the string unchanged when nothing needs escaping", () => {
+    expect(escapeHtml("hello world")).toBe("hello world");
+  });
+});
+
+describe("renderMarkdown", () => {
+  test("returns empty string for empty input", () => {
+    expect(renderMarkdown("")).toBe("");
+  });
+  test("renders fenced code blocks as <pre><code>", () => {
+    const html = renderMarkdown("```js\nconst x = 1;\n```");
+    expect(html).toMatch(/<pre>/);
+    expect(html).toMatch(/<code class="language-js">/);
+    expect(html).toContain("const x = 1;");
+  });
+  test("renders inline code as <code>", () => {
+    const html = renderMarkdown("hello `world`");
+    expect(html).toMatch(/<code>world<\/code>/);
+  });
+  test("renders newlines as <br> with breaks: true", () => {
+    const html = renderMarkdown("line one\nline two");
+    expect(html).toMatch(/<br>/);
+  });
+});
+
+describe("renderTurn", () => {
+  test("user turn escapes content and uses a <pre> block", () => {
+    const html = renderTurn({ role: "user", text: "<script>alert(1)</script>" });
+    expect(html).toContain('<article class="turn turn-user">');
+    expect(html).toContain('<pre class="user-text">');
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    // No raw script tag anywhere — XSS would be unforgivable here.
+    expect(html).not.toMatch(/<script>/);
+  });
+  test("assistant turn renders markdown", () => {
+    const html = renderTurn({ role: "assistant", text: "**bold**" });
+    expect(html).toContain('<article class="turn turn-assistant">');
+    expect(html).toContain("<strong>bold</strong>");
+  });
+  test("includes a <time> stamp when timestamp is provided", () => {
+    const html = renderTurn({ role: "user", text: "hi", timestamp: 1700000000000 });
+    expect(html).toMatch(/<time datetime=/);
+  });
+});
+
+describe("renderHitlCard", () => {
+  test("includes prompt + Approve/Reject buttons + escaped requestId", () => {
+    const html = renderHitlCard({
+      requestId: 'req"1',
+      prompt: "Delete <i>foo.txt</i>?",
+    });
+    expect(html).toContain('data-request-id="req&quot;1"');
+    expect(html).toContain("Delete &lt;i&gt;foo.txt&lt;/i&gt;?");
+    expect(html).toContain('data-decision="approve"');
+    expect(html).toContain('data-decision="reject"');
+  });
+  test("renders details JSON when provided, omits the block when undefined", () => {
+    const withDetails = renderHitlCard({
+      requestId: "r",
+      prompt: "p",
+      details: { file: "/etc/passwd" },
+    });
+    expect(withDetails).toContain('class="hitl-details"');
+    expect(withDetails).toContain("/etc/passwd");
+    const withoutDetails = renderHitlCard({ requestId: "r", prompt: "p" });
+    expect(withoutDetails).not.toContain("hitl-details");
+  });
+});
+
+describe("renderSubTaskRow", () => {
+  test("renders id + status, percentage when progress provided", () => {
+    const row = renderSubTaskRow({ subTaskId: "t1", status: "running", progress: 0.42 });
+    expect(row).toContain('data-subtask-id="t1"');
+    expect(row).toContain(">running<");
+    expect(row).toContain("42%");
+  });
+  test("omits percentage block when progress not provided", () => {
+    const row = renderSubTaskRow({ subTaskId: "t1", status: "queued" });
+    expect(row).not.toContain("subtask-pct");
+  });
+});
+
+describe("renderEmptyState", () => {
+  test("no-transcript variant", () => {
+    const html = renderEmptyState({ sub: "no-transcript" });
+    expect(html).toContain("empty-no-transcript");
+    expect(html).toContain("Nothing yet");
+  });
+  test("disconnected variant includes startGateway action and socketPath", () => {
+    const html = renderEmptyState({
+      sub: "disconnected",
+      socketPath: "/tmp/nimbus.sock",
+    });
+    expect(html).toContain("empty-disconnected");
+    expect(html).toContain('data-action="startGateway"');
+    expect(html).toContain("/tmp/nimbus.sock");
+  });
+  test("permission-denied variant includes openLogs action", () => {
+    const html = renderEmptyState({ sub: "permission-denied" });
+    expect(html).toContain("empty-permission-denied");
+    expect(html).toContain('data-action="openLogs"');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the placeholder webview shipped in PR3 with the full streaming chat surface and routes inline HITL through the panel when it's visible+focused.

- **`src/chat/webview/render.ts`** — pure-string render helpers (markdown via the existing `marked` dep, escapes for user-controlled metadata, HITL card, sub-task row, three empty-state variants). No DOM/jsdom required.
- **`src/chat/webview/main.ts`** — DOM glue; re-renders the streaming assistant turn on every token (markdown is not stable mid-fence). Cmd/Ctrl+Enter submits, Stop disables Send while streaming, delegated click handler routes HITL Approve/Reject + empty-state action buttons through `acquireVsCodeApi().postMessage(...)`.
- **`src/chat/webview/styles.css`** — theme-aware via `--vscode-*` CSS variables only.
- **`src/extension.ts`**
  - `createInlineHitlSurface` extracted + exported so the webview round-trip is unit-testable. Posts `hitlInline`, parks a resolver in a shared map, awaits the matching `hitlResponse`. Falls back to the toast surface when no panel is mounted (HITL never goes silent).
  - `createRealChatPanelFactory` now wires real CSP (default-src `'none'`, per-load nonce on script-src, `cspSource` on style-src), `localResourceRoots: [mediaRoot]`, and serves `media/webview.{js,css}` via `asWebviewUri`. HTML scaffold matches the selectors `main.ts` queries.
  - `panel.onMessage` dispatches every `WebviewToExtension` type: `ready`/`requestRehydrate` → `rehydrateIfNeeded`, `submitAsk` → `start`, `stopStream` → `stop`, `hitlResponse` → resolve, `openLogs` → channel show, `startGateway` → invoke the command, `openExternal` → `vscode.env.openExternal`. On panel disposal, in-flight inline-HITL promises resolve to `undefined` so the router doesn't hang.
- **Tests**: 16 render-helper cases + 4 inline-HITL round-trip cases. **62/62 vitest green.**
- **`.gitignore`** — `packages/vscode-extension/media/webview.js{,.map}`/`webview.css` (esbuild output) were showing as untracked on every clean checkout; now ignored.

## WS7 acceptance gate after this PR

| Criterion | Status |
|---|---|
| Status bar health dot updates on connector state change | ✅ PR4 |
| `Nimbus: Ask` streams a result from the running Gateway | ✅ this PR |
| Inline HITL consent approves correctly | ✅ this PR (webview round-trip when panel focused; toast/modal otherwise) |
| Installs from Open VSX without manual config | 🔵 needs publishing pipeline (next PR) |

## Test plan

- [x] `bun run typecheck` — workspace clean
- [x] `bunx biome check packages/vscode-extension/src packages/vscode-extension/test` — clean
- [x] `bunx vitest run` — 12 files / 62 tests pass
- [x] `bun run build` — `dist/extension.js` 29.0 kB, `media/webview.js` 41.7 kB, no errors
- [ ] Manual: install the bundled extension in a VS Code dev host, run `Nimbus: Ask`, verify streamed response renders incrementally
- [ ] Manual: trigger a HITL action from a connected Gateway with the chat panel focused → card appears in the panel; clicking Approve dispatches `consent.respond`

🤖 Generated with [Claude Code](https://claude.com/claude-code)