### PR TITLE
ci(vscode-extension): publish-vscode.yml → Marketplace + Open VSX (WS7 PR6)

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,0 +1,147 @@
+name: Publish Nimbus VS Code Extension
+
+# Triggered by tags of the form `vscode-v0.1.0`. The version inside the tag
+# is written into packages/vscode-extension/package.json before packaging so
+# the marketplace and Open VSX entries match the tag.
+#
+# Required repository secrets:
+#   * VSCE_PAT — Microsoft Azure DevOps Personal Access Token with the
+#     "Marketplace (Manage)" scope for the `nimbus-dev` publisher.
+#     https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+#   * OVSX_PAT — Open VSX Registry token for the `nimbus-dev` namespace.
+#     https://open-vsx.org/user-settings/tokens
+#
+# Failure modes:
+#   * Marketplace publish fails → Open VSX step is skipped (the workflow has
+#     already proven the build is releasable; we don't want a partial split).
+#   * Either token missing → workflow fails before publish; no .vsix is
+#     released so the tag can be retried.
+
+on:
+  push:
+    tags:
+      - "vscode-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      # Upload the .vsix as a GitHub Release asset alongside the marketplace push.
+      contents: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-nimbus-ci
+
+      # vsce + ovsx are Node CLIs; pin Node so behavior is predictable across
+      # runner-image refreshes.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      # The vscode-extension package imports types from @nimbus-dev/client,
+      # which only emits .d.ts after `bun run build` runs in that package.
+      - name: Build @nimbus-dev/client (for vscode-extension typecheck)
+        run: cd packages/client && bun run build
+
+      - name: Typecheck vscode-extension
+        run: cd packages/vscode-extension && bun run typecheck
+
+      - name: Lint vscode-extension
+        run: cd packages/vscode-extension && bun run lint
+
+      - name: Test vscode-extension
+        run: cd packages/vscode-extension && bun run test
+        env:
+          CI: "true"
+
+      # ----------------------------------------------------------------------
+      # Resolve the version from the tag and write it into package.json so the
+      # .vsix metadata matches the tag. We never amend the commit — the tag
+      # itself is the authoritative version source.
+      - name: Resolve version from tag
+        id: version
+        run: |
+          # github.ref_name e.g. "vscode-v0.1.0" → "0.1.0"
+          tag="${GITHUB_REF_NAME#vscode-v}"
+          if ! [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::tag '$GITHUB_REF_NAME' did not parse as semver after stripping 'vscode-v'"
+            exit 1
+          fi
+          echo "version=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp package.json with the tag version
+        working-directory: packages/vscode-extension
+        run: npm pkg set version="${{ steps.version.outputs.version }}"
+
+      - name: Build extension bundle (esbuild)
+        run: cd packages/vscode-extension && bun run build
+
+      # ----------------------------------------------------------------------
+      # Package the .vsix. `--no-dependencies` is required because the package
+      # declares workspace and bundled deps (esbuild has already inlined them
+      # into dist/extension.js); without the flag, vsce walks the dependency
+      # tree and rejects the workspace: protocol.
+      - name: Package .vsix
+        working-directory: packages/vscode-extension
+        run: |
+          mkdir -p ../../dist
+          bunx vsce package --no-dependencies --out ../../dist/nimbus-${{ steps.version.outputs.version }}.vsix
+
+      - name: Verify required publish secrets are present
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "::error::VSCE_PAT secret is not configured. Marketplace publish would fail; aborting before any release artifact is produced."
+            exit 1
+          fi
+          if [ -z "$OVSX_PAT" ]; then
+            echo "::error::OVSX_PAT secret is not configured. Open VSX publish would fail; aborting before any release artifact is produced."
+            exit 1
+          fi
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          bunx vsce publish \
+            --pat "$VSCE_PAT" \
+            --no-dependencies \
+            --packagePath dist/nimbus-${{ steps.version.outputs.version }}.vsix
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          bunx ovsx publish \
+            -p "$OVSX_PAT" \
+            dist/nimbus-${{ steps.version.outputs.version }}.vsix
+
+      # ----------------------------------------------------------------------
+      # Mirror the .vsix on the GitHub Release so users on locked-down networks
+      # (or anyone preferring manual install) can grab it without touching either
+      # marketplace.
+      - name: Upload .vsix to GitHub Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a21967200391e1b9067ad0ba5 # v2.6.2
+        with:
+          files: dist/nimbus-${{ steps.version.outputs.version }}.vsix
+          tag_name: ${{ github.ref_name }}
+          name: VS Code extension ${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,11 @@ cd packages/docs && bunx astro dev     # local dev server
 
 # Publish @nimbus-dev/client (triggered by git tag client-v*)
 # git tag client-v0.1.0 && git push origin client-v0.1.0
+
+# Publish Nimbus VS Code extension (triggered by git tag vscode-v*)
+# Pushes to VS Code Marketplace + Open VSX + GitHub Release.
+# Requires repo secrets VSCE_PAT (Marketplace) + OVSX_PAT (Open VSX).
+# git tag vscode-v0.1.0 && git push origin vscode-v0.1.0
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds the publishing pipeline for the Nimbus VS Code extension. Tag `vscode-vX.Y.Z` → builds + tests + packages the `.vsix` → publishes to VS Code Marketplace, Open VSX, and the GitHub Release page.

- **Version resolved from tag**, stamped into `package.json` via `npm pkg set version=<X>` before packaging (no commit amend; tag is authoritative).
- **Sequential gating**: typecheck → lint → vitest → esbuild → `vsce package --no-dependencies` → secret presence check → marketplace publish → Open VSX publish → release upload. First failure aborts.
- **`--no-dependencies` flag** is required because the workspace declares bundled deps (`@nimbus-dev/client` workspace + `marked`); vsce would otherwise reject the `workspace:` protocol. esbuild has already inlined them into `dist/extension.js`.
- **Secret presence check** runs *before* either publish so a missing PAT aborts cleanly without a half-finished split between the two registries.
- **All actions SHA-pinned** to the same versions other workflows already use (`harden-runner`, `checkout`, `setup-node`, `softprops/action-gh-release` — last one matches `release.yml`).

## Required repo secrets (must be set before tagging)

| Secret | Scope |
|---|---|
| `VSCE_PAT` | Azure DevOps PAT, "Marketplace (Manage)" scope, `nimbus-dev` publisher |
| `OVSX_PAT` | open-vsx.org token for the `nimbus-dev` namespace |

## Local dry-run

```
bun run typecheck     ✓
bun run lint          ✓
bun run test          42/42 ✓ (this base; 62/62 once PR #173 lands)
bun run build         ✓ dist/extension.js + media/*
bunx vsce package --no-dependencies → 14.78 KB .vsix, 10 files
bunx vsce / bunx ovsx --help        → both callable
```

## WS7 acceptance gate after this PR

| Criterion | Status |
|---|---|
| Status bar health dot updates on connector state change | ✅ PR4 |
| `Nimbus: Ask` streams a result from the running Gateway | ✅ PR5 |
| Inline HITL consent approves correctly | ✅ PR5 |
| Installs from Open VSX without manual config | ✅ this PR (gated on the two secrets being configured + a tag push) |

## Test plan

- [x] Workflow YAML parses (no `actionlint` available locally; verified against the `publish-client.yml` template structure).
- [x] All steps that don't need secrets run green locally — see dry-run above.
- [ ] Repo secrets `VSCE_PAT` + `OVSX_PAT` configured by the maintainer before the first `vscode-v*` tag is pushed.
- [ ] First release: tag `vscode-v0.1.0` pushed to `main` → workflow runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)