### PR TITLE
chore(vscode-extension): rename publisher nimbus-dev → nimbus-agent + fix repo URL

### DIFF
--- a/docs/install-macos-unsigned.md
+++ b/docs/install-macos-unsigned.md
@@ -12,8 +12,8 @@ One-liner that downloads the verify helper, verifies the binary, strips the quar
 
 ```bash
 # Replace <ver> and <arch> (x64 or arm64 — run `uname -m` to check)
-curl -LO https://github.com/nimbus-dev/Nimbus/releases/download/v<ver>/nimbus-headless-macos-<arch>.tar.gz
-curl -LO https://github.com/nimbus-dev/Nimbus/releases/download/v<ver>/nimbus-verify.sh
+curl -LO https://github.com/asafgolombek/Nimbus/releases/download/v<ver>/nimbus-headless-macos-<arch>.tar.gz
+curl -LO https://github.com/asafgolombek/Nimbus/releases/download/v<ver>/nimbus-verify.sh
 bash nimbus-verify.sh --version <ver>                         # ✅ signature + hash
 tar -xzf nimbus-headless-macos-<arch>.tar.gz                  # extracts nimbus-gateway-macos-<arch>, nimbus-cli-macos-<arch>, README, LICENSE
 xattr -d com.apple.quarantine ./nimbus-gateway-macos-<arch>   # remove the Gatekeeper quarantine bit
@@ -33,7 +33,7 @@ Run `uname -m` in a terminal: `arm64` → arm64 archive; `x86_64` → x64 archiv
 
 If you prefer clicking through the UI:
 
-1. Download the archive from the [GitHub Release page](https://github.com/nimbus-dev/Nimbus/releases).
+1. Download the archive from the [GitHub Release page](https://github.com/asafgolombek/Nimbus/releases).
 2. Double-click the `.tar.gz` in Finder — macOS extracts it automatically.
 3. Open Terminal (Spotlight → "Terminal").
 4. `cd Downloads` (or wherever the archive extracted).

--- a/docs/install-windows-unsigned.md
+++ b/docs/install-windows-unsigned.md
@@ -12,8 +12,8 @@ One-liner that downloads the verify helper, **unblocks the Zone.Identifier** (se
 
 ```powershell
 # Replace <ver>
-Invoke-WebRequest -Uri https://github.com/nimbus-dev/Nimbus/releases/download/v<ver>/nimbus-headless-windows-x64.zip -OutFile nimbus-headless.zip
-Invoke-WebRequest -Uri https://github.com/nimbus-dev/Nimbus/releases/download/v<ver>/nimbus-verify.ps1       -OutFile nimbus-verify.ps1
+Invoke-WebRequest -Uri https://github.com/asafgolombek/Nimbus/releases/download/v<ver>/nimbus-headless-windows-x64.zip -OutFile nimbus-headless.zip
+Invoke-WebRequest -Uri https://github.com/asafgolombek/Nimbus/releases/download/v<ver>/nimbus-verify.ps1       -OutFile nimbus-verify.ps1
 Unblock-File -Path .\nimbus-verify.ps1                              # removes the Zone.Identifier marker from the downloaded .ps1
 .\nimbus-verify.ps1 -Version <ver>                                  # ✅ signature + hash
 Expand-Archive -Path nimbus-headless.zip -DestinationPath .\nimbus  # extract binaries + README + LICENSE
@@ -31,7 +31,7 @@ PowerShell 7 ships with `Expand-Archive`. On older Windows with only Windows Pow
 
 If you prefer clicking through the UI:
 
-1. Download the `.zip` from the [GitHub Release page](https://github.com/nimbus-dev/Nimbus/releases).
+1. Download the `.zip` from the [GitHub Release page](https://github.com/asafgolombek/Nimbus/releases).
 2. Right-click the downloaded `.zip` → **Extract All…** → pick a destination → **Extract**.
 3. In the extracted folder, **double-click** `nimbus-gateway-windows-x64.exe`.
 4. SmartScreen shows: *"Windows protected your PC. Microsoft Defender SmartScreen prevented an unrecognized app from starting."* → **More info** → **Run anyway**.

--- a/docs/release/v0.1.0-prerequisites.md
+++ b/docs/release/v0.1.0-prerequisites.md
@@ -175,22 +175,22 @@ Every secret below goes here. Do not reuse your personal credentials manager if 
 
 **Steps:**
 
-1. **Create an Azure DevOps organization** (free) at https://dev.azure.com. Name it `nimbus-dev` if available (this is only the org name, not the publisher).
+1. **Create an Azure DevOps organization** (free) at https://dev.azure.com. Any org name works (this is only the AD org, not the publisher).
 2. **Create a Personal Access Token:**
    - User Settings → Personal Access Tokens → New Token.
    - Organization: **All accessible organizations** (required — Marketplace is not tied to a single AD org).
    - Scopes: **Custom defined → Marketplace → Manage**.
    - Expiry: 1 year (set a calendar reminder to rotate).
 3. **Create the Marketplace publisher** at https://marketplace.visualstudio.com/manage.
-   - Publisher ID: `nimbus-dev` (lowercase, used in the extension's `package.json` as `"publisher": "nimbus-dev"`).
+   - Publisher ID: `nimbus-agent` (lowercase, used in the extension's `package.json` as `"publisher": "nimbus-agent"`). Note: `nimbus-dev` was the original choice but the matching GitHub org is taken; `nimbus-agent` is the rename target.
    - Display name: `Nimbus`.
    - Accept publisher agreement.
 4. **Install `vsce`** on your dev machine: `npm i -g @vscode/vsce`.
-5. **Smoke test with the PAT:** `vsce login nimbus-dev` → paste PAT. No publish yet — just verify the token works.
+5. **Smoke test with the PAT:** `vsce login nimbus-agent` → paste PAT. No publish yet — just verify the token works.
 6. **CI integration:** GHA secret `VSCE_PAT` used by `.github/workflows/publish-vscode.yml` which will trigger on `vscode-v*` tags.
 
 **Output:**
-- Publisher ID `nimbus-dev`
+- Publisher ID `nimbus-agent`
 - Azure DevOps PAT (GHA secret + password manager, with expiry reminder)
 
 ---
@@ -203,15 +203,15 @@ Every secret below goes here. Do not reuse your personal credentials manager if 
 
 1. **Sign in** at https://open-vsx.org/ using the GitHub account that will own releases.
 2. **Accept the publisher agreement** (one-time, required before you can create a namespace).
-3. **Request a namespace** via their UI. `nimbus-dev` should match the VS Code Marketplace publisher ID for consistency.
+3. **Request a namespace** via their UI. `nimbus-agent` matches the VS Code Marketplace publisher ID. (An earlier `nimbus-dev` namespace may exist — leave it abandoned; the active publisher is `nimbus-agent`.)
 4. **Create an access token:**
    - https://open-vsx.org/user-settings/tokens → Generate New Token.
 5. **Install `ovsx`:** `npm i -g ovsx`.
-6. **Smoke test:** `ovsx create-namespace nimbus-dev -p <token>` (if not already created via UI).
+6. **Smoke test:** `ovsx create-namespace nimbus-agent -p <token>` (if not already created via UI).
 7. **CI integration:** GHA secret `OVSX_PAT` used by `publish-vscode.yml` in the same job as VS Code Marketplace publishing.
 
 **Output:**
-- Open VSX namespace `nimbus-dev`
+- Open VSX namespace `nimbus-agent`
 - Access token (GHA secret)
 
 ---

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -10,8 +10,8 @@ Local-first AI agent for the editor. Ask, search, and run workflows against your
 
 ## Install
 
-VS Code Marketplace: `ext install nimbus-dev.nimbus`
-Open VSX (Cursor, VSCodium): `ext install nimbus-dev.nimbus`
+VS Code Marketplace: `ext install nimbus-agent.nimbus`
+Open VSX (Cursor, VSCodium): `ext install nimbus-agent.nimbus`
 Manual: download the `.vsix` from the GitHub Release and run `code --install-extension nimbus-<ver>.vsix`.
 
 ## Requires

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Nimbus",
   "description": "Local-first AI agent for the editor. Ask, search, and run workflows against your private Nimbus index.",
   "version": "0.1.0",
-  "publisher": "nimbus-dev",
+  "publisher": "nimbus-agent",
   "license": "MIT",
   "private": false,
   "engines": {
@@ -29,10 +29,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nimbus-dev/Nimbus"
+    "url": "https://github.com/asafgolombek/Nimbus"
   },
   "bugs": {
-    "url": "https://github.com/nimbus-dev/Nimbus/issues"
+    "url": "https://github.com/asafgolombek/Nimbus/issues"
   },
   "homepage": "https://nimbus.dev/vscode",
   "activationEvents": [


### PR DESCRIPTION
## Summary

The `nimbus-dev` GitHub org is taken; rename the VS Code Marketplace publisher and Open VSX namespace to `nimbus-agent` so the GitHub org / Marketplace publisher / Open VSX namespace can be claimed under one consistent identity. Also fix `repository.url` + `bugs.url` in the extension's `package.json` (and the install-*-unsigned.md docs) — they pointed at the fictional `github.com/nimbus-dev/Nimbus` instead of the real repo.

## Out of scope (deliberately untouched)

- **`@nimbus-dev/client`** and **`@nimbus-dev/sdk`** — npm scope identifiers, separate from the Marketplace publisher. `@nimbus-dev/client` is already on npm; renaming the scope would break consumers, require a major version bump + republish + migration, and serves no purpose here.
- **`docs/phase-4-plan.md`** and **`docs/superpowers/{plans,specs}/2026-04-24-ws7-*`** — dated planning artifacts. They captured the design as of April 2026 when `nimbus-dev` was still the choice; rewriting them would falsify the historical record.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx biome check src/ test/` clean
- [x] `bunx vitest run` — 62/62 green
- [x] `bun run build` — `dist/extension.js` 29.0 KB, `media/webview.js` 65.6 KB
- [x] `bunx vsce package --no-dependencies` → 39.2 KB .vsix produced cleanly with the new `publisher: nimbus-agent` metadata
- [ ] Maintainer verifies `nimbus-agent` is available as a Marketplace publisher AND on Open VSX before configuring secrets / claiming the namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)