### PR TITLE
docs: mark Phase 4 (Presence) as complete

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@
 [![MCP](https://img.shields.io/badge/protocol-MCP-purple)](https://modelcontextprotocol.io)
 [![Platforms](https://img.shields.io/badge/platforms-Windows_%7C_macOS_%7C_Linux-blue)]()
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](../LICENSE)
-[![Status: Phase 4](https://img.shields.io/badge/status-Phase_4_Active-blue)]()
+[![Status: Phase 4 Complete](https://img.shields.io/badge/status-Phase_4_Complete-brightgreen)]()
 
 </div>
 
@@ -645,8 +645,9 @@ Nimbus uses phases, not calendar dates. A phase completes when its acceptance cr
 | 2 | The Bridge (15 connectors) | ✅ Complete |
 | 3 | Intelligence (semantic search, CI/CD, cloud) | ✅ Complete |
 | 3.5 | Observability (health model, query API, recovery, telemetry, docs) | ✅ Complete |
-| 4 | Presence (Tauri UI, local LLM, v0.1.0 release) | 🔵 Active |
-| 5–9 | Extended Surface → Enterprise | Planned |
+| 4 | Presence (Tauri UI, local LLM, v0.1.0 release) | ✅ Complete |
+| 5 | The Extended Surface | 🔵 Active |
+| 6–9 | Team → Enterprise | Planned |
 
 See [`roadmap.md`](./roadmap.md) for full acceptance criteria and sequencing.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -281,7 +281,7 @@ Commercial license also available now for organizations that need to embed Nimbu
 
 ---
 
-## Phase 4 — Presence 🔵
+## Phase 4 — Presence ✅
 
 **Goal:** Give Nimbus a face, a local AI backbone that requires no cloud API key, and the trust foundations needed for a public `v0.1.0` release.
 


### PR DESCRIPTION
## Summary

Phase 4 is code-complete on `main` — all three workstream PRs merged:

- **#207** (Plan C — User Guide + custom domain) → site live at https://nimbus-agent.dev/
- **#196** (Plan A — release prerequisites + dependabot bumps + CodeQL fix) merged via the dependabot bundle work
- **#206** (Plan B — cross-platform install scripts) merged after the install-smoke fix

Only the v0.1.0 release-cut sequence remains (rc1 dry-run → manual smoke matrix → `vscode-v0.1.0` / `v0.1.0` tag pushes), which is **delivery work**, not phase-acceptance work. CLAUDE.md already reflected `Phase 4 — Presence ✅ Complete`; the user-facing README and roadmap had drifted.

## Changes

- `docs/README.md`:
  - Status badge: `Phase_4_Active` (blue) → `Phase_4_Complete` (brightgreen)
  - Roadmap table: Phase 4 row flipped to ✅ Complete
  - Roadmap table: split the old `5–9` row so Phase 5 (The Extended Surface) shows as 🔵 Active and 6–9 as Planned
- `docs/roadmap.md`: section header `## Phase 4 — Presence 🔵` → `## Phase 4 — Presence ✅` (the status-overview table on line 46 already says Complete)

## Test plan

- [ ] CI green
- [ ] Manual: open https://nimbus-agent.dev/ — splash hero shows "Phase 4 Complete" badge once next deploy runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)