### PR TITLE
ci(release): trigger on pre-release tags (vN.N.N-rcN/beta/alpha)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,14 @@ name: Release
 on:
   push:
     tags:
+      # Production releases (vN.N.N) get marked Latest and feed the auto-update manifest.
       - "v[0-9]+.[0-9]+.[0-9]+"
+      # Pre-release tags (vN.N.N-rcN, -beta.N, -alpha.N, …) exercise the same
+      # signing + packaging pipeline but are flipped to GitHub Pre-release via
+      # the `contains(github.ref_name, '-')` check on the publish-release job.
+      # The update-manifest job is also gated on the non-prerelease form so rc
+      # builds do not consume CI minutes producing a manifest no one reaches.
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -414,6 +421,11 @@ jobs:
   update-manifest:
     name: Publish updater manifest
     needs: publish-release
+    # Skip for pre-release tags: production updater URL points at
+    # `releases/latest/download/latest.json` which only resolves to the
+    # non-prerelease "Latest" GitHub Release. Building a manifest for rc/
+    # beta/alpha tags burns CI minutes producing an asset nobody reaches.
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     environment: release


### PR DESCRIPTION
## Summary

Plan A Task 12 expects `v0.1.0-rc1` to exercise `release.yml` end-to-end against production secrets, but the current trigger regex only matches strict semver `v[0-9]+.[0-9]+.[0-9]+`. **`v0.1.0-rc1` was pushed and didn't fire the workflow at all** (confirmed empirically). This fix lets the rc/beta/alpha suffix variants share the same pipeline.

## Changes

### 1. Trigger pattern

```diff
 on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
```

Production tags still match the strict pattern. Pre-release tags now fire the workflow too.

### 2. `update-manifest` job: skip on pre-release

```diff
   update-manifest:
     name: Publish updater manifest
     needs: publish-release
+    if: ${{ !contains(github.ref_name, '-') }}
```

The production updater URL (`releases/latest/download/latest.json`) only resolves to the non-prerelease release marked "Latest." Building a manifest for rc/beta/alpha tags burns CI minutes producing an asset nobody reaches.

## What's already wired correctly

- **Pre-release flag** (line 412): `prerelease: ${{ contains(github.ref_name, '-') }}` already flips correctly. Unchanged.
- **Version derivation** (line 263, 286, 447): `V="${GITHUB_REF_NAME#v}"` strips the leading `v` — `v0.1.0-rc1` → `0.1.0-rc1`, fine for filenames and dpkg.

## After this merges

Push `v0.1.0-rc2` to dry-run the pipeline. (`rc1` is permanent — the deletion-protection rule on the tag ruleset blocks recycling — and points at a commit predating this fix, so it's not reusable.)

## Test plan

- [ ] CI green
- [ ] After merge, push `v0.1.0-rc2`; `release.yml` fires and pauses on `release` env approval
- [ ] After approval, all matrix jobs (validate / test / build-gateway × 4 / build-cli × 4 / publish-release) complete green
- [ ] `update-manifest` is **skipped** for `v0.1.0-rc2` (per the new conditional)
- [ ] Published GitHub Release for `v0.1.0-rc2` is marked as **Pre-release**
- [ ] `gpg --verify` of `SHA256SUMS.asc` against the published `SHA256SUMS` succeeds with the production fingerprint `5A20457CCD8B53FFAA945240886ADA6B487CAB6E`

🤖 Generated with [Claude Code](https://claude.com/claude-code)