### PR TITLE
ci(release): build @nimbus-dev/client before typecheck

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           verify-lock: "false"
 
+      # Required before Typecheck — vscode-extension imports @nimbus-dev/client
+      # whose `exports` field points at `dist/index.d.ts`. Without an explicit
+      # build the workspace symlink resolves but the type declarations don't
+      # exist, and `bun run --filter '*' typecheck` fails on packages/vscode-
+      # extension. _test-suite.yml and publish-vscode.yml already do this.
+      - name: Build @nimbus-dev/client (for vscode-extension typecheck)
+        run: cd packages/client && bun run build
+
       - name: Typecheck
         run: bun run typecheck
 


### PR DESCRIPTION
## Summary

`release.yml`'s `validate` job runs the workspace-wide `bun run typecheck` (which calls `bun run --filter '*' typecheck`) without first building `packages/client`. The vscode-extension package imports `@nimbus-dev/client` whose `exports` field points at `dist/index.d.ts` — the workspace symlink resolves but TypeScript can't find the type declarations until the client has been built.

**Empirically observed on rc2:**

```
src/extension.ts(23,68): error TS2307: Cannot find module '@nimbus-dev/client'
  or its corresponding type declarations.
(and 8 more identical errors across chat, hitl, test files)
```

This was a latent bug — `release.yml` would have failed this way for **any** release tag the moment vscode-extension started importing `@nimbus-dev/client`. The rc2 dry-run surfaced it before `v0.1.0` ever ran. Exactly what rc dry-runs are for.

## Fix

One step added to the `validate` job, before `Typecheck`:

```yaml
- name: Build @nimbus-dev/client (for vscode-extension typecheck)
  run: cd packages/client && bun run build
```

Both `_test-suite.yml` (line 77) and `publish-vscode.yml` (line 65) already do this. `release.yml` was the outlier.

## After this merges

Push `v0.1.0-rc3` to retry the dry-run. (`rc1` and `rc2` are both permanent; tag deletion is blocked by the protection ruleset.)

## Test plan

- [ ] CI green on this PR
- [ ] After merge, push `v0.1.0-rc3`
- [ ] `validate` job goes green
- [ ] `test`, `build-gateway × 4`, `build-cli × 4` go green
- [ ] `publish-release` pauses for `release` env approval
- [ ] After approval, GitHub Release is created and marked **Pre-release**
- [ ] `update-manifest` is skipped (PR #210 conditional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)