### PR TITLE
fix(client-test): bump gateway-startup timeout 15s → 60s

### DIFF
--- a/packages/client/test/node-compat.test.ts
+++ b/packages/client/test/node-compat.test.ts
@@ -21,9 +21,17 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 const GATEWAY_BIN = process.env.NIMBUS_GATEWAY_BIN;
-const STARTUP_TIMEOUT_MS = 15000;
-const STREAM_TIMEOUT_MS = 30000;
-const NODE_TEST_TIMEOUT_MS = 60000;
+// Gateway startup includes initializing the embedding runtime (@xenova/
+// transformers + native sharp binaries). On a cold-cache Windows GHA
+// runner this regularly takes 20-40 s. Empirical: rc3 release run
+// 25454797314 had the gateway alive (exit=null) but pipe-not-yet-ready
+// at the 15 s cutoff. 60 s gives ~2× headroom over observed worst-case.
+const STARTUP_TIMEOUT_MS = 60_000;
+const STREAM_TIMEOUT_MS = 30_000;
+// Per-test cap. Must comfortably exceed STARTUP_TIMEOUT_MS + STREAM_TIMEOUT_MS
+// + teardown, otherwise node:test cancels the whole test before its assertions
+// can run. 60 s + 30 s + slack = 120 s.
+const NODE_TEST_TIMEOUT_MS = 120_000;
 
 if (GATEWAY_BIN === undefined) {
   await test("node-compat (skipped — NIMBUS_GATEWAY_BIN not set)", { skip: true }, () => undefined);


### PR DESCRIPTION
## Summary

The `node-compat` client test spawns a Gateway subprocess and waits for the IPC pipe to appear. On Windows with a cold-cache runner, the Gateway hangs at `starting embedding runtime` while `@xenova/transformers` + `sharp` native bindings load — empirically 20-40s. The 15s `STARTUP_TIMEOUT_MS` is too tight.

## Empirical evidence

rc3 release run [25454797314](https://github.com/nimbus-agent/Nimbus/actions/runs/25454797314) failure:

```
Gateway socket did not appear within 15000ms: \.\pipe\nimbus-gateway
  exitCode=null exitSignal=null
  --- gateway stdout ---
[gateway] initializing platform services
[gateway] starting embedding runtime
```

`exitCode=null` confirms the gateway is still alive — it just hadn't gotten the IPC pipe up yet.

## Fix

```diff
-const STARTUP_TIMEOUT_MS = 15000;
+const STARTUP_TIMEOUT_MS = 60_000;   // ~2× observed worst-case cold Windows
-const NODE_TEST_TIMEOUT_MS = 60000;
+const NODE_TEST_TIMEOUT_MS = 120_000; // STARTUP + STREAM + teardown headroom
```

Plus a comment block explaining the regression so the next person doesn't bump it back down.

## Why this isn't a deeper fix

The right architectural fix is to open the IPC listener *before* initialising the embedding runtime — so cold-start latency on Windows doesn't gate IPC readiness. That's a code change in the Gateway, out of scope for the v0.1.0 cut. The timeout bump unblocks the release pipeline now; the architectural change can ride a Phase 5 PR.

## After this merges

Push `v0.1.0-rc4` to retry the dry-run.

## Test plan

- [ ] CI green
- [ ] After merge, push `v0.1.0-rc4`
- [ ] `validate` passes (PR #212 fix in place)
- [ ] `test` (the node-compat client test) passes — Windows job no longer times out at 15s
- [ ] Build matrix completes
- [ ] `publish-release` pauses for `release` env approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)