### PR TITLE
fix(release): wire correct GPG secret + restore tweetnacl root dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         if: matrix.target.os == 'linux'
         timeout-minutes: 15
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_SUBKEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: bash scripts/sign-linux-gpg.sh dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}
 
@@ -283,7 +283,7 @@ jobs:
 
       - name: Sign Linux installer artifacts
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_SUBKEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         shell: bash
         run: |
@@ -409,7 +409,7 @@ jobs:
 
       - name: Sign SHA256SUMS
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_SUBKEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         shell: bash
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "dependency-cruiser": "^17.4.0",
         "jscpd": "^4.0.9",
         "knip": "^6.12.0",
+        "tweetnacl": "^1.0.3",
         "typescript": "^6.0.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "dependency-cruiser": "^17.4.0",
     "jscpd": "^4.0.9",
     "knip": "^6.12.0",
+    "tweetnacl": "^1.0.3",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Two coordinated bugs in `release.yml`'s signing path, both surfaced by the rc4 dry-run ([release run 25456161197](https://github.com/nimbus-agent/Nimbus/actions/runs/25456161197) — all four `build-gateway` matrix legs failed at the "Sign binary (Ed25519 updater)" step).

## Bug 1 — GPG secret name mismatch

`release.yml` has three places referencing `secrets.GPG_PRIVATE_KEY`, but the configured GHA secret is **`GPG_SIGNING_SUBKEY`** (per `docs/release/v0.1.0-prerequisites.md` §1.7). The shell script `sign-linux-gpg.sh` reads from env var `GPG_PRIVATE_KEY`, so the **env-var name stays** — only the secret reference on the right side of the colon changes:

```diff
-  GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+  GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_SUBKEY }}
```

Three call sites updated (build-gateway sign, installer sign, SHA256SUMS sign).

**Symptom:** `signing skipped: GPG_PRIVATE_KEY not set` printed by `sign-linux-gpg.sh:11`. The `set -e` at the top of the script exits 0 silently in this branch (the `||` short-circuit), so the failure is invisible until the *next* step (`Sign binary (Ed25519 updater)`) runs and fails loudly.

## Bug 2 — `tweetnacl` missing from root devDependencies

`scripts/sign-ed25519.ts` imports `tweetnacl`, but the package was silently dropped from `package.json` when the dependabot bumps for `dependency-cruiser` and `knip` merged through PR #196 — both touched root devDependencies, and the merge resolution kept their version blocks but lost the `tweetnacl` line that had been added locally.

**Symptom:**
```
error: Cannot find package 'tweetnacl' from
  '/home/runner/work/Nimbus/Nimbus/scripts/sign-ed25519.ts'
```

Re-added to root devDependencies. `bun.lock` regenerated.

## Test plan

- [ ] CI green
- [ ] After merge, push `v0.1.0-rc5`
- [ ] All 4 `build-gateway` matrix legs pass (Ed25519 sign step now finds `tweetnacl`)
- [ ] Linux installer-signing step actually signs (no `signing skipped` line in the log)
- [ ] `SHA256SUMS.asc` is created and `gpg --verify` against the production fingerprint succeeds
- [ ] `publish-release` pauses for `release` env approval
- [ ] `update-manifest` is skipped (PR #210 conditional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)