### PR TITLE
fix(release): write SBOM to known path; cp from there

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,12 +349,19 @@ jobs:
       # dependency graphs that produced the binaries downloaded above. Output is
       # attached to the release for downstream consumers and signed via OIDC by
       # the anchore action's call to attest-build-provenance.
+      #
+      # NOTE on `output-file`: anchore/sbom-action@v0.24.0 does NOT define any
+      # action outputs (no `outputs:` block in its action.yml), so the previous
+      # `${{ steps.sbom.outputs.fileName }}` reference always evaluated to the
+      # empty string. Pin the local file path explicitly so the staging step
+      # below can `cp` from a known location.
       - name: Generate SBOM (CycloneDX)
         id: sbom
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
           format: cyclonedx-json
+          output-file: dist/sbom.cdx.json
           artifact-name: nimbus-${{ github.ref_name }}-sbom.cdx.json
           # Don't auto-attach to GitHub Release (we do it explicitly below to control filename).
           upload-release-assets: false
@@ -387,8 +394,8 @@ jobs:
           # Archives
           cp dist/archives/*                                                    dist/stage/
 
-          # SBOM
-          cp "${{ steps.sbom.outputs.fileName }}"                              "dist/stage/nimbus-${GITHUB_REF_NAME}-sbom.cdx.json"
+          # SBOM (path matches `output-file:` set on the SBOM step above).
+          cp dist/sbom.cdx.json                                                "dist/stage/nimbus-${GITHUB_REF_NAME}-sbom.cdx.json"
 
           # Verify scripts (uploaded as release assets so users can curl them)
           cp scripts/release/nimbus-verify.sh                                   dist/stage/


### PR DESCRIPTION
## Summary

`anchore/sbom-action@v0.24.0` (the version we pinned) does **not** define any action outputs — there's no `outputs:` block in its `action.yml`. The previous `${{ steps.sbom.outputs.fileName }}` reference in `release.yml` always evaluated to the empty string, so the staging step effectively ran:

```bash
cp "" "dist/stage/nimbus-v0.1.0-rc6-sbom.cdx.json"
# → cp: cannot stat '': No such file or directory
```

## Empirical evidence

rc6 release run [25478546854](https://github.com/nimbus-agent/Nimbus/actions/runs/25478546854):

```
Stage release assets
$ cp: cannot stat '': No such file or directory
##[error]Process completed with exit code 1.
```

Verified the action has no outputs:
```
$ curl https://raw.githubusercontent.com/anchore/sbom-action/<our-pin>/action.yml | grep "^outputs:"
(no match)
```

## Why this didn't show up earlier

This staging step has been broken since the SBOM step was added. rc1–rc5 all failed at earlier stages (validate / test / build-gateway / publish-release action-resolution), so the staging step was never reached. rc6 cleared the previous blockers and surfaced this for the first time.

## Fix

```diff
   - name: Generate SBOM (CycloneDX)
     id: sbom
     uses: anchore/sbom-action@…
     with:
       path: .
       format: cyclonedx-json
+      output-file: dist/sbom.cdx.json
       artifact-name: nimbus-${{ github.ref_name }}-sbom.cdx.json
       upload-release-assets: false
       upload-artifact: true

   - name: Stage release assets
     ...
       # SBOM
-      cp "${{ steps.sbom.outputs.fileName }}" "dist/stage/nimbus-${GITHUB_REF_NAME}-sbom.cdx.json"
+      cp dist/sbom.cdx.json                   "dist/stage/nimbus-${GITHUB_REF_NAME}-sbom.cdx.json"
```

Plus a comment block explaining why the path is hard-coded so the next person doesn't try to switch back to a `steps.sbom.outputs.*` reference.

## Test plan

- [ ] CI green
- [ ] After merge, push `v0.1.0-rc7`
- [ ] All upstream stages pass (already verified through rc6)
- [ ] `Stage release assets` cp succeeds
- [ ] `Compute SHA256SUMS` produces a manifest that includes the SBOM
- [ ] `Sign SHA256SUMS` produces `SHA256SUMS.asc`
- [ ] `Create GitHub Release` succeeds with all assets attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)