### PR TITLE
fix(release): rename archive binaries to canonical names + rewrite quickstart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,32 +300,39 @@ jobs:
           mkdir -p dist/archives
           V="${GITHUB_REF_NAME#v}"
 
+          # NOTE: install.sh / install.ps1 look for `nimbus` and `nimbus-gateway`
+          # (or `.exe` on Windows) — NOT the `-<os>-<arch>` suffixed names. The
+          # raw release assets keep their suffixed filenames (so users can grab
+          # one binary from the release page without confusion), but inside the
+          # extracted archive we rename to the canonical names that the install
+          # scripts (and `nimbus start`) expect.
+
           # macOS x64 tarball
           mkdir -p dist/stage-macos-x64
-          cp dist/nimbus-gateway-macos-x64/nimbus-gateway-macos-x64 dist/stage-macos-x64/
-          cp dist/nimbus-cli-macos-x64/nimbus-cli-macos-x64         dist/stage-macos-x64/
+          cp dist/nimbus-gateway-macos-x64/nimbus-gateway-macos-x64 dist/stage-macos-x64/nimbus-gateway
+          cp dist/nimbus-cli-macos-x64/nimbus-cli-macos-x64         dist/stage-macos-x64/nimbus
           cp scripts/release/archive-contents/README-QUICKSTART.txt dist/stage-macos-x64/
           cp scripts/release/archive-contents/LICENSE-AGPL.txt      dist/stage-macos-x64/
           cp scripts/install/unix/install.sh                         dist/stage-macos-x64/
           cp scripts/install/unix/uninstall.sh                       dist/stage-macos-x64/
-          chmod +x dist/stage-macos-x64/nimbus-* dist/stage-macos-x64/install.sh dist/stage-macos-x64/uninstall.sh
+          chmod +x dist/stage-macos-x64/nimbus dist/stage-macos-x64/nimbus-gateway dist/stage-macos-x64/install.sh dist/stage-macos-x64/uninstall.sh
           tar -czf dist/archives/nimbus-headless-macos-x64.tar.gz -C dist/stage-macos-x64 .
 
           # macOS arm64 tarball
           mkdir -p dist/stage-macos-arm64
-          cp dist/nimbus-gateway-macos-arm64/nimbus-gateway-macos-arm64 dist/stage-macos-arm64/
-          cp dist/nimbus-cli-macos-arm64/nimbus-cli-macos-arm64         dist/stage-macos-arm64/
+          cp dist/nimbus-gateway-macos-arm64/nimbus-gateway-macos-arm64 dist/stage-macos-arm64/nimbus-gateway
+          cp dist/nimbus-cli-macos-arm64/nimbus-cli-macos-arm64         dist/stage-macos-arm64/nimbus
           cp scripts/release/archive-contents/README-QUICKSTART.txt     dist/stage-macos-arm64/
           cp scripts/release/archive-contents/LICENSE-AGPL.txt          dist/stage-macos-arm64/
           cp scripts/install/unix/install.sh                             dist/stage-macos-arm64/
           cp scripts/install/unix/uninstall.sh                           dist/stage-macos-arm64/
-          chmod +x dist/stage-macos-arm64/nimbus-* dist/stage-macos-arm64/install.sh dist/stage-macos-arm64/uninstall.sh
+          chmod +x dist/stage-macos-arm64/nimbus dist/stage-macos-arm64/nimbus-gateway dist/stage-macos-arm64/install.sh dist/stage-macos-arm64/uninstall.sh
           tar -czf dist/archives/nimbus-headless-macos-arm64.tar.gz -C dist/stage-macos-arm64 .
 
           # Windows x64 zip
           mkdir -p dist/stage-windows-x64
-          cp dist/nimbus-gateway-windows-x64/nimbus-gateway-windows-x64.exe dist/stage-windows-x64/
-          cp dist/nimbus-cli-windows-x64/nimbus-cli-windows-x64.exe         dist/stage-windows-x64/
+          cp dist/nimbus-gateway-windows-x64/nimbus-gateway-windows-x64.exe dist/stage-windows-x64/nimbus-gateway.exe
+          cp dist/nimbus-cli-windows-x64/nimbus-cli-windows-x64.exe         dist/stage-windows-x64/nimbus.exe
           cp scripts/release/archive-contents/README-QUICKSTART.txt         dist/stage-windows-x64/
           cp scripts/release/archive-contents/LICENSE-AGPL.txt              dist/stage-windows-x64/
           cp scripts/install/windows/install.ps1                             dist/stage-windows-x64/

--- a/scripts/release/archive-contents/README-QUICKSTART.txt
+++ b/scripts/release/archive-contents/README-QUICKSTART.txt
@@ -1,38 +1,65 @@
 Nimbus Headless — Quickstart
 ============================
 
-This archive contains the Nimbus headless Gateway and CLI binaries.
+This archive contains the Nimbus headless Gateway and CLI binaries plus
+small per-OS install/uninstall scripts that put `nimbus` on your PATH.
 
 Contents:
-  nimbus-gateway-<os>-<arch>   The long-running Gateway daemon.
-  nimbus-cli-<os>-<arch>       The CLI client.
-  README-QUICKSTART.txt        This file.
-  LICENSE-AGPL.txt             AGPL-3.0 license (full text).
+  nimbus                     The CLI client (nimbus.exe on Windows).
+  nimbus-gateway             The long-running Gateway daemon (.exe on Windows).
+  install.sh / install.ps1   Per-user installer (no admin, no sudo). Copies
+                             the two binaries to a per-user directory and
+                             adds it to your PATH so a new shell can run
+                             `nimbus`.
+  uninstall.sh / uninstall.ps1   Reverses install: removes the binaries and
+                                 the PATH entry the installer added.
+  README-QUICKSTART.txt      This file.
+  LICENSE-AGPL.txt           AGPL-3.0 license (full text).
 
 Getting started (macOS / Linux):
   1. Extract this archive.
-  2. chmod +x ./nimbus-gateway-* ./nimbus-cli-*
-  3. Start the Gateway:   ./nimbus-gateway-<os>-<arch>
-  4. In another terminal: ./nimbus-cli-<os>-<arch> --help
+  2. cd into the extracted directory.
+  3. ./install.sh --yes
+  4. Open a NEW shell so PATH refreshes, then:
+       nimbus start    # spawn the Gateway as a managed background process
+       nimbus status   # confirm it's running
+       nimbus --help
 
 Getting started (Windows):
-  1. Extract this archive (right-click → Extract All).
-  2. Double-click nimbus-gateway-windows-x64.exe to start the Gateway.
-  3. From a new PowerShell window: .\nimbus-cli-windows-x64.exe --help
+  1. Right-click the .zip → "Extract All".
+  2. Open a PowerShell window in the extracted directory.
+  3. .\install.ps1 -Yes
+  4. Open a NEW PowerShell window so PATH refreshes, then:
+       nimbus start    # spawn the Gateway as a managed background process
+       nimbus status   # confirm it's running
+       nimbus --help
+
+Don't run nimbus-gateway directly. Use `nimbus start` / `nimbus stop` —
+the CLI manages the Gateway's lifecycle, PID file, log rotation, and
+graceful shutdown. Running the gateway binary directly bypasses all of
+that and leaves orphaned state if the process is killed abnormally.
+
+Uninstall:
+  ./uninstall.sh --yes        (macOS / Linux)
+  .\uninstall.ps1 -Yes        (Windows)
 
 Integrity verification:
   Before running, verify the archive's hash against the published
   SHA256SUMS manifest on the GitHub Release page. The manifest is
-  GPG-signed — see docs/verify-release-integrity.md for a full walkthrough,
-  or run the nimbus-verify.sh / nimbus-verify.ps1 helper from the same
-  release page.
+  GPG-signed — see https://nimbus-agent.dev/user-guide/verify-your-download/
+  for a full walkthrough, or run the bundled nimbus-verify.sh /
+  nimbus-verify.ps1 helper from the release page.
 
 Project GPG fingerprint:
-  See docs/SECURITY.md — cross-reference four independent sources
-  before trusting any key material.
+  5A20 457C CD8B 53FF AA94 5240 886A DA6B 487C AB6E
+  Cross-reference against four independent sources before trusting any
+  key material — see https://nimbus-agent.dev/user-guide/verify-your-download/
+  for the recommended cross-check procedure.
 
 License:
   AGPL-3.0. Full text in LICENSE-AGPL.txt.
 
 More information:
-  https://github.com/asafgolombek/Nimbus
+  Docs:        https://nimbus-agent.dev/
+  Source:      https://github.com/nimbus-agent/Nimbus
+  Issues:      https://github.com/nimbus-agent/Nimbus/issues


### PR DESCRIPTION
## Summary

User-reported: the rc7 Windows zip's `README-QUICKSTART.txt` doesn't mention `install.ps1` / `uninstall.ps1` and tells the user to double-click the gateway binary instead of using `nimbus start`. Investigating that surfaced a third coordinated bug — **the binaries inside the archives have the wrong filenames**, so `install.ps1 -Yes` from an extracted archive would have failed with "Cannot locate 'nimbus.exe' or 'nimbus-gateway.exe'".

Three fixes in one PR.

## Fix 1 — Binary names match install scripts

The "Build macOS + Windows archives" step was placing binaries into the archive staging dir under their RAW release-asset names (`nimbus-gateway-macos-x64`, `nimbus-cli-windows-x64.exe`, etc.). But the bundled `install.sh` / `install.ps1` look for the canonical names:

- Unix: `nimbus`, `nimbus-gateway`
- Windows: `nimbus.exe`, `nimbus-gateway.exe`

So running `.\install.ps1 -Yes` from inside the extracted zip would have thrown:

```
Cannot locate 'nimbus.exe' or 'nimbus-gateway.exe' beside this script.
```

Empirically confirmed by inspecting the rc7 zip contents on the release page.

**Fix:** rename during the `cp` into the staging dir. Raw release assets on the release page keep their `-<os>-<arch>` suffixes (so a user browsing the release listing can grab one binary without confusion); inside the extracted archive the binaries are just `nimbus` and `nimbus-gateway`, matching what the install scripts and `nimbus start` expect.

## Fix 2 — Rewrite `README-QUICKSTART.txt`

Old README told Windows users to "Double-click `nimbus-gateway-windows-x64.exe`", which:

- Bypasses `nimbus start`'s lifecycle / PID file / log rotation
- Doesn't put `nimbus` on PATH so the CLI isn't reachable from a new shell
- Closes the gateway when the window closes (foreground process)
- References a binary name that doesn't exist after Fix #1

Symmetric problem on macOS / Linux ("Start the Gateway: `./nimbus-gateway-<os>-<arch>`").

**Fix:** full rewrite. New README documents the `install.sh` / `install.ps1` flow, calls out `nimbus start` as the proper way to spawn the Gateway, and explicitly tells users **not** to run `nimbus-gateway` directly. Adds an Uninstall section. Cross-links the `verify-your-download` user-guide page on nimbus-agent.dev.

## Fix 3 — Stale GitHub URL

README footer pointed at `https://github.com/asafgolombek/Nimbus` — the repo lives at `https://github.com/nimbus-agent/Nimbus`. Updated. Also added explicit links to the docs site and issue tracker.

## After this merges

Push `v0.1.0-rc8`. The verification ritual:

1. Download rc8 Windows zip from the release page.
2. Extract.
3. Read `README-QUICKSTART.txt` — should mention `install.ps1`.
4. `.\install.ps1 -Yes` — should succeed and add `%LOCALAPPDATA%\Programs\Nimbus\bin` to User PATH.
5. Open new shell → `nimbus --help` → `nimbus start` → `nimbus status`.
6. `.\uninstall.ps1 -Yes` — clean teardown.
7. If all of that passes, walk the manual smoke matrix and cut `vscode-v0.1.0` then `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)