### PR TITLE
docs: fix stale URLs + Phase 4 status drift across project docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,8 +439,8 @@ A system that orchestrates real actions against real data cannot rely on develop
 | Phase 2 | The Bridge — 15 MCP connectors, unified index, people graph, context ranker, installers | ✅ Complete |
 | Phase 3 | Intelligence — Semantic layer, extensions, CI/CD + cloud MCPs, workflows, watchers | ✅ Complete |
 | Phase 3.5 | Observability — Connector health model, `nimbus query` / `diag` / `doctor` / `db`, config profiles, `@nimbus-dev/client`, telemetry, docs site | ✅ Complete |
-| Phase 4 | Presence — Tauri UI, VS Code ext, local LLM (Ollama), multi-agent, data portability | 🔵 Active |
-| Phase 5 | The Extended Surface — browser/reading, IMAP, finance, CRM, HR, design connectors; Marketplace v2 | Planned |
+| Phase 4 | Presence — Tauri UI, VS Code ext, local LLM (Ollama), multi-agent, data portability | ✅ Complete |
+| Phase 5 | The Extended Surface — browser/reading, IMAP, finance, CRM, HR, design connectors; Marketplace v2 | 🔵 Active |
 | Phase 6 | Team — federation, Team Vault, shared namespaces, SSO/SCIM, multi-user HITL, org policy | Planned |
 | Phase 7 | The Autonomous Agent — standing approvals, scheduled tasks, incident correlation, fine-tuning, SRE loop | Planned |
 | Phase 8 | Sovereign Mesh — P2P sync, mobile companion, hardware vault, DIDs, Digital Executor | Planned |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -414,8 +414,8 @@ mcp-connectors/*  ← depend on @nimbus-dev/sdk only
 | Phase 2 | The Bridge — 15 MCP connectors, unified index, people graph, context ranker, installers | ✅ Complete |
 | Phase 3 | Intelligence — Semantic layer, extensions, CI/CD + cloud MCPs, workflows, watchers | ✅ Complete |
 | Phase 3.5 | Observability — Health model, `nimbus query`, `diag`, recovery, telemetry, docs site | ✅ Complete |
-| Phase 4 | Presence — Tauri UI, VS Code ext, local LLM (Ollama), multi-agent, data portability | 🔵 Active |
-| Phase 5 | The Extended Surface — browser/reading, IMAP, finance, CRM, HR, design connectors; Marketplace v2 | Planned |
+| Phase 4 | Presence — Tauri UI, VS Code ext, local LLM (Ollama), multi-agent, data portability | ✅ Complete |
+| Phase 5 | The Extended Surface — browser/reading, IMAP, finance, CRM, HR, design connectors; Marketplace v2 | 🔵 Active |
 | Phase 6 | Team — federation, Team Vault, shared namespaces, SSO/SCIM, multi-user HITL, org policy | Planned |
 | Phase 7 | The Autonomous Agent — standing approvals, scheduled tasks, incident correlation, fine-tuning, SRE loop | Planned |
 | Phase 8 | Sovereign Mesh — P2P sync, mobile companion, hardware vault, DIDs, Digital Executor | Planned |

--- a/docs/README.md
+++ b/docs/README.md
@@ -266,8 +266,8 @@ Once installed, run **`nimbus doctor`** — it checks every prerequisite above a
 #### Linux (`.deb`)
 
 ```bash
-curl -L https://github.com/asafgolombek/Nimbus/releases/latest/download/nimbus_amd64.deb -o nimbus.deb
-curl -L https://github.com/asafgolombek/Nimbus/releases/latest/download/nimbus_amd64.deb.asc -o nimbus.deb.asc
+curl -L https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus_amd64.deb -o nimbus.deb
+curl -L https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus_amd64.deb.asc -o nimbus.deb.asc
 gpg --keyserver keys.openpgp.org --recv-keys 5A20457CCD8B53FFAA945240886ADA6B487CAB6E
 gpg --verify nimbus.deb.asc nimbus.deb
 sudo dpkg -i nimbus.deb
@@ -278,7 +278,7 @@ The `.deb` installs `nimbus` and `nimbus-gateway` wrappers under `/usr/local/bin
 #### macOS / Linux (tarball)
 
 ```bash
-curl -L https://github.com/asafgolombek/Nimbus/releases/latest/download/nimbus-macos-arm64.tar.gz -o nimbus.tar.gz
+curl -L https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-macos-arm64.tar.gz -o nimbus.tar.gz
 tar -xzf nimbus.tar.gz
 cd nimbus-*
 ./install.sh --yes
@@ -291,7 +291,7 @@ The bundled `install.sh` copies the binaries to `~/.local/bin` and adds a sentin
 #### Windows (zip)
 
 ```powershell
-Invoke-WebRequest https://github.com/asafgolombek/Nimbus/releases/latest/download/nimbus-windows-x64.zip -OutFile nimbus.zip
+Invoke-WebRequest https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-windows-x64.zip -OutFile nimbus.zip
 Expand-Archive nimbus.zip
 cd (Get-ChildItem nimbus-*).Name
 .\install.ps1 -Yes
@@ -304,7 +304,7 @@ The bundled `install.ps1` (PowerShell 7+) copies the binaries to `%LOCALAPPDATA%
 #### AppImage (Linux)
 
 ```bash
-curl -L https://github.com/asafgolombek/Nimbus/releases/latest/download/Nimbus-x86_64.AppImage -o Nimbus.AppImage
+curl -L https://github.com/nimbus-agent/Nimbus/releases/latest/download/Nimbus-x86_64.AppImage -o Nimbus.AppImage
 chmod +x Nimbus.AppImage
 # Run directly:
 ./Nimbus.AppImage --version
@@ -317,8 +317,8 @@ chmod +x Nimbus.AppImage
 Every release ships a GPG-signed `SHA256SUMS.asc`:
 
 ```bash
-curl -L https://github.com/asafgolombek/Nimbus/releases/latest/download/SHA256SUMS -o SHA256SUMS
-curl -L https://github.com/asafgolombek/Nimbus/releases/latest/download/SHA256SUMS.asc -o SHA256SUMS.asc
+curl -L https://github.com/nimbus-agent/Nimbus/releases/latest/download/SHA256SUMS -o SHA256SUMS
+curl -L https://github.com/nimbus-agent/Nimbus/releases/latest/download/SHA256SUMS.asc -o SHA256SUMS.asc
 gpg --keyserver keys.openpgp.org --recv-keys 5A20457CCD8B53FFAA945240886ADA6B487CAB6E
 gpg --verify SHA256SUMS.asc SHA256SUMS
 sha256sum --check --ignore-missing SHA256SUMS
@@ -329,7 +329,7 @@ The fingerprint is published at [`docs/release/SIGNING-KEY.asc`](docs/release/SI
 ### Option B — Build from Source
 
 ```bash
-git clone https://github.com/asafgolombek/Nimbus.git
+git clone https://github.com/nimbus-agent/Nimbus.git
 cd Nimbus
 bun install          # NOT "bun run install" — that looks for a script and fails
                      # Installs sharp + platform @img/sharp-* for embeddings (via @xenova/transformers)
@@ -527,9 +527,11 @@ nimbus extension list
 | **Config dir** | `%APPDATA%\Nimbus` | `~/Library/…/Nimbus` | `~/.config/nimbus` |
 | **Desktop UI** | WebView2 | WKWebView | WebKitGTK |
 | **CI runner** | `windows-2025` | `macos-15` | `ubuntu-24.04` |
-| **Release** | `.exe` (signed) | `.dmg` (notarized) | `.deb` + AppImage |
+| **Release** | `.zip` (unsigned, v0.1.0 cut-line) † | `.tar.gz` (unsigned, v0.1.0 cut-line) † | `.deb` (GPG-signed) + AppImage |
 
 † **Ubuntu 22.04 is supported for source builds only.** Pre-built Linux binaries are compiled on Ubuntu 24.04 and require **glibc ≥ 2.39** at runtime — Ubuntu 22.04 LTS, Debian 12, and RHEL 9 (and derivatives) will fail with `GLIBC_2.39 not found`. See [SECURITY.md](./SECURITY.md#linux-runtime-support--glibc-floor).
+
+† **macOS and Windows ship unsigned in v0.1.0.** Cross-platform integrity is provided by the GPG-signed `SHA256SUMS.asc` manifest. macOS Gatekeeper and Windows SmartScreen will prompt on first run; this is expected. Apple Developer notarization and Windows Authenticode signing are deferred to a later point release — see [SECURITY.md](./SECURITY.md#v010-signing-cut-line).
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -306,7 +306,7 @@ HIGH and CRITICAL findings block merges when branch protection checks are requir
 Release binaries (Gateway + CLI, all four platform builds) carry a **GitHub build provenance attestation** (`actions/attest-build-provenance`) and a **CycloneDX SBOM**, both attached to the GitHub Release. Verify with:
 
 ```bash
-gh attestation verify nimbus-gateway-linux-x64 --owner asafgolombek
+gh attestation verify nimbus-gateway-linux-x64 --owner nimbus-agent
 ```
 
 ---


### PR DESCRIPTION
## Summary

End-to-end review of the public docs (README + architecture + GEMINI/CLAUDE context + SECURITY + security-hardening) ahead of the v0.1.0 release cut surfaced three categories of drift. This PR fixes the **user-visible-breakage tier** (everything that misleads a user who copy-pastes from the docs or that has the project contradicting itself).

## 1. Stale `asafgolombek/Nimbus` GitHub URLs (9 sites)

The repo lives at `github.com/nimbus-agent/Nimbus`; old URLs were left over from when the project was under the maintainer's personal account. Every download URL in the README install snippets pointed at the wrong org and **returned 404 to anyone copy-pasting**:

- `.deb` + `.deb.asc`
- macOS / Linux tarball
- Windows zip
- AppImage
- `SHA256SUMS` + `SHA256SUMS.asc`
- `git clone` URL in the source-build section
- `gh attestation verify --owner` example in `SECURITY.md`

All 9 fixed.

## 2. Misleading release-format / signing claim in `docs/README.md` "Cross-Platform Support" table

The row claimed:

```
**Release** | `.exe` (signed) | `.dmg` (notarized) | `.deb` + AppImage
```

Both Windows and macOS claims are wrong:

- macOS and Windows ship **unsigned** in v0.1.0 per the explicit signing cut-line documented at `SECURITY.md` §"v0.1.0 signing cut-line".
- The actual formats are `.zip` (Windows) and `.tar.gz` (macOS), not `.exe` / `.dmg`.

Corrected the row + added a footnote cross-linking the SECURITY.md cut-line section so readers understand why notarization/Authenticode are deferred and when they might land.

## 3. Internal Phase-4 status contradictions (`CLAUDE.md` + `GEMINI.md`)

Both context files had a Status header on line 8/10 saying:

> Phase 4 — Presence ✅ Complete; Phase 5 — Extended Surface 🔵 Active

…but the Roadmap Context table later in the same file (line 442 / 417) said:

> Phase 4 | 🔵 Active · Phase 5 | Planned

Each file was contradicting itself by ~400 lines. Flipped both roadmap rows to match the Status header. `README.md` + `architecture.md` were already consistent and didn't need a change.

## Intentionally deferred to v0.1.0 release-notes prep

- `SECURITY.md:12` — "Once versioned releases begin (target: Phase 4 — v0.1.0)" is future-tense; will be edited when v0.1.0 actually ships.
- `SECURITY.md:214` — "Phase 4 migration N+3 will add row_hash and prev_hash" is future-tense; the migration shipped, language should be past-tense.
- `SECURITY.md:77` — B1 audit's three Phase-4 polish blockers should be marked closed (or punted explicitly to Phase 5) now that Phase 4 is complete.

These three are honest editorial polish that benefit from a coordinated review pass alongside the v0.1.0 changelog, rather than churning SECURITY.md twice.

## Test plan

- [ ] CI green
- [ ] Manual: `grep -rn "asafgolombek" docs/ GEMINI.md CLAUDE.md` returns 0 hits
- [ ] Manual: paste each install URL from `docs/README.md` into a browser → real release page (or 404 only because v0.1.0 isn't tagged yet, not because of the wrong org)
- [ ] Manual: `CLAUDE.md` and `GEMINI.md` Status header agrees with their own roadmap table

🤖 Generated with [Claude Code](https://claude.com/claude-code)