### PR TITLE
fix(cli): v0.1.0 smoke bugs — banner suppression + data HITL deadlock

### DIFF
--- a/docs/release/v0.1.0-smoke-bugs.md
+++ b/docs/release/v0.1.0-smoke-bugs.md
@@ -8,8 +8,8 @@ Status legend: `open` / `in-progress` / `fixed` / `wontfix-deferred`.
 
 | ID | Title | Severity | Surface | Status |
 |---|---|---|---|---|
-| BUG-001 | `nimbus diag --json` wraps JSON with Clack banner | low (programmatic-only) | CLI / `diag.ts` | open |
-| BUG-002 | `nimbus data export` deadlocks waiting for HITL consent | **high (deadlocks the CLI)** | CLI / `data.ts` | open |
+| BUG-001 | `nimbus diag --json` wraps JSON with Clack banner | low (programmatic-only) | CLI / `diag.ts` | fixed |
+| BUG-002 | `nimbus data export` deadlocks waiting for HITL consent | **high (deadlocks the CLI)** | CLI / `data.ts` | fixed |
 | BUG-003 | TUI Connector Health pane stuck on "loading…" — wrong IPC method + shape | medium (smoke §1.1 visual check fails) | CLI / TUI `ConnectorHealth.tsx` | open |
 | BUG-004 | TUI right-pane is visually lost on wide terminals; labels lack context | low (UX polish) | CLI / TUI `App.tsx`, panes | open |
 
@@ -19,7 +19,7 @@ Status legend: `open` / `in-progress` / `fixed` / `wontfix-deferred`.
 
 **Severity:** low. Cosmetic for human stdout; breaks any programmatic JSON consumer (`ConvertFrom-Json`, `jq`, the smoke run sheet).
 **Surface:** CLI — `nimbus diag --json` (and any other JSON-emitting CLI command).
-**Status:** open.
+**Status:** fixed in `packages/cli/src/index.ts` — `intro`/`outro` are now gated behind `isQuiet = !stdout.isTTY || argv.includes("--json") || NIMBUS_QUIET=1`. Regression coverage in `packages/cli/test/integration/cli-banner-suppression.integration.test.ts`.
 **First seen:** smoke run, 2026-05-07, Windows 11 / PowerShell 7.
 
 ### Repro
@@ -94,7 +94,7 @@ This relies on the JSON body being a single top-level object, which is true for 
 
 **Severity:** high. The CLI hangs forever; the only escape is Ctrl+C, and the Gateway is left with a stranded pending HITL request. Any user following the Phase 4 acceptance criterion ("`nimbus data export` ... restores full functionality on a fresh machine") hits this immediately.
 **Surface:** CLI — `nimbus data export`. Likely affects `nimbus data import` and `nimbus data delete` for the same reason (each has a server-side gate but no consent handler in the CLI command).
-**Status:** open.
+**Status:** fixed. `packages/cli/src/commands/data.ts` `withClient` now registers a consent handler before the IPC call: `registerConsentPromptHandler` for interactive runs, `registerAutoApproveConsentHandler` (new) when `--yes` is passed. `--yes` is now accepted by `data export` and `data import` (delete already had it). Regression coverage in `packages/cli/src/lib/interactive-ipc-handlers.test.ts`.
 **First seen:** smoke run, 2026-05-07, Windows 11 / PowerShell 7.
 
 ### Repro

--- a/packages/cli/src/commands/data.ts
+++ b/packages/cli/src/commands/data.ts
@@ -1,5 +1,9 @@
 import { IPCClient } from "../ipc-client/index.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
+import {
+  registerAutoApproveConsentHandler,
+  registerConsentPromptHandler,
+} from "../lib/interactive-ipc-handlers.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
 export async function runData(args: string[]): Promise<void> {
@@ -16,12 +20,27 @@ export async function runData(args: string[]): Promise<void> {
   }
 }
 
-async function withClient<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
+/**
+ * Open an IPC connection and register the right HITL consent handler before
+ * invoking the caller. Without this, `data.export|import|delete` deadlock —
+ * the Gateway emits `consent.request` and waits for `consent.respond`, while
+ * the CLI waits for the IPC method's response (BUG-002).
+ *
+ * `yes`: when true, every consent prompt is auto-approved with a stderr
+ * warning (and a Gateway-side audit entry). When false, a Clack confirm
+ * prompt is shown in the terminal.
+ */
+async function withClient<T>(yes: boolean, fn: (c: IPCClient) => Promise<T>): Promise<T> {
   const paths = getCliPlatformPaths();
   const state = await readGatewayState(paths);
   if (state === undefined) throw new Error("Gateway is not running. Start with: nimbus start");
   const client = new IPCClient(state.socketPath);
   await client.connect();
+  if (yes) {
+    registerAutoApproveConsentHandler(client);
+  } else {
+    registerConsentPromptHandler(client);
+  }
   try {
     return await fn(client);
   } finally {
@@ -33,14 +52,15 @@ async function runDataExportCli(args: string[]): Promise<void> {
   const outIdx = args.indexOf("--output");
   const noIndex = args.includes("--no-index");
   const passIdx = args.indexOf("--passphrase");
+  const yes = args.includes("--yes");
   if (outIdx < 0 || passIdx < 0) {
     throw new Error(
-      "Usage: nimbus data export --output <path.tar.gz> --passphrase <pw> [--no-index]",
+      "Usage: nimbus data export --output <path.tar.gz> --passphrase <pw> [--no-index] [--yes]",
     );
   }
   const output = args[outIdx + 1];
   const passphrase = args[passIdx + 1];
-  await withClient(async (client) => {
+  await withClient(yes, async (client) => {
     const result = await client.call<{
       outputPath: string;
       recoverySeed: string;
@@ -59,17 +79,18 @@ async function runDataImportCli(args: string[]): Promise<void> {
   const bundlePath = args[0];
   if (bundlePath === undefined) {
     throw new Error(
-      "Usage: nimbus data import <path.tar.gz> [--passphrase <pw> | --recovery-seed <mnemonic>]",
+      "Usage: nimbus data import <path.tar.gz> [--passphrase <pw> | --recovery-seed <mnemonic>] [--yes]",
     );
   }
   const passIdx = args.indexOf("--passphrase");
   const seedIdx = args.indexOf("--recovery-seed");
   const passphrase = passIdx >= 0 ? args[passIdx + 1] : undefined;
   const recoverySeed = seedIdx >= 0 ? args[seedIdx + 1] : undefined;
+  const yes = args.includes("--yes");
   if (passphrase === undefined && recoverySeed === undefined) {
     throw new Error("Provide either --passphrase or --recovery-seed");
   }
-  await withClient(async (client) => {
+  await withClient(yes, async (client) => {
     const result = await client.call<{ credentialsRestored: number; oauthEntriesFlagged: number }>(
       "data.import",
       { bundlePath, passphrase, recoverySeed },
@@ -91,7 +112,7 @@ async function runDataDeleteCli(args: string[]): Promise<void> {
   const service = args[svcIdx + 1];
   const dryRun = args.includes("--dry-run");
   const yes = args.includes("--yes");
-  await withClient(async (client) => {
+  await withClient(yes, async (client) => {
     const pre = await client.call<{
       preflight: { itemsToDelete: number; vaultEntriesToDelete: number };
       deleted: boolean;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,16 @@ import { getCliPlatformPaths } from "./paths.ts";
 const rawArgv = process.argv.slice(2);
 const isInteractiveShell = process.stdin.isTTY === true && process.stdout.isTTY === true;
 
+// BUG-001: suppress the Clack `intro("Nimbus")` / `outro("Done.")` chrome
+// when stdout is piped (non-TTY), when any arg is `--json` (every JSON-
+// emitting command), or when `NIMBUS_QUIET=1`. Without this, programmatic
+// consumers (`ConvertFrom-Json`, `jq`, shell pipelines) choke on the banner
+// bytes wrapping the JSON body. Banner stays for human interactive runs.
+const isQuiet =
+  process.stdout.isTTY !== true ||
+  rawArgv.includes("--json") ||
+  process.env["NIMBUS_QUIET"] === "1";
+
 type CommandHandler = (args: string[]) => Promise<void> | void;
 
 const COMMAND_HANDLERS: Readonly<Record<string, CommandHandler>> = {
@@ -101,7 +111,7 @@ async function dispatchCommand(command: string, args: string[]): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  intro("Nimbus");
+  if (!isQuiet) intro("Nimbus");
   const paths = getCliPlatformPaths();
   const { logger } = await createCliFileLogger(paths);
   logger.info({ event: "cli.invoke", argv: process.argv }, "invoke");
@@ -131,7 +141,7 @@ async function main(): Promise<void> {
     logger.info({ event: "cli.finished", exitCode: process.exitCode ?? 0 }, "finished");
   }
 
-  outro("Done.");
+  if (!isQuiet) outro("Done.");
 }
 
 await main();

--- a/packages/cli/src/lib/interactive-ipc-handlers.test.ts
+++ b/packages/cli/src/lib/interactive-ipc-handlers.test.ts
@@ -1,0 +1,83 @@
+/**
+ * BUG-002 regression coverage for the auto-approve consent handler.
+ *
+ * The smoke run found that `nimbus data export` deadlocked: the gateway
+ * emits `consent.request` for HITL-gated actions, but `withClient` in
+ * `commands/data.ts` never registered a handler for it, so neither side
+ * progressed. The fix is to register an auto-approving handler when the
+ * caller passes `--yes`, and an interactive prompt handler otherwise.
+ *
+ * This test pins the auto-approve helper in isolation: when the fake
+ * IPCClient surfaces a `consent.request`, the helper must respond with
+ * `consent.respond { approved: true }` and emit a stderr warning.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { IPCClient } from "../ipc-client/index.ts";
+import { registerAutoApproveConsentHandler } from "./interactive-ipc-handlers.ts";
+
+interface RecordedCall {
+  method: string;
+  params: unknown;
+}
+
+function makeFakeClient(): {
+  client: IPCClient;
+  fireConsent: (params: unknown) => Promise<void>;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let consentHandler: ((params: unknown) => void | Promise<void>) | null = null;
+  const fake = {
+    onNotification: (method: string, handler: (params: unknown) => void | Promise<void>) => {
+      if (method === "consent.request") consentHandler = handler;
+    },
+    call: async (method: string, params: unknown): Promise<unknown> => {
+      calls.push({ method, params });
+      return undefined;
+    },
+  };
+  const fireConsent = async (params: unknown): Promise<void> => {
+    if (consentHandler === null) throw new Error("no consent handler registered");
+    await consentHandler(params);
+  };
+  return { client: fake as unknown as IPCClient, fireConsent, calls };
+}
+
+describe("registerAutoApproveConsentHandler (BUG-002)", () => {
+  test("responds approved=true when gateway emits consent.request", async () => {
+    const { client, fireConsent, calls } = makeFakeClient();
+    registerAutoApproveConsentHandler(client);
+    await fireConsent({ requestId: "req-123", prompt: "Approve data.export?" });
+    expect(calls).toEqual([
+      { method: "consent.respond", params: { requestId: "req-123", approved: true } },
+    ]);
+  });
+
+  test("ignores malformed consent.request payloads (no requestId)", async () => {
+    const { client, fireConsent, calls } = makeFakeClient();
+    registerAutoApproveConsentHandler(client);
+    await fireConsent({ prompt: "missing requestId" });
+    expect(calls).toEqual([]);
+  });
+
+  test("emits stderr warning so non-interactive auto-approve is observable", async () => {
+    const { client, fireConsent } = makeFakeClient();
+    registerAutoApproveConsentHandler(client);
+
+    let warning = "";
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: unknown): boolean => {
+      warning += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await fireConsent({ requestId: "req-xyz", prompt: "Approve action?" });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    expect(warning).toContain("--yes");
+    expect(warning).toContain("auto-approving");
+  });
+});

--- a/packages/cli/src/lib/interactive-ipc-handlers.ts
+++ b/packages/cli/src/lib/interactive-ipc-handlers.ts
@@ -29,6 +29,27 @@ export function registerConsentPromptHandler(client: IPCClient): void {
   });
 }
 
+/**
+ * Auto-approve every HITL consent request and emit a stderr warning so the
+ * action is observable in non-interactive runs (CI, scripts). Used by `nimbus
+ * data export|import|delete --yes`. The Gateway audit log records every
+ * `consent.respond` regardless of source, so the durable trail lives there.
+ */
+export function registerAutoApproveConsentHandler(client: IPCClient): void {
+  client.onNotification("consent.request", async (params: unknown) => {
+    const p = params as { requestId?: string; prompt?: string };
+    if (typeof p.requestId !== "string") {
+      return;
+    }
+    const detail = typeof p.prompt === "string" && p.prompt.length > 0 ? p.prompt : p.requestId;
+    process.stderr.write(`[--yes] auto-approving HITL request: ${detail}\n`);
+    await client.call("consent.respond", {
+      requestId: p.requestId,
+      approved: true,
+    });
+  });
+}
+
 /** Consent prompts + streaming chunks — typical setup for interactive CLI commands. */
 export function registerInteractiveCliIpcHandlers(client: IPCClient): void {
   registerConsentPromptHandler(client);

--- a/packages/cli/test/integration/cli-banner-suppression.integration.test.ts
+++ b/packages/cli/test/integration/cli-banner-suppression.integration.test.ts
@@ -1,0 +1,69 @@
+/**
+ * BUG-001 regression coverage.
+ *
+ * `nimbus diag --json` (and any other JSON-emitting command) must not wrap
+ * its body with the Clack `intro("Nimbus")` header or the `outro("Done.")`
+ * footer when stdout is non-TTY or when `--json` is in the argv. The smoke
+ * run on Windows (2026-05-07) caught this: every consumer that piped CLI
+ * stdout into `ConvertFrom-Json` / `jq` / a shell pipeline choked on the
+ * banner prefix.
+ *
+ * These tests spawn the real CLI entry point with stdout piped (so isTTY
+ * is false in the child) and assert the banner bytes never appear.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const cliEntry = fileURLToPath(new URL("../../src/index.ts", import.meta.url));
+
+async function spawnCli(
+  args: readonly string[],
+  env: Record<string, string> = {},
+): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}> {
+  const proc = Bun.spawn({
+    cmd: [process.execPath, "run", cliEntry, ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("CLI banner suppression (BUG-001)", () => {
+  test("non-TTY stdout suppresses Clack intro/outro", async () => {
+    const { stdout, exitCode } = await spawnCli(["help"]);
+    expect(exitCode).toBe(0);
+    // The Clack outro renders `Done.` on its own line. Any `Done.` substring
+    // in stdout means the outro fired. The CLI's help text never uses that
+    // word, so this is a clean signal.
+    expect(stdout).not.toContain("Done.");
+    // The Clack intro renders the title prefixed with a box-drawing glyph
+    // (`┌  Nimbus`, possibly downgraded to `T  Nimbus` on Windows). The help
+    // output starts with `Nimbus CLI` (no glyph prefix), so we assert the
+    // first non-empty line does not begin with the banner shape.
+    const firstLine = stdout.split("\n").find((l) => l.trim().length > 0) ?? "";
+    expect(firstLine).not.toMatch(/^\s*[┌T│|]\s+Nimbus\s*$/);
+  });
+
+  test("--json arg suppresses banner even when TTY heuristic would otherwise fire", async () => {
+    const { stdout, exitCode } = await spawnCli(["help", "--json"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("Done.");
+  });
+
+  test("NIMBUS_QUIET=1 suppresses banner", async () => {
+    const { stdout, exitCode } = await spawnCli(["help"], { NIMBUS_QUIET: "1" });
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("Done.");
+  });
+});


### PR DESCRIPTION
## Summary

Closes BUG-001 (low) and BUG-002 (high) from `docs/release/v0.1.0-smoke-bugs.md`.

- **BUG-001** — `nimbus diag --json` (and any other JSON-emitting command) wrapped its body with the Clack `intro("Nimbus")` / `outro("Done.")` banner, breaking every programmatic consumer (`ConvertFrom-Json`, `jq`, shell pipelines). Fix: gate `intro`/`outro` behind `isQuiet = !stdout.isTTY || argv.includes("--json") || NIMBUS_QUIET=1`. Banner stays for human interactive runs.
- **BUG-002** — `nimbus data export|import|delete` deadlocked because `withClient` never registered a `consent.request` handler; the Gateway emits `consent.request` for HITL-gated actions and waits forever. Fix: register `registerConsentPromptHandler` (interactive Clack confirm) by default, or the new `registerAutoApproveConsentHandler` (auto-approve with stderr warning) when `--yes` is passed. `--yes` is now accepted by `data export` and `data import` (delete already had it).

## Test plan

TDD: every fix has a failing test that pre-dates the implementation.

- [x] `bun test packages/cli/test/integration/cli-banner-suppression.integration.test.ts` — 3/3 (BUG-001 spawn-based)
- [x] `bun test packages/cli/src/lib/interactive-ipc-handlers.test.ts` — 3/3 (BUG-002 auto-approve helper)
- [x] `bun test packages/cli` — 172/172 (no regressions)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] CI green on this branch

## Notes

- `nimbus data export --yes` writes `[--yes] auto-approving HITL request: <prompt>` to stderr for every consent prompt. The Gateway audit log records each `consent.respond` regardless of source, so the durable trail lives there.
- BUG-003 (TUI Connector Health pane) and BUG-004 (TUI right-pane polish) ship in a follow-up TUI PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)