### PR TITLE
fix(cli/tui): v0.1.0 smoke bugs — Connector Health pane + right-pane polish

### DIFF
--- a/docs/release/v0.1.0-smoke-bugs.md
+++ b/docs/release/v0.1.0-smoke-bugs.md
@@ -10,8 +10,8 @@ Status legend: `open` / `in-progress` / `fixed` / `wontfix-deferred`.
 |---|---|---|---|---|
 | BUG-001 | `nimbus diag --json` wraps JSON with Clack banner | low (programmatic-only) | CLI / `diag.ts` | fixed |
 | BUG-002 | `nimbus data export` deadlocks waiting for HITL consent | **high (deadlocks the CLI)** | CLI / `data.ts` | fixed |
-| BUG-003 | TUI Connector Health pane stuck on "loading…" — wrong IPC method + shape | medium (smoke §1.1 visual check fails) | CLI / TUI `ConnectorHealth.tsx` | open |
-| BUG-004 | TUI right-pane is visually lost on wide terminals; labels lack context | low (UX polish) | CLI / TUI `App.tsx`, panes | open |
+| BUG-003 | TUI Connector Health pane stuck on "loading…" — wrong IPC method + shape | medium (smoke §1.1 visual check fails) | CLI / TUI `ConnectorHealth.tsx` | fixed |
+| BUG-004 | TUI right-pane is visually lost on wide terminals; labels lack context | low (UX polish) | CLI / TUI `App.tsx`, panes | fixed |
 
 ---
 
@@ -174,7 +174,7 @@ There is no working CLI workaround for the export — the gate is structural. Op
 
 **Severity:** medium. The smoke §1.1 verification "google_photos shows degraded in ConnectorHealth pane" is impossible to satisfy — the pane never renders any rows. Cosmetically the pane stays on the placeholder "loading…" indefinitely, which is also what BUG-004 covers.
 **Surface:** CLI — TUI `ConnectorHealth.tsx`. Likely also affects any code path or test that assumes `connector.list` is a real Gateway method.
-**Status:** open.
+**Status:** fixed. `packages/cli/src/tui/ConnectorHealth.tsx` now polls `connector.listStatus` and parses the real `SyncStatus` shape (`{ serviceId, status: ok|syncing|paused|backoff|error }`); glyphs map ok→●, syncing/paused→◐, backoff/error→○. Tests in `ConnectorHealth.test.tsx` and `App.test.tsx` were aligned to the real method+shape so future drift fails CI.
 **First seen:** smoke run, 2026-05-07, Windows 11 / PowerShell 7.
 
 ### Repro
@@ -263,7 +263,7 @@ None. The TUI Connector Health pane is non-functional. For the smoke run, mark �
 
 **Severity:** low. Pure UX polish, no functional regression. Surfaced because the user reading the TUI for the first time could not tell what the right-pane lines were ("what are all those lines on the right side?").
 **Surface:** CLI — TUI `App.tsx`, `ConnectorHealth.tsx`, `WatcherPane.tsx`, `SubTaskPane.tsx`.
-**Status:** open.
+**Status:** fixed. The right pane now ships with `borderStyle="single" borderColor="gray" paddingX={1}` so it reads as one visual unit. The left `ResultStream` pane width is capped at `Math.min(max(cols-32, 40), 120)` so on a 250-col terminal the right pane sits adjacent instead of floating at the far edge. Empty-state copy across the three panes was rewritten as full sentences ("Loading connector status…", "No connectors registered", "No watchers configured", "No sub-tasks running yet") and a one-line `Ctrl+C twice to exit` footer was added so first-time users have an exit anchor. Regression coverage in `ConnectorHealth.test.tsx`, `WatcherPane.test.tsx`, `SubTaskPane.test.tsx`, and `App.test.tsx`.
 **First seen:** smoke run, 2026-05-07, Windows 11 / PowerShell 7 (Windows Terminal at ~250 columns).
 
 ### Repro

--- a/packages/cli/src/tui/App.test.tsx
+++ b/packages/cli/src/tui/App.test.tsx
@@ -9,7 +9,7 @@ import { StubIpcClient } from "./test-helpers/stub-client.ts";
 function setupStub(): StubIpcClient {
   return new StubIpcClient({
     results: {
-      "connector.list": [],
+      "connector.listStatus": [],
       "watcher.list": [],
       "engine.askStream": { streamId: "s-test" },
     },
@@ -89,10 +89,32 @@ describe("App state machine", () => {
     teardown();
   });
 
+  test("BUG-004: renders the keybind footer in idle mode", async () => {
+    const stub = setupStub();
+    const { lastFrame, teardown } = renderApp(stub);
+    await settle();
+    // The TUI now ships a one-line footer so first-time users have an anchor
+    // for the only universally-available exit keybind.
+    expect(lastFrame() ?? "").toContain("Ctrl+C twice to exit");
+    teardown();
+  });
+
+  test("BUG-004: right pane is enclosed in a single-line box border", async () => {
+    const stub = setupStub();
+    const { lastFrame, teardown } = renderApp(stub);
+    await settle();
+    const frame = lastFrame() ?? "";
+    // Ink's borderStyle="single" emits Unicode box-drawing characters.
+    // Asserting `│` (vertical bar) is the cheapest invariant that survives
+    // terminal-width changes and content reshuffles.
+    expect(frame).toContain("│");
+    teardown();
+  });
+
   test("disconnect banner appears when an IPC call throws ECONNRESET", async () => {
     const stub = new StubIpcClient({
       errors: { "engine.askStream": new Error("ECONNRESET") },
-      results: { "connector.list": [], "watcher.list": [] },
+      results: { "connector.listStatus": [], "watcher.list": [] },
     });
     const { stdin, lastFrame, teardown } = renderApp(stub);
     await settle();

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -327,16 +327,29 @@ export function App({ historyPath, onExit }: Props): React.JSX.Element {
         </Box>
       ) : (
         <Box flexDirection="row">
-          <Box flexDirection="column" flexGrow={1}>
+          {/*
+            BUG-004: cap the left pane width so the right pane sits adjacent
+            instead of floating at the far edge on wide modern terminals
+            (250-col Windows Terminal was the trigger). 32 = right-pane
+            width 30 + 2 cols of slack.
+          */}
+          <Box flexDirection="column" width={Math.min(Math.max(cols - 32, 40), 120)}>
             <ResultStream entries={entries} liveBuffer={state.liveBuffer} hitlBanner={hitlBanner} />
           </Box>
-          <Box flexDirection="column" width={30}>
+          <Box
+            flexDirection="column"
+            width={30}
+            borderStyle="single"
+            borderColor="gray"
+            paddingX={1}
+          >
             <ConnectorHealth mode={state.mode} />
             <WatcherPane mode={state.mode} />
             <SubTaskPane clearKey={clearKey} />
           </Box>
         </Box>
       )}
+      <Text dimColor>Ctrl+C twice to exit</Text>
     </Box>
   );
 }

--- a/packages/cli/src/tui/ConnectorHealth.test.tsx
+++ b/packages/cli/src/tui/ConnectorHealth.test.tsx
@@ -17,14 +17,22 @@ function ctx(client: StubIpcClient): IpcContextValue {
   };
 }
 
+/**
+ * BUG-003 regression coverage. The TUI was calling the non-existent IPC
+ * method `connector.list` with a fictional `{ service, status: ok|degraded|down }`
+ * shape, while the Gateway exposes `connector.listStatus` returning
+ * `SyncStatus` rows shaped `{ serviceId, status: ok|syncing|paused|backoff|error, ... }`.
+ * These tests now stub the real method+shape; the previous tests passed
+ * because they aligned the stub to the broken caller, masking the drift.
+ */
 describe("ConnectorHealth", () => {
   test("renders a line per connector with a status glyph", async () => {
     const stub = new StubIpcClient({
       results: {
-        "connector.list": [
-          { service: "github", status: "ok" },
-          { service: "slack", status: "degraded" },
-          { service: "notion", status: "down" },
+        "connector.listStatus": [
+          { serviceId: "github", status: "ok" },
+          { serviceId: "slack", status: "paused" },
+          { serviceId: "notion", status: "error" },
         ],
       },
     });
@@ -39,14 +47,14 @@ describe("ConnectorHealth", () => {
     expect(frame).toContain("slack");
     expect(frame).toContain("notion");
     expect(frame).toContain("●"); // ok
-    expect(frame).toContain("◐"); // degraded
-    expect(frame).toContain("○"); // down
+    expect(frame).toContain("◐"); // paused (in-flight / held)
+    expect(frame).toContain("○"); // error (failure)
     unmount();
   });
 
-  test("prefixes degraded with ⚠", async () => {
+  test("prefixes degraded statuses (backoff/error) with ⚠", async () => {
     const stub = new StubIpcClient({
-      results: { "connector.list": [{ service: "slack", status: "degraded" }] },
+      results: { "connector.listStatus": [{ serviceId: "slack", status: "error" }] },
     });
     const { lastFrame, unmount } = render(
       <IpcContext.Provider value={ctx(stub)}>
@@ -59,7 +67,7 @@ describe("ConnectorHealth", () => {
   });
 
   test("shows (stale) marker in the title when disconnected", async () => {
-    const stub = new StubIpcClient({ results: { "connector.list": [] } });
+    const stub = new StubIpcClient({ results: { "connector.listStatus": [] } });
     const { lastFrame, unmount } = render(
       <IpcContext.Provider value={ctx(stub)}>
         <ConnectorHealth mode="disconnected" />
@@ -71,13 +79,56 @@ describe("ConnectorHealth", () => {
   });
 
   test("shows loading state before first poll response", () => {
-    const stub = new StubIpcClient({ results: { "connector.list": [] } });
+    const stub = new StubIpcClient({ results: { "connector.listStatus": [] } });
     const { lastFrame, unmount } = render(
       <IpcContext.Provider value={ctx(stub)}>
         <ConnectorHealth mode="idle" />
       </IpcContext.Provider>,
     );
-    expect(lastFrame() ?? "").toContain("Connectors");
+    // BUG-004: placeholder copy is a full sentence, not a bare "loading…".
+    expect(lastFrame() ?? "").toContain("Loading connector status…");
+    unmount();
+  });
+
+  test("BUG-004: shows 'No connectors registered' when poll returned an empty list", async () => {
+    const stub = new StubIpcClient({ results: { "connector.listStatus": [] } });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <ConnectorHealth mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("No connectors registered");
+    expect(frame).not.toContain("(none)");
+    unmount();
+  });
+
+  test("syncing maps to the half-circle glyph (in-flight)", async () => {
+    const stub = new StubIpcClient({
+      results: { "connector.listStatus": [{ serviceId: "github", status: "syncing" }] },
+    });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <ConnectorHealth mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastFrame() ?? "").toContain("◐");
+    unmount();
+  });
+
+  test("backoff maps to the empty-circle glyph (failure)", async () => {
+    const stub = new StubIpcClient({
+      results: { "connector.listStatus": [{ serviceId: "slack", status: "backoff" }] },
+    });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <ConnectorHealth mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastFrame() ?? "").toContain("○");
     unmount();
   });
 });

--- a/packages/cli/src/tui/ConnectorHealth.tsx
+++ b/packages/cli/src/tui/ConnectorHealth.tsx
@@ -5,9 +5,19 @@ import { STATUS_POLL_INTERVAL_MS } from "./constants.ts";
 import type { TuiMode } from "./state.ts";
 import { useIpcPoll } from "./useIpcPoll.ts";
 
+/**
+ * Mirrors `SyncStatus` from `packages/gateway/src/sync/types.ts` — the row
+ * shape returned by the Gateway's `connector.listStatus` IPC method. Only
+ * the two fields we render are pulled into this local row.
+ *
+ * BUG-003: previously the TUI declared `{ service, status: ok|degraded|down }`
+ * and called the non-existent `connector.list` method. The Gateway dispatcher
+ * silently returned method-not-found, the parser rejected the empty result,
+ * and the pane rendered `loading…` forever.
+ */
 interface ConnectorRow {
-  service: string;
-  status: "ok" | "degraded" | "down";
+  serviceId: string;
+  status: "ok" | "syncing" | "paused" | "backoff" | "error";
 }
 
 function isConnectorRow(row: unknown): row is ConnectorRow {
@@ -16,8 +26,12 @@ function isConnectorRow(row: unknown): row is ConnectorRow {
   }
   const r = row as Record<string, unknown>;
   return (
-    typeof r["service"] === "string" &&
-    (r["status"] === "ok" || r["status"] === "degraded" || r["status"] === "down")
+    typeof r["serviceId"] === "string" &&
+    (r["status"] === "ok" ||
+      r["status"] === "syncing" ||
+      r["status"] === "paused" ||
+      r["status"] === "backoff" ||
+      r["status"] === "error")
   );
 }
 
@@ -29,10 +43,15 @@ function glyph(status: ConnectorRow["status"]): string {
   if (status === "ok") {
     return "●";
   }
-  if (status === "degraded") {
+  if (status === "syncing" || status === "paused") {
     return "◐";
   }
+  // backoff, error
   return "○";
+}
+
+function isDegraded(status: ConnectorRow["status"]): boolean {
+  return status === "backoff" || status === "error";
 }
 
 interface ConnectorHealthProps {
@@ -44,17 +63,17 @@ function renderBody(
   rows: ConnectorRow[],
 ): React.JSX.Element {
   if (poll.data === null && rows.length === 0) {
-    return <Text dimColor>loading…</Text>;
+    return <Text dimColor>Loading connector status…</Text>;
   }
   if (rows.length === 0) {
-    return <Text dimColor>(none)</Text>;
+    return <Text dimColor>No connectors registered</Text>;
   }
   return (
     <>
       {rows.map((r) => (
-        <Text key={r.service}>
-          {r.status === "degraded" ? "⚠ " : "  "}
-          {glyph(r.status)} {r.service}
+        <Text key={r.serviceId}>
+          {isDegraded(r.status) ? "⚠ " : "  "}
+          {glyph(r.status)} {r.serviceId}
         </Text>
       ))}
     </>
@@ -62,7 +81,7 @@ function renderBody(
 }
 
 export function ConnectorHealth({ mode }: ConnectorHealthProps): React.JSX.Element {
-  const poll = useIpcPoll<unknown>("connector.list", STATUS_POLL_INTERVAL_MS, mode);
+  const poll = useIpcPoll<unknown>("connector.listStatus", STATUS_POLL_INTERVAL_MS, mode);
   const rows = isConnectorList(poll.data) ? poll.data : [];
   return (
     <Box flexDirection="column">

--- a/packages/cli/src/tui/SubTaskPane.test.tsx
+++ b/packages/cli/src/tui/SubTaskPane.test.tsx
@@ -18,14 +18,14 @@ function ctx(client: StubIpcClient): IpcContextValue {
 }
 
 describe("SubTaskPane", () => {
-  test("renders 'No active sub-tasks' when empty", () => {
+  test("renders 'No sub-tasks running yet' when empty", () => {
     const stub = new StubIpcClient();
     const { lastFrame, unmount } = render(
       <IpcContext.Provider value={ctx(stub)}>
         <SubTaskPane clearKey={0} />
       </IpcContext.Provider>,
     );
-    expect(lastFrame() ?? "").toContain("No active sub-tasks");
+    expect(lastFrame() ?? "").toContain("No sub-tasks running yet");
     unmount();
   });
 
@@ -103,7 +103,7 @@ describe("SubTaskPane", () => {
       </IpcContext.Provider>,
     );
     await new Promise((r) => setTimeout(r, 10));
-    expect(lastFrame() ?? "").toContain("No active sub-tasks");
+    expect(lastFrame() ?? "").toContain("No sub-tasks running yet");
     unmount();
   });
 

--- a/packages/cli/src/tui/SubTaskPane.tsx
+++ b/packages/cli/src/tui/SubTaskPane.tsx
@@ -97,7 +97,7 @@ export function SubTaskPane({ clearKey }: SubTaskPaneProps): React.JSX.Element {
     <Box flexDirection="column">
       <Text bold>Sub-Tasks</Text>
       {ordered.length === 0 ? (
-        <Text dimColor>No active sub-tasks</Text>
+        <Text dimColor>No sub-tasks running yet</Text>
       ) : (
         <>
           {shown.map((t) => (

--- a/packages/cli/src/tui/WatcherPane.test.tsx
+++ b/packages/cli/src/tui/WatcherPane.test.tsx
@@ -62,6 +62,22 @@ describe("WatcherPane", () => {
     unmount();
   });
 
+  test("BUG-004: shows 'No watchers configured' when the list is empty", async () => {
+    const stub = new StubIpcClient({ results: { "watcher.list": [] } });
+    const { lastFrame, unmount } = render(
+      <IpcContext.Provider value={ctx(stub)}>
+        <WatcherPane mode="idle" />
+      </IpcContext.Provider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("No watchers configured");
+    // The bare-numbers `0 active, 0 firing` line is a poor empty-state hint
+    // for a first-time user; the sentence form replaces it.
+    expect(frame).not.toContain("0 active, 0 firing");
+    unmount();
+  });
+
   test("(stale) marker when disconnected", async () => {
     const stub = new StubIpcClient({ results: { "watcher.list": [] } });
     const { lastFrame, unmount } = render(

--- a/packages/cli/src/tui/WatcherPane.tsx
+++ b/packages/cli/src/tui/WatcherPane.tsx
@@ -44,9 +44,13 @@ export function WatcherPane({ mode }: WatcherPaneProps): React.JSX.Element {
   return (
     <Box flexDirection="column">
       <Text bold>Watchers{poll.stale ? " (stale)" : ""}</Text>
-      <Text>
-        {String(active)} active, {String(firing.length)} firing
-      </Text>
+      {rows.length === 0 ? (
+        <Text dimColor>No watchers configured</Text>
+      ) : (
+        <Text>
+          {String(active)} active, {String(firing.length)} firing
+        </Text>
+      )}
       {shown.map((w) => (
         <Text key={w.id}>• {w.name}</Text>
       ))}


### PR DESCRIPTION
## Summary

Closes BUG-003 (medium) and BUG-004 (low) from `docs/release/v0.1.0-smoke-bugs.md`. With this PR + #222 + #223, every bug surfaced by the v0.1.0 smoke run is closed.

- **BUG-003** — TUI Connector Health pane was stuck on `loading…` because `ConnectorHealth.tsx` polled the non-existent `connector.list` method with a fictional `{ service, status: ok|degraded|down }` shape. The Gateway exposes `connector.listStatus` returning real `SyncStatus` rows. Tests stubbed the broken caller, masking the drift. Fix: poll `connector.listStatus`, mirror `SyncStatus`, expand glyph mapping to the real five statuses (ok→●, syncing/paused→◐, backoff/error→○). Tests now pin the real method+shape so future drift fails CI.
- **BUG-004** — On wide terminals (Windows Terminal at ~250 cols was the trigger), the right pane floated orphaned at the far edge with hundreds of columns of whitespace; bare placeholder copy gave first-time users no anchor. Fix: right pane gets `borderStyle="single"` + padding; left pane width capped at `min(max(cols-32, 40), 120)` so the right pane sits adjacent; empty-state copy is now full sentences across all three panes; new `Ctrl+C twice to exit` footer.

## Test plan

TDD: every fix has a failing test that pre-dates the implementation.

- [x] `bun test packages/cli/src/tui/ConnectorHealth.test.tsx` — 7/7 (BUG-003 method+shape + BUG-004 copy)
- [x] `bun test packages/cli/src/tui/WatcherPane.test.tsx` — 4/4 (BUG-004 empty-state copy)
- [x] `bun test packages/cli/src/tui/SubTaskPane.test.tsx` — 5/5 (BUG-004 copy update)
- [x] `bun test packages/cli/src/tui/App.test.tsx` — 6/6 (BUG-004 footer + border)
- [x] `bun test packages/cli` — 178/178 (no regressions)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] CI green on this branch

## Manual sanity (optional)

```powershell
nimbus start
nimbus connector pause google_photos
bun run packages/cli/src/index.ts tui
# Right pane: bordered box, "Connectors" heading, google_photos with ◐ glyph
# (paused), other connectors with ● (ok). Footer: "Ctrl+C twice to exit".
nimbus connector unpause google_photos
# Within one poll interval: google_photos glyph flips to ●.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)