### PR TITLE
fix(gateway): ship sqlite-vec as sidecar binary alongside the compiled gateway (BUG-009)

### DIFF
--- a/docs/release/v0.1.0-smoke-bugs.md
+++ b/docs/release/v0.1.0-smoke-bugs.md
@@ -15,6 +15,7 @@ Status legend: `open` / `in-progress` / `fixed` / `wontfix-deferred`.
 | BUG-005 | TUI multi-turn memory broken — every turn is a fresh contextless agent run | **high (multi-turn TUI is unusable)** | engine / TUI `App.tsx` | fixed |
 | BUG-006 | Agent contradicts itself about its own tools across turns | **high (agent gaslights user)** | engine / agent | fixed |
 | BUG-007 | Agent fakes consent in chat instead of triggering the structural HITL gate | **high (violates non-negotiable #2)** | engine / agent | fixed |
+| BUG-009 | `sqlite-vec` native binary doesn't survive `bun build --compile`; semantic memory silently disabled in shipped gateway | high (root cause of BUG-005-c, blocks semantic recall) | gateway / build pipeline | fixed |
 
 ---
 
@@ -448,3 +449,40 @@ Restate the prompt as imperative ("send a gmail to me NOW, do not ask for confir
 - After fix: the §1.3 smoke prompt fires `──[ consent required ]──` mid-stream, exactly as the checklist specifies.
 - After fix: `packages/gateway/src/security-invariants.test.ts` retains its `I2`/`I3` assertions (no regression in the gate itself).
 - New static check: scan every system prompt and tool-description string fed to the LLM for the regex `/confirm(?:ation)?|are you sure|irreversible/i`; fail if any instructs the agent to ask the user before calling the tool. The structural gate must remain the only consent surface.
+
+---
+
+## BUG-009 — `sqlite-vec` native binary doesn't survive `bun build --compile`
+
+**Severity:** high. Root cause of BUG-005-c (memory writes silently no-op'd in the compiled binary) and the blocker for any future feature that depends on a native dep packaged via npm `optionalDependencies` plus `require.resolve`.
+**Surface:** gateway compile pipeline + the sqlite-vec load wrapper.
+**Status:** fixed. (a) `packages/gateway/compile-gateway.ts` now copies the platform-matching `vec0.{dll|so|dylib}` from `node_modules/sqlite-vec-{os}-{arch}/` into `<repoRoot>/dist/` next to `nimbus-gateway`. (b) `packages/gateway/src/index/sqlite-vec-load.ts` falls back to `dirname(process.execPath) + vec0.{ext}` when the upstream `loadSqliteVec(db)` throws (which it always does in the compiled binary because `require.resolve` can't see node_modules from inside the embedded VFS). (c) Pino `debug`-level logs cover the load chain (`via:"npm"`, `via:"sidecar"`, `sidecar not found`) so future support has observability without changing the silent-degrade UX. Regression coverage in `packages/gateway/src/index/sqlite-vec-load.test.ts` (11 tests). Design + review-feedback table at `docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md`.
+**First seen:** investigation of BUG-005-c, 2026-05-08.
+
+### Repro
+
+Pre-fix, with the gateway running from the compiled binary:
+
+```powershell
+bun scripts/diagnose-bug-005.ts
+# [diag] sqlite-vec loaded on fresh connection: false
+# [diag] tryLoadSqliteVec(db) -> true   # works in dev (this script)
+# but the gateway's own connection: ensureReady() returns false → 0 rows
+```
+
+In a TUI session, multi-turn memory was silently broken even though the JS-side `append` and `getRecentTurns` looked correct — `ensureSqliteVecForConnection` returned `false` because vec wasn't loadable, gating every store method.
+
+### Workaround until fixed
+
+None at the binary level. Workarounds were the layered fixes in BUG-005 (TUI sessionId threading, embedding decoupling, schema-only readiness split) — only the schema-only split can be partially undone now that the root cause is fixed.
+
+### Verification
+
+- After fix: `dist/vec0.{ext}` is present after `bun run build`.
+- After fix: `bun scripts/diagnose-bug-005.ts` reports `session_memory has N rows` after a TUI session run against the compiled gateway.
+- After fix: `packages/gateway/src/index/sqlite-vec-load.test.ts` covers `sidecarFilename`, `sidecarPath`, `tryLoadFromSidecar` (success / missing-file / load-throws / default-baseDir), and `tryLoadSqliteVec` upstream success. 11 tests total.
+
+### Out-of-scope follow-ups
+
+- **BUG-009-b:** ship the ONNX runtime native deps the same way so `@xenova/transformers` works in the compiled binary and the embedding worker initializes successfully. Without this, semantic recall stays disabled even with vec working — but literal-turn replay (the BUG-005 primary use case) doesn't need it.
+- **`nimbus doctor` vec check:** at gateway start (or via the `doctor` command), probe `vec_version()` on a fresh connection and surface an actionable warning if it fails.

--- a/docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md
+++ b/docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md
@@ -354,6 +354,8 @@ The compile script currently runs `bun build --compile` and exits with the build
 
 This is a build-time script; it doesn't have a unit test. We verify it by running the build and checking the artifact.
 
+> **CI note:** This step assumes `bun install` on the build runner has already populated `packages/gateway/node_modules/sqlite-vec-{os}-{arch}/`. Each `compile-gateway` matrix job in `.github/workflows/release.yml` runs on its **target's native runner** (`ubuntu-24.04`, `macos-15-intel`, `macos-15`, `windows-2025`); each runner's own `bun install` automatically picks up its matching `sqlite-vec-{os}-{arch}` optional dep. There is no cross-compile step in our pipeline. If you adapt this script for a single-runner cross-build later, you'll need an explicit `bun add sqlite-vec-{target-os}-{target-arch}` before the compile.
+
 - [ ] **Step 1: Add the copy logic at the bottom of `compile-gateway.ts`**
 
 In `packages/gateway/compile-gateway.ts`, change the import line:
@@ -627,3 +629,18 @@ Note the PR URL it returns and watch CI from there.
 **Type consistency:** `sidecarFilename(platform)`, `sidecarPath(execPath, platform)`, `tryLoadFromSidecar(db, baseDir)` all keep the same signatures across Tasks 1–3. The compile-script helpers (`npmOsSegment`, `vec0Filename`) are local to `compile-gateway.ts` and don't collide with the runtime helpers.
 
 **Scope check:** One PR. Single feature: sidecar-bundle vec0 + load-from-sidecar fallback. ONNX and `nimbus doctor` are explicitly deferred and listed as out-of-scope follow-ups.
+
+---
+
+## Responses to external review feedback (round 2)
+
+External review of this plan at `docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar-feedback.md` (Gemini CLI, 2026-05-08). Each item verified against the codebase before disposition.
+
+| # | Item | Disposition | Reason |
+|---|---|---|---|
+| 1 | CI cross-compile safety pre-check | **Fix** | Added a "CI note" callout in Task 4 above the implementation step. Confirms the build script runs on each target's native runner (per the verified `release.yml` matrix from the spec-feedback round) and points future contributors at the explicit-`bun add` workaround if they ever adapt the script for cross-compile. No code change in the script itself. |
+| 2 | Add `nimbus doctor` `vec_version()` check now (re-iterated) | **Defer** | User scoped this out in the brainstorm and confirmed it again in the spec-feedback round. Per the receiving-code-review framework, repeated suggestions don't override the user's decision. The follow-up is tracked in the spec under "Out-of-scope follow-ups" and in the BUG-009 entry of `v0.1.0-smoke-bugs.md`. |
+| 3 | Bump sidecar-missing log to `warn`/`info` | **Defer** | Conflicts with the user's explicit brainstorm choice: "Silent degrade … no noisy errors, but also no signal." The `debug`-level lines added in Task 2 step 3 are already a compromise on the stated preference (justified because `debug` isn't visible at default log levels). Bumping further deviates from intent. |
+| 4 | `.prev` binary cleanup / sidecar version mismatch | **Verified — not an issue** | The `.prev` rename in `compile-gateway.ts` is a **Windows file-lock workaround** (rename the running binary out of the way so `bun build` can write the replacement), not a rollback artifact. `copyFileSync` then atomically overwrites `dist/vec0.{ext}` on every build, so there's no scenario where a stale `vec0` pairs with a fresh gateway binary. |
+| 5 | Tauri sidecar config | **Defer to Phase 6** | Same disposition as the spec-feedback round. Tauri release vehicle is deferred from `v0.1.0` to Phase 6 (`desktop-v0.1.0`) per the CLAUDE.md non-negotiables table. |
+| 6 | Linux musl variant for `npmOsSegment` | **Defer (with technical pushback)** | Verified directly against `packages/gateway/node_modules/sqlite-vec/package.json`. The `optionalDependencies` field is exactly: `{ "sqlite-vec-darwin-x64", "sqlite-vec-linux-x64", "sqlite-vec-darwin-arm64", "sqlite-vec-windows-x64", "sqlite-vec-linux-arm64" }`. There is **no `sqlite-vec-linux-x64-musl` package** for sqlite-vec 0.1.9. The reviewer's claim is incorrect for this version. The musl/glibc concern is real for Alpine users but inherited from upstream — our pipeline doesn't introduce or worsen it. If/when upstream ships a musl variant, the existing `npmOsSegment` mapping needs an extension; until then it's a non-issue. |

--- a/docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md
+++ b/docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md
@@ -388,13 +388,21 @@ function vec0Filename(platform: NodeJS.Platform): string {
  * Resolve the platform-specific vec0 binary in node_modules. Throws with a
  * clear, actionable message if the optional dep wasn't installed for this
  * platform — the resulting gateway would fail to load semantic memory.
+ *
+ * Two-step resolve: `sqlite-vec-{os}-{arch}` is an `optionalDependency` of
+ * `sqlite-vec`, not of `@nimbus/gateway`, so a `createRequire` rooted at
+ * `compile-gateway.ts` can't see it under Bun's isolated install layout
+ * (`node_modules/.bun/<pkg>@<ver>/...`). We resolve `sqlite-vec` first (a
+ * direct gateway dep), then `createRequire` rooted at that file to find the
+ * sister platform package — same trick upstream `sqlite-vec/index.cjs` uses.
  */
 function resolveVec0SourceOrThrow(): string {
   const pkg = `sqlite-vec-${npmOsSegment(process.platform)}-${process.arch}`;
   const fname = vec0Filename(process.platform);
   try {
-    const req = createRequire(import.meta.url);
-    return req.resolve(`${pkg}/${fname}`);
+    const sqliteVecIndex = createRequire(import.meta.url).resolve("sqlite-vec");
+    const reqFromVec = createRequire(sqliteVecIndex);
+    return reqFromVec.resolve(`${pkg}/${fname}`);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     throw new Error(

--- a/docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md
+++ b/docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md
@@ -1,0 +1,629 @@
+# BUG-009 — sqlite-vec Sidecar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `sqlite-vec` extension load successfully inside the compiled `nimbus-gateway` binary by shipping `vec0.{dll|so|dylib}` next to the executable and falling back to that path when the upstream npm resolver fails.
+
+**Architecture:** The npm `sqlite-vec` shim uses `require.resolve()` which is broken when the gateway is bundled via `bun build --compile`. We add a sidecar fallback in the load wrapper that resolves `vec0.{ext}` via `dirname(process.execPath)`, and a post-compile step in `compile-gateway.ts` that copies the platform-specific `vec0` from `node_modules` into `dist/`. Dev-mode load (via `node_modules`) stays unchanged; the fallback is only exercised when the upstream resolver throws.
+
+**Tech Stack:** Bun 1.2+, TypeScript strict, `bun:sqlite`, `sqlite-vec` 0.1.x, `pino` for logs, `bun:test`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `packages/gateway/src/index/sqlite-vec-load.ts` | Modify | Add `sidecarFilename`, `sidecarPath`, `tryLoadFromSidecar`; chain it into existing `tryLoadSqliteVec`. Add pino debug logs. |
+| `packages/gateway/src/index/sqlite-vec-load.test.ts` | Create | Unit tests for the new helpers. |
+| `packages/gateway/compile-gateway.ts` | Modify | After `bun build --compile` succeeds, copy `node_modules/sqlite-vec-{os}-{arch}/vec0.{ext}` into `<repoRoot>/dist/vec0.{ext}`. |
+| `docs/release/v0.1.0-smoke-bugs.md` | Modify | Add BUG-009 entry to the index table and a section after BUG-007. |
+
+No new dependencies. No schema changes. No public-API changes.
+
+---
+
+## Task 1: Pure helpers — `sidecarFilename` and `sidecarPath`
+
+**Files:**
+- Modify: `packages/gateway/src/index/sqlite-vec-load.ts`
+- Test: `packages/gateway/src/index/sqlite-vec-load.test.ts`
+
+These are platform-suffix and path-join helpers. Pure functions, easy TDD.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/index/sqlite-vec-load.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import { sidecarFilename, sidecarPath } from "./sqlite-vec-load.ts";
+
+describe("sidecarFilename", () => {
+  test("win32 → vec0.dll", () => {
+    expect(sidecarFilename("win32")).toBe("vec0.dll");
+  });
+  test("darwin → vec0.dylib", () => {
+    expect(sidecarFilename("darwin")).toBe("vec0.dylib");
+  });
+  test("linux → vec0.so", () => {
+    expect(sidecarFilename("linux")).toBe("vec0.so");
+  });
+  test("any other Unix-shaped platform → vec0.so", () => {
+    expect(sidecarFilename("freebsd")).toBe("vec0.so");
+  });
+});
+
+describe("sidecarPath", () => {
+  test("returns vec0.{ext} adjacent to the given exec path", () => {
+    expect(sidecarPath("/opt/nimbus/bin/nimbus-gateway", "linux")).toBe(
+      join("/opt/nimbus/bin", "vec0.so"),
+    );
+  });
+  test("works for a Windows-style path", () => {
+    expect(sidecarPath("C:\\Program Files\\Nimbus\\nimbus-gateway.exe", "win32")).toBe(
+      join("C:\\Program Files\\Nimbus", "vec0.dll"),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+bun test packages/gateway/src/index/sqlite-vec-load.test.ts
+```
+
+Expected: FAIL with `Export named 'sidecarFilename' not found in module ...sqlite-vec-load.ts` (the symbols don't exist yet).
+
+- [ ] **Step 3: Implement the pure helpers**
+
+Add to `packages/gateway/src/index/sqlite-vec-load.ts` (append at the end of the file, BEFORE the existing `ensureSqliteVecForConnection` export — order doesn't matter functionally but keeps the file readable):
+
+```ts
+import { dirname, join } from "node:path";
+
+/**
+ * Native filename of the sqlite-vec shared library for the given platform.
+ * Mirrors upstream `sqlite-vec/index.cjs::extensionSuffix(platform)`.
+ */
+export function sidecarFilename(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "vec0.dll";
+  if (platform === "darwin") return "vec0.dylib";
+  return "vec0.so";
+}
+
+/**
+ * Path where the gateway expects the sidecar `vec0.{ext}` at runtime —
+ * adjacent to the running executable. Used when the upstream npm resolver
+ * fails (compiled-binary case).
+ */
+export function sidecarPath(execPath: string, platform: NodeJS.Platform): string {
+  return join(dirname(execPath), sidecarFilename(platform));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+bun test packages/gateway/src/index/sqlite-vec-load.test.ts
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/gateway/src/index/sqlite-vec-load.ts packages/gateway/src/index/sqlite-vec-load.test.ts
+git commit -m "feat(gateway): add sidecarFilename + sidecarPath helpers (BUG-009)"
+```
+
+---
+
+## Task 2: `tryLoadFromSidecar` — fallback that loads vec0 from disk
+
+**Files:**
+- Modify: `packages/gateway/src/index/sqlite-vec-load.ts`
+- Test: `packages/gateway/src/index/sqlite-vec-load.test.ts`
+
+The fallback loader takes a `baseDir` parameter (defaulting to `dirname(process.execPath)`) so tests can drive it deterministically with a temp directory.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/gateway/src/index/sqlite-vec-load.test.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+import { tryLoadFromSidecar } from "./sqlite-vec-load.ts";
+
+describe("tryLoadFromSidecar", () => {
+  test("calls db.loadExtension with the sidecar path when the file exists", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "nimbus-vec-sidecar-"));
+    const fname = sidecarFilename(process.platform);
+    writeFileSync(join(tmp, fname), "");
+    const calls: string[] = [];
+    const fakeDb = {
+      loadExtension: (p: string) => {
+        calls.push(p);
+      },
+    } as unknown as Database;
+
+    const ok = tryLoadFromSidecar(fakeDb, tmp);
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([join(tmp, fname)]);
+  });
+
+  test("returns false silently when the sidecar file is missing", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "nimbus-vec-sidecar-empty-"));
+    const fakeDb = {
+      loadExtension: (_p: string) => {
+        throw new Error("should not be called when sidecar is absent");
+      },
+    } as unknown as Database;
+
+    const ok = tryLoadFromSidecar(fakeDb, tmp);
+
+    expect(ok).toBe(false);
+  });
+
+  test("returns false when db.loadExtension throws (e.g. corrupt binary)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "nimbus-vec-sidecar-corrupt-"));
+    writeFileSync(join(tmp, sidecarFilename(process.platform)), "");
+    const fakeDb = {
+      loadExtension: (_p: string) => {
+        throw new Error("not a valid extension");
+      },
+    } as unknown as Database;
+
+    const ok = tryLoadFromSidecar(fakeDb, tmp);
+
+    expect(ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+bun test packages/gateway/src/index/sqlite-vec-load.test.ts
+```
+
+Expected: FAIL with `Export named 'tryLoadFromSidecar' not found`.
+
+- [ ] **Step 3: Implement `tryLoadFromSidecar` + the pino debug logger**
+
+In `packages/gateway/src/index/sqlite-vec-load.ts`, add at the top of the file (just under the existing `import` statements):
+
+```ts
+import { existsSync } from "node:fs";
+import pino from "pino";
+
+const log = pino({
+  name: "sqlite-vec-load",
+  level: process.env["NIMBUS_LOG_LEVEL"] ?? "info",
+});
+```
+
+Then add the function (after `sidecarPath`, before `ensureSqliteVecForConnection`):
+
+```ts
+/**
+ * Compiled-binary fallback: load `vec0.{ext}` from the directory adjacent to
+ * the running executable. Used when the upstream `loadSqliteVec(db)` throws
+ * because `bun build --compile` doesn't preserve native deps reachable via
+ * `require.resolve()`. Returns `false` silently on any failure — the caller
+ * is expected to disable vec-dependent features (semantic memory).
+ *
+ * `baseDir` defaults to `dirname(process.execPath)` and is overridable for
+ * tests; production callers should not supply it.
+ */
+export function tryLoadFromSidecar(
+  db: Database,
+  baseDir: string = dirname(process.execPath),
+): boolean {
+  const path = join(baseDir, sidecarFilename(process.platform));
+  if (!existsSync(path)) {
+    log.debug({ sidecar: path }, "sqlite-vec sidecar not found; semantic memory disabled");
+    return false;
+  }
+  try {
+    db.loadExtension(path);
+    log.debug({ via: "sidecar", sidecar: path }, "sqlite-vec loaded");
+    return true;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.debug({ sidecar: path, err: msg }, "sqlite-vec sidecar load failed");
+    return false;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+bun test packages/gateway/src/index/sqlite-vec-load.test.ts
+```
+
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/gateway/src/index/sqlite-vec-load.ts packages/gateway/src/index/sqlite-vec-load.test.ts
+git commit -m "feat(gateway): add tryLoadFromSidecar fallback for compiled binary (BUG-009)"
+```
+
+---
+
+## Task 3: Chain the fallback into `tryLoadSqliteVec`
+
+**Files:**
+- Modify: `packages/gateway/src/index/sqlite-vec-load.ts`
+- Test: `packages/gateway/src/index/sqlite-vec-load.test.ts`
+
+Existing `tryLoadSqliteVec` only calls upstream `loadSqliteVec(db)`. Chain to `tryLoadFromSidecar` when upstream throws.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/gateway/src/index/sqlite-vec-load.test.ts`:
+
+```ts
+// IMPORTANT: this test exercises tryLoadSqliteVec end-to-end with a real
+// in-memory db. On any platform where the upstream `sqlite-vec` package is
+// installed (every dev / CI machine), upstream succeeds and the fallback is
+// never reached. We assert the success-via-upstream path here; the
+// fallback chain is covered by tryLoadFromSidecar's own tests above.
+import { Database } from "bun:sqlite";
+import { tryLoadSqliteVec } from "./sqlite-vec-load.ts";
+
+describe("tryLoadSqliteVec — upstream-first chain", () => {
+  test("returns true on a fresh db when upstream sqlite-vec is installed", () => {
+    const db = new Database(":memory:");
+    const ok = tryLoadSqliteVec(db);
+    expect(ok).toBe(true);
+    db.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes (upstream already wired)**
+
+```
+bun test packages/gateway/src/index/sqlite-vec-load.test.ts
+```
+
+Expected: PASS — this test is a regression guard, not a RED step. The chain change in step 3 must not break it.
+
+- [ ] **Step 3: Update `tryLoadSqliteVec` to chain to the sidecar**
+
+In `packages/gateway/src/index/sqlite-vec-load.ts`, replace the existing `tryLoadSqliteVec`:
+
+```ts
+export function tryLoadSqliteVec(db: Database): boolean {
+  try {
+    loadSqliteVec(db);
+    log.debug({ via: "npm" }, "sqlite-vec loaded");
+    return true;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.debug({ err: msg }, "upstream sqlite-vec load failed; trying sidecar");
+    return tryLoadFromSidecar(db);
+  }
+}
+```
+
+(The existing `loadSqliteVecOrThrow`, `isVecLoaded`, and `ensureSqliteVecForConnection` are unchanged — they all delegate to `tryLoadSqliteVec` indirectly via the same module surface.)
+
+- [ ] **Step 4: Run the full test file to verify nothing regressed**
+
+```
+bun test packages/gateway/src/index/sqlite-vec-load.test.ts
+```
+
+Expected: PASS, 10 tests (6 helpers + 3 sidecar + 1 chain).
+
+- [ ] **Step 5: Run the broader gateway memory tests to confirm no regressions**
+
+```
+bun test packages/gateway/src/memory/session-memory-store.test.ts packages/gateway/src/engine/run-ask.test.ts
+```
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/gateway/src/index/sqlite-vec-load.ts packages/gateway/src/index/sqlite-vec-load.test.ts
+git commit -m "feat(gateway): tryLoadSqliteVec falls back to sidecar on upstream failure (BUG-009)"
+```
+
+---
+
+## Task 4: Post-compile sidecar copy in `compile-gateway.ts`
+
+**Files:**
+- Modify: `packages/gateway/compile-gateway.ts`
+
+The compile script currently runs `bun build --compile` and exits with the build's status code. After a successful build (status 0), copy the platform-matching `vec0.{ext}` from `packages/gateway/node_modules/sqlite-vec-{os}-{arch}/vec0.{ext}` into `<repoRoot>/dist/vec0.{ext}`. Hard-fail with a clear stderr message if the optional dep is missing.
+
+This is a build-time script; it doesn't have a unit test. We verify it by running the build and checking the artifact.
+
+- [ ] **Step 1: Add the copy logic at the bottom of `compile-gateway.ts`**
+
+In `packages/gateway/compile-gateway.ts`, change the import line:
+
+```ts
+import { copyFileSync, existsSync, renameSync, statSync, unlinkSync } from "node:fs";
+```
+
+Add these helpers above `main()`:
+
+```ts
+/**
+ * The npm `os` segment of the platform-specific sqlite-vec subpackage.
+ * Mirrors upstream `sqlite-vec/index.cjs::platformPackageName`. Note that
+ * `process.platform` is `"win32"` but the npm package uses `"windows"`.
+ */
+function npmOsSegment(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "windows";
+  if (platform === "darwin") return "darwin";
+  return "linux";
+}
+
+function vec0Filename(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "vec0.dll";
+  if (platform === "darwin") return "vec0.dylib";
+  return "vec0.so";
+}
+
+/**
+ * Resolve the platform-specific vec0 binary in node_modules. Throws with a
+ * clear, actionable message if the optional dep wasn't installed for this
+ * platform — the resulting gateway would fail to load semantic memory.
+ */
+function resolveVec0SourceOrThrow(): string {
+  const pkg = `sqlite-vec-${npmOsSegment(process.platform)}-${process.arch}`;
+  const fname = vec0Filename(process.platform);
+  try {
+    const req = createRequire(import.meta.url);
+    return req.resolve(`${pkg}/${fname}`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `compile-gateway: native dep "${pkg}" not found in node_modules (${msg}); ` +
+        `bun install may have skipped it on this platform — the resulting gateway binary cannot load semantic memory.`,
+    );
+  }
+}
+
+function copyVec0Sidecar(): void {
+  const src = resolveVec0SourceOrThrow();
+  const dest = join(distDir, vec0Filename(process.platform));
+  copyFileSync(src, dest);
+  const size = statSync(dest).size;
+  process.stdout.write(
+    `compile-gateway: copied ${src} → ${dest} (${String(size)} bytes)\n`,
+  );
+}
+```
+
+Add the import at the top:
+
+```ts
+import { createRequire } from "node:module";
+```
+
+Replace the final lines of `main()` (the `process.exit(...)` after `spawnSync`):
+
+```ts
+  const status = r.status === null ? 1 : r.status;
+  if (status !== 0) {
+    process.exit(status);
+  }
+  copyVec0Sidecar();
+  process.exit(0);
+```
+
+- [ ] **Step 2: Kill any running gateway and run the build**
+
+```
+# kill stale processes that hold the binary
+tasklist 2>&1 | grep -iE "nimbus" | awk '{print $2}' | xargs -I{} taskkill //PID {} //F 2>&1   # Windows (Bash tool / mingw)
+# OR  pkill -f nimbus-gateway   # macOS / Linux
+
+bun run build
+```
+
+Expected output (last few lines):
+
+```
+compile-gateway: copied <repoRoot>/packages/gateway/node_modules/.bun/sqlite-vec-windows-x64@0.1.9/node_modules/sqlite-vec-windows-x64/vec0.dll → <repoRoot>/dist/vec0.dll (NNNNNN bytes)
+@nimbus/gateway build: Exited with code 0
+```
+
+(Exact paths vary by platform; `vec0.so` on Linux, `vec0.dylib` on macOS.)
+
+- [ ] **Step 3: Verify the sidecar exists in `dist/`**
+
+```
+ls -la dist/vec0.* dist/nimbus-gateway*
+```
+
+Expected: a `dist/vec0.{dll|so|dylib}` matching the host platform, sized in the low MB range, and `dist/nimbus-gateway{.exe}` next to it.
+
+- [ ] **Step 4: Smoke-test the binary loads vec via the sidecar**
+
+```
+# Stop any running gateway
+./packages/cli/dist/nimbus stop  || true   # OK if not running
+./packages/cli/dist/nimbus start
+bun scripts/diagnose-bug-005.ts
+```
+
+Expected `[diag]` output to include:
+
+```
+[diag] sqlite-vec loaded on fresh connection: false
+[diag] tryLoadSqliteVec(db) -> true
+```
+
+(The "fresh connection" line is `false` because the diagnostic opens a brand-new connection and vec isn't auto-loaded; the manual `tryLoadSqliteVec` call then succeeds via the npm package OR the sidecar fallback. Both pass.)
+
+Then submit a single TUI prompt to exercise the gateway-side load:
+
+```
+./packages/cli/dist/nimbus tui
+# type: hi
+# wait for reply, then Ctrl+C twice
+```
+
+Re-run the diagnostic:
+
+```
+bun scripts/diagnose-bug-005.ts
+```
+
+Expected `[summary]` line: `✅ session_memory has N rows across recent sessions.` (was `zero rows` before this fix.)
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/gateway/compile-gateway.ts
+git commit -m "build(gateway): copy vec0.{ext} sidecar into dist/ after compile (BUG-009)"
+```
+
+---
+
+## Task 5: Bug log entry for BUG-009
+
+**Files:**
+- Modify: `docs/release/v0.1.0-smoke-bugs.md`
+
+- [ ] **Step 1: Add a row to the bug index table**
+
+Open `docs/release/v0.1.0-smoke-bugs.md`. Find the index table (top of the file). Add a row after the BUG-007 row:
+
+```markdown
+| BUG-009 | `sqlite-vec` native binary doesn't survive `bun build --compile`; semantic memory silently disabled in shipped gateway | high (root cause of BUG-005-c, blocks semantic recall) | gateway / build pipeline | fixed |
+```
+
+- [ ] **Step 2: Add the BUG-009 section at the bottom of the file**
+
+Append at the end of `docs/release/v0.1.0-smoke-bugs.md`:
+
+```markdown
+---
+
+## BUG-009 — `sqlite-vec` native binary doesn't survive `bun build --compile`
+
+**Severity:** high. Root cause of BUG-005-c (memory writes silently no-op'd in the compiled binary) and the blocker for any future feature that depends on a native dep packaged via npm `optionalDependencies` plus `require.resolve`.
+**Surface:** gateway compile pipeline + the sqlite-vec load wrapper.
+**Status:** fixed. (a) `packages/gateway/compile-gateway.ts` now copies the platform-matching `vec0.{dll|so|dylib}` from `node_modules/sqlite-vec-{os}-{arch}/` into `<repoRoot>/dist/` next to `nimbus-gateway`. (b) `packages/gateway/src/index/sqlite-vec-load.ts` falls back to `dirname(process.execPath) + vec0.{ext}` when the upstream `loadSqliteVec(db)` throws (which it always does in the compiled binary because `require.resolve` can't see node_modules from inside the embedded VFS). (c) Pino `debug`-level logs cover the load chain (`via:"npm"`, `via:"sidecar"`, `sidecar not found`) so future support has observability without changing the silent-degrade UX. Regression coverage in `packages/gateway/src/index/sqlite-vec-load.test.ts` (10 tests). Design + review-feedback table at `docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md`.
+**First seen:** investigation of BUG-005-c, 2026-05-08.
+
+### Repro
+
+Pre-fix, with the gateway running from the compiled binary:
+
+```powershell
+bun scripts/diagnose-bug-005.ts
+# [diag] sqlite-vec loaded on fresh connection: false
+# [diag] tryLoadSqliteVec(db) -> true   # works in dev (this script)
+# but the gateway's own connection: ensureReady() returns false → 0 rows
+```
+
+In a TUI session, multi-turn memory was silently broken even though the JS-side `append` and `getRecentTurns` looked correct — `ensureSqliteVecForConnection` returned `false` because vec wasn't loadable, gating every store method.
+
+### Workaround until fixed
+
+None at the binary level. Workarounds were the layered fixes in BUG-005 (TUI sessionId threading, embedding decoupling, schema-only readiness split) — only the schema-only split can be partially undone now that the root cause is fixed.
+
+### Verification
+
+- After fix: `dist/vec0.{ext}` is present after `bun run build`.
+- After fix: `bun scripts/diagnose-bug-005.ts` reports `session_memory has N rows` after a TUI session run against the compiled gateway.
+- After fix: `packages/gateway/src/index/sqlite-vec-load.test.ts` covers `sidecarFilename`, `sidecarPath`, `tryLoadFromSidecar` (success / missing-file / load-throws), and `tryLoadSqliteVec` upstream success.
+
+### Out-of-scope follow-ups
+
+- **BUG-009-b:** ship the ONNX runtime native deps the same way so `@xenova/transformers` works in the compiled binary and the embedding worker initializes successfully. Without this, semantic recall stays disabled even with vec working — but literal-turn replay (the BUG-005 primary use case) doesn't need it.
+- **`nimbus doctor` vec check:** at gateway start (or via the `doctor` command), probe `vec_version()` on a fresh connection and surface an actionable warning if it fails.
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add docs/release/v0.1.0-smoke-bugs.md
+git commit -m "docs(release): record BUG-009 (sqlite-vec native dep sidecar) as fixed"
+```
+
+---
+
+## Task 6: Preflight, push, open PR
+
+**Files:**
+- (no source changes; this is shipping the work)
+
+- [ ] **Step 1: Run preflight (CI-parity targeted subset, per the project's durable rule)**
+
+```
+bun run typecheck
+bun run lint
+bun test packages/gateway/src/index/sqlite-vec-load.test.ts \
+         packages/gateway/src/memory/session-memory-store.test.ts \
+         packages/gateway/src/engine/run-ask.test.ts
+```
+
+Expected:
+- `typecheck` exits 0 across all packages.
+- `lint` exits 0.
+- All listed tests pass.
+
+If any step fails, fix and re-run before pushing.
+
+- [ ] **Step 2: Push the branch**
+
+```
+git push -u origin dev/asafgolombek/v0.1.0-bug-009-sqlite-vec-sidecar
+```
+
+- [ ] **Step 3: Open the PR**
+
+```
+gh pr create \
+  --title "fix(gateway): ship sqlite-vec as sidecar binary alongside the compiled gateway (BUG-009)" \
+  --body "$(cat docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md | head -60)
+
+Full design: docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md
+Implementation plan: docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Note the PR URL it returns and watch CI from there.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Each design section maps to a task.
+
+| Spec section | Plan task |
+|---|---|
+| §1 Compile script copies vec0.{ext} | Task 4 |
+| §2 Load wrapper sidecar fallback | Task 1 (helpers) + Task 2 (fallback) + Task 3 (chain) |
+| §3 Coverage | Task 1, 2, 3 unit tests + Task 4 manual smoke |
+| §4 Failure mode silent degrade | Task 2 step 3 (returns false silently with debug log only) |
+| Review-feedback dispositions | Task 4 step 1 has the verbatim error string (item 8); Task 2 step 3 has debug logs (item 4); Task 4 step 1 has the `npmOsSegment` mapping comment (item 6); deferred items are tracked in the spec only — no plan tasks |
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" / vague-error-handling / "similar to Task N" patterns.
+
+**Type consistency:** `sidecarFilename(platform)`, `sidecarPath(execPath, platform)`, `tryLoadFromSidecar(db, baseDir)` all keep the same signatures across Tasks 1–3. The compile-script helpers (`npmOsSegment`, `vec0Filename`) are local to `compile-gateway.ts` and don't collide with the runtime helpers.
+
+**Scope check:** One PR. Single feature: sidecar-bundle vec0 + load-from-sidecar fallback. ONNX and `nimbus doctor` are explicitly deferred and listed as out-of-scope follow-ups.

--- a/docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md
+++ b/docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md
@@ -1,0 +1,103 @@
+# BUG-009 — Ship `sqlite-vec` as a sidecar binary alongside the compiled gateway
+
+**Status:** approved · **Author:** asafgolombek · **Date:** 2026-05-08
+
+## Problem
+
+`bun build --compile` produces a self-contained `nimbus-gateway.exe` by bundling all imported JS into the binary's embedded virtual filesystem. Native dependencies that are loaded via `require.resolve()` at runtime — specifically `sqlite-vec`'s platform-specific shared library (`vec0.dll` on Windows, `vec0.so` on Linux, `vec0.dylib` on macOS) — do **not** survive the compile: the JS shim still calls `require.resolve("sqlite-vec-windows-x64/vec0.dll")`, but at runtime that resolves to a path inside the embedded VFS where SQLite's `loadExtension` cannot read the file as a real OS binary.
+
+Observable consequences in the production gateway binary:
+
+- `tryLoadSqliteVec(db)` returns `false`.
+- `ensureSqliteVecForConnection` returns `false`.
+- `SessionMemoryStore.ensureReady()` returns `false` → both `append()` and `getRecentTurns()` silently no-op (root cause of BUG-005-c, currently worked around by a vec-decoupled split that is intentionally not in `main`).
+- Semantic recall is disabled across the board.
+
+This spec covers `sqlite-vec` only. ONNX / `@xenova/transformers` (the embedding worker) has the same shape of failure but is tracked separately and stays out of scope.
+
+## Goals
+
+- `db.loadExtension(...)` succeeds in the compiled gateway binary on every supported platform.
+- After the fix, the per-platform release artifacts in `dist/` contain everything required to boot the gateway with vec available — no separate `npm install` step on the user's machine.
+- The fix is invisible at the API surface: callers of `tryLoadSqliteVec` continue to call it the same way; only the resolver underneath changes.
+- Failure mode when `vec0.{ext}` is missing remains "silent degrade" — identical to today's behavior. No new noisy startup errors, no new ways to refuse to start.
+
+## Non-goals
+
+- Bundling ONNX runtime / `@xenova/transformers` native deps. Tracked as a separate follow-up.
+- Adding a `nimbus doctor` check for the missing native binary. Adjacent and useful, but adjacent scope.
+- Changing the dev-mode load path (`bun run`, `bun test`). Those keep using the upstream `sqlite-vec` package's `require.resolve` from `node_modules` and stay unchanged.
+- Cross-platform fat binaries. One install carries one platform's `vec0` file.
+
+## Design
+
+### 1. Compile script — copy `vec0.{ext}` into `dist/`
+
+`packages/gateway/compile-gateway.ts` already orchestrates `bun build --compile --outfile ../../dist/nimbus-gateway`. After the build succeeds, add a copy step:
+
+1. Resolve the platform-specific package path via `require.resolve("sqlite-vec-{os}-{arch}/vec0.{ext}")` from the gateway package directory. The naming convention matches upstream `sqlite-vec/index.cjs:platformPackageName(...)`.
+2. Copy the resolved file to `<repoRoot>/dist/vec0.{dll|so|dylib}` next to the gateway binary.
+3. Log the source path, destination, and file size on stdout. If `require.resolve` throws (because the optional dep wasn't installed for this platform), emit a clear stderr line and exit non-zero — the build artifact would be unusable.
+
+Per-platform extension mapping (mirrors upstream `extensionSuffix(platform)`):
+
+| `process.platform` | extension |
+|---|---|
+| `win32` | `.dll` |
+| `darwin` | `.dylib` |
+| (everything else: `linux`, etc.) | `.so` |
+
+### 2. Load wrapper — sidecar fallback
+
+`packages/gateway/src/index/sqlite-vec-load.ts` keeps its current public API. The change is internal: `tryLoadSqliteVec` chains to a sidecar resolver if the upstream loader throws.
+
+```ts
+export function tryLoadSqliteVec(db: Database): boolean {
+  try {
+    loadSqliteVec(db);   // upstream — works in dev (node_modules present)
+    return true;
+  } catch {
+    return tryLoadFromSidecar(db);   // works in compiled binary (vec0 next to .exe)
+  }
+}
+
+function tryLoadFromSidecar(db: Database): boolean {
+  try {
+    const sidecar = join(dirname(process.execPath), sidecarFilename());
+    if (!existsSync(sidecar)) return false;
+    db.loadExtension(sidecar);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sidecarFilename(): string {
+  if (process.platform === "win32") return "vec0.dll";
+  if (process.platform === "darwin") return "vec0.dylib";
+  return "vec0.so";
+}
+```
+
+`loadSqliteVecOrThrow` keeps its current behavior — wraps the chain and re-throws with the existing actionable message if both attempts fail.
+
+### 3. Coverage
+
+- **New unit test** at `packages/gateway/src/index/sqlite-vec-load.test.ts`. With a fake `db` whose `loadExtension(path)` records the path argument and `existsSync` mocked to return true for a temp directory, verify the fallback resolves to `dirname(process.execPath) + sidecarFilename()`.
+- **Existing BUG-005 tests** in `packages/gateway/src/memory/session-memory-store.test.ts` continue to provide end-to-end coverage. They run with vec loadable (test mode uses upstream `sqlite-vec` from `node_modules`), so they verify the loader still works in dev mode after the wrapper changes.
+- **Manual verify post-merge:** run `verify-bug-005.ps1` against the compiled gateway binary, then check `bun scripts/diagnose-bug-005.ts`. Expected: `session_memory has N rows` after a multi-turn TUI session, and `[diag] sqlite-vec loaded on fresh connection: true` against a connection opened by the running gateway.
+
+### 4. Failure mode — silent degrade
+
+When `vec0.{ext}` is not next to the gateway binary at runtime, `tryLoadSqliteVec` returns `false` (same as today). `SessionMemoryStore.ensureReady()` returns `false`, and semantic memory is silently disabled. No log line, no startup gate, no panic. The release-engineering side of this is "ensure the build pipeline produces the right artifact"; the runtime side accepts the consequences if it doesn't.
+
+## Risks
+
+- **Cross-platform release pipelines must each produce their own `vec0`.** When `release.yml` builds for Linux, macOS-x64, macOS-arm64, and Windows-x64 in matrix jobs, each job's compile step must run on a runner where `sqlite-vec-{platform}` is installed. This is implicit because each runner does its own `bun install`, but the compile script's hard-fail (point 1) makes the dependency explicit and noisy.
+- **`process.execPath` semantics.** When users symlink or wrap the binary, `process.execPath` is the real path, not the link path — the sidecar must live next to the real file. Fine for our official artifacts; users who hand-package may trip on this.
+- **Optional-dep install gotchas.** `bun install` may skip the platform-specific subpackage on some constrained CI containers; the build will hard-fail with a clear message rather than silently producing a broken binary.
+
+## Out-of-scope follow-ups
+
+- **BUG-009-b (separate spec):** ship the ONNX runtime native deps the same way, so `@xenova/transformers` works in the compiled binary and the embedding worker initializes successfully. Without this, semantic recall stays disabled even with vec working — but literal-turn replay (the BUG-005 primary path) doesn't need it.
+- **`nimbus doctor` vec check:** at gateway start (or via the `doctor` command), probe `vec_version()` on a fresh connection and surface an actionable warning if it fails. Eight-line addition; defer to a follow-up so this PR stays scoped to the build/load fix.

--- a/docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md
+++ b/docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md
@@ -35,39 +35,48 @@ This spec covers `sqlite-vec` only. ONNX / `@xenova/transformers` (the embedding
 
 `packages/gateway/compile-gateway.ts` already orchestrates `bun build --compile --outfile ../../dist/nimbus-gateway`. After the build succeeds, add a copy step:
 
-1. Resolve the platform-specific package path via `require.resolve("sqlite-vec-{os}-{arch}/vec0.{ext}")` from the gateway package directory. The naming convention matches upstream `sqlite-vec/index.cjs:platformPackageName(...)`.
+1. Resolve the platform-specific package path via `require.resolve("sqlite-vec-{os}-{arch}/vec0.{ext}")` from the gateway package directory. The npm package's `os` segment is **`windows` on Windows**, `linux` and `darwin` elsewhere (see mapping below — `process.platform === "win32"` does NOT match the package name segment, so the build script must translate). The convention matches upstream `sqlite-vec/index.cjs:platformPackageName(...)`.
 2. Copy the resolved file to `<repoRoot>/dist/vec0.{dll|so|dylib}` next to the gateway binary.
-3. Log the source path, destination, and file size on stdout. If `require.resolve` throws (because the optional dep wasn't installed for this platform), emit a clear stderr line and exit non-zero — the build artifact would be unusable.
+3. Log the source path, destination, and file size on stdout. If `require.resolve` throws (because the optional dep wasn't installed for this platform), emit a stderr line of the form `compile-gateway: native dep "sqlite-vec-{os}-{arch}" not found in node_modules; bun install may have skipped it on this platform — the resulting gateway binary cannot load semantic memory.` and exit non-zero. The hard-fail is intentional: silently producing a binary without `vec0` would be the same regression we're fixing.
 
-Per-platform extension mapping (mirrors upstream `extensionSuffix(platform)`):
+Per-platform mapping (mirrors upstream `platformPackageName` + `extensionSuffix`):
 
-| `process.platform` | extension |
-|---|---|
-| `win32` | `.dll` |
-| `darwin` | `.dylib` |
-| (everything else: `linux`, etc.) | `.so` |
+| `process.platform` | npm `os` segment | extension |
+|---|---|---|
+| `win32` | `windows` | `.dll` |
+| `darwin` | `darwin` | `.dylib` |
+| (everything else: `linux`, etc.) | `linux` | `.so` |
 
 ### 2. Load wrapper — sidecar fallback
 
 `packages/gateway/src/index/sqlite-vec-load.ts` keeps its current public API. The change is internal: `tryLoadSqliteVec` chains to a sidecar resolver if the upstream loader throws.
 
 ```ts
+const log = pino({ name: "sqlite-vec-load", level: process.env.NIMBUS_LOG_LEVEL ?? "info" });
+
 export function tryLoadSqliteVec(db: Database): boolean {
   try {
     loadSqliteVec(db);   // upstream — works in dev (node_modules present)
+    log.debug({ via: "npm" }, "sqlite-vec loaded");
     return true;
-  } catch {
+  } catch (e) {
+    log.debug({ err: (e as Error).message }, "upstream sqlite-vec load failed; trying sidecar");
     return tryLoadFromSidecar(db);   // works in compiled binary (vec0 next to .exe)
   }
 }
 
 function tryLoadFromSidecar(db: Database): boolean {
+  const sidecar = join(dirname(process.execPath), sidecarFilename());
+  if (!existsSync(sidecar)) {
+    log.debug({ sidecar }, "sqlite-vec sidecar not found; semantic memory disabled");
+    return false;
+  }
   try {
-    const sidecar = join(dirname(process.execPath), sidecarFilename());
-    if (!existsSync(sidecar)) return false;
     db.loadExtension(sidecar);
+    log.debug({ via: "sidecar", sidecar }, "sqlite-vec loaded");
     return true;
-  } catch {
+  } catch (e) {
+    log.debug({ sidecar, err: (e as Error).message }, "sqlite-vec sidecar load failed");
     return false;
   }
 }
@@ -78,6 +87,8 @@ function sidecarFilename(): string {
   return "vec0.so";
 }
 ```
+
+The log lines are `debug` level by design — they don't surface to a user running `nimbus start` at default log level, but `NIMBUS_LOG_LEVEL=debug nimbus start` (or the gateway log file at debug level) shows the full attempt chain. This satisfies the "silent degrade for users, observable for support" balance.
 
 `loadSqliteVecOrThrow` keeps its current behavior — wraps the chain and re-throws with the existing actionable message if both attempts fail.
 
@@ -101,3 +112,19 @@ When `vec0.{ext}` is not next to the gateway binary at runtime, `tryLoadSqliteVe
 
 - **BUG-009-b (separate spec):** ship the ONNX runtime native deps the same way, so `@xenova/transformers` works in the compiled binary and the embedding worker initializes successfully. Without this, semantic recall stays disabled even with vec working — but literal-turn replay (the BUG-005 primary path) doesn't need it.
 - **`nimbus doctor` vec check:** at gateway start (or via the `doctor` command), probe `vec_version()` on a fresh connection and surface an actionable warning if it fails. Eight-line addition; defer to a follow-up so this PR stays scoped to the build/load fix.
+
+## Responses to external review feedback
+
+External review at `docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-feedback.md` (Gemini CLI, 2026-05-08). Each item verified against the codebase before disposition.
+
+| # | Item | Disposition | Reason |
+|---|---|---|---|
+| 1 | Cross-compilation: `bun install` may not fetch optional deps for non-host platforms | **Defer (not applicable)** | Verified `release.yml` lines 74–101: `compile-gateway` job uses a 4-platform matrix where each artifact is built on its **native** runner (`ubuntu-24.04`, `macos-15-intel`, `macos-15`, `windows-2025`). No cross-compile step exists; each runner's own `bun install` picks up its matching `sqlite-vec-{os}-{arch}` optional dep automatically. The risk Gemini flagged is real for cross-compile pipelines — ours isn't one. |
+| 2 | macOS signing of `vec0.dylib` | **Defer to Phase 6** | `release.yml` has no `codesign`/`notarytool` step today — `nimbus-gateway` ships unsigned in v0.1.0. macOS code signing is owned by the Phase 6 `desktop-v0.1.0` track per CLAUDE.md non-negotiable table. When that lands, the sidecar joins the same sign-everything-in-the-bundle step. |
+| 3 | Tauri bundling | **Defer to Phase 6** | Tauri release vehicle is deferred from `v0.1.0` to Phase 6 (`desktop-v0.1.0`) per CLAUDE.md. v0.1.0 ships only the headless gateway + CLI + VS Code extension; no Tauri bundle to integrate with. The sidecar will need a brief revisit when Tauri bundles the gateway-as-sidecar. |
+| 4 | Logging: silent-degrade obscures support diagnosis | **Fix** | Added pino `debug`-level log lines in `tryLoadSqliteVec` and `tryLoadFromSidecar` covering all three branches (npm-resolved / sidecar-resolved / both-failed). `debug` level keeps it invisible to default users (preserves the silent-degrade UX choice) but visible at `NIMBUS_LOG_LEVEL=debug` and in the gateway log file when log level is debug. |
+| 5 | Pull `nimbus doctor` vec check forward into this PR | **Defer (tracked follow-up)** | User explicitly scoped this out to keep the PR focused on the build/load fix. The follow-up is small (~20 LOC) and listed in this spec under "Out-of-scope follow-ups". |
+| 6 | Explicit `win32` → `windows` mapping for npm package name segment | **Fix** | Real implementer trap. The mapping table is now explicit in §1: shows `process.platform`, the npm `os` segment, and the extension separately. Build script translates `win32` → `windows` when building the package name. |
+| 7 | Linux distro variance (gnu vs musl) | **Defer (upstream limitation)** | `node_modules/sqlite-vec/package.json` lists only `linux-x64` and `linux-arm64` optional deps — no `-musl` variants. On Alpine the upstream package fails today, and our sidecar pipeline doesn't make it worse: same prebuilt artifact, same OS-level behavior. If/when upstream ships musl builds, our pipeline picks them up automatically. |
+| 8 | `require.resolve` error wording | **Already addressed (strengthened)** | Spec already required exit-non-zero with a clear stderr line; the message in §1 is now spelled out verbatim ("native dep \"sqlite-vec-{os}-{arch}\" not found … the resulting gateway binary cannot load semantic memory.") so reviewers and CI logs see exactly what's missing. |
+| 9 | Sidecar filename: namespacing vs upstream-compatible | **No change** | User picked the upstream-compatible name (`vec0.{ext}`) in the brainstorm; Gemini agrees ("sticking to the upstream name is likely safer for compatibility"). |

--- a/packages/gateway/compile-gateway.ts
+++ b/packages/gateway/compile-gateway.ts
@@ -4,7 +4,8 @@
  * Terminate the compiled gateway process, rotate the existing binary aside, then compile.
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, renameSync, unlinkSync } from "node:fs";
+import { copyFileSync, existsSync, renameSync, statSync, unlinkSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +35,47 @@ function rotateExistingBinaryOrThrow(): void {
   if (existsSync(outfileAbs)) {
     renameSync(outfileAbs, prevAbs);
   }
+}
+
+// `process.platform === "win32"` but the npm sub-package uses "windows".
+function npmOsSegment(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "windows";
+  if (platform === "darwin") return "darwin";
+  return "linux";
+}
+
+function vec0Filename(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "vec0.dll";
+  if (platform === "darwin") return "vec0.dylib";
+  return "vec0.so";
+}
+
+// Two-step resolve: `sqlite-vec-{os}-{arch}` is an optionalDependency of sqlite-vec,
+// not of @nimbus/gateway. Under Bun's isolated install layout, createRequire rooted
+// at this file can't see it; createRequire rooted at the resolved sqlite-vec entry
+// point can — same trick upstream sqlite-vec/index.cjs uses internally.
+function resolveVec0SourceOrThrow(): string {
+  const pkg = `sqlite-vec-${npmOsSegment(process.platform)}-${process.arch}`;
+  const fname = vec0Filename(process.platform);
+  try {
+    const sqliteVecIndex = createRequire(import.meta.url).resolve("sqlite-vec");
+    const reqFromVec = createRequire(sqliteVecIndex);
+    return reqFromVec.resolve(`${pkg}/${fname}`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `compile-gateway: native dep "${pkg}" not found in node_modules (${msg}); ` +
+        `bun install may have skipped it on this platform — the resulting gateway binary cannot load semantic memory.`,
+    );
+  }
+}
+
+function copyVec0Sidecar(): void {
+  const src = resolveVec0SourceOrThrow();
+  const dest = join(distDir, vec0Filename(process.platform));
+  copyFileSync(src, dest);
+  const size = statSync(dest).size;
+  process.stdout.write(`compile-gateway: copied ${src} → ${dest} (${String(size)} bytes)\n`);
 }
 
 async function main(): Promise<void> {
@@ -69,7 +111,12 @@ async function main(): Promise<void> {
     { cwd: gatewayPkgDir, stdio: "inherit", env: process.env },
   );
 
-  process.exit(r.status === null ? 1 : r.status);
+  const status = r.status === null ? 1 : r.status;
+  if (status !== 0) {
+    process.exit(status);
+  }
+  copyVec0Sidecar();
+  process.exit(0);
 }
 
 await main();

--- a/packages/gateway/src/index/sqlite-vec-load.test.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.test.ts
@@ -1,7 +1,10 @@
+import type { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { sidecarFilename, sidecarPath } from "./sqlite-vec-load.ts";
+import { sidecarFilename, sidecarPath, tryLoadFromSidecar } from "./sqlite-vec-load.ts";
 
 describe("sidecarFilename", () => {
   test("win32 → vec0.dll", () => {
@@ -28,5 +31,63 @@ describe("sidecarPath", () => {
     expect(sidecarPath("C:\\Program Files\\Nimbus\\nimbus-gateway.exe", "win32")).toBe(
       join("C:\\Program Files\\Nimbus", "vec0.dll"),
     );
+  });
+});
+
+describe("tryLoadFromSidecar", () => {
+  test("calls db.loadExtension with the sidecar path when the file exists", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "nimbus-vec-sidecar-"));
+    const fname = sidecarFilename(process.platform);
+    writeFileSync(join(tmp, fname), "");
+    const calls: string[] = [];
+    const fakeDb = {
+      loadExtension: (p: string) => {
+        calls.push(p);
+      },
+    } as unknown as Database;
+
+    const ok = tryLoadFromSidecar(fakeDb, tmp);
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([join(tmp, fname)]);
+  });
+
+  test("returns false silently when the sidecar file is missing", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "nimbus-vec-sidecar-empty-"));
+    const fakeDb = {
+      loadExtension: (_p: string) => {
+        throw new Error("should not be called when sidecar is absent");
+      },
+    } as unknown as Database;
+
+    const ok = tryLoadFromSidecar(fakeDb, tmp);
+
+    expect(ok).toBe(false);
+  });
+
+  test("returns false when db.loadExtension throws (e.g. corrupt binary)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "nimbus-vec-sidecar-corrupt-"));
+    writeFileSync(join(tmp, sidecarFilename(process.platform)), "");
+    const fakeDb = {
+      loadExtension: (_p: string) => {
+        throw new Error("not a valid extension");
+      },
+    } as unknown as Database;
+
+    const ok = tryLoadFromSidecar(fakeDb, tmp);
+
+    expect(ok).toBe(false);
+  });
+
+  test("falls back to dirname(process.execPath) as default baseDir", () => {
+    // process.execPath in tests is the Bun binary; vec0.{ext} won't be next to it,
+    // so the function must return false without throwing — exercising the default-arg branch.
+    const fakeDb = {
+      loadExtension: (_p: string) => {
+        throw new Error("should not be called when sidecar is absent");
+      },
+    } as unknown as Database;
+
+    expect(tryLoadFromSidecar(fakeDb)).toBe(false);
   });
 });

--- a/packages/gateway/src/index/sqlite-vec-load.test.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.test.ts
@@ -1,10 +1,15 @@
-import type { Database } from "bun:sqlite";
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { sidecarFilename, sidecarPath, tryLoadFromSidecar } from "./sqlite-vec-load.ts";
+import {
+  sidecarFilename,
+  sidecarPath,
+  tryLoadFromSidecar,
+  tryLoadSqliteVec,
+} from "./sqlite-vec-load.ts";
 
 describe("sidecarFilename", () => {
   test("win32 → vec0.dll", () => {
@@ -89,5 +94,19 @@ describe("tryLoadFromSidecar", () => {
     } as unknown as Database;
 
     expect(tryLoadFromSidecar(fakeDb)).toBe(false);
+  });
+});
+
+// IMPORTANT: this test exercises tryLoadSqliteVec end-to-end with a real
+// in-memory db. On any platform where the upstream `sqlite-vec` package is
+// installed (every dev / CI machine), upstream succeeds and the fallback is
+// never reached. We assert the success-via-upstream path here; the
+// fallback chain is covered by tryLoadFromSidecar's own tests above.
+describe("tryLoadSqliteVec — upstream-first chain", () => {
+  test("returns true on a fresh db when upstream sqlite-vec is installed", () => {
+    const db = new Database(":memory:");
+    const ok = tryLoadSqliteVec(db);
+    expect(ok).toBe(true);
+    db.close();
   });
 });

--- a/packages/gateway/src/index/sqlite-vec-load.test.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix as posixPath, win32 as winPath } from "node:path";
 
 import {
   sidecarFilename,
@@ -27,14 +27,16 @@ describe("sidecarFilename", () => {
 });
 
 describe("sidecarPath", () => {
-  test("returns vec0.{ext} adjacent to the given exec path", () => {
+  // Platform-explicit `posix.join` / `win32.join` — must not depend on host OS
+  // (a Linux runner asserting a Windows-shaped path is the regression that broke CI).
+  test("returns vec0.{ext} adjacent to the given exec path (linux)", () => {
     expect(sidecarPath("/opt/nimbus/bin/nimbus-gateway", "linux")).toBe(
-      join("/opt/nimbus/bin", "vec0.so"),
+      posixPath.join("/opt/nimbus/bin", "vec0.so"),
     );
   });
   test("works for a Windows-style path", () => {
     expect(sidecarPath("C:\\Program Files\\Nimbus\\nimbus-gateway.exe", "win32")).toBe(
-      join("C:\\Program Files\\Nimbus", "vec0.dll"),
+      winPath.join("C:\\Program Files\\Nimbus", "vec0.dll"),
     );
   });
 });

--- a/packages/gateway/src/index/sqlite-vec-load.test.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import { sidecarFilename, sidecarPath } from "./sqlite-vec-load.ts";
+
+describe("sidecarFilename", () => {
+  test("win32 → vec0.dll", () => {
+    expect(sidecarFilename("win32")).toBe("vec0.dll");
+  });
+  test("darwin → vec0.dylib", () => {
+    expect(sidecarFilename("darwin")).toBe("vec0.dylib");
+  });
+  test("linux → vec0.so", () => {
+    expect(sidecarFilename("linux")).toBe("vec0.so");
+  });
+  test("any other Unix-shaped platform → vec0.so", () => {
+    expect(sidecarFilename("freebsd")).toBe("vec0.so");
+  });
+});
+
+describe("sidecarPath", () => {
+  test("returns vec0.{ext} adjacent to the given exec path", () => {
+    expect(sidecarPath("/opt/nimbus/bin/nimbus-gateway", "linux")).toBe(
+      join("/opt/nimbus/bin", "vec0.so"),
+    );
+  });
+  test("works for a Windows-style path", () => {
+    expect(sidecarPath("C:\\Program Files\\Nimbus\\nimbus-gateway.exe", "win32")).toBe(
+      join("C:\\Program Files\\Nimbus", "vec0.dll"),
+    );
+  });
+});

--- a/packages/gateway/src/index/sqlite-vec-load.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.ts
@@ -1,6 +1,13 @@
 import type { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
+import pino from "pino";
 import { load as loadSqliteVec } from "sqlite-vec";
+
+const log = pino({
+  name: "sqlite-vec-load",
+  level: process.env["NIMBUS_LOG_LEVEL"] ?? "info",
+});
 
 /**
  * Loads the sqlite-vec extension into this connection.
@@ -68,4 +75,24 @@ export function sidecarFilename(platform: NodeJS.Platform): string {
 // Compiled-binary fallback path: vec0.{ext} adjacent to the running executable.
 export function sidecarPath(execPath: string, platform: NodeJS.Platform): string {
   return join(dirname(execPath), sidecarFilename(platform));
+}
+
+export function tryLoadFromSidecar(
+  db: Database,
+  baseDir: string = dirname(process.execPath),
+): boolean {
+  const path = join(baseDir, sidecarFilename(process.platform));
+  if (!existsSync(path)) {
+    log.debug({ sidecar: path }, "sqlite-vec sidecar not found; semantic memory disabled");
+    return false;
+  }
+  try {
+    db.loadExtension(path);
+    log.debug({ via: "sidecar", sidecar: path }, "sqlite-vec loaded");
+    return true;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.debug({ sidecar: path, err: msg }, "sqlite-vec sidecar load failed");
+    return false;
+  }
 }

--- a/packages/gateway/src/index/sqlite-vec-load.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite";
+import { dirname, join } from "node:path";
 import { load as loadSqliteVec } from "sqlite-vec";
 
 /**
@@ -56,4 +57,15 @@ export function ensureSqliteVecForConnection(db: Database, indexedUserVersion: n
   } catch {
     return tryLoadSqliteVec(db);
   }
+}
+
+export function sidecarFilename(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "vec0.dll";
+  if (platform === "darwin") return "vec0.dylib";
+  return "vec0.so";
+}
+
+// Compiled-binary fallback path: vec0.{ext} adjacent to the running executable.
+export function sidecarPath(execPath: string, platform: NodeJS.Platform): string {
+  return join(dirname(execPath), sidecarFilename(platform));
 }

--- a/packages/gateway/src/index/sqlite-vec-load.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, posix as posixPath, win32 as winPath } from "node:path";
 import pino from "pino";
 import { load as loadSqliteVec } from "sqlite-vec";
 
@@ -73,8 +73,11 @@ export function sidecarFilename(platform: NodeJS.Platform): string {
 }
 
 // Compiled-binary fallback path: vec0.{ext} adjacent to the running executable.
+// Uses the platform-specific path module so the result is correct regardless of host OS
+// (a Linux CI runner computing a Windows path must not rely on POSIX `dirname`/`join`).
 export function sidecarPath(execPath: string, platform: NodeJS.Platform): string {
-  return join(dirname(execPath), sidecarFilename(platform));
+  const p = platform === "win32" ? winPath : posixPath;
+  return p.join(p.dirname(execPath), sidecarFilename(platform));
 }
 
 export function tryLoadFromSidecar(

--- a/packages/gateway/src/index/sqlite-vec-load.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.ts
@@ -16,9 +16,12 @@ const log = pino({
 export function tryLoadSqliteVec(db: Database): boolean {
   try {
     loadSqliteVec(db);
+    log.debug({ via: "npm" }, "sqlite-vec loaded");
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.debug({ err: msg }, "upstream sqlite-vec load failed; trying sidecar");
+    return tryLoadFromSidecar(db);
   }
 }
 
@@ -26,12 +29,9 @@ export function tryLoadSqliteVec(db: Database): boolean {
  * Loads sqlite-vec or throws with a short, actionable message (Gateway / tests).
  */
 export function loadSqliteVecOrThrow(db: Database): void {
-  try {
-    loadSqliteVec(db);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+  if (!tryLoadSqliteVec(db)) {
     throw new Error(
-      `sqlite-vec could not be loaded (${msg}). Embeddings require a supported platform (see sqlite-vec npm optionalDependencies).`,
+      "sqlite-vec could not be loaded. Embeddings require a supported platform (see sqlite-vec npm optionalDependencies).",
     );
   }
 }


### PR DESCRIPTION
## Summary

Make the `sqlite-vec` extension load successfully inside the compiled `nimbus-gateway` binary by shipping `vec0.{dll|so|dylib}` next to the executable and falling back to that path when the upstream npm resolver fails.

**Root cause:** `bun build --compile` bundles JS into the binary's embedded VFS, but native deps loaded via `require.resolve()` at runtime (sqlite-vec's platform-specific shared library) don't survive the compile — `loadExtension` can't read the VFS path as a real OS binary. This is the underlying cause of BUG-005-c (silent multi-turn-memory failure in the shipped gateway) and a blocker for any future feature that relies on `optionalDependencies` + `require.resolve` + a native binary.

**Fix:**
- `packages/gateway/compile-gateway.ts` post-build copies `node_modules/sqlite-vec-{os}-{arch}/vec0.{ext}` into `dist/` next to `nimbus-gateway`. Two-step `createRequire` is used because the platform sub-package is an `optionalDependency` of `sqlite-vec`, not a direct dep of `@nimbus/gateway`.
- `packages/gateway/src/index/sqlite-vec-load.ts` falls back to `dirname(process.execPath) + vec0.{ext}` when upstream `loadSqliteVec(db)` throws. `loadSqliteVecOrThrow` now delegates through the chain, so it gets the fallback for free.
- pino `debug` logs cover the load chain (`via:"npm"`, `via:"sidecar"`, `sidecar not found`) for support visibility without changing the silent-degrade UX.

## What's in
- 11 unit tests in `packages/gateway/src/index/sqlite-vec-load.test.ts` (helpers / fallback success/missing-file/load-throws/default-baseDir / chain regression guard)
- BUG-009 entry added to `docs/release/v0.1.0-smoke-bugs.md`

## Out of scope (tracked follow-ups)
- BUG-009-b: ship the ONNX runtime native deps the same way so `@xenova/transformers` works in the compiled binary.
- `nimbus doctor` `vec_version()` check at startup.

## Test plan
- [x] `bun test packages/gateway/src/index/sqlite-vec-load.test.ts` — 11 pass
- [x] `bun test packages/gateway/src/memory/session-memory-store.test.ts packages/gateway/src/engine/run-ask.test.ts` — 7 pass (no regression)
- [x] `bun run typecheck` — 37 packages clean
- [x] `bun run lint` — clean
- [x] `bun run --filter @nimbus/gateway build` — produces `dist/nimbus-gateway.exe` + `dist/vec0.dll` (289,280 bytes)
- [x] Full `bun run test:ci` — every test step **0 fail**, every coverage gate passed. The sole non-zero exit is `@nimbus/ui test:coverage` reporting `Error: Coverage APIs are not supported` (Vitest + Bun V8-coverage tooling regression, **pre-existing**). Verified by running UI tests without coverage: `bunx vitest run` → 493/493 pass. No files under `packages/ui/` are touched in this PR.
- [ ] **Manual smoke (run on the merged binary):** `nimbus stop && nimbus start && nimbus tui` for one round-trip, then `bun scripts/diagnose-bug-005.ts` — expect `session_memory has N rows` (was `zero rows` before this fix).

## Design + plan
- Spec: `docs/superpowers/specs/2026-05-08-bug-009-sqlite-vec-sidecar-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-bug-009-sqlite-vec-sidecar.md` (with the round-2 review-feedback dispositions table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)