### PR TITLE
chore(deps): bump fast-uri to 3.1.2 (patches GHSA-q3j6-qgpj-74h6)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -537,6 +537,7 @@
     },
   },
   "overrides": {
+    "fast-uri": "3.1.2",
     "protobufjs": "7.5.5",
     "sharp": "0.34.5",
   },
@@ -1871,7 +1872,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "overrides": {
     "sharp": "0.34.5",
-    "protobufjs": "7.5.5"
+    "protobufjs": "7.5.5",
+    "fast-uri": "3.1.2"
   },
   "workspaces": [
     "packages/gateway",


### PR DESCRIPTION
## Summary

`bun audit --audit-level high` flagged **fast-uri ≤3.1.0** as vulnerable to path traversal via percent-encoded dot segments ([GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6)). It was a transitive dep of:

- `@mastra/core` (gateway)
- `@modelcontextprotocol/sdk` (mcp-aws)
- `@vscode/vsce` (vscode-extension)
- `@astrojs/check` (docs)

## Fix

Root `package.json` `overrides` entry pinning `fast-uri` to `3.1.2`. The override is consistent with the existing `sharp` and `protobufjs` entries already in this block.

## Verification

- [x] `bun audit --audit-level high` — clean (was: 1 high)
- [x] `bun pm ls --all | grep fast-uri@` — single resolution: `fast-uri@3.1.2`
- [x] `bun run typecheck` — 37 packages, 0 errors
- [x] `bun run lint` — clean
- [x] `bun test packages/gateway/src` — 1205 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)