### PR TITLE
chore(claude): bootstrap Nimbus skills, safety hooks, and CLAUDE.md index

### DIFF
--- a/.claude/commands/nimbus-tauri-allowlist.md
+++ b/.claude/commands/nimbus-tauri-allowlist.md
@@ -1,0 +1,132 @@
+---
+name: nimbus-tauri-allowlist
+description: >
+  Reference for the Tauri renderer-callable IPC method allowlist (security invariant
+  `I7`). Use this skill whenever you are exposing a new Gateway IPC method to the
+  Tauri desktop UI, removing or renaming an existing renderer-callable method, marking
+  a method as long-running (no-timeout), classifying a notification for global
+  rebroadcast across windows, or auditing whether the renderer can reach an RCE-class
+  surface. Also trigger for questions like "should this method be in `ALLOWED_METHODS`?",
+  "why does the Rust allowlist test fail?", "is `vault.*` reachable from the
+  renderer?", "where do I add a new long-running method?", or "the count assertion
+  is wrong". Consult before any change to `packages/ui/src-tauri/src/gateway_bridge.rs`
+  — chain C1 in the B1 audit (renderer XSS → `extension.install` → credential
+  exfiltration) was a single allowlist mistake.
+---
+
+# Nimbus Tauri Allowlist (I7)
+
+## Why This Skill Exists
+
+The Tauri renderer is a WebView with the same trust level as any browser frame. Anything in the `ALLOWED_METHODS` array is reachable from JavaScript — including JavaScript injected via prompt-injected indexed content if any soft barrier ever fails. The B1 audit's chain C1 was triggered by `extension.install` being on the allowlist with no compensating HITL, turning a renderer XSS into full credential exfiltration. The fix removed `extension.install`; the allowlist is now treated as **the single source of truth for the renderer-callable surface**, protected by four Rust unit tests.
+
+This skill is the rule a contributor consults **before** editing the allowlist.
+
+## Where It Lives
+
+| File | Role |
+|---|---|
+| [`packages/ui/src-tauri/src/gateway_bridge.rs:63`](../../packages/ui/src-tauri/src/gateway_bridge.rs) | `ALLOWED_METHODS: &[&str]` — the single sorted, asserted-size array |
+| [`packages/ui/src-tauri/src/gateway_bridge.rs:134`](../../packages/ui/src-tauri/src/gateway_bridge.rs) | `NO_TIMEOUT_METHODS` — subset that bypasses the 30 s default RPC timeout |
+| [`packages/ui/src-tauri/src/gateway_bridge.rs:149`](../../packages/ui/src-tauri/src/gateway_bridge.rs) | `GLOBAL_BROADCAST_METHODS` — notifications that fan out across all Tauri windows |
+| [`packages/ui/src-tauri/src/gateway_bridge.rs`](../../packages/ui/src-tauri/src/gateway_bridge.rs) `mod tests` | Four enforcement tests: `allowlist_exact_size`, `allowlist_is_alphabetized`, `allowlist_has_no_duplicates`, `allowlist_rejects_vault_and_raw_db_writes` |
+
+## The Three Lists
+
+### `ALLOWED_METHODS`
+
+Every JSON-RPC method the renderer is permitted to call via `rpc_call`. Currently 57 entries. The list is:
+
+- **Alphabetized** — enforced by `allowlist_is_alphabetized`. Insert in order; do not append at the end.
+- **Size-asserted** — `allowlist_exact_size` checks `ALLOWED_METHODS.len() == 57`. **Adding a method requires updating this constant.** Removing a method also requires updating it.
+- **Deduplicated** — `allowlist_has_no_duplicates` covers copy-paste mistakes.
+- **Free of forbidden namespaces** — `allowlist_rejects_vault_and_raw_db_writes` asserts that `vault.*`, `db.put` / `db.delete`, `config.set`, `index.rebuild`, and `index.querySql` are absent. Add to this test if you introduce a new forbidden namespace.
+
+### `NO_TIMEOUT_METHODS`
+
+Methods that legitimately take many minutes and are tracked for liveness via streamed progress notifications instead of the default 30 s RPC timeout. Currently 4: `data.export`, `data.import`, `llm.pullModel`, `updater.applyUpdate`. The list is:
+
+- **A subset of `ALLOWED_METHODS`** — enforced by `no_timeout_methods_are_subset_of_allowlist`.
+- **Size-asserted** — `no_timeout_methods_exact_size` checks `NO_TIMEOUT_METHODS.len() == 4`.
+
+A new no-timeout method must (a) emit periodic progress notifications the UI polls for liveness, (b) support cancellation via a partner method (e.g. `llm.cancelPull`), and (c) appear in both lists with both size constants updated.
+
+### `GLOBAL_BROADCAST_METHODS`
+
+Notifications that are intentionally fanned out to every Tauri window — not just the one that subscribed. Currently 1: `profile.switched`. Adding to this list means accepting that the notification may interrupt unrelated UI flows in non-focused windows; only do it for events that materially change app-wide state (active profile, gateway disconnection, …). Size-asserted at 1.
+
+## Forbidden Categories
+
+These namespaces must **never** be reachable from the renderer:
+
+| Namespace | Reason |
+|---|---|
+| `vault.*` (any method) | Credentials are owner-only; renderer XSS must never reach the keystore. Vault access is gateway-internal only. |
+| `db.put`, `db.delete`, raw DB writes | Renderer-controlled DB writes bypass the index integrity contracts in `db/write.ts` (SQLite full handling, audit). Domain operations like `data.delete` go through the Gateway and are gated separately. |
+| `index.querySql` | The raw-SQL escape hatch behind `nimbus query --sql`; arbitrary SELECT from the renderer is an exfiltration channel. |
+| `config.set` | Profile-scoped config changes go through `profile.*` methods, which are HITL-gated and broadcast. |
+| `index.rebuild` | High-cost destructive op; CLI-only. |
+| `extension.install` | **Removed for security** — the renderer must never install extensions; that path is now Rust-native via a Tauri file picker (S4-F6). Do not re-add. |
+| `lan.pair` and friends | LAN pairing requires out-of-band code transmission (see `docs/SECURITY.md` §"LAN remote access"); CLI-only. |
+| `updater.*` write-side | Auto-update is initiated from the gateway side or via CLI; renderer-driven updates would let an XSS install attacker-controlled binaries. The currently-allowed `updater.*` methods are read-only status / explicit user actions like `rollback` initiated from a settings panel — re-evaluate before adding any others. |
+
+When you add a new namespace, add a new line in `allowlist_rejects_vault_and_raw_db_writes` to lock the absence in.
+
+## Adding a Renderer-Callable Method — Checklist
+
+When the desktop UI needs a new IPC method:
+
+- [ ] Confirm a Gateway handler already exists for the method id. The Rust bridge does not synthesize handlers; if `connector.startAuth` is in the allowlist but unhandled at the Gateway, every renderer call fails (S4-F2 was exactly this).
+- [ ] Confirm the method is **not** in any forbidden category above. If it is destructive, route through a HITL-gated wrapper at the Gateway, not directly.
+- [ ] Insert the method id in `ALLOWED_METHODS` **alphabetically**.
+- [ ] Bump the constant in `allowlist_exact_size` to the new total.
+- [ ] If the method can take longer than 30 s and emits progress notifications, also add it to `NO_TIMEOUT_METHODS` and bump `no_timeout_methods_exact_size`. Confirm a partner cancellation method exists.
+- [ ] Run `cargo test` from `packages/ui/src-tauri/`. All four allowlist tests must be green.
+- [ ] Add the method to the [`docs/cli-reference.md`](../../docs/cli-reference.md) IPC section if it is also CLI-callable.
+- [ ] Update [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) §I7 if the wiring shape changed (it usually does not for a routine add).
+- [ ] Update the count in [`CLAUDE.md`](../../CLAUDE.md) (`ALLOWED_METHODS (N)` line) so that AI assistants do not propose stale numbers.
+
+## Removing or Renaming a Method
+
+- [ ] Delete the entry from `ALLOWED_METHODS`.
+- [ ] Decrement `allowlist_exact_size`.
+- [ ] If it was in `NO_TIMEOUT_METHODS` or `GLOBAL_BROADCAST_METHODS`, remove from there too and update those size assertions.
+- [ ] Remove all renderer call sites in `packages/ui/src/` — the bridge will reject the call but the UI call site is dead code that confuses future readers.
+- [ ] Add a test line in `allowlist_rejects_vault_and_raw_db_writes` (or the relevant guard test) if the removal was security-driven, so the absence is locked in. The pattern is the comment + assert pair used for `extension.install` and `index.querySql`.
+
+## Adding a Long-Running Method (`NO_TIMEOUT_METHODS`)
+
+- [ ] Method already in `ALLOWED_METHODS` (subset rule).
+- [ ] Method emits a progress notification at least every few seconds (`*.progress` style) so the UI has a liveness signal.
+- [ ] A partner cancellation method exists (`llm.cancelPull` for `llm.pullModel`, etc.).
+- [ ] Insert in `NO_TIMEOUT_METHODS` and bump `no_timeout_methods_exact_size`.
+- [ ] Run `cargo test no_timeout_methods` from `packages/ui/src-tauri/`. Both subset and size assertions must pass.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's bad | What to do instead |
+|---|---|---|
+| Adding a method without updating the count assertion | The Rust test fails CI immediately, but if you `--no-verify` the commit, you have shipped an allowlist whose CI guarantees no longer hold | Always update both. The count is the integrity check. |
+| Appending to the end of the array instead of inserting alphabetically | `allowlist_is_alphabetized` fails, but the diff also becomes unreviewable for security purposes — the order is the audit trail | Insert alphabetically; review tools then highlight only the new line |
+| Adding `extension.install` "for the marketplace flow" | This was the chain-C1 vector; the marketplace UI now goes through a Rust-native file picker with explicit user gesture. There is no renderer-controlled install path by design | Use the `@tauri-apps/plugin-dialog` file picker pattern; HITL-gate the install at the Gateway |
+| Synthesizing a "convenience" method that wraps a forbidden namespace (e.g. `vault.read_credentials_for_ui_display`) | Trivially defeats the whole point. The renderer never sees credential bytes. | If the UI needs to know whether a credential exists, expose a presence check (returns boolean) at the Gateway and add only that. |
+| Marking a method `NO_TIMEOUT_METHODS` because it "sometimes" takes 35 seconds | The 30 s timeout is the renderer's protection against gateway hangs. Adding to no-timeout removes that protection in exchange for a slow-progress signal. | Fix the gateway-side latency, or split the method into a fast initiator + a follow-up status method |
+| Adding a notification to `GLOBAL_BROADCAST_METHODS` because it "should also reach the popup window" | Most notifications target a specific window registry; global broadcast is a cross-cutting hammer that creates UI race conditions in unrelated panes | Use the per-window emission API and explicitly emit to each relevant window |
+
+## How to Comply (Short Form)
+
+1. Confirm the Gateway handler exists.
+2. Confirm the method id is **not** in any forbidden category.
+3. Insert alphabetically into `ALLOWED_METHODS` and bump the size assertion.
+4. (If long-running) also update `NO_TIMEOUT_METHODS` and its size assertion.
+5. `cargo test` from `packages/ui/src-tauri/` — four allowlist tests pass.
+6. Update CLAUDE.md's `ALLOWED_METHODS (N)` count.
+7. All in the same commit.
+
+## See Also
+
+- [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) §I7 — full invariant statement and audit cross-references
+- [`docs/SECURITY.md`](../../docs/SECURITY.md) §"IPC Surface" — Gateway IPC trust model
+- [`packages/ui/src-tauri/src/gateway_bridge.rs`](../../packages/ui/src-tauri/src/gateway_bridge.rs) — production source of truth
+- `nimbus-ipc` skill — Gateway-side IPC method conventions; pair with this skill when adding a method that is *both* CLI-callable and renderer-callable
+- `nimbus-security-invariants` skill — the invariant triple rule (wiring + docs + test) that all twelve invariants follow

--- a/.claude/commands/nimbus-tool-output-envelope.md
+++ b/.claude/commands/nimbus-tool-output-envelope.md
@@ -1,0 +1,107 @@
+---
+name: nimbus-tool-output-envelope
+description: >
+  Reference for the `<tool_output>` envelope that wraps every LLM-facing tool result
+  in Nimbus (security invariant `I11`). Use this skill whenever you are adding a new
+  agent surface, registering a new Mastra tool, exposing an MCP-backed tool to the
+  LLM, building a sub-agent worker, or auditing a path where tool output reaches the
+  conversational model. Also trigger for questions like "should I wrap this with
+  `wrapToolOutput`?", "where does the envelope live?", "why is my prompt-injection
+  test failing?", or "is this an LLM-facing surface?". Consult before any code that
+  hands a tool result to the LLM — the B1 audit found the envelope was orphan-defined
+  and a similar gap is the easiest way to regress prompt-injection defenses.
+---
+
+# Nimbus Tool-Output Envelope (I11)
+
+## Why This Skill Exists
+
+The B1 internal security audit (Phase 4, 2026-04-25) found that `wrapToolOutput` had been **defined in code but had zero production callers** for a meaningful window. Documentation continued to claim prompt-injection defense was active. The defense is now wired at two production sites and protected by an enforcement test in [`packages/gateway/src/security-invariants.test.ts`](../../packages/gateway/src/security-invariants.test.ts), but the gap can be reintroduced silently every time a new agent surface is added.
+
+This skill is the rule a contributor consults **before** adding such a surface.
+
+## The Rule
+
+Every tool result that flows into an LLM context is wrapped at the LLM-facing boundary in a textual envelope:
+
+```
+<tool_output service="…" tool="…">…JSON-stringified body…</tool_output>
+```
+
+The envelope is applied **at the LLM-facing path only** — not on the planner-side `ConnectorDispatcher → ToolExecutor` path, where the structural HITL gate (invariants `I2`/`I3`/`I4`) is the defense.
+
+If your new code hands a tool result to the LLM and does not call `wrapToolOutput`, **the defense is regressed for that surface** regardless of what other surfaces do.
+
+## Where It Lives
+
+| File | Role |
+|---|---|
+| [`packages/gateway/src/engine/tool-output-envelope.ts`](../../packages/gateway/src/engine/tool-output-envelope.ts) | `wrapToolOutput(ctx, result)` — the only correct way to produce the envelope |
+| [`packages/gateway/src/engine/agent.ts`](../../packages/gateway/src/engine/agent.ts) `wrapToolForLlm` (lines 28–41) | Tool-definition decorator applied to each Mastra-registered tool when the agent is built. Replaces the tool's `execute` so its return value flows through `wrapToolOutput` before reaching the LLM. Every `searchLocalIndex` / `fetchMoreIndexResults` / etc. result is wrapped here. |
+| [`packages/gateway/src/connectors/lazy-mesh/mesh.ts:397`](../../packages/gateway/src/connectors/lazy-mesh/mesh.ts) | Lazy-mesh dispatcher — wraps every MCP tool result that is exposed via Mastra to the LLM |
+| [`packages/gateway/src/security-invariants.test.ts`](../../packages/gateway/src/security-invariants.test.ts) | Enforcement test — fails if a known wiring site stops calling `wrapToolOutput` |
+
+If you add a third LLM-facing path, **you also add a wiring assertion in `security-invariants.test.ts`** so the next regression fails CI immediately.
+
+## Anatomy of the Envelope
+
+```typescript
+export function wrapToolOutput(ctx: ToolOutputContext, result: unknown): string {
+  const body = JSON.stringify(result ?? null);
+  const safeBody = body.replaceAll("</tool_output>", String.raw`<\/tool_output>`);
+  return `<tool_output service="${escapeAttr(ctx.service)}" tool="${escapeAttr(ctx.tool)}">${safeBody}</tool_output>`;
+}
+```
+
+Three load-bearing details:
+
+1. **`escapeAttr` on `service` and `tool`** — defends against attribute injection if either string is ever attacker-influenced. Don't pass in unescaped user input as `service`.
+2. **Body is JSON-stringified** — the LLM is instructed to treat the inner content as JSON data. A bare string body would let an attacker drift the boundary.
+3. **Literal `</tool_output>` in the body is escaped to `<\/tool_output>`** — without this, any tool that ever returned the literal close tag could terminate the envelope and re-enter "instruction mode".
+
+If you change any of these, the I11 enforcement test must be updated in the **same commit**, and the design rationale belongs in [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) under I11.
+
+## What "LLM-facing" Means
+
+A surface is LLM-facing if the result string ends up in a model context window — typically as the response to a tool call the model just emitted. Concretely:
+
+- ✅ **LLM-facing — wrap:** Mastra `Agent.tools.<name>` handlers; sub-agent worker `runSubAgent` results that are returned to the coordinator as tool output; any new MCP-tool registration that is bridged into Mastra's tool registry; agent surfaces like `runAsk`, `runConversationalAgent` when they synthesize tool output back to the model.
+- ❌ **Not LLM-facing — do not wrap:** the planner's `ConnectorDispatcher → ToolExecutor` path (HITL is the defense there); IPC-direct results returned to a CLI/UI client (`engine.askStream` token notifications carry already-composed text); audit log payloads (use `redactPayloadForConsentDisplay` instead); tool results consumed by other Gateway code that does not feed an LLM.
+
+If you are unsure, the test is "would a user-controlled byte sequence in this result *change the model's behavior*?". If yes, wrap.
+
+## Adding a New LLM-facing Tool — Checklist
+
+When registering a new agent tool or extending a sub-agent worker:
+
+- [ ] Tool handler returns its raw object/string result; **the wrapping happens in the agent surface, not the handler**. Do not double-wrap.
+- [ ] The agent surface that exposes this tool to the LLM calls `wrapToolOutput({ service, tool }, raw)` immediately before returning to the model — same shape as `engine/agent.ts:38`.
+- [ ] `service` and `tool` are well-known identifiers (matching connector ids and MCP tool ids), not free-form strings derived from user input.
+- [ ] If the result type is `Promise<string>` already (rare — you are bypassing JSON), audit whether you are losing the body-escape protection. The default path (`Promise<unknown>` → `wrapToolOutput`) is preferred.
+- [ ] An enforcement assertion exists in [`packages/gateway/src/security-invariants.test.ts`](../../packages/gateway/src/security-invariants.test.ts) for the new wiring site (typically a grep against the source file).
+- [ ] [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) §I11 names the new wiring site (file:line).
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's bad | What to do instead |
+|---|---|---|
+| Building a new agent surface that calls a tool and feeds the raw result to the LLM | This is the exact gap S8-F3 / chain C4 documented; the prompt-injection defense becomes "the model probably won't follow attacker instructions" | Always go through `wrapToolOutput` at the LLM-facing boundary |
+| Adding the wrap call inside the tool handler ("wrap once, both paths benefit") | Two harms: the planner path also routes through this handler and now sees an envelope-wrapped string instead of a structured result, breaking HITL preview rendering and `redactPayloadForConsentDisplay`; and on the LLM-facing path the outer `wrapToolForLlm` then JSON-stringifies an already-wrapped string, so the inner `<tool_output>` tag appears verbatim inside the outer body and the LLM's structural boundary is destroyed | Wrap at the agent surface (`wrapToolForLlm`), not in the tool handler |
+| Using a different envelope shape ("`<<TOOL_RESULT>>…<<END>>`") because the existing one is "verbose" | Token cost is negligible; consistency is the defense — every model fine-tune that handles `<tool_output>` correctly is now wrong on your variant | Use the existing `wrapToolOutput`. If you genuinely need a new shape, change `tool-output-envelope.ts` and update the enforcement test |
+| Letting `service` or `tool` be derived from extension-controlled strings without `escapeAttr` | Attribute injection — an extension can break the envelope by including `"` in its declared service id | Read connector id from the registry, not from inbound payloads |
+| Storing the *unwrapped* result in `audit_log` and reconstructing the envelope at view time | Audit and LLM contexts have different requirements; mixing them creates a second class of bug | Audit stores its own redacted view; the envelope is applied separately at the LLM boundary |
+
+## How to Comply (Short Form)
+
+1. Find the LLM-facing site in your new code.
+2. Call `wrapToolOutput({ service, tool }, raw)` there.
+3. Add a wiring grep to `security-invariants.test.ts`.
+4. Update [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) §I11 with the new file:line.
+5. All four happen in the **same commit**.
+
+## See Also
+
+- [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) — full I-numbered list with anti-patterns
+- [`docs/SECURITY.md`](../../docs/SECURITY.md) §"Prompt Injection" — the hard structural barrier (HITL gate) vs the soft barrier (envelope) split
+- [`docs/architecture.md`](../../docs/architecture.md) §"Security Model" — threat-to-mitigation table
+- `nimbus-security-invariants` skill — the invariant triple rule (production wiring + docs entry + enforcement test) that all twelve invariants follow

--- a/.claude/hooks/bash-safety.sh
+++ b/.claude/hooks/bash-safety.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# .claude/hooks/bash-safety.sh
+#
+# PreToolUse hook for Bash — blocks well-known unsafe patterns before they run.
+# Exits 2 (blocking) only on confirmed match; fails open (exit 0) on any error
+# parsing the input so a malformed payload never bricks the agent's Bash access.
+#
+# Reads the Claude Code tool-call payload as JSON on stdin. The payload shape is:
+#   { "tool_name": "Bash", "tool_input": { "command": "...", ... } }
+#
+# Patterns enforced (from CLAUDE.md non-negotiables and "Git Safety Protocol"):
+#  - --no-verify on git commit/push/rebase/pull
+#  - force push to main/master
+#  - git config writes (read-side --get / --list / --show-* / -l are allowed)
+#
+# To bypass intentionally for a one-off, the user can disable the hook in
+# .claude/settings.local.json. Do not weaken the patterns here without a PR.
+
+set -u
+
+# Read stdin into a variable; if empty/unparseable, fail open.
+input=$(cat 2>/dev/null || echo '')
+if [ -z "$input" ]; then
+  exit 0
+fi
+
+# Extract the command. Prefer jq when available; fall back to a sed scrape that
+# handles the common shape without pulling in extra deps. Either way, fail open
+# on extraction error.
+cmd=""
+if command -v jq >/dev/null 2>&1; then
+  cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo '')
+else
+  # Coarse fallback: pull the value of the first "command" key. Misses edge
+  # cases but never produces a false positive that blocks a safe command,
+  # because we still grep the result for explicit dangerous tokens.
+  cmd=$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | head -1)
+fi
+
+if [ -z "$cmd" ]; then
+  exit 0
+fi
+
+block() {
+  echo "BLOCKED by .claude/hooks/bash-safety.sh: $1" >&2
+  echo "If this is intentional, edit .claude/settings.local.json to disable the hook for this session." >&2
+  exit 2
+}
+
+# 1. --no-verify on git commit/push/rebase/pull
+if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+(commit|push|rebase|pull)\b[^|;&]*--no-verify\b'; then
+  block "--no-verify on git commit/push/rebase/pull is forbidden (CLAUDE.md non-negotiables)."
+fi
+
+# 2. Force push to main/master (any of: --force, -f, --force-with-lease against main/master)
+if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+push\b[^|;&]*(--force\b|--force-with-lease\b|[[:space:]]-f\b)[^|;&]*\b(main|master)\b'; then
+  block "force push to main/master is forbidden."
+fi
+if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+push\b[^|;&]*\b(main|master)\b[^|;&]*(--force\b|--force-with-lease\b|[[:space:]]-f\b)'; then
+  block "force push to main/master is forbidden."
+fi
+
+# 3. git config writes — allow read-side flags only
+if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+config\b'; then
+  if ! printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+config[[:space:]]+(--get\b|--list\b|-l\b|--show-origin\b|--show-scope\b|--get-all\b|--get-regexp\b)'; then
+    block "git config writes are forbidden (read-only flags --get / --list / --show-* are allowed)."
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/connector-invariants-check.sh
+++ b/.claude/hooks/connector-invariants-check.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# .claude/hooks/connector-invariants-check.sh
+#
+# PostToolUse hook for Edit / Write — when the touched file is under
+# packages/gateway/src/connectors/, run `bun run audit:invariants` and surface
+# any failures back to the agent so it can self-correct before continuing.
+#
+# This is a static-time complement to the runtime tests in
+# packages/gateway/src/security-invariants.test.ts. The static check enforces:
+#   - Invariant I1: every spawn() under connectors/ uses extensionProcessEnv()
+#   - Vault-key allow-list: connector code touches only manifest-declared keys
+#
+# Fails open (exit 0) on any error parsing the input or running the script,
+# so a transient toolchain hiccup never blocks the agent. Surfaces a non-zero
+# exit + stderr only when audit:invariants itself reports a violation.
+
+set -u
+
+input=$(cat 2>/dev/null || echo '')
+if [ -z "$input" ]; then
+  exit 0
+fi
+
+# Extract the file path that was edited. Fail open on any parse trouble.
+path=""
+if command -v jq >/dev/null 2>&1; then
+  path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null || echo '')
+else
+  path=$(printf '%s' "$input" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | head -1)
+fi
+
+# Only run for edits under packages/gateway/src/connectors/.
+case "$path" in
+  *packages/gateway/src/connectors/*) ;;
+  *) exit 0 ;;
+esac
+
+# Only run for TypeScript sources; markdown / json / test fixtures don't move
+# the invariants needle.
+case "$path" in
+  *.ts|*.tsx) ;;
+  *) exit 0 ;;
+esac
+
+# Locate repo root by walking up to a directory that has package.json with the
+# nimbus workspace marker. Hooks run with cwd at the repo root in practice, but
+# this is the same fail-open posture used in bash-safety.sh.
+if ! command -v bun >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! [ -f package.json ]; then
+  exit 0
+fi
+
+# Run the audit. The script is intentionally fast and binary (--binary-only).
+output=$(bun run audit:invariants 2>&1)
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+fi
+
+echo "audit:invariants reported a finding after editing $path" >&2
+echo "" >&2
+printf '%s\n' "$output" >&2
+echo "" >&2
+echo "Re-read .claude/commands/nimbus-security-invariants.md and the relevant" >&2
+echo "invariant entry in docs/SECURITY-INVARIANTS.md before continuing." >&2
+exit 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ runs. See `docs/structure-audit/baseline.md` for current findings.
 | `packages/ui/src/store/slices/telemetry.ts` | Telemetry slice — `TelemetryStatus` + `telemetryActionInFlight`; transient |
 | `packages/ui/src/store/slices/connectors.ts` | Connectors slice — `PersistedConnectorRow[]` (persisted) + transient `perServiceInFlight` + `highlightService` + `patchConnectorRow` |
 | `packages/ui/src/store/slices/model.ts` | Model slice — `installedModels` + `activePullId` (persisted) + transient `routerStatus`, `pullProgress`, `pullStalled`, `loadedKeys` |
-| `packages/ui/src-tauri/src/gateway_bridge.rs` | Rust IPC bridge — `ALLOWED_METHODS` (38), `NO_TIMEOUT_METHODS` (4), `GLOBAL_BROADCAST_METHODS` (`profile.switched`), `rpc_call`, reconnect loop |
+| `packages/ui/src-tauri/src/gateway_bridge.rs` | Rust IPC bridge — `ALLOWED_METHODS` (57), `NO_TIMEOUT_METHODS` (4), `GLOBAL_BROADCAST_METHODS` (`profile.switched`), `rpc_call`, reconnect loop |
 | `packages/ui/src-tauri/src/tray.rs` | System tray icon, menu, state forwarding |
 | `packages/ui/src-tauri/src/quick_query.rs` | Quick Query window lifecycle — spawn/focus, focus-loss close |
 | `packages/ui/src-tauri/src/hitl_popup.rs` | HITL popup window lifecycle — spawn / focus / close |
@@ -488,6 +488,12 @@ When all three checks pass, include the package's published age and maintainer i
 ## Skill References
 
 @.claude/commands/nimbus-agent-patterns.md
+@.claude/commands/nimbus-architecture.md
 @.claude/commands/nimbus-connector-authoring.md
 @.claude/commands/nimbus-db-migrations.md
+@.claude/commands/nimbus-ipc.md
+@.claude/commands/nimbus-phase-4.md
 @.claude/commands/nimbus-security-invariants.md
+@.claude/commands/nimbus-tauri-allowlist.md
+@.claude/commands/nimbus-testing.md
+@.claude/commands/nimbus-tool-output-envelope.md


### PR DESCRIPTION
## Summary

- Adds two new project skills — [`nimbus-tauri-allowlist`](.claude/commands/nimbus-tauri-allowlist.md) (I7) and [`nimbus-tool-output-envelope`](.claude/commands/nimbus-tool-output-envelope.md) (I11) — so future Claude Code sessions consult the production wiring + invariant rules before touching `gateway_bridge.rs` or any LLM-facing tool surface. These are the two surfaces the B1 audit flagged as silently regressable.
- Adds two `.claude/hooks/` scripts that turn CLAUDE.md non-negotiables into structural blocks: [`bash-safety.sh`](.claude/hooks/bash-safety.sh) (PreToolUse/Bash) blocks `--no-verify`, force-push to main/master, and git config writes; [`connector-invariants-check.sh`](.claude/hooks/connector-invariants-check.sh) (PostToolUse/Edit|Write) re-runs `bun run audit:invariants` whenever a `packages/gateway/src/connectors/**/*.ts` file changes so I1 / vault-key-allowlist regressions surface immediately. Both fail open on parser/toolchain errors so a malformed payload never bricks Bash or Edit access.
- Updates [`CLAUDE.md`](CLAUDE.md) to reference all 10 skill files (was 4) and bumps the stale `ALLOWED_METHODS` count from 38 → 57 so assistants stop quoting the old number.

## Why now

These changes do not touch any production code — they're agent tooling only. They land before any further Phase 5 work so subsequent edits get the new guardrails (especially the connector-invariants hook).

## Test Plan

- [ ] Open a Bash command containing `git push --force main` — confirm `bash-safety.sh` blocks with exit 2.
- [ ] Open a Bash command containing `git config user.email` — confirm read flag (`--get`) passes, plain `git config` blocks.
- [ ] Edit any file under `packages/gateway/src/connectors/` and observe `audit:invariants` run via the PostToolUse hook (smoke only — no failures expected on the current main).
- [ ] Open a fresh Claude Code session in the repo and confirm both new skills load via the Skill tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)