### PR TITLE
chore(release): point shipping artifacts at nimbus-agent/Nimbus

### DIFF
--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -430,7 +430,7 @@ export type NimbusUpdaterToml = {
 
 export const DEFAULT_NIMBUS_UPDATER_TOML: NimbusUpdaterToml = {
   enabled: true,
-  url: "https://github.com/asafgolombek/Nimbus/releases/latest/download/latest.json",
+  url: "https://github.com/nimbus-agent/Nimbus/releases/latest/download/latest.json",
   checkOnStartup: true,
   autoApply: false,
 };

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -29,10 +29,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/asafgolombek/Nimbus"
+    "url": "https://github.com/nimbus-agent/Nimbus"
   },
   "bugs": {
-    "url": "https://github.com/asafgolombek/Nimbus/issues"
+    "url": "https://github.com/nimbus-agent/Nimbus/issues"
   },
   "homepage": "https://nimbus-agent.dev/vscode",
   "activationEvents": [

--- a/scripts/release/nimbus-verify.ps1
+++ b/scripts/release/nimbus-verify.ps1
@@ -42,7 +42,7 @@ $ErrorActionPreference = "Stop"
 $TrustedFingerprints = @(
   "5A20457CCD8B53FFAA945240886ADA6B487CAB6E"
 )
-$GithubRepo = "asafgolombek/Nimbus"
+$GithubRepo = "nimbus-agent/Nimbus"
 
 if ($env:NIMBUS_VERIFY_FINGERPRINT_OVERRIDE) {
   $TrustedFingerprints = @($env:NIMBUS_VERIFY_FINGERPRINT_OVERRIDE)

--- a/scripts/release/nimbus-verify.sh
+++ b/scripts/release/nimbus-verify.sh
@@ -13,7 +13,7 @@ TRUSTED_FINGERPRINTS=(
   "5A20457CCD8B53FFAA945240886ADA6B487CAB6E"
 )
 DEFAULT_KEYSERVER="keys.openpgp.org"
-GITHUB_REPO="asafgolombek/Nimbus"
+GITHUB_REPO="nimbus-agent/Nimbus"
 
 # Runtime-override: tests inject NIMBUS_VERIFY_FINGERPRINT_OVERRIDE with a
 # scratch fingerprint so real releases use production FPs but tests use throwaway keys.


### PR DESCRIPTION
## Summary

Pre-flight cleanup for `v0.1.0` — four files still embedded `asafgolombek/Nimbus` (the pre-org-transfer repo path). GitHub's redirect masks the wrong-org references at runtime, but each of these artifacts is **shipped to users** and would rely on that redirect for the lifetime of the release:

- `packages/gateway/src/config/nimbus-toml.ts` — `DEFAULT_NIMBUS_UPDATER_TOML.url` is compiled into every shipped Gateway binary and fetched via `fetch()` on every update check. A future redirect break (transfer reversal, account collision, GitHub policy change) would silently brick auto-update across all installed clients.
- `scripts/release/nimbus-verify.{sh,ps1}` — ship inside the GitHub Release archive; users invoke them to verify GPG signatures + SHA-256 hashes. They hit the GitHub API directly.
- `packages/vscode-extension/package.json` — `repository.url` + `bugs.url` are published to the VS Code Marketplace and Open VSX listing pages on `vscode-v0.1.0`.

Out of scope (tracked separately): user-guide install docs, `packages/ui/src-tauri/Cargo.toml` (desktop deferred to Phase 6), `scripts/check-package.ts` user-agent string, `bench-ci.test.ts` fixtures, and historical specs under `docs/superpowers/`.

## Test plan

- [x] `bun run test:ci` — full CI-parity suite (493 vitest tests + workspace bun tests, all green locally)
- [ ] CI green on PR
- [ ] Manual: confirm `gh release view v0.1.0` after release shows `latest.json` reachable at the new URL