### PR TITLE
fix(release): nimbus-verify trusts primary FP, accepts subkey signatures

### DIFF
--- a/packages/gateway/src/platform/platform.test.ts
+++ b/packages/gateway/src/platform/platform.test.ts
@@ -125,7 +125,7 @@ describe("Platform Abstraction Layer", () => {
       services.localIndex?.close();
       await new Promise((r) => setTimeout(r, 100));
     }
-  });
+  }, 15000); // 15s timeout to allow for migrations on fresh DB (matches sibling test above)
 
   it("throws PlatformInitError for missing Linux secret-tool (subprocess)", () => {
     if (platform() !== "linux") {

--- a/scripts/release/fixtures/gen-test-key.sh
+++ b/scripts/release/fixtures/gen-test-key.sh
@@ -9,11 +9,19 @@ chmod 700 "$TARGET"
 
 export GNUPGHOME="$TARGET"
 
+# Mirror production GPG hygiene from docs/release/v0.1.0-prerequisites.md §1.2:
+# certify-only master + sign subkey. gpg --detach-sign auto-picks the subkey,
+# so this fixture exercises the same VALIDSIG primary/subkey distinction the
+# release pipeline produces. A flat single-key fixture passes the verify script
+# trivially and hides the master-vs-subkey trust comparison bug.
 cat > "$TARGET/gen-key.batch" <<EOF
 %no-protection
 Key-Type: EDDSA
 Key-Curve: ed25519
-Key-Usage: sign
+Key-Usage: cert
+Subkey-Type: EDDSA
+Subkey-Curve: ed25519
+Subkey-Usage: sign
 Name-Real: Nimbus Test Signing
 Name-Email: test@nimbus.local
 Expire-Date: 1y
@@ -23,5 +31,6 @@ EOF
 gpg --batch --generate-key "$TARGET/gen-key.batch" 2>/dev/null
 rm -f "$TARGET/gen-key.batch"
 
-# Print the fingerprint — caller captures it.
+# Print the PRIMARY (master) fingerprint — caller adds it to TRUSTED_FINGERPRINTS.
+# `--list-keys --with-colons` emits the primary fpr first, before any subkey fprs.
 gpg --list-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }'

--- a/scripts/release/nimbus-verify.ps1
+++ b/scripts/release/nimbus-verify.ps1
@@ -117,17 +117,28 @@ Write-Host "  4. The same fingerprint on $Keyserver"
 Write-Host ""
 
 # ---- gpg --verify ----------------------------------------------------------
+# VALIDSIG layout (GPG 1.4+):
+#   [GNUPG:] VALIDSIG <signing-fp> <date> <ts> <expire> <ver> <reserved>
+#                     <pubkey-algo> <hash-algo> <sig-class> <primary-fp>
+# Group 1 is the signing-key FP (sign-only subkey under standard hygiene); the
+# last whitespace-separated token is the PRIMARY (master) FP. We trust the
+# primary because subkeys rotate every ~2 years per docs/release/v0.1.0-
+# prerequisites.md and the trust anchor in docs/release/SIGNING-KEY.asc and
+# README.md is the primary fingerprint. When a key has no subkey, signing-fp
+# == primary-fp and this still works.
 $verifyOut = & gpg --status-fd 1 --verify SHA256SUMS.asc SHA256SUMS 2>&1 | Out-String
-$validsig = [regex]::Match($verifyOut, '\[GNUPG:\] VALIDSIG (\S+)')
+$validsig = [regex]::Match($verifyOut, '\[GNUPG:\] VALIDSIG (\S+)(?:\s+\S+){8}\s+(\S+)')
 if (-not $validsig.Success) {
   Write-Host "❌ SHA256SUMS.asc: GPG signature verification FAILED" -ErrorAction Continue
   Write-Host $verifyOut
   exit 1
 }
-$sigFp = $validsig.Groups[1].Value
+$signingFp = $validsig.Groups[1].Value
+$primaryFp = $validsig.Groups[2].Value
 
-if ($TrustedFingerprints -notcontains $sigFp) {
-  Write-Host "❌ SHA256SUMS.asc: signed by UNTRUSTED fingerprint $sigFp"
+if ($TrustedFingerprints -notcontains $primaryFp) {
+  Write-Host "❌ SHA256SUMS.asc: signed by UNTRUSTED primary fingerprint $primaryFp"
+  Write-Host "   (signing key was $signingFp)"
   Write-Host "   trusted fingerprints: $($TrustedFingerprints -join ', ')"
   exit 1
 }
@@ -137,7 +148,11 @@ if ($verifyOut -match '\[GNUPG:\] (EXPKEYSIG|REVKEYSIG)') {
   exit 1
 }
 
-Write-Host "✅ SHA256SUMS.asc: signature OK (fingerprint $sigFp)"
+if ($signingFp -eq $primaryFp) {
+  Write-Host "✅ SHA256SUMS.asc: signature OK (fingerprint $primaryFp)"
+} else {
+  Write-Host "✅ SHA256SUMS.asc: signature OK (signed by subkey $signingFp, bound to primary $primaryFp)"
+}
 Write-Host ""
 
 # ---- Hash verification -----------------------------------------------------

--- a/scripts/release/nimbus-verify.sh
+++ b/scripts/release/nimbus-verify.sh
@@ -162,9 +162,18 @@ echo ""
 
 VERIFY_OUT="$(gpg --status-fd 1 --verify SHA256SUMS.asc SHA256SUMS 2>&1 || true)"
 
-# Look for GOODSIG <fp> or VALIDSIG <fp> — but the FP must be in TRUSTED_FINGERPRINTS.
-SIG_FP="$(echo "$VERIFY_OUT" | awk '/^\[GNUPG:\] VALIDSIG/ {print $3; exit}')"
-if [[ -z "$SIG_FP" ]]; then
+# VALIDSIG line layout (GPG 1.4+):
+#   [GNUPG:] VALIDSIG <signing-fp> <date> <ts> <expire> <ver> <reserved>
+#                     <pubkey-algo> <hash-algo> <sig-class> <primary-fp>
+# $3 is the signing-key FP (a sign-only subkey under standard hygiene); the
+# last field is the PRIMARY (master) FP. We trust the primary because subkeys
+# rotate every ~2 years per docs/release/v0.1.0-prerequisites.md and the
+# trust anchor published in docs/release/SIGNING-KEY.asc and README.md is
+# the primary fingerprint. When a key has no subkey, signing-fp == primary-fp
+# and this still works.
+SIGNING_FP="$(echo "$VERIFY_OUT" | awk '/^\[GNUPG:\] VALIDSIG/ {print $3; exit}')"
+PRIMARY_FP="$(echo "$VERIFY_OUT" | awk '/^\[GNUPG:\] VALIDSIG/ {print $NF; exit}')"
+if [[ -z "$PRIMARY_FP" ]]; then
   echo "❌ SHA256SUMS.asc: GPG signature verification FAILED" >&2
   echo "$VERIFY_OUT" >&2
   exit 1
@@ -172,13 +181,14 @@ fi
 
 FOUND=0
 for fp in "${TRUSTED_FINGERPRINTS[@]}"; do
-  if [[ "$SIG_FP" == "$fp" ]]; then
+  if [[ "$PRIMARY_FP" == "$fp" ]]; then
     FOUND=1; break
   fi
 done
 
 if [[ "$FOUND" -ne 1 ]]; then
-  echo "❌ SHA256SUMS.asc: signed by UNTRUSTED fingerprint $SIG_FP" >&2
+  echo "❌ SHA256SUMS.asc: signed by UNTRUSTED primary fingerprint $PRIMARY_FP" >&2
+  echo "   (signing key was $SIGNING_FP)" >&2
   echo "   trusted fingerprints: ${TRUSTED_FINGERPRINTS[*]}" >&2
   exit 1
 fi
@@ -190,7 +200,11 @@ if echo "$VERIFY_OUT" | grep -qE "\[GNUPG:\] (EXPKEYSIG|REVKEYSIG)"; then
   exit 1
 fi
 
-echo "✅ SHA256SUMS.asc: signature OK (fingerprint $SIG_FP)"
+if [[ "$SIGNING_FP" == "$PRIMARY_FP" ]]; then
+  echo "✅ SHA256SUMS.asc: signature OK (fingerprint $PRIMARY_FP)"
+else
+  echo "✅ SHA256SUMS.asc: signature OK (signed by subkey $SIGNING_FP, bound to primary $PRIMARY_FP)"
+fi
 echo ""
 
 # ---- Hash check ($SHACMD -c) -------------------------------------------------


### PR DESCRIPTION
## Summary

`nimbus-verify.{sh,ps1}` rejected every real release. Discovered while spot-checking `v0.1.0-rc9` artifacts before tagging `v0.1.0`.

**Symptom (against rc9 release):**
```
$ bash nimbus-verify.sh nimbus-headless-windows-x64.zip
❌ SHA256SUMS.asc: signed by UNTRUSTED fingerprint C4F331E91827CF897C6C47EF156554654F4A0639
   trusted fingerprints: 5A20457CCD8B53FFAA945240886ADA6B487CAB6E
```

But `gpg --verify` directly says:
```
gpg: Good signature from "Nimbus Agent Release Signing <release@nimbus-agent.dev>" [ultimate]
```

**Root cause:** Production GPG hygiene per [`docs/release/v0.1.0-prerequisites.md`](https://github.com/nimbus-agent/Nimbus/blob/main/docs/release/v0.1.0-prerequisites.md) §1.2 uses a Certify-only **master** + Sign **subkey**. `gpg --detach-sign` auto-picks the sign subkey, so `SHA256SUMS.asc` carries the *subkey* fingerprint. `TRUSTED_FINGERPRINTS` correctly holds the master FP (the published anchor in `docs/release/SIGNING-KEY.asc` and `README.md`). The script compared exact-match against the signing key from `VALIDSIG`'s `$3` — the subkey — instead of the primary FP at `$NF`.

**Without this fix, every user following [`docs/verify-release-integrity.md`](https://github.com/nimbus-agent/Nimbus/blob/main/docs/verify-release-integrity.md) sees rejection — the trust anchor is broken end-to-end.**

## Fix

- `nimbus-verify.sh`: extract `PRIMARY_FP` from `VALIDSIG` last field, compare against `TRUSTED_FINGERPRINTS`. Success message discloses both signing and primary FP.
- `nimbus-verify.ps1`: regex captures both fingerprints (`(\S+)(?:\s+\S+){8}\s+(\S+)`); compare on primary.
- `scripts/release/fixtures/gen-test-key.sh`: previously generated a flat single-master `Key-Usage: sign` key, hiding the master/subkey distinction. Now mirrors production: Certify-only master + Sign subkey. The 4 existing `nimbus-verify-ps1.test.ts` cases automatically become the regression test.

## Verification

Local fixed `nimbus-verify.sh` re-run against rc9 artifacts:
```
✅ SHA256SUMS.asc: signature OK (signed by subkey C4F331E9..., bound to primary 5A20457C...)
```

## Test plan

- [x] `bun test scripts/release/nimbus-verify-ps1.test.ts` — fails on the unfixed scripts (proves the bug), passes after fix
- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run test:ci` — full CI-parity (493 vitest tests + workspace bun tests, all green)
- [x] Manual: fixed `nimbus-verify.sh` against real `v0.1.0-rc9` artifacts succeeds
- [ ] Linux runner: `bun test scripts/release/nimbus-verify.test.ts` (skipped on Windows; CI exercises this)
- [ ] CI green on this PR

## Release sequencing

This is the last pre-flight blocker for `v0.1.0`. After merge:

1. Cut `v0.1.0-rc10` against post-merge main
2. Spot-check rc10 artifacts with `nimbus-verify.sh` end-to-end (should print `✅ signature OK`)
3. Tag `vscode-v0.1.0` then `v0.1.0`