### PR TITLE
fix(vscode-extension): rename displayName to "Nimbus Agent"

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -515,7 +515,7 @@
     },
     "packages/vscode-extension": {
       "name": "nimbus-vscode",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@nimbus-dev/client": "workspace:*",
         "dompurify": "^3.2.0",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nimbus-vscode",
-  "displayName": "Nimbus",
+  "displayName": "Nimbus Agent",
   "description": "Local-first AI agent for the editor. Ask, search, and run workflows against your private Nimbus index.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "nimbus-agent",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

`vscode-v0.1.1` publish to VS Code Marketplace failed with:

```
Publishing 'nimbus-agent.nimbus-vscode v0.1.1'...
##[error]This extension display name is taken. Please try a different one.
For help, you can contact VSMarketplace@microsoft.com.
```

Marketplace policy enforces uniqueness on **both** the technical `name` and the human-facing `displayName`. PR #235 resolved the `name` collision (`nimbus` → `nimbus-vscode`), but `displayName: "Nimbus"` still collided with `usenimbus.nimbus`'s displayName.

## Fix

- `displayName`: `"Nimbus"` → `"Nimbus Agent"`. Matches the publisher (`nimbus-agent`) and the project's existing brand throughout the codebase + docs.
- `version`: `0.1.1` → `0.1.2` to align with the new tag (`vscode-v0.1.2`).
- `bun.lock` patched directly for the workspace-member version bump (a full `bun install` regen pulled forward many unrelated transitive deps; targeted edit keeps the diff minimal). `bun install --frozen-lockfile` passes.

## Burned tags

`vscode-v0.1.0` (technical-name conflict) and `vscode-v0.1.1` (displayName conflict) both ran their workflows but published zero artifacts. Both stay in the repo per `manual-smoke-v0.1.0.md` "do not delete the tag" doctrine.

## Test plan

- [x] `bun install --frozen-lockfile` — no lockfile drift
- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run test:ci` — full CI-parity, all green locally
- [ ] CI green on this PR
- [ ] Push `vscode-v0.1.2` after merge → publish-vscode.yml succeeds end-to-end

The third name is the charm.