### PR TITLE
fix(release): include Ed25519 sidecar files in build-gateway artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,11 +135,18 @@ jobs:
           UPDATER_SIGNING_KEY: ${{ secrets.UPDATER_SIGNING_KEY }}
         run: bun scripts/sign-ed25519.ts dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}
 
+      # Glob to include the binary plus the sidecar files produced by the
+      # signing steps above:
+      #   - <bin>.sha256 + <bin>.sig from sign-ed25519.ts (every platform)
+      #   - <bin>.asc from sign-linux-gpg.sh (Linux only)
+      # The update-manifest job downloads this artifact and reads <bin>.sha256
+      # + <bin>.sig per target — without the sidecars, build-update-manifest.ts
+      # fails with ENOENT and the v0.1.0 latest.json was never produced.
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.target.artifact }}
-          path: dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}
+          path: dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}*
           if-no-files-found: error
           retention-days: 30
 


### PR DESCRIPTION
## Summary

`v0.1.0` published 24 release assets but the `Publish updater manifest` job failed:

```
ENOENT: no such file or directory, open 'nimbus-gateway-macos-x64.sha256'
  at scripts/build-update-manifest.ts:53:15
```

The `sign-ed25519.ts` step in `build-gateway` writes `<binary>.sha256` + `<binary>.sig` to `dist/`, but the `upload-artifact` step path was the bare binary only:

```yaml
path: dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}
```

So the sidecars were dropped at the end of each gateway build job. The `update-manifest` job downloads those artifacts, expects the sidecars, and ENOENTs on the first read.

## Why this didn't surface in rc1..rc10

`update-manifest` is gated on `!contains(github.ref_name, '-')`, so every RC tag skips it. `v0.1.0` was the first production-tag run, exercising the path for the first time.

## Fix

Single-file change in `.github/workflows/release.yml`. Switch the gateway artifact upload to a glob:

```diff
-          path: dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}
+          path: dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}*
```

This now uploads:
- the binary itself
- `<binary>.sha256` + `<binary>.sig` (every platform — `sign-ed25519.ts`)
- `<binary>.asc` (Linux only — `sign-linux-gpg.sh`)

`if-no-files-found: error` still catches the case where the binary itself is missing, since the glob always matches at least the binary.

`build-cli`'s upload step is intentionally not changed — CLI binaries are not signed by `sign-ed25519.ts` and do not feed the updater manifest.

## Validation plan

After merge:
1. Push `v0.1.1` against post-merge main
2. Watch `release.yml` end-to-end — `update-manifest` job must publish `latest.json` to the GitHub Release
3. Spot-check: `curl https://github.com/nimbus-agent/Nimbus/releases/latest/download/latest.json | jq '.platforms'`

`v0.1.0`'s release artifacts (binaries, signatures, SBOM) are already shipped. Only `latest.json` is missing, so `v0.1.0` users can't auto-update. `v0.1.1` unblocks the auto-update path from then on.

## Test plan

- [x] Diff is 1 line + comment, scoped to `.github/workflows/release.yml`
- [ ] CI green on this PR
- [ ] `v0.1.1` push validates the fix end-to-end (only true test; CI doesn't exercise release.yml)