### PR TITLE
feat(phase-5/T4 PR1): OpenAPI surface + drift CI gate + CI hook template

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -93,6 +93,9 @@ jobs:
         # forward-looking phase files by design).
         run: bun run audit:doc-refs
 
+      - name: OpenAPI drift check
+        run: bun run audit:openapi-drift
+
       - name: regen-slo drift check
         run: bun run regen-slo:check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict
 **Linter:** Biome
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence ✅ Complete (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅ · B3 Phase 1 ✅ · B3 Phase 2 ✅); **`v0.1.0` released 2026-05-09** (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 10); **Phase 5** — Extended Surface 🔵 Active (T1 sequencing spec ✅ · T3 PR 1 coordinator parallelism + `nimbus expert` ✅ · T3 PR 2 `nimbus impact` ✅ · T3 PR 3 `nimbus catchup` ✅ · Wave A PR 1 OpenAPI / AsyncAPI spec indexer ✅ · Wave A PR 2 Obsidian vault connector ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence ✅ Complete (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅ · B3 Phase 1 ✅ · B3 Phase 2 ✅); **`v0.1.0` released 2026-05-09** (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 10); **Phase 5** — Extended Surface 🔵 Active (T1 sequencing spec ✅ · T3 PR 1 coordinator parallelism + `nimbus expert` ✅ · T3 PR 2 `nimbus impact` ✅ · T3 PR 3 `nimbus catchup` ✅ · Wave A PR 1 OpenAPI / AsyncAPI spec indexer ✅ · Wave A PR 2 Obsidian vault connector ✅ · T4 PR 1 foundations in flight)
 
 **Gemini CLI:** [`GEMINI.md`](./GEMINI.md) mirrors this file for the same repository — update both when changing commands, roadmap rows, or non-negotiables.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict  
 **Linter:** Biome  
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)  
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence ✅ Complete (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅ · B3 Phase 1 ✅ · B3 Phase 2 ✅); **`v0.1.0` released 2026-05-09** (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 10); **Phase 5** — Extended Surface 🔵 Active (T1 sequencing spec ✅ · T3 PR 1 coordinator parallelism + `nimbus expert` ✅ · T3 PR 2 `nimbus impact` ✅ · T3 PR 3 `nimbus catchup` ✅ · Wave A PR 1 OpenAPI / AsyncAPI spec indexer ✅ · Wave A PR 2 Obsidian vault connector ✅)
+**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence ✅ Complete (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅ · B3 Phase 1 ✅ · B3 Phase 2 ✅); **`v0.1.0` released 2026-05-09** (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 10); **Phase 5** — Extended Surface 🔵 Active (T1 sequencing spec ✅ · T3 PR 1 coordinator parallelism + `nimbus expert` ✅ · T3 PR 2 `nimbus impact` ✅ · T3 PR 3 `nimbus catchup` ✅ · Wave A PR 1 OpenAPI / AsyncAPI spec indexer ✅ · Wave A PR 2 Obsidian vault connector ✅ · T4 PR 1 foundations in flight)
 
 Companion context for other agents: [`CLAUDE.md`](./CLAUDE.md) (same project facts; keep both files aligned when changing commands, roadmap rows, or non-negotiables).
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "dependency-cruiser": "^17.4.0",
+        "js-yaml": "^4.1.1",
         "jscpd": "^4.0.9",
         "knip": "^6.12.0",
         "tweetnacl": "^1.0.3",

--- a/docs/cli/use-in-ci.md
+++ b/docs/cli/use-in-ci.md
@@ -1,0 +1,83 @@
+# Using `nimbus query` in CI
+
+> **Self-hosted runners only.** The Gateway HTTP API binds to `127.0.0.1`, so a hosted GitHub-runner / GitLab-shared-runner cannot reach it. Run a self-hosted runner with Nimbus installed and the Gateway started (`nimbus serve` or via systemd / launchd), then use the patterns below.
+
+This page shows three ways to gate a CI step on already-indexed Nimbus data — without writing any TypeScript or running an MCP connector. Each example uses `nimbus query --json` and pipes through `jq` for the boolean check.
+
+## Example 1 — GitHub Actions: block deploy on active P1 incident
+
+```yaml
+# .github/workflows/deploy.yml — runs on a self-hosted runner
+jobs:
+  deploy:
+    runs-on: [self-hosted, linux, nimbus]   # tag your runner accordingly
+    steps:
+      - name: Block on active P1 incident
+        env:
+          SERVICE: payment-service
+        run: |
+          set -euo pipefail
+          count=$(nimbus query --service pagerduty --type incident \
+                              --since 24h --json \
+                  | jq --arg svc "$SERVICE" \
+                      '[ .[] | select(.metadata.severity == "p1" and .metadata.service == $svc) ] | length')
+          if [ "$count" -gt 0 ]; then
+            echo "::error::Active P1 incident on $SERVICE — blocking deploy."
+            exit 1
+          fi
+          echo "No active P1 — proceeding."
+
+      - name: Deploy
+        run: ./deploy.sh
+```
+
+## Example 2 — GitLab CI: warn on failing CI runs for the target branch
+
+```yaml
+# .gitlab-ci.yml — runner tagged `nimbus`
+deploy:
+  tags: [nimbus]
+  script:
+    - |
+      failures=$(nimbus query --service github_actions --type ci_run \
+                              --since 4h --json \
+                  | jq --arg branch "$CI_COMMIT_REF_NAME" \
+                      '[ .[] | select(.metadata.headBranch == $branch and .metadata.conclusion == "failure") ] | length')
+      if [ "$failures" -gt 0 ]; then
+        echo "WARNING: $failures recent CI failures on $CI_COMMIT_REF_NAME"
+      fi
+    - ./deploy.sh
+```
+
+## Example 3 — Jenkins (Pipeline / `Jenkinsfile`)
+
+```groovy
+pipeline {
+  agent { label 'nimbus' }
+  stages {
+    stage('Block on conflicted PRs') {
+      steps {
+        sh '''
+          conflicted=$(nimbus query --service github --type pr \
+                                    --json \
+                       | jq '[ .[] | select(.metadata.mergeable == false) ] | length')
+          if [ "$conflicted" -gt 0 ]; then
+            echo "ERROR: $conflicted PRs in merge-conflict state — resolve before deploy."
+            exit 1
+          fi
+        '''
+      }
+    }
+    stage('Deploy') {
+      steps { sh './deploy.sh' }
+    }
+  }
+}
+```
+
+## Notes
+
+- `nimbus query --json` emits an array of indexed-item rows; `jq` filters cleanly without extra dependencies.
+- The `metadata.*` field names follow the connector's chosen shape — check `docs/architecture.md` § "Local Database Schema" or the connector source for the exact set.
+- For typed access from a Node/Bun CI script, prefer `@nimbus-dev/client` (`packages/client`) over raw `nimbus query`.
+- The runner needs the `nimbus` binary on `PATH`. On a fresh runner, install once via `bun run package:headless` output and `cp` the binary into `/usr/local/bin/`.

--- a/docs/templates/nimbus-pre-commit.sh
+++ b/docs/templates/nimbus-pre-commit.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Nimbus pre-commit hook template.
+#
+# Install:
+#   cp docs/templates/nimbus-pre-commit.sh .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+#
+# Configurable via environment:
+#   NIMBUS_HOOK_BLOCK_ON_INCIDENT=1   block when an active P1 incident is found
+#                                     (default: warn-only)
+#   NIMBUS_HOOK_BLOCK_ON_FAILING_CI=1 block when a failing CI run on the current
+#                                     branch is found (default: warn-only)
+#
+# Both preflight checks below are fail-open: if `nimbus` is not on PATH or the
+# Gateway is unreachable, the hook prints a one-line note to stderr and exits 0
+# so commits are never blocked by missing tooling.
+
+set -uo pipefail
+
+# Preflight 1: nimbus binary on PATH?
+if ! command -v nimbus >/dev/null 2>&1; then
+  echo "[nimbus pre-commit] nimbus not on PATH; skipping checks." >&2
+  exit 0
+fi
+
+# Preflight 2: Gateway reachable?
+if ! nimbus diag --json >/dev/null 2>&1; then
+  echo "[nimbus pre-commit] Gateway not reachable; skipping checks." >&2
+  exit 0
+fi
+
+# Resolve the current branch — used by the failing-CI check.
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+
+block_or_warn() {
+  local label="$1" envvar="$2" count="$3"
+  if [ "$count" -le 0 ]; then
+    return 0
+  fi
+  if [ "${!envvar:-0}" = "1" ]; then
+    echo "[nimbus pre-commit] BLOCK: $label ($count)." >&2
+    return 1
+  fi
+  echo "[nimbus pre-commit] warn: $label ($count). Set $envvar=1 to block." >&2
+  return 0
+}
+
+# Check 1: active P1 incidents.
+incident_count=$(nimbus query --service pagerduty --type incident --since 24h --json 2>/dev/null \
+                  | jq '[ .[] | select(.metadata.severity == "p1") ] | length' 2>/dev/null \
+                  || echo 0)
+
+# Check 2: failing CI runs on the current branch.
+ci_failures=$(nimbus query --service github_actions --type ci_run --since 4h --json 2>/dev/null \
+               | jq --arg branch "$branch" \
+                  '[ .[] | select(.metadata.headBranch == $branch and .metadata.conclusion == "failure") ] | length' 2>/dev/null \
+               || echo 0)
+
+status=0
+block_or_warn "active P1 incidents in last 24h" NIMBUS_HOOK_BLOCK_ON_INCIDENT  "$incident_count" || status=1
+block_or_warn "failing CI runs on $branch in last 4h" NIMBUS_HOOK_BLOCK_ON_FAILING_CI "$ci_failures"     || status=1
+
+exit "$status"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "audit:any": "bun scripts/structure-audit/count-any-usage.ts",
     "audit:invariants": "bun scripts/structure-audit/check-nimbus-invariants.ts --binary-only",
     "audit:doc-refs": "bun scripts/structure-audit/check-doc-references.ts --check",
+    "audit:openapi-drift": "bun scripts/structure-audit/check-openapi-drift.ts --check",
     "audit:js-licenses": "bun scripts/structure-audit/check-js-licenses.ts --check",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -108,6 +109,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "dependency-cruiser": "^17.4.0",
+    "js-yaml": "^4.1.1",
     "jscpd": "^4.0.9",
     "knip": "^6.12.0",
     "tweetnacl": "^1.0.3",

--- a/packages/gateway/openapi/v1.yaml
+++ b/packages/gateway/openapi/v1.yaml
@@ -81,11 +81,18 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [data]
+                required: [data, meta]
                 properties:
                   data:
                     type: array
                     items: { type: object }
+                  meta:
+                    type: object
+                    required: [total, limit, offset]
+                    properties:
+                      total: { type: integer }
+                      limit: { type: integer }
+                      offset: { type: integer }
 
   /v1/people:
     get:

--- a/packages/gateway/openapi/v1.yaml
+++ b/packages/gateway/openapi/v1.yaml
@@ -1,0 +1,186 @@
+openapi: 3.1.0
+info:
+  title: Nimbus Local HTTP API
+  version: 1.0.0
+  description: |
+    Read-only HTTP surface served by `nimbus serve` on `127.0.0.1`.
+    Never exposed to a network outside the loopback interface.
+    See https://github.com/nimbus-agent/Nimbus/blob/main/docs/architecture.md
+    for the broader IPC story.
+  license:
+    name: AGPL-3.0
+servers:
+  - url: http://127.0.0.1:7474
+    description: Local Gateway (default port; override with NIMBUS_HTTP_PORT)
+paths:
+  /v1/health:
+    get:
+      operationId: getHealth
+      summary: Liveness check
+      responses:
+        "200":
+          description: Gateway is up.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, gateway]
+                properties:
+                  status:
+                    type: string
+                    enum: [ok]
+                  gateway:
+                    type: string
+
+  /v1/items:
+    get:
+      operationId: listItems
+      summary: List indexed items
+      parameters:
+        - { in: query, name: service, required: false, schema: { type: array, items: { type: string } }, style: form, explode: true }
+        - { in: query, name: type, required: false, schema: { type: string } }
+        - { in: query, name: limit, required: false, schema: { type: integer, minimum: 1, maximum: 1000, default: 50 } }
+        - { in: query, name: since, required: false, schema: { type: string }, description: "Relative window, e.g. `7d`, `24h`." }
+        - { in: query, name: sinceMs, required: false, schema: { type: integer } }
+        - { in: query, name: untilMs, required: false, schema: { type: integer } }
+      responses:
+        "200":
+          description: A page of items.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ItemPage"
+
+  /v1/items/{id}:
+    get:
+      operationId: getItem
+      summary: Fetch one indexed item by id
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: "Item found (or `data: null`)."
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    nullable: true
+                    type: object
+
+  /v1/connectors:
+    get:
+      operationId: listConnectors
+      summary: List connector health snapshots
+      responses:
+        "200":
+          description: Array of connector health rows.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: array
+                    items: { type: object }
+
+  /v1/people:
+    get:
+      operationId: listPeople
+      summary: List indexed people
+      responses:
+        "200":
+          description: A page of people.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data: { type: array, items: { type: object } }
+                  meta:
+                    type: object
+                    required: [total, limit, offset]
+                    properties:
+                      total: { type: integer }
+                      limit: { type: integer }
+                      offset: { type: integer }
+
+  /v1/people/{id}:
+    get:
+      operationId: getPerson
+      summary: Fetch one person by id
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: "Person found (or `data: null`)."
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data: { nullable: true, type: object }
+
+  /v1/audit:
+    get:
+      operationId: listAuditLog
+      summary: Tail the audit log (most recent first)
+      parameters:
+        - { in: query, name: limit, required: false, schema: { type: integer, minimum: 1, maximum: 200, default: 50 } }
+      responses:
+        "200":
+          description: Recent audit entries.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data: { type: array, items: { type: object } }
+                  meta:
+                    type: object
+                    required: [total, limit, offset]
+                    properties:
+                      total: { type: integer }
+                      limit: { type: integer }
+                      offset: { type: integer }
+
+  /v1/openapi.json:
+    get:
+      operationId: getOpenApiSchema
+      summary: This document, served as JSON
+      responses:
+        "200":
+          description: The full OpenAPI 3.1 schema rendered as JSON.
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /v1/metrics/dora:
+    x-nimbus-status: reserved
+    description: |
+      Reserved for Phase 5 T4 PR 2. The drift CI gate exempts paths
+      whose `x-nimbus-status` is `reserved`. PR 2 replaces this stub.
+
+components:
+  schemas:
+    ItemPage:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          type: array
+          items: { type: object }
+        meta:
+          type: object
+          required: [total, limit, offset]
+          properties:
+            total: { type: integer }
+            limit: { type: integer }
+            offset: { type: integer }

--- a/packages/gateway/src/ipc/http-routes.test.ts
+++ b/packages/gateway/src/ipc/http-routes.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { READ_ONLY_HTTP_ROUTES } from "./http-routes.ts";
+
+describe("READ_ONLY_HTTP_ROUTES", () => {
+  it("includes the seven existing endpoints plus /v1/openapi.json", () => {
+    const paths = READ_ONLY_HTTP_ROUTES.map((r) => r.path);
+    expect(paths).toEqual([
+      "/v1/audit",
+      "/v1/connectors",
+      "/v1/health",
+      "/v1/items",
+      "/v1/items/{id}",
+      "/v1/openapi.json",
+      "/v1/people",
+      "/v1/people/{id}",
+    ]);
+  });
+
+  it("declares every route as GET", () => {
+    for (const route of READ_ONLY_HTTP_ROUTES) {
+      expect(route.method).toBe("GET");
+    }
+  });
+
+  it("is frozen (immutable)", () => {
+    expect(Object.isFrozen(READ_ONLY_HTTP_ROUTES)).toBe(true);
+  });
+});

--- a/packages/gateway/src/ipc/http-routes.ts
+++ b/packages/gateway/src/ipc/http-routes.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical list of read-only HTTP routes served by `startReadOnlyHttpServer`.
+ * The OpenAPI drift CI gate (`scripts/structure-audit/check-openapi-drift.ts`)
+ * compares this constant against `packages/gateway/openapi/v1.yaml` to ensure
+ * the published schema and the running handler agree.
+ *
+ * Adding a route: append here AND add a `paths:` entry in `v1.yaml`.
+ */
+export type ReadOnlyHttpRoute = {
+  readonly method: "GET";
+  /** OpenAPI-style path with `{param}` placeholders. */
+  readonly path: string;
+};
+
+export const READ_ONLY_HTTP_ROUTES: readonly ReadOnlyHttpRoute[] = Object.freeze([
+  { method: "GET", path: "/v1/audit" },
+  { method: "GET", path: "/v1/connectors" },
+  { method: "GET", path: "/v1/health" },
+  { method: "GET", path: "/v1/items" },
+  { method: "GET", path: "/v1/items/{id}" },
+  { method: "GET", path: "/v1/openapi.json" },
+  { method: "GET", path: "/v1/people" },
+  { method: "GET", path: "/v1/people/{id}" },
+] as const);

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -4,8 +4,10 @@
  */
 
 import { Database } from "bun:sqlite";
+import { resolve } from "node:path";
 import { getAllConnectorHealth } from "../connectors/health.ts";
 import { buildItemListSql, parseRelativeSinceToWindowMs } from "../index/item-list-query.ts";
+import { loadOpenApiJsonBytes } from "./openapi-loader.ts";
 
 export type ReadOnlyHttpServerHandle = {
   readonly stop: () => void;
@@ -123,6 +125,16 @@ function handleAudit(url: URL, db: Database): Response {
   return json({ data: rows, meta: { total: rows.length, limit: lim, offset: 0 } });
 }
 
+const OPENAPI_YAML_PATH = resolve(import.meta.dir, "..", "..", "openapi", "v1.yaml");
+
+function handleOpenApiJson(): Response {
+  const bytes = loadOpenApiJsonBytes(OPENAPI_YAML_PATH);
+  return new Response(bytes, {
+    status: 200,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
 function dispatchReadOnlyGet(path: string, url: URL, db: Database): Response {
   if (path === "/v1/health") {
     return json({ status: "ok", gateway: "read_only_http" });
@@ -144,6 +156,9 @@ function dispatchReadOnlyGet(path: string, url: URL, db: Database): Response {
   }
   if (path === "/v1/audit") {
     return handleAudit(url, db);
+  }
+  if (path === "/v1/openapi.json") {
+    return handleOpenApiJson();
   }
   return new Response("Not Found", { status: 404 });
 }

--- a/packages/gateway/src/ipc/openapi-loader.test.ts
+++ b/packages/gateway/src/ipc/openapi-loader.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadOpenApiJsonBytes } from "./openapi-loader.ts";
+
+function tmpYaml(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-openapi-"));
+  const p = join(dir, "v1.yaml");
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+describe("loadOpenApiJsonBytes", () => {
+  it("loads a well-formed YAML and returns JSON bytes", () => {
+    const p = tmpYaml("openapi: 3.1.0\ninfo:\n  title: t\n  version: 1.0.0\npaths: {}\n");
+    const bytes = loadOpenApiJsonBytes(p);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    const parsed = JSON.parse(new TextDecoder().decode(bytes));
+    expect(parsed.openapi).toBe("3.1.0");
+    expect(parsed.info.title).toBe("t");
+  });
+
+  it("throws on malformed YAML with a clear message", () => {
+    const p = tmpYaml("openapi: 3.1.0\n  badly indented:\n    nested\n  back\n");
+    expect(() => loadOpenApiJsonBytes(p)).toThrow(/openapi schema/i);
+  });
+
+  it("throws when the file is missing", () => {
+    expect(() => loadOpenApiJsonBytes("/nonexistent/v1.yaml")).toThrow();
+  });
+
+  it("returns the same bytes object on repeated calls (cached)", () => {
+    const p = tmpYaml("openapi: 3.1.0\ninfo:\n  title: t\n  version: 1.0.0\npaths: {}\n");
+    const a = loadOpenApiJsonBytes(p);
+    const b = loadOpenApiJsonBytes(p);
+    expect(a).toBe(b);
+  });
+});

--- a/packages/gateway/src/ipc/openapi-loader.ts
+++ b/packages/gateway/src/ipc/openapi-loader.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+
+/**
+ * Loads `packages/gateway/openapi/v1.yaml` once per absolute path and returns
+ * the JSON-encoded bytes. Subsequent calls with the same path return the
+ * cached bytes (`===` identity preserved).
+ *
+ * Throws with a wrapped error if the file is missing, unreadable, or contains
+ * malformed YAML. The Gateway should fail to start on that error rather than
+ * serve a stale or empty schema.
+ */
+const cache = new Map<string, Uint8Array>();
+
+export function loadOpenApiJsonBytes(absolutePath: string): Uint8Array {
+  const cached = cache.get(absolutePath);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(absolutePath, "utf8");
+  } catch (e) {
+    const cause = e instanceof Error ? e.message : String(e);
+    throw new Error(`failed to read openapi schema at ${absolutePath}: ${cause}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw, { filename: absolutePath });
+  } catch (e) {
+    const cause = e instanceof Error ? e.message : String(e);
+    throw new Error(`failed to parse openapi schema at ${absolutePath}: ${cause}`);
+  }
+  const bytes = new TextEncoder().encode(JSON.stringify(parsed));
+  cache.set(absolutePath, bytes);
+  return bytes;
+}
+
+/** Test-only — clears the in-memory cache. Not exported in the runtime path. */
+export function _clearOpenApiCache(): void {
+  cache.clear();
+}

--- a/packages/gateway/src/ipc/openapi-loader.ts
+++ b/packages/gateway/src/ipc/openapi-loader.ts
@@ -2,13 +2,18 @@ import { readFileSync } from "node:fs";
 import yaml from "js-yaml";
 
 /**
- * Loads `packages/gateway/openapi/v1.yaml` once per absolute path and returns
- * the JSON-encoded bytes. Subsequent calls with the same path return the
- * cached bytes (`===` identity preserved).
+ * Loads an OpenAPI YAML file from an absolute path and returns the
+ * JSON-encoded bytes. The result is cached per absolute path; subsequent
+ * calls with the same path return the same `Uint8Array` (`===` identity
+ * preserved) so HTTP handlers can serve from memory without per-request
+ * parse cost.
  *
- * Throws with a wrapped error if the file is missing, unreadable, or contains
- * malformed YAML. The Gateway should fail to start on that error rather than
- * serve a stale or empty schema.
+ * Throws with a wrapped error if the file is missing, unreadable, or
+ * contains malformed YAML. The Gateway should fail to start on that error
+ * rather than serve a stale or empty schema.
+ *
+ * The single production caller is `packages/gateway/src/ipc/http-server.ts`,
+ * which passes the absolute path to `packages/gateway/openapi/v1.yaml`.
  */
 const cache = new Map<string, Uint8Array>();
 
@@ -34,9 +39,4 @@ export function loadOpenApiJsonBytes(absolutePath: string): Uint8Array {
   const bytes = new TextEncoder().encode(JSON.stringify(parsed));
   cache.set(absolutePath, bytes);
   return bytes;
-}
-
-/** Test-only — clears the in-memory cache. Not exported in the runtime path. */
-export function _clearOpenApiCache(): void {
-  cache.clear();
 }

--- a/packages/gateway/test/integration/http/openapi-route.test.ts
+++ b/packages/gateway/test/integration/http/openapi-route.test.ts
@@ -1,0 +1,46 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startReadOnlyHttpServer } from "../../../src/ipc/http-server.ts";
+
+describe("GET /v1/openapi.json", () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let handle: { stop: () => void } | undefined;
+  let port: number;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nimbus-openapi-route-"));
+    dbPath = join(tmpDir, "nimbus.db");
+    // Empty schema is fine — the openapi route does not query the DB.
+    new Database(dbPath).close();
+    // Pick a high random port to avoid collisions with running gateways.
+    port = 49000 + Math.floor(Math.random() * 1000);
+    handle = startReadOnlyHttpServer(dbPath, port);
+  });
+
+  afterEach(() => {
+    handle?.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns a parseable OpenAPI 3.1 document", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/v1/openapi.json`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json();
+    expect(body.openapi).toBe("3.1.0");
+    expect(body.info.title).toBe("Nimbus Local HTTP API");
+    expect(body.paths["/v1/openapi.json"]).toBeDefined();
+    expect(body.paths["/v1/items"]).toBeDefined();
+  });
+
+  it("returns identical bytes on repeated requests (cached)", async () => {
+    const a = await (await fetch(`http://127.0.0.1:${port}/v1/openapi.json`)).text();
+    const b = await (await fetch(`http://127.0.0.1:${port}/v1/openapi.json`)).text();
+    expect(a).toBe(b);
+    expect(a.length).toBeGreaterThan(500);
+  });
+});

--- a/scripts/structure-audit/check-openapi-drift.test.ts
+++ b/scripts/structure-audit/check-openapi-drift.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { READ_ONLY_HTTP_ROUTES } from "../../packages/gateway/src/ipc/http-routes.ts";
+import { findOpenApiDrift } from "./check-openapi-drift.ts";
+
+function tmpYaml(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-drift-"));
+  const p = join(dir, "v1.yaml");
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+describe("findOpenApiDrift", () => {
+  it("returns no issues when YAML and ROUTE_TABLE agree", () => {
+    const pathsBlock = READ_ONLY_HTTP_ROUTES.map(
+      (r) => `  ${r.path}:\n    get:\n      responses:\n        "200":\n          description: ok`,
+    ).join("\n");
+    const yaml = `openapi: 3.1.0\ninfo:\n  title: t\n  version: 1.0.0\npaths:\n${pathsBlock}\n`;
+    const file = tmpYaml(yaml);
+    const issues = findOpenApiDrift(file, READ_ONLY_HTTP_ROUTES);
+    expect(issues).toEqual([]);
+  });
+
+  it("reports a schema-without-handler entry", () => {
+    const yaml = `openapi: 3.1.0
+info: { title: t, version: 1.0.0 }
+paths:
+  /v1/health: { get: { responses: { "200": { description: ok } } } }
+  /v1/ghost:  { get: { responses: { "200": { description: ok } } } }
+`;
+    const file = tmpYaml(yaml);
+    const routes = [{ method: "GET" as const, path: "/v1/health" }];
+    const issues = findOpenApiDrift(file, routes);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].kind).toBe("schema_without_handler");
+    expect(issues[0].path).toBe("/v1/ghost");
+  });
+
+  it("reports a handler-without-schema entry", () => {
+    const yaml = `openapi: 3.1.0
+info: { title: t, version: 1.0.0 }
+paths:
+  /v1/health: { get: { responses: { "200": { description: ok } } } }
+`;
+    const file = tmpYaml(yaml);
+    const routes = [
+      { method: "GET" as const, path: "/v1/health" },
+      { method: "GET" as const, path: "/v1/orphan" },
+    ];
+    const issues = findOpenApiDrift(file, routes);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].kind).toBe("handler_without_schema");
+    expect(issues[0].path).toBe("/v1/orphan");
+  });
+
+  it("exempts paths with x-nimbus-status: reserved from handler check", () => {
+    const yaml = `openapi: 3.1.0
+info: { title: t, version: 1.0.0 }
+paths:
+  /v1/health: { get: { responses: { "200": { description: ok } } } }
+  /v1/metrics/dora:
+    x-nimbus-status: reserved
+    description: reserved for PR 2
+`;
+    const file = tmpYaml(yaml);
+    const routes = [{ method: "GET" as const, path: "/v1/health" }];
+    const issues = findOpenApiDrift(file, routes);
+    expect(issues).toEqual([]);
+  });
+
+  it("reports a method mismatch (POST in schema, GET in handler)", () => {
+    const yaml = `openapi: 3.1.0
+info: { title: t, version: 1.0.0 }
+paths:
+  /v1/health: { post: { responses: { "200": { description: ok } } } }
+`;
+    const file = tmpYaml(yaml);
+    const routes = [{ method: "GET" as const, path: "/v1/health" }];
+    const issues = findOpenApiDrift(file, routes);
+    expect(issues.length).toBeGreaterThan(0);
+    const kinds = issues.map((i) => i.kind);
+    expect(kinds).toContain("schema_without_handler"); // POST /v1/health has no handler
+    expect(kinds).toContain("handler_without_schema"); // GET /v1/health is in routes but the schema only documents POST
+  });
+});

--- a/scripts/structure-audit/check-openapi-drift.ts
+++ b/scripts/structure-audit/check-openapi-drift.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+// OpenAPI ↔ handler drift detector.
+//
+// Asserts that every `path × method` documented in
+// packages/gateway/openapi/v1.yaml has a corresponding entry in
+// packages/gateway/src/ipc/http-routes.ts (READ_ONLY_HTTP_ROUTES) and
+// vice versa.
+//
+// Paths flagged with `x-nimbus-status: reserved` in the YAML are exempt
+// from the "must have a handler" half — they're placeholders for upcoming
+// work.
+//
+// Modes:
+//   --check (default)  exit non-zero on any drift; prints GitHub annotations
+//   --report           list every drift item; exit non-zero if any
+//
+// Exit codes:
+//   0  no drift
+//   1  drift detected
+//   2  usage error / could not read schema
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import yaml from "js-yaml";
+import {
+  READ_ONLY_HTTP_ROUTES,
+  type ReadOnlyHttpRoute,
+} from "../../packages/gateway/src/ipc/http-routes.ts";
+import { REPO_ROOT } from "./lib.ts";
+
+type DriftIssueKind = "schema_without_handler" | "handler_without_schema" | "yaml_unparseable";
+
+export type DriftIssue = {
+  kind: DriftIssueKind;
+  method: string;
+  path: string;
+  reason: string;
+};
+
+const RESERVED_TAG = "x-nimbus-status";
+const RESERVED_VALUE = "reserved";
+
+const DEFAULT_SCHEMA_PATH = resolve(REPO_ROOT, "packages", "gateway", "openapi", "v1.yaml");
+
+/**
+ * Pure function — exported for testing. Reads the YAML, walks `paths`, and
+ * compares against the supplied route table.
+ */
+export function findOpenApiDrift(
+  schemaFile: string,
+  routes: readonly ReadOnlyHttpRoute[],
+): DriftIssue[] {
+  const issues: DriftIssue[] = [];
+  let parsed: unknown;
+  try {
+    const raw = readFileSync(schemaFile, "utf8");
+    parsed = yaml.load(raw, { filename: schemaFile });
+  } catch (e) {
+    return [
+      {
+        kind: "yaml_unparseable",
+        method: "-",
+        path: schemaFile,
+        reason: e instanceof Error ? e.message : String(e),
+      },
+    ];
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return [
+      {
+        kind: "yaml_unparseable",
+        method: "-",
+        path: schemaFile,
+        reason: "top-level value is not a YAML mapping",
+      },
+    ];
+  }
+  const paths = (parsed as Record<string, unknown>)["paths"];
+  if (typeof paths !== "object" || paths === null) {
+    return [
+      {
+        kind: "yaml_unparseable",
+        method: "-",
+        path: schemaFile,
+        reason: "missing or non-object `paths` block",
+      },
+    ];
+  }
+
+  // Build the schema-side set: { method:GET path:/v1/health, ... } excluding reserved.
+  const schemaSet = new Set<string>();
+  for (const [pathKey, pathValueRaw] of Object.entries(paths as Record<string, unknown>)) {
+    if (typeof pathValueRaw !== "object" || pathValueRaw === null) {
+      continue;
+    }
+    const pathValue = pathValueRaw as Record<string, unknown>;
+    const status = pathValue[RESERVED_TAG];
+    if (status === RESERVED_VALUE) {
+      // Reserved slot — skipped entirely (no handler check, no method check).
+      continue;
+    }
+    for (const verb of ["get", "post", "put", "patch", "delete", "head", "options"]) {
+      if (pathValue[verb] !== undefined) {
+        schemaSet.add(`${verb.toUpperCase()} ${pathKey}`);
+      }
+    }
+  }
+
+  // Build the route-side set.
+  const routeSet = new Set<string>();
+  for (const r of routes) {
+    routeSet.add(`${r.method} ${r.path}`);
+  }
+
+  // Schema-side entries missing from routes.
+  for (const key of schemaSet) {
+    if (!routeSet.has(key)) {
+      const [method, ...rest] = key.split(" ");
+      issues.push({
+        kind: "schema_without_handler",
+        method,
+        path: rest.join(" "),
+        reason: "documented in v1.yaml but no entry in READ_ONLY_HTTP_ROUTES",
+      });
+    }
+  }
+  // Route-side entries missing from schema.
+  for (const key of routeSet) {
+    if (!schemaSet.has(key)) {
+      const [method, ...rest] = key.split(" ");
+      issues.push({
+        kind: "handler_without_schema",
+        method,
+        path: rest.join(" "),
+        reason: "in READ_ONLY_HTTP_ROUTES but not documented in v1.yaml",
+      });
+    }
+  }
+  return issues;
+}
+
+type Mode = "check" | "report";
+
+function parseArgs(argv: readonly string[]): { mode: Mode } {
+  let mode: Mode = "check";
+  for (const a of argv.slice(2)) {
+    if (a === "--check") mode = "check";
+    else if (a === "--report") mode = "report";
+    else {
+      console.error(`unknown flag: ${a}`);
+      process.exit(2);
+    }
+  }
+  return { mode };
+}
+
+async function run(): Promise<void> {
+  const { mode } = parseArgs(Bun.argv);
+  const issues = findOpenApiDrift(DEFAULT_SCHEMA_PATH, READ_ONLY_HTTP_ROUTES);
+
+  if (mode === "report") {
+    for (const i of issues) {
+      console.log(`${i.kind.toUpperCase()}  ${i.method} ${i.path}  (${i.reason})`);
+    }
+    console.log(`${issues.length} drift items`);
+    process.exit(issues.length === 0 ? 0 : 1);
+  }
+  // mode === "check"
+  if (issues.length === 0) {
+    console.log(
+      `OpenAPI drift check: schema and READ_ONLY_HTTP_ROUTES agree (${READ_ONLY_HTTP_ROUTES.length} routes).`,
+    );
+    return;
+  }
+  for (const i of issues) {
+    console.error(
+      `::error file=packages/gateway/openapi/v1.yaml::${i.kind} ${i.method} ${i.path}: ${i.reason}`,
+    );
+  }
+  console.error(`\n${issues.length} OpenAPI drift items.`);
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  run().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

PR 1 of three for **Phase 5 T4 — CI/CD Data Layer**. Foundations only: ships the published OpenAPI 3.1 surface contract, the drift CI gate that locks the schema and the running handler together, plus supporting docs and the pre-commit hook template. **No DORA logic here** — that lands in PR 2.

- New `packages/gateway/openapi/v1.yaml` — hand-authored OpenAPI 3.1 schema for the seven existing read-only endpoints (`/v1/health`, `/v1/items`, `/v1/items/{id}`, `/v1/connectors`, `/v1/people`, `/v1/people/{id}`, `/v1/audit`) plus the new `/v1/openapi.json`. Reserves `/v1/metrics/dora` with `x-nimbus-status: reserved` so PR 2 fills it without re-reviewing path declarations.
- New `GET /v1/openapi.json` — serves the YAML as cached JSON (parsed once at startup, bytes returned identical across requests).
- New `READ_ONLY_HTTP_ROUTES` constant at `packages/gateway/src/ipc/http-routes.ts` — single source of truth for which paths exist; consumed by the drift gate.
- New `scripts/structure-audit/check-openapi-drift.ts` + `audit:openapi-drift` script. CI fails on `schema_without_handler` or `handler_without_schema`. Reserved-tagged paths exempt.
- New `docs/cli/use-in-ci.md` — three worked `nimbus query --json | jq` examples (GitHub Actions self-hosted, GitLab CI, Jenkins).
- New `docs/templates/nimbus-pre-commit.sh` — Bash hook with PATH + Gateway-reachability preflight (both fail-open).
- `CLAUDE.md` + `GEMINI.md` status lines updated to reflect "T4 PR 1 foundations in flight".

## Plan + spec

- Spec: `docs/superpowers/specs/2026-05-10-phase-5-t4-cicd-data-layer-design.md` (PR #253).
- Plan: `docs/superpowers/plans/2026-05-10-phase-5-t4-pr1-foundations.md`.

## Commits (12)

| | |
|---|---|
| `5827ddd` | `feat(openapi): hand-authored v1 schema for the read-only HTTP API` |
| `5952e70` | `fix(openapi): /v1/connectors response includes meta` (code-review follow-up) |
| `5ff9a84` | `feat(ipc): export READ_ONLY_HTTP_ROUTES as the canonical route list` |
| `a8783f9` | `feat(ipc): cached OpenAPI loader (yaml→json bytes)` |
| `65351ab` | `fix(ipc): tighten openapi-loader doc + drop unused test helper` (code-review follow-up) |
| `1892387` | `feat(ipc): GET /v1/openapi.json serves the cached schema` |
| `724e609` | `feat(audit): OpenAPI drift detector` |
| `625a86c` | `ci: wire audit:openapi-drift into _test-suite.yml` |
| `b7ad8e5` | `docs(cli): worked examples for nimbus query in CI` |
| `8cb6712` | `docs(templates): nimbus pre-commit hook template` |
| `eb21def` | `docs(meta): point CLAUDE.md at T4 PR 1 surface` |
| `6c9038f` | `docs(meta): mirror T4 PR 1 status into GEMINI.md` |

## Test plan

- [x] `bun run test:ci` passes locally (full CI parity sweep — exit 0).
- [x] `bun run audit:openapi-drift` passes against the live `v1.yaml` + `READ_ONLY_HTTP_ROUTES`.
- [x] `bun run audit:openapi-drift` fails non-zero when a fake schema entry is added (manually verified end-to-end with `/v1/fake-route`).
- [x] `bun run audit:openapi-drift` fails non-zero when a fake route is added to `READ_ONLY_HTTP_ROUTES` (manually verified end-to-end with `/v1/orphan`).
- [x] `GET /v1/openapi.json` returns a parseable OpenAPI 3.1 doc (integration test) and identical bytes across repeated requests (cache identity verified).
- [x] Pre-commit hook fail-open on missing `nimbus` binary verified manually (`PATH=/nonexistent docs/templates/nimbus-pre-commit.sh` → exit 0 with skip message).
- [x] All 208 IPC unit tests still pass; no regression.

## Out of scope (deferred to PR 2 / PR 3)

- DORA metrics (`nimbus metrics dora` CLI + IPC method + `[metrics.dora.<service-id>]` config + `metrics/dora.ts` calculators).
- `nimbus-dev/query-action` GitHub Action (PR 3).
- Parameter-level drift detection (path × method only in PR 1; param parity deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)