### PR TITLE
docs(phase-5): roadmap expansion II + slim CLAUDE.md + T4 PR 2 plan

### DIFF
--- a/.claude/commands/nimbus-commands.md
+++ b/.claude/commands/nimbus-commands.md
@@ -1,0 +1,273 @@
+---
+name: nimbus-commands
+description: >
+  Reference for the bun scripts, CLI subcommands, and environment-variable overrides used to develop
+  on, test, build, package, and release Nimbus. Use this skill whenever the user asks "how do I run
+  X?", "which coverage gate covers Y?", "what's the bun script for Z?", "what env var overrides
+  the LLM model?", or before proposing a `bun add` (the dependency-safety section names the
+  pre-flight check). Also trigger when wiring CI gates, drafting release commands, or deciding
+  whether a subsystem is covered by an existing coverage threshold. Faster and more accurate than
+  re-reading `package.json` from scratch — the skill groups scripts by concern and includes
+  rationale (what each gate covers, why a script exists).
+---
+
+# Nimbus Commands Reference
+
+Resolution order for ambiguous commands: `package.json` `scripts` is authoritative if a script name conflicts with the table below. Run `bun run` (no args) to list the live workspace scripts.
+
+## Develop
+
+```bash
+bun install                     # install all workspace deps
+bun run typecheck               # tsc --noEmit across all packages
+bun run lint                    # Biome — format + lint
+bun run lint:fix                # auto-fix
+bun run dev-doctor              # contributor env health (Bun version, node_modules, Rust, gcloud, libsecret on Linux)
+```
+
+## Test
+
+```bash
+bun test                                  # all unit tests (workspace + scripts/)
+bun run test:scripts                      # only scripts/**/*.test.ts (regen-slo, structure-audit, package-linux-installers, nimbus-verify)
+bun run test:coverage                     # all packages with coverage
+bun run test:integration                  # integration suite
+bun run test:e2e:cli                      # E2E CLI scenarios
+
+cd packages/ui && bunx vitest run                     # UI components (Vitest, separate runner)
+cd packages/ui && bunx vitest run --coverage          # UI with coverage
+
+bun run test:ci                           # full CI parity — same sequence as .github/workflows/_test-suite.yml
+```
+
+## Coverage gates (enforced in CI)
+
+Run all via `bun run test:ci`. Individual gates:
+
+```bash
+# Engine + agents
+bun run test:coverage:engine          # ≥85% (engine)
+bun run test:coverage:agents          # ≥80% (built-in agents)
+
+# Vault + security-adjacent
+bun run test:coverage:vault           # ≥90% (vault)
+bun run test:coverage:extensions      # ≥85% (extension registry + manifest + verify)
+
+# Sync + rate limiting
+bun run test:coverage:sync            # ≥80% (sync scheduler)
+bun run test:coverage:rate-limiter    # ≥85% (per-provider rate limiter)
+
+# Index + people graph + embeddings
+bun run test:coverage:people          # ≥80% (people graph + cross-service linker)
+bun run test:coverage:embedding       # ≥80% (embedding)
+
+# Workflow + watcher
+bun run test:coverage:workflow        # ≥80% (workflow runner + store)
+bun run test:coverage:watcher         # ≥80% (watcher engine + store + anomaly stub)
+
+# Phase 3.5 — observability + portability
+bun run test:coverage:db              # ≥85% (verify, repair, snapshot, health, metrics, latency buffer)
+bun run test:coverage:health          # ≥85% (connectors/health.ts)
+bun run test:coverage:config          # ≥80% (config loader, profiles, env overrides)
+bun run test:coverage:client          # ≥80% (@nimbus-dev/client)
+bun run test:coverage:telemetry       # ≥85% (telemetry collector — payload safety gate)
+bun run test:coverage:doctor          # ≥80% (nimbus doctor)
+bun run test:coverage:tui             # ≥80% (packages/cli/src/tui)
+bun run test:coverage:mcp             # ≥70% (mcp-connectors)
+bun run test:coverage:sdk             # ≥80% (@nimbus-dev/sdk)
+
+# Phase 4 WS4 — release infrastructure
+bun run test:coverage:updater         # ≥80% (updater state machine + manifest fetcher)
+bun run test:coverage:lan             # ≥80% (lan-crypto, lan-pairing, lan-rate-limit, lan-rpc, lan-server)
+bun run test:coverage:perf            # ≥80% (perf bench harness)
+
+# UI Vitest gate
+cd packages/ui && bunx vitest run --coverage   # ≥80% lines / ≥75% branches
+```
+
+## Build + clean
+
+```bash
+bun run build                   # all packages
+bun run build:debug             # debug build w/ sourcemaps (also: scripts/{linux,windows}/build-debug.{sh,ps1})
+bun run build:release           # production build       (also: scripts/{linux,windows}/build-release.{sh,ps1})
+bun run clean                   # remove all build outputs
+bun run clean-deep              # workspace-aware deep clean (root + per-package node_modules + bun.lock)
+```
+
+## Security audits
+
+```bash
+bun audit --audit-level high
+bun run audit:high              # same; root script alias
+```
+
+## Structure audit (Phase 4 B3)
+
+```bash
+bun run audit:structure                 # full pack via orchestrator → run-<ts>.json
+bun run audit:boundaries                # dep-cruiser: D1 cross-pkg / D2 cycles / D3 PAL leakage
+bun run audit:duplication               # jscpd token duplication (D6)
+bun run audit:dead-code                 # knip unused exports / orphan files (D7)
+bun run audit:any                       # D8 any-count print
+bun run audit:invariants                # D10 spawn rule + D11 vault-key allow-list (binary, --binary-only)
+
+bun scripts/structure-audit/count-any-usage.ts --check     # D8 CI gate (fails on regression OR reduction without --update)
+bun scripts/structure-audit/count-any-usage.ts --update    # rewrite docs/structure-audit/any-baseline.json
+
+bun scripts/structure-audit/check-doc-references.ts --check  # doc-ref drift (broken markdown links + backtick paths)
+```
+
+Baselines: `docs/structure-audit/{any-baseline.json,db-run-census.json,churn-90d.json,baseline.md}`.
+CI gate (reusable workflow): `.github/workflows/_structure.yml`.
+
+## Headless packaging + Linux installers
+
+After compiling gateway + CLI to `dist/`:
+
+```bash
+bun run package:headless                            # bundle headless gateway + CLI
+bun run package:installers:linux -- --version 0.1.0 # Linux .deb + tarball
+```
+
+Optional: set `NIMBUS_EMBEDDING_MODEL_DIR` (or pass `--embedding-model-dir`) to embed pre-downloaded MiniLM weights in the bundle.
+
+## CLI subcommands (reference)
+
+These are runtime CLI commands, not bun scripts.
+
+### Phase 3.5 — query, config, profile, diag, doctor, db, telemetry
+
+```bash
+nimbus query --service github --type pr --since 7d --json
+nimbus query --sql "SELECT title FROM items WHERE pinned = 1" --pretty
+nimbus config get <key> / set <key> <value> / list / validate / edit
+nimbus profile create <name> / list / switch <name> / delete <name>
+nimbus diag [--json]
+nimbus diag slow-queries [--limit N] [--since <duration>]
+nimbus doctor
+nimbus db verify
+nimbus db repair [--yes]
+nimbus db snapshot
+nimbus db restore <snapshot>
+nimbus db snapshots list / backups list
+nimbus db prune [--yes]
+nimbus telemetry show
+nimbus telemetry disable
+nimbus serve [--port 7474]
+nimbus docs [topic]
+nimbus connector history <name>
+nimbus connector reindex <name> [--depth <metadata_only|summary|full>]
+```
+
+### Phase 4 WS3 — Data Sovereignty
+
+```bash
+nimbus data export --output <path.tar.gz> --passphrase <pw> [--no-index]
+nimbus data import <path.tar.gz> [--passphrase <pw> | --recovery-seed <mnemonic>]
+nimbus data delete --service <name> [--dry-run] [--yes]
+nimbus audit verify [--full] [--since <id>]
+nimbus audit export --output <path.json>
+```
+
+### Phase 4 B2 — Perf bench
+
+```bash
+nimbus bench --surface S2-a --runs 5 --corpus small --gha
+nimbus bench --all --reference        # interactive protocol confirmation required
+```
+
+### Phase 4 WS4 — Release infrastructure
+
+```bash
+# Auto-update
+nimbus update --check                  # exit 1 if newer available
+nimbus update [--yes]                  # download, verify Ed25519, install
+
+# LAN remote access
+nimbus lan enable [--allow-pairing]    # start LAN server; open 5-min pairing window
+nimbus lan disable
+nimbus lan pair <host-ip> <code>       # exchange X25519 keys with a host using pairing code
+nimbus lan status
+nimbus lan list-peers                  # id, direction, write-allowed
+nimbus lan grant-write <peer-id>       # allow peer to call write/HITL methods
+nimbus lan revoke-write <peer-id>
+nimbus lan remove-peer <peer-id>
+```
+
+### Phase 5 T3 — Team Intelligence built-in agents
+
+```bash
+nimbus expert <topic-or-file>     # IPC: agents.expert; emits agents.expert.briefReady
+nimbus impact <file-or-PR-url>    # IPC: agents.impact; emits agents.impact.briefReady
+```
+
+## Environment-variable overrides
+
+### Multi-agent loop guards (Phase 4)
+
+```
+NIMBUS_MAX_AGENT_DEPTH=3              # sub-agent recursion limit (1–10; default 3)
+NIMBUS_MAX_TOOL_CALLS_PER_SESSION=20  # hard cap on tool calls per session (1–200; default 20)
+```
+
+Exceeding either fires `agent.gasLimitReached` and halts new decomposition.
+
+### Release infrastructure (Phase 4 WS4)
+
+```
+NIMBUS_UPDATER_URL=<url>               # override update manifest URL (default: official endpoint)
+NIMBUS_UPDATER_DISABLE=true            # disable auto-update entirely
+NIMBUS_LAN_PORT=<port>                 # override LAN TCP listen port (default 7475)
+NIMBUS_DEV_UPDATER_PUBLIC_KEY=<base64> # override embedded Ed25519 public key (tests only)
+```
+
+### LLM model selection
+
+Resolution priority: env > `[llm]` TOML > hardcoded default.
+Bare model ids work; the engine auto-prefixes for Mastra (`claude-*` → `anthropic/...`, `gpt-*` / `o1-*` / `o3-*` / `o4-*` → `openai/...`).
+
+```
+NIMBUS_AGENT_MODEL=claude-sonnet-4-6                # overrides [llm].remote_model       (Mastra agent)
+NIMBUS_CLASSIFIER_MODEL=claude-haiku-4-5-20251001   # overrides [llm].classifier_model   (Anthropic intent classifier)
+NIMBUS_OPENAI_CLASSIFIER_MODEL=gpt-4o-mini          # OpenAI classifier when ANTHROPIC_API_KEY is unset
+```
+
+## Docs site
+
+```bash
+bun run docs:build                              # from repo root (workspace filter)
+cd packages/docs && bunx astro build            # static build
+cd packages/docs && bunx astro dev              # local dev server
+```
+
+## Release tags (publish triggers)
+
+```bash
+# @nimbus-dev/client → npm
+git tag client-v0.1.0 && git push origin client-v0.1.0
+
+# Nimbus VS Code extension → Marketplace + Open VSX + GitHub Release
+# Requires repo secrets VSCE_PAT (Marketplace) + OVSX_PAT (Open VSX)
+git tag vscode-v0.1.0 && git push origin vscode-v0.1.0
+```
+
+Extension author CI template: `docs/templates/nimbus-extension-ci.yml`.
+
+## Dependency safety
+
+Before suggesting any `bun add` (or `bun add -d`), run:
+
+```bash
+bun run check-package <name>
+```
+
+The script fetches metadata from `registry.npmjs.org` and prints author, maintainers, created date, version count.
+
+**Do not propose `bun add`** if any of:
+
+- Script exits with code `1` (package does not exist on npm)
+- Script emits the `< 7 days old` warning (typo/slopsquatting risk)
+- Author/maintainer is unfamiliar for a name resembling a well-known package (`expresss`, `lodahs`, `react-domm`)
+
+When all three checks pass, include the package's published age and maintainer in your suggestion.

--- a/.claude/commands/nimbus-file-map.md
+++ b/.claude/commands/nimbus-file-map.md
@@ -1,0 +1,201 @@
+---
+name: nimbus-file-map
+description: >
+  Pointer index from "what subsystem owns X" to the file path holding the canonical implementation,
+  for the Nimbus monorepo. Use this skill when the user asks "where does X live?" or "where is the
+  HITL gate / vault / migration runner / Tauri allowlist / agents directory?", or when you are about
+  to grep for an entry-point and would benefit from a curated, semantically-described starting list.
+  This is faster and more accurate than `Glob` for high-traffic files like `engine/executor.ts`,
+  `vault/index.ts`, `connectors/`, `db/`, `llm/`, `ipc/`, agent surfaces (`agents/expert.ts`,
+  `agents/impact.ts`, `agents/_lib/*`), Tauri bridge (`gateway_bridge.rs`), and UI store slices.
+  Decay note: the table is curated by hand and lags real changes. If the user asks about something
+  recent (last 24 h) or a file you cannot find in the repo, treat the entry as a hint and verify
+  with `Glob` / `Grep` before recommending changes.
+---
+
+# Nimbus Key File Locations
+
+This is the curated pointer index. Source-of-truth is the working tree — verify a path with `Glob` before relying on it for code changes.
+
+## Engine + Security
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/engine/executor.ts` | HITL gate — `HITL_REQUIRED` frozen set; most security-critical file |
+| `packages/gateway/src/engine/coordinator.ts` | `AgentCoordinator` — multi-agent sub-task orchestration, depth + tool-call guards; `executeAll` runs sub-tasks in parallel (Phase 5 T3 PR 1) |
+| `packages/gateway/src/engine/sub-agent.ts` | `runSubAgent` — single sub-task executor with `sub_task_results` DB lifecycle |
+| `packages/gateway/src/engine/tool-output-envelope.ts` | `wrapToolOutput` — invariant `I11` envelope at the LLM-facing boundary |
+
+## Platform Abstraction Layer
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/platform/index.ts` | PAL — `createPlatformServices()` dispatch |
+| `packages/gateway/src/platform/win32.ts` | Windows platform implementation |
+| `packages/gateway/src/platform/darwin.ts` | macOS platform implementation |
+| `packages/gateway/src/platform/linux.ts` | Linux platform implementation |
+
+## Vault + Auth
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/vault/index.ts` | `NimbusVault` interface |
+| `packages/gateway/src/auth/google-access-token.ts` | Google per-service OAuth token resolution — `resolveGoogleOAuthVaultKey()`, `anyGoogleOAuthVaultPresent()` |
+| `packages/gateway/src/auth/oauth-vault-tokens.ts` | Generic OAuth token storage/refresh helpers — `getValidVaultOAuthAccessToken()`, `microsoftOAuthAccessFromConfig()` |
+
+## Connectors + MCP Mesh
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/connectors/` | MCP connector mesh (`lazy-mesh/` — Phase 3 bundle spawns AWS/Azure/GCP/IaC/observability MCPs when vault keys exist) |
+| `packages/gateway/src/connectors/health.ts` | Connector health state machine — `transitionHealth()`, `ConnectorHealthSnapshot` |
+| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers + typed connector-secret reader — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()`, `readConnectorSecret()` |
+| `packages/gateway/src/connectors/connector-secrets-manifest.ts` | `CONNECTOR_VAULT_SECRET_KEYS` — per-connector PAT/API-key vault manifest; `clearConnectorVaultSecretKeys()` |
+| `packages/gateway/src/connectors/remove-intent.ts` | Connector removal — cascade vault + index cleanup via `executeRemoveIntent()` |
+| `packages/gateway/src/connectors/openapi-indexer-sync.ts` | OpenAPI / AsyncAPI spec indexer (Phase 5 Wave A PR 1); `getLastSyncStats()` exposes skipped-spec counters |
+| `packages/gateway/src/connectors/obsidian-sync.ts` | Obsidian vault connector (Phase 5 Wave A PR 2); emits `obsidian_note` items + `backlinks` graph edges |
+| `packages/mcp-connectors/obsidian/src/server.ts` | Obsidian MCP server — reads + HITL-gated `obsidian_append_to_daily_note` |
+| `packages/gateway/src/sync/connectivity.ts` | Network connectivity probe — guards the sync scheduler against consuming backoff on offline events |
+
+## Local Index + Migrations + DB
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/index/migrations/runner.ts` | Migration runner; orchestrates `INDEXED_SCHEMA_STEPS`; pre-migration backup; rollback on throw |
+| `packages/gateway/src/index/*-v<N>-sql.ts` | Migration SQL constants (e.g., `obsidian-notes-v26-sql.ts`, `api-endpoint-v25-sql.ts`, `audit-session-v24-sql.ts`, `lan-peers-v19-sql.ts`) |
+| `packages/gateway/src/automation/graph-predicate.ts` | Graph predicate types/parser/evaluator |
+| `packages/gateway/src/automation/watcher-engine.ts` | Watcher evaluation loop; applies `graph_predicate_json` post-filter |
+| `packages/gateway/src/db/verify.ts` | `nimbus db verify` — non-destructive integrity checks |
+| `packages/gateway/src/db/repair.ts` | `nimbus db repair` — targeted recovery, audit-logged |
+| `packages/gateway/src/db/snapshot.ts` | Manual + scheduled snapshots |
+| `packages/gateway/src/db/metrics.ts` | `IndexMetrics` — counts, embedding coverage, latency percentiles |
+| `packages/gateway/src/db/latency-ring-buffer.ts` | In-memory ring buffer; async batch flush to `query_latency_log` |
+| `packages/gateway/src/db/write.ts` | Central DB write wrapper — catches `SQLITE_FULL`, re-throws `DiskFullError` |
+
+## LLM + Voice
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/llm/types.ts` | `LlmProvider`, `LlmTaskType`, `LlmModelInfo`, `LlmGenerateOptions/Result` |
+| `packages/gateway/src/llm/gpu-arbiter.ts` | `GpuArbiter` — single-slot GPU VRAM mutex with activity-aware timeout |
+| `packages/gateway/src/llm/ollama-provider.ts` | `OllamaProvider` — Ollama HTTP wrapper |
+| `packages/gateway/src/llm/llamacpp-provider.ts` | `LlamaCppProvider` — llama-server HTTP wrapper |
+| `packages/gateway/src/llm/router.ts` | `LlmRouter` — task routing, air-gap enforcement |
+| `packages/gateway/src/llm/registry.ts` | `LlmRegistry` — discovery, `llm_models` DB sync |
+| `packages/gateway/src/voice/service.ts` | `VoiceService` — STT (`whisper-cli`), TTS, wake-word loop |
+| `packages/gateway/src/voice/tts.ts` | `NativeTtsProvider` — `say` (mac), SAPI (Win), `espeak-ng`/`spd-say` (Linux) |
+
+## Built-in Agents
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/agents/expert.ts` | `nimbus expert <topic-or-file>` — parallel sub-agents over PR/review/incident; emits `agents.expert.briefReady` |
+| `packages/gateway/src/agents/impact.ts` | `nimbus impact <file-or-PR-url>` — 5-way reverse-dep blast radius; emits `agents.impact.briefReady` |
+| `packages/gateway/src/agents/_lib/findings.ts` | `ExpertBrief` / `ExpertFinding` / `Evidence` types + ranking helpers |
+| `packages/gateway/src/agents/_lib/gap-notes.ts` | Gap-note detectors (empty index, missing connector, missing entity, missing relation) |
+| `packages/gateway/src/agents/_lib/render.ts` | Deterministic Markdown fallback renderer |
+| `packages/gateway/src/agents/_lib/synthesize.ts` | LLM synthesis layer with deterministic fallback |
+
+## IPC
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/ipc/` | JSON-RPC 2.0 IPC server (one file per namespace under `handlers/`) |
+| `packages/gateway/src/ipc/agents-rpc.ts` | `agents.expert` + `agents.impact` handlers; rejects array payloads |
+| `packages/gateway/src/ipc/llm-rpc.ts` | `dispatchLlmRpc` — `llm.listModels` / `llm.getStatus` |
+| `packages/gateway/src/ipc/voice-rpc.ts` | `dispatchVoiceRpc` — `voice.*` handlers |
+| `packages/gateway/src/ipc/updater-rpc.ts` | `dispatchUpdaterRpc` — `updater.getStatus`/`checkNow`/`applyUpdate`/`rollback` |
+| `packages/gateway/src/ipc/http-server.ts` | Read-only local HTTP API (`localhost` only, `SQLITE_OPEN_READONLY`) |
+| `packages/gateway/src/ipc/metrics-server.ts` | Prometheus endpoint (`localhost`, off by default) |
+| `packages/gateway/src/ipc/lan-crypto.ts` | NaCl box keypair, `sealBoxFrame` / `openBoxFrame` |
+| `packages/gateway/src/ipc/lan-pairing.ts` | `PairingWindow` — single-use base58 pairing code, 5-min expiry |
+| `packages/gateway/src/ipc/lan-rate-limit.ts` | `LanRateLimiter` — per-IP sliding-window failure tracking |
+| `packages/gateway/src/ipc/lan-rpc.ts` | `LanError`, `checkLanMethodAllowed` — invariant `I5` |
+| `packages/gateway/src/ipc/lan-server.ts` | `LanServer` — `Bun.listen` TCP server; length-framed NaCl-box RPC |
+
+## Updater
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/updater/updater.ts` | `Updater` state machine — manifest, semver compare, download, Ed25519 verify, install |
+| `packages/gateway/src/updater/manifest-fetcher.ts` | `fetchUpdateManifest` — typed fetch with `AbortController` timeout |
+| `packages/gateway/src/updater/signature-verifier.ts` | `verifyBinarySignature` — Ed25519 over SHA-256 |
+| `packages/gateway/src/updater/public-key.ts` | Embedded Ed25519 public key; `NIMBUS_DEV_UPDATER_PUBLIC_KEY` override for tests |
+
+## Telemetry + Config + Perf
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/telemetry/collector.ts` | Opt-in telemetry — aggregate counters only, no content |
+| `packages/gateway/src/config/profiles.ts` | Named config profiles (`work`, `personal`); Vault key prefixing |
+| `packages/gateway/src/perf/` | B2 bench harness — `BenchHarness`, `PerfFixture`, `HistoryLine`, `bench-cli.ts` |
+
+## CLI
+
+| File | Purpose |
+|---|---|
+| `packages/cli/src/index.ts` | CLI entry point |
+| `packages/cli/src/ipc-client/` | IPC client + consent channel |
+| `packages/cli/src/commands/query.ts` | `nimbus query` — structured query with `--sql` guard |
+| `packages/cli/src/commands/config.ts` | `nimbus config get/set/list/validate/edit` |
+| `packages/cli/src/commands/profile.ts` | `nimbus profile create/list/switch/delete` |
+| `packages/cli/src/commands/diag.ts` | `nimbus diag` — diagnostic snapshot; `slow-queries` subcommand |
+| `packages/cli/src/commands/doctor.ts` | `nimbus doctor` — environment health |
+| `packages/cli/src/commands/telemetry.ts` | `nimbus telemetry show/disable` |
+| `packages/cli/src/commands/expert.ts` | `nimbus expert` — calls `agents.expert`, streams Markdown |
+| `packages/cli/src/commands/impact.ts` | `nimbus impact` — calls `agents.impact`; `--json` / `--service` filter |
+| `packages/cli/src/commands/bench.ts` | `nimbus bench` — `Bun.spawn` wrapper around `bench-runner.ts` |
+| `packages/cli/src/commands/tui.tsx` | `nimbus tui` entry — gateway check, fallback detection, Ink |
+| `packages/cli/src/tui/App.tsx` | TUI root — state machine + Option-1 layout |
+| `packages/cli/src/tui/state.ts` | Top-level reducer: `idle` / `streaming` / `awaiting-hitl` / `disconnected` |
+
+## SDK / Client / VS Code
+
+| File | Purpose |
+|---|---|
+| `packages/sdk/src/index.ts` | `@nimbus-dev/sdk` public API |
+| `packages/client/src/index.ts` | `@nimbus-dev/client` — `NimbusClient`, `MockClient` |
+| `packages/vscode-extension/` | `nimbus-vscode` — Marketplace + Open VSX (current tag `vscode-v0.1.2`) |
+
+## Tauri UI (frontend + Rust bridge)
+
+| File | Purpose |
+|---|---|
+| `packages/ui/src-tauri/src/gateway_bridge.rs` | Rust IPC bridge — `ALLOWED_METHODS` (60), `NO_TIMEOUT_METHODS` (4), `GLOBAL_BROADCAST_METHODS` (`profile.switched`); invariant `I7` |
+| `packages/ui/src-tauri/src/tray.rs` | System tray icon, menu, state forwarding |
+| `packages/ui/src-tauri/src/quick_query.rs` | Quick Query window lifecycle |
+| `packages/ui/src-tauri/src/hitl_popup.rs` | HITL popup window lifecycle |
+| `packages/ui/src-tauri/src/lib.rs` | Tauri app entry — plugins, tray init, global shortcut, macOS accessory mode |
+| `packages/ui/src-tauri/capabilities/default.json` | Tauri capability set — windows, permissions |
+| `packages/ui/src-tauri/tauri.conf.json` | CSP + window config (invariant `I8`) |
+| `packages/ui/src/ipc/client.ts` | `NimbusIpcClient`, `createIpcClient()`, `parseError()`; credential redaction (5 forbidden keys) |
+| `packages/ui/src/ipc/types.ts` | Shared IPC types |
+| `packages/ui/src/store/index.ts` | `useNimbusStore` — Zustand v5 + `persist`; 11 slices |
+| `packages/ui/src/store/partialize.ts` | `persistPartialize` — 5-key whitelist + 5-key forbidden deep-scrub |
+| `packages/ui/src/providers/GatewayConnectionProvider.tsx` | `onConnectionState` mirror + first-run routing |
+| `packages/ui/src/App.tsx` | `createBrowserRouter` — all UI routes |
+| `packages/ui/src/pages/` | Route-level pages: `QuickQuery`, `Onboarding`, `Dashboard`, `HitlPopup`, `Settings`, `settings/*` panels |
+| `packages/ui/src/components/hitl/HitlPopupPage.tsx` | Head-of-queue consent dialog → `consent.respond` |
+| `packages/ui/src/components/hitl/StructuredPreview.tsx` | XSS-safe recursive preview of `consent.request` details |
+| `packages/ui/src/hooks/useIpcQuery.ts` | Typed polling hook (pauses on hidden / disconnected) |
+| `packages/ui/src/hooks/useIpcSubscription.ts` | Typed Tauri event listener hook |
+| `packages/ui/src/hooks/useConfirm.tsx` | Inline confirm dialog hook with typed-name confirmation |
+| `packages/ui/src/store/slices/` | Per-domain Zustand slices (dashboard / hitl / settings / profile / telemetry / connectors / model / data) |
+
+## Audit + Structure Audit
+
+| File | Purpose |
+|---|---|
+| `scripts/structure-audit/lib.ts` | Shared B3 audit helpers — `REPO_ROOT`, `stripComments`, `countAnyInSource`, `iterateSourceFiles` |
+| `scripts/structure-audit/check-doc-references.ts` | Doc-ref drift audit (broken `[text](path)` and backtick path refs) |
+| `scripts/structure-audit/check-nimbus-invariants.ts` | Static-time complement to `security-invariants.test.ts` (invariants `I1`, vault-key allow-list) |
+| `docs/structure-audit/baseline.md` | Phase 1 baseline reference; per-dimension state + Phase 2 thresholds |
+
+## Top-level docs
+
+| File | Purpose |
+|---|---|
+| `docs/architecture.md` | Full subsystem design — read before modifying any subsystem |
+| `docs/roadmap.md` | Phases, acceptance criteria, delivered summary |
+| `docs/SECURITY-INVARIANTS.md` | I1–I12 rationale + anti-patterns + audit cross-references |
+| `docs/release/manual-smoke-headless.md` | Reusable manual smoke checklist for headless releases; per-platform results matrix |

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"b1a38e60-d819-45cf-b3bb-8ce02f06db65","pid":12224,"acquiredAt":1777397944927}
+{"sessionId":"ce7a5922-d4ff-4f24-8c30-4128d0fbe737","pid":25208,"procStart":"639140415545727890","acquiredAt":1778435402869}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict
 **Linter:** Biome
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence ✅ Complete (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅ · B3 Phase 1 ✅ · B3 Phase 2 ✅); **`v0.1.0` released 2026-05-09** (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 10); **Phase 5** — Extended Surface 🔵 Active (T1 sequencing spec ✅ · T3 PR 1 coordinator parallelism + `nimbus expert` ✅ · T3 PR 2 `nimbus impact` ✅ · T3 PR 3 `nimbus catchup` ✅ · Wave A PR 1 OpenAPI / AsyncAPI spec indexer ✅ · Wave A PR 2 Obsidian vault connector ✅)
+**Status:** Phase 4 ✅ Complete · Phase 5 (Extended Surface) 🔵 Active · `v0.1.0` released 2026-05-09 (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 13). Workstream-level status is in [`docs/roadmap.md`](./docs/roadmap.md).
 
 **Gemini CLI:** [`GEMINI.md`](./GEMINI.md) mirrors this file for the same repository — update both when changing commands, roadmap rows, or non-negotiables.
 
@@ -31,7 +31,7 @@ These constraints are architectural, not preferences. Do not suggest changes tha
 
 ## Security Invariants
 
-These are the structural defenses Nimbus relies on. Each one has a production wiring site and an enforcement test in `packages/gateway/src/security-invariants.test.ts` that fails if the defense is removed or orphaned. Full rationale, anti-patterns, and audit cross-references in [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md).
+Each invariant has a production wiring site and an enforcement test in `packages/gateway/src/security-invariants.test.ts`. Full rationale, anti-patterns, and audit cross-references in [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md).
 
 | # | Invariant | Wired at | Anti-pattern that regresses it |
 |---|---|---|---|
@@ -48,381 +48,26 @@ These are the structural defenses Nimbus relies on. Each one has a production wi
 | I11 | LLM-facing tool results wrapped via `wrapToolOutput` | `engine/agent.ts`, `engine/tool-output-envelope.ts` | New agent surface that feeds raw tool results to the LLM |
 | I12 | DPAPI calls pass `pOptionalEntropy` from `<configDir>/vault/.entropy` | `vault/win32.ts` | Dropping the entropy parameter "for compatibility" |
 
-When changing a wiring site referenced above, update both the test and `SECURITY-INVARIANTS.md` in the same commit. When retiring an invariant, delete the row — never leave it as documentation drift.
+When changing a wiring site, update both the test and `SECURITY-INVARIANTS.md` in the same commit. When retiring an invariant, delete the row — never leave it as documentation drift.
 
-**Static-time complement:** Phase 1 of the B3 structure audit added
-`scripts/structure-audit/check-nimbus-invariants.ts` which enforces I1
-(`spawn` under `connectors/` must use `extensionProcessEnv()`) and the
-vault-key allow-list at static time. The runtime tests in
-`packages/gateway/src/security-invariants.test.ts` remain authoritative
-for invariant wiring; the static checks catch regressions before the test
-runs. See `docs/structure-audit/baseline.md` for current findings.
+**Static-time complement:** `scripts/structure-audit/check-nimbus-invariants.ts` enforces I1 (`spawn` under `connectors/` must use `extensionProcessEnv()`) and the vault-key allow-list at static time. Runtime tests remain authoritative; the static checks fail before the test suite runs.
 
 ---
 
-## Key File Locations
+## Subsystems (monorepo)
 
-| File | Purpose |
-|---|---|
-| `packages/gateway/src/engine/executor.ts` | HITL gate — `HITL_REQUIRED` frozen set; most security-critical file |
-| `packages/gateway/src/platform/index.ts` | PAL — `createPlatformServices()` dispatch |
-| `packages/gateway/src/platform/win32.ts` | Windows platform implementation |
-| `packages/gateway/src/platform/darwin.ts` | macOS platform implementation |
-| `packages/gateway/src/platform/linux.ts` | Linux platform implementation |
-| `packages/gateway/src/vault/index.ts` | `NimbusVault` interface |
-| `packages/gateway/src/auth/google-access-token.ts` | Google per-service OAuth token resolution — `resolveGoogleOAuthVaultKey()`, `anyGoogleOAuthVaultPresent()` |
-| `packages/gateway/src/auth/oauth-vault-tokens.ts` | Generic OAuth token storage/refresh helpers — `getValidVaultOAuthAccessToken()`, `microsoftOAuthAccessFromConfig()` |
-| `packages/gateway/src/connectors/` | MCP connector mesh (`lazy-mesh/` — Phase 3 bundle spawns AWS/Azure/GCP/IaC/observability MCPs when vault keys exist) |
-| `packages/gateway/src/connectors/health.ts` | Connector health state machine — `transitionHealth()`, `ConnectorHealthSnapshot` |
-| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers + typed connector-secret reader — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()`, `readConnectorSecret()` (Phase 4 / D11 Bucket B) |
-| `packages/gateway/src/connectors/connector-secrets-manifest.ts` | `CONNECTOR_VAULT_SECRET_KEYS` — per-connector PAT/API-key vault manifest; `clearConnectorVaultSecretKeys()` |
-| `packages/gateway/src/connectors/remove-intent.ts` | Connector removal — cascade vault + index cleanup via `executeRemoveIntent()` |
-| `packages/gateway/src/automation/graph-predicate.ts` | Graph predicate types, parser, evaluator; `parseGraphPredicate` / `itemMatchesGraphPredicate` / `countItemsMatchingGraphPredicate` / `listCandidateGraphRelations` |
-| `packages/gateway/src/automation/watcher-engine.ts` | Watcher evaluation loop; applies `graph_predicate_json` as a post-filter when `[automation].graph_conditions = true` |
-| `packages/gateway/src/index/watcher-graph-v22-sql.ts` | V22 migration — `watcher.graph_predicate_json` column |
-| `packages/gateway/src/index/workflow-run-columns-v23-sql.ts` | V23 migration — `dry_run` and `params_override_json` columns |
-| `packages/gateway/src/index/audit-session-v24-sql.ts` | V24 migration — `audit_log.session_id` column |
-| `packages/gateway/src/index/api-endpoint-v25-sql.ts` | V25 migration — `api_endpoint` shadow table for OpenAPI / AsyncAPI indexer (Phase 5 Wave A PR 1) |
-| `packages/gateway/src/connectors/openapi-indexer-sync.ts` | OpenAPI / AsyncAPI spec indexer — gateway-side syncable that emits `api_endpoint` items + `api_endpoint → service` graph edges (Phase 5 Wave A PR 1); `getLastSyncStats()` exposes skipped-spec counters |
-| `packages/gateway/src/index/obsidian-notes-v26-sql.ts` | V26 migration — `obsidian_notes` shadow table + `backlinks` `graph_relation_type` seed (Phase 5 Wave A PR 2) |
-| `packages/gateway/src/connectors/obsidian-sync.ts` | Obsidian vault connector — gateway-side syncable that emits `obsidian_note` items + `backlinks` graph edges via `syncObsidianNoteGraph` (Phase 5 Wave A PR 2) |
-| `packages/mcp-connectors/obsidian/src/server.ts` | Obsidian MCP server — `obsidian_list` / `_get` / `_search` reads + HITL-gated `obsidian_append_to_daily_note` (gated by `obsidian.note.append`); receives vault paths via `OBSIDIAN_VAULT_PATHS_JSON` |
-| `packages/gateway/src/sync/connectivity.ts` | Network connectivity probe — guards the sync scheduler against consuming backoff on offline events |
-| `packages/gateway/src/db/verify.ts` | `nimbus db verify` — non-destructive index integrity checks (integrity_check, FTS5, vec rowid, FK, schema version) |
-| `packages/gateway/src/db/repair.ts` | `nimbus db repair` — targeted recovery actions; writes audit log entry |
-| `packages/gateway/src/db/snapshot.ts` | Manual and scheduled snapshot management |
-| `packages/gateway/src/db/metrics.ts` | `IndexMetrics` — item counts, embedding coverage, query latency percentiles |
-| `packages/gateway/src/db/latency-ring-buffer.ts` | In-memory ring buffer for query latency samples; async batch flush to `query_latency_log` |
-| `packages/gateway/src/db/write.ts` | Central DB write wrapper — catches `SQLITE_FULL`, re-throws `DiskFullError` |
-| `packages/gateway/src/perf/` | B2 bench harness — `BenchHarness`, `PerfFixture`, `HistoryLine`, `bench-cli.ts`; one S2-a driver under `surfaces/` |
-| `packages/cli/src/commands/bench.ts` | `nimbus bench` CLI command — thin `Bun.spawn` wrapper around `bench-runner.ts` |
-| `scripts/structure-audit/lib.ts` | Shared B3 audit helpers — `REPO_ROOT`, `stripComments`, `countAnyInSource`, `iterateSourceFiles`, `auditOutputPath`; imported by every audit driver |
-| `docs/structure-audit/baseline.md` | Phase 1 baseline reference for the B3 structure audit; per-dimension starting state + Phase 2 thresholds |
-| `packages/gateway/src/telemetry/collector.ts` | Opt-in telemetry — aggregate counters only, no content, configurable endpoint |
-| `packages/gateway/src/config/profiles.ts` | Named configuration profiles (`work`, `personal`); Vault key prefixing |
-| `packages/gateway/src/llm/types.ts` | LLM provider interfaces — `LlmProvider`, `LlmTaskType`, `LlmModelInfo`, `LlmGenerateOptions/Result` |
-| `packages/gateway/src/llm/gpu-arbiter.ts` | `GpuArbiter` — single-slot GPU VRAM mutex with activity-aware timeout |
-| `packages/gateway/src/llm/ollama-provider.ts` | `OllamaProvider` — Ollama HTTP API wrapper (batch + streaming) |
-| `packages/gateway/src/llm/llamacpp-provider.ts` | `LlamaCppProvider` — llama-server HTTP API wrapper |
-| `packages/gateway/src/llm/router.ts` | `LlmRouter` — task-to-provider routing, air-gap enforcement, local/remote preference |
-| `packages/gateway/src/llm/registry.ts` | `LlmRegistry` — model discovery, `llm_models` DB sync, availability checks |
-| `packages/gateway/src/ipc/llm-rpc.ts` | `dispatchLlmRpc` — `llm.listModels` / `llm.getStatus` IPC handlers |
-| `packages/gateway/src/voice/service.ts` | `VoiceService` — STT (`whisper-cli`), TTS, wake-word loop |
-| `packages/gateway/src/voice/tts.ts` | `NativeTtsProvider` — `say` (macOS), PowerShell SAPI (Windows), `espeak-ng`/`spd-say` (Linux) |
-| `packages/gateway/src/ipc/voice-rpc.ts` | `dispatchVoiceRpc` — `voice.*` IPC handlers |
-| `packages/gateway/src/engine/coordinator.ts` | `AgentCoordinator` — multi-agent sub-task orchestration, depth + tool-call guards; `executeAll` runs sub-tasks in parallel (Phase 5 T3 PR 1) |
-| `packages/gateway/src/engine/sub-agent.ts` | `runSubAgent` — single sub-task executor with `sub_task_results` DB lifecycle |
-| `packages/gateway/src/agents/expert.ts` | First built-in agent — `nimbus expert <topic-or-file>`; parallel sub-agents over indexed PR authorship + review history + incident involvement; emits `agents.expert.briefReady` notification |
-| `packages/gateway/src/agents/impact.ts` | Second built-in agent — `nimbus impact <file-or-PR-url>`; reverse-dependency blast radius across services / pipelines / dashboards / oncall; 5 parallel sub-agents over the relationship graph; emits `agents.impact.briefReady` notification |
-| `packages/gateway/src/agents/_lib/findings.ts` | `ExpertBrief` / `ExpertFinding` / `Evidence` types + ranking helpers shared across built-in agents |
-| `packages/gateway/src/agents/_lib/gap-notes.ts` | Gap-note detectors (empty index, missing connector, missing entity type, missing relation emit) used by built-in agents |
-| `packages/gateway/src/agents/_lib/render.ts` | Deterministic Markdown renderer for `ExpertBrief` and `ImpactBrief` (used as fallback when LLM synthesis is unavailable) |
-| `packages/gateway/src/agents/_lib/synthesize.ts` | LLM synthesis layer for built-in agents; falls back to deterministic renderer when no LLM is available |
-| `packages/gateway/src/ipc/agents-rpc.ts` | `dispatchAgentsRpc` — `agents.expert` + `agents.impact` JSON-RPC handlers; rejects array payloads; emits `agents.expert.briefReady` and `agents.impact.briefReady` |
-| `packages/gateway/src/index/llm-models-v16-sql.ts` | V16 migration SQL — `llm_models` table + `sync_state.context_window_tokens` |
-| `packages/gateway/src/index/sub-task-results-v17-sql.ts` | V17 migration SQL — `sub_task_results` table for multi-agent persistence |
-| `packages/gateway/src/ipc/http-server.ts` | Read-only local HTTP API (`localhost` only, `SQLITE_OPEN_READONLY` connection) |
-| `packages/gateway/src/ipc/metrics-server.ts` | Prometheus-compatible metrics endpoint (`localhost` only, off by default) |
-| `packages/gateway/src/ipc/lan-crypto.ts` | NaCl box keypair generation, `sealBoxFrame` / `openBoxFrame` for LAN E2E encryption |
-| `packages/gateway/src/ipc/lan-pairing.ts` | `PairingWindow` — single-use base58 pairing code with 5-minute expiry |
-| `packages/gateway/src/ipc/lan-rate-limit.ts` | `LanRateLimiter` — per-IP sliding-window failure tracking and lockout |
-| `packages/gateway/src/ipc/lan-rpc.ts` | `LanError`, `checkLanMethodAllowed` — forbidden-method and write-grant enforcement for LAN peers |
-| `packages/gateway/src/ipc/lan-server.ts` | `LanServer` — `Bun.listen` TCP server; length-framed, NaCl box encrypted RPC after pairing handshake |
-| `packages/gateway/src/ipc/updater-rpc.ts` | `dispatchUpdaterRpc` — `updater.getStatus`, `updater.checkNow`, `updater.applyUpdate`, `updater.rollback` |
-| `packages/gateway/src/updater/updater.ts` | `Updater` state machine — manifest fetch, semver compare, download, Ed25519 verify, install |
-| `packages/gateway/src/updater/manifest-fetcher.ts` | `fetchUpdateManifest` — typed manifest fetch with `AbortController` timeout |
-| `packages/gateway/src/updater/signature-verifier.ts` | `verifyBinarySignature` — Ed25519 over SHA-256 of binary |
-| `packages/gateway/src/updater/public-key.ts` | Embedded Ed25519 updater public key; `NIMBUS_DEV_UPDATER_PUBLIC_KEY` override for tests |
-| `packages/gateway/src/index/lan-peers-v19-sql.ts` | V19 migration SQL — `lan_peers` table |
-| `packages/gateway/src/ipc/` | JSON-RPC 2.0 IPC server |
-| `packages/cli/src/index.ts` | CLI entry point |
-| `packages/cli/src/ipc-client/` | IPC client + consent channel |
-| `packages/cli/src/commands/query.ts` | `nimbus query` — structured index query with `--sql` guard |
-| `packages/cli/src/commands/config.ts` | `nimbus config get/set/list/validate/edit` |
-| `packages/cli/src/commands/profile.ts` | `nimbus profile create/list/switch/delete` |
-| `packages/cli/src/commands/diag.ts` | `nimbus diag` — full diagnostic snapshot; `slow-queries` subcommand |
-| `packages/cli/src/commands/doctor.ts` | `nimbus doctor` — environment health checks, actionable remediation output |
-| `packages/cli/src/commands/telemetry.ts` | `nimbus telemetry show/disable` |
-| `packages/cli/src/commands/expert.ts` | `nimbus expert <topic-or-file>` — calls `agents.expert` IPC, streams Markdown brief to stdout (respects `NO_COLOR`) |
-| `packages/cli/src/commands/impact.ts` | `nimbus impact <file-or-PR-url>` — calls `agents.impact` IPC, streams Markdown brief to stdout; supports `--json` / `--depth` (reserved) / `--service` filter |
-| `packages/cli/src/commands/tui.tsx` | `nimbus tui` entry — gateway check, fallback detection, Ink render orchestration |
-| `packages/cli/src/tui/App.tsx` | TUI root — state machine + Option-1 layout + narrow/short-terminal behavior |
-| `packages/cli/src/tui/state.ts` | Top-level state reducer: `idle` / `streaming` / `awaiting-hitl` / `disconnected` |
-| `packages/sdk/src/index.ts` | `@nimbus-dev/sdk` public API |
-| `packages/client/src/index.ts` | `@nimbus-dev/client` public API — `NimbusClient`, `MockClient` |
-| `packages/vscode-extension/` | `nimbus-vscode` (displayName "Nimbus Agent") — VS Code extension; published to Marketplace + Open VSX; current tag `vscode-v0.1.2` |
-| `packages/ui/src/ipc/client.ts` | `NimbusIpcClient` singleton, `createIpcClient()`, `parseError()` — includes credential redaction (5 forbidden keys) |
-| `packages/ui/src/ipc/types.ts` | Shared IPC types — `ConnectionState`, `DiagSnapshot`, `ConnectorSummary`, `ProfileListResult`, `TelemetryStatus`, `RouterDecision`/`RouterStatusResult`, `LlmModelInfo`/`LlmListModelsResult`, `LlmAvailabilityResult`, `LlmPullStartedResult`/`LlmPullProgressPayload`/`LlmPullTerminalPayload`, error types |
-| `packages/ui/src/store/index.ts` | `useNimbusStore` — Zustand v5 store with `persist` middleware; 11 slices composed; `partialize` whitelist excludes secrets |
-| `packages/ui/src/store/partialize.ts` | `persistPartialize` — 5-key whitelist + 5-key forbidden deep-scrub for Zustand persist |
-| `packages/ui/src/providers/GatewayConnectionProvider.tsx` | `onConnectionState` mirror + first-run routing logic |
-| `packages/ui/src/App.tsx` | `createBrowserRouter` — all UI routes including nested `/settings/*` |
-| `packages/ui/src/pages/QuickQuery.tsx` | Quick Query popup page — stream + auto-close |
-| `packages/ui/src/pages/Onboarding.tsx` | Onboarding wizard frame + step pills |
-| `packages/ui/src/pages/Dashboard.tsx` | Dashboard page (metrics strip + connector grid + audit feed) |
-| `packages/ui/src/pages/HitlPopup.tsx` | HITL popup page hosted inside the `hitl-popup` Tauri window |
-| `packages/ui/src/pages/Settings.tsx` | Settings layout — `SettingsSidebar` + `<Outlet />` for nested panel routes |
-| `packages/ui/src/pages/settings/ProfilesPanel.tsx` | Profiles panel — list, create, switch, delete with typed-name confirm guard |
-| `packages/ui/src/pages/settings/TelemetryPanel.tsx` | Telemetry panel — toggle, counter cards, payload sample expander |
-| `packages/ui/src/pages/settings/ConnectorsPanel.tsx` | Connectors panel — interval editor (60 s min inline-validated), depth selector, enable toggle, `connector.configChanged` reconcile, Dashboard deep-link highlight |
-| `packages/ui/src/pages/settings/connectors/interval-parts.ts` | Interval input parser/formatter shared by `ConnectorsPanel` |
-| `packages/ui/src/pages/settings/ModelPanel.tsx` | Model panel — `RouterStatus` cards, per-task default pickers, load/unload row actions, `PullDialog` launcher, re-attaches to in-flight pull via persisted `activePullId` |
-| `packages/ui/src/components/settings/model/RouterStatus.tsx` | Per-task router decision cards driven by `llm.getRouterStatus`; emits `llm.setDefault` |
-| `packages/ui/src/components/settings/model/PullDialog.tsx` | Streaming model pull dialog — provider radio filtered by `llm.getStatus`, 15 s stall detection via `setTimeout`, cancel via `llm.cancelPull` |
-| `packages/ui/src/components/hitl/HitlPopupPage.tsx` | Head-of-queue consent dialog; Approve / Reject → `consent.respond` |
-| `packages/ui/src/components/hitl/StructuredPreview.tsx` | Recursive, XSS-safe preview of `consent.request` details |
-| `packages/ui/src/components/chrome/Sidebar.tsx` | Labelled sidebar nav with pending-HITL badge |
-| `packages/ui/src/components/chrome/PageHeader.tsx` | Page title + profile/health pill |
-| `packages/ui/src/components/dashboard/ConnectorTile.tsx` | Single connector card with health dot + degradation tooltip |
-| `packages/ui/src/components/settings/SettingsSidebar.tsx` | Settings secondary nav — 7 panel entries with `NavLink` active styling |
-| `packages/ui/src/components/settings/PanelHeader.tsx` | Shared panel title + description + optional live-status pill |
-| `packages/ui/src/components/settings/PanelError.tsx` | Error state with optional Retry button |
-| `packages/ui/src/components/settings/StaleChip.tsx` | Offline / stale indicator chip |
-| `packages/ui/src/components/settings/PanelComingSoon.tsx` | Placeholder for panels not yet implemented |
-| `packages/ui/src/hooks/useIpcQuery.ts` | Typed polling hook (pauses on hidden / disconnected) |
-| `packages/ui/src/hooks/useIpcSubscription.ts` | Typed Tauri event listener hook |
-| `packages/ui/src/hooks/useConfirm.tsx` | Inline confirm dialog hook — supports typed-name confirmation |
-| `packages/ui/src/lib/restart.ts` | `restartApp()` — invokes Tauri `plugin:app\|restart`; fallback to `location.reload()` |
-| `packages/ui/src/store/slices/dashboard.ts` | Dashboard store slice (metrics / connectors / audit / highlight) |
-| `packages/ui/src/store/slices/hitl.ts` | HITL pending-request FIFO queue |
-| `packages/ui/src/store/slices/settings.ts` | Settings slice — `activePanel` navigation state |
-| `packages/ui/src/store/slices/profile.ts` | Profile slice — list, active, `lastFetchAt`, `actionInFlight`; persisted |
-| `packages/ui/src/store/slices/telemetry.ts` | Telemetry slice — `TelemetryStatus` + `telemetryActionInFlight`; transient |
-| `packages/ui/src/store/slices/connectors.ts` | Connectors slice — `PersistedConnectorRow[]` (persisted) + transient `perServiceInFlight` + `highlightService` + `patchConnectorRow` |
-| `packages/ui/src/store/slices/model.ts` | Model slice — `installedModels` + `activePullId` (persisted) + transient `routerStatus`, `pullProgress`, `pullStalled`, `loadedKeys` |
-| `packages/ui/src-tauri/src/gateway_bridge.rs` | Rust IPC bridge — `ALLOWED_METHODS` (60), `NO_TIMEOUT_METHODS` (4), `GLOBAL_BROADCAST_METHODS` (`profile.switched`), `rpc_call`, reconnect loop |
-| `packages/ui/src-tauri/src/tray.rs` | System tray icon, menu, state forwarding |
-| `packages/ui/src-tauri/src/quick_query.rs` | Quick Query window lifecycle — spawn/focus, focus-loss close |
-| `packages/ui/src-tauri/src/hitl_popup.rs` | HITL popup window lifecycle — spawn / focus / close |
-| `packages/ui/src-tauri/src/lib.rs` | Tauri app entry — plugins, tray init, global shortcut, macOS accessory mode |
-| `packages/ui/src-tauri/capabilities/default.json` | Tauri capability set — windows, permissions |
-| `docs/release/manual-smoke-headless.md` | Reusable manual smoke checklist for headless Gateway + CLI + VS Code releases; per-platform results matrix; companion Windows run sheet at `manual-smoke-headless-windows.md` |
-| `packages/ui/src/pages/settings/DataPanel.tsx` | Data panel — Export/Import/Delete wizard launcher with preflight stats |
-| `packages/ui/src/components/settings/data/ExportWizard.tsx` | Export wizard — passphrase gate, zxcvbn, overwrite confirm, progress, seed display |
-| `packages/ui/src/components/settings/data/ImportWizard.tsx` | Import wizard — passphrase + recovery-seed auth, version-compat error handling |
-| `packages/ui/src/components/settings/data/DeleteServiceDialog.tsx` | Delete service dialog — preflight preview, typed-name confirm, `data.delete` call |
-| `packages/ui/src/store/slices/data.ts` | Data store slice — exportFlow / importFlow / deleteFlow state machines + markDisconnected |
-| `docs/architecture.md` | Full subsystem design — read before modifying any subsystem |
-| `docs/roadmap.md` | Phases, acceptance criteria, Phase 3 delivered summary |
+- `packages/gateway` — Engine, MCP mesh, Vault, local index, IPC
+- `packages/cli` — Terminal client (CLI + Ink TUI)
+- `packages/ui` — Tauri 2.0 + React (desktop)
+- `packages/sdk` — `@nimbus-dev/sdk` for extensions (MIT)
+- `packages/client` — `@nimbus-dev/client` (typed IPC wrapper, MIT)
+- `packages/mcp-connectors/*` — First-party MCP servers (AGPL)
+- `packages/vscode-extension` — `nimbus-vscode` (Marketplace + Open VSX)
+- `packages/docs` — Astro Starlight documentation site
 
----
+**PAL:** All OS-specific logic lives under `packages/gateway/src/platform/` and is accessed via `PlatformServices` — never import `win32` / `darwin` / `linux` from business logic.
 
-## Development Workflow
-
-**Worktree directory:** `.worktrees/` (project-local, git-ignored)
-
-When setting up isolated workspaces for feature branches, use `.worktrees/<branch-name>`.
-
----
-
-## Commands
-
-```bash
-# Install all dependencies
-bun install
-
-# Type check all packages
-bun run typecheck
-
-# Lint (Biome — format + lint)
-bun run lint
-bun run lint:fix
-
-# Run all unit tests (workspace packages + scripts/)
-bun test
-
-# Run only scripts/**/*.test.ts (regen-slo, structure-audit, package-linux-installers, nimbus-verify)
-bun run test:scripts
-
-# Run with coverage
-bun run test:coverage
-
-# Coverage gates (enforced in CI) — run all: bun run test:ci
-bun run test:coverage:engine       # ≥85% threshold (engine)
-bun run test:coverage:agents       # ≥80% threshold (built-in agents)
-bun run test:coverage:vault        # ≥90% threshold (vault)
-bun run test:coverage:sync         # ≥80% threshold (sync scheduler)
-bun run test:coverage:rate-limiter # ≥85% threshold (per-provider rate limiter)
-bun run test:coverage:people       # ≥80% threshold (people graph + cross-service linker)
-bun run test:coverage:embedding    # ≥80% threshold (embedding)
-bun run test:coverage:workflow     # ≥80% threshold (workflow runner + store)
-bun run test:coverage:watcher      # ≥80% threshold (watcher engine + store + anomaly stub)
-bun run test:coverage:extensions   # ≥85% threshold (extension registry + manifest + verify)
-# Phase 3.5 coverage gates
-bun run test:coverage:db           # ≥85% threshold (verify, repair, snapshot, health, metrics, latency buffer)
-bun run test:coverage:health       # ≥85% threshold (connectors/health.ts)
-bun run test:coverage:config       # ≥80% threshold (config loader, profiles, env overrides)
-bun run test:coverage:client       # ≥80% threshold (@nimbus-dev/client)
-bun run test:coverage:telemetry    # ≥85% threshold (telemetry collector — payload safety gate)
-bun run test:coverage:doctor       # ≥80% threshold (nimbus doctor checks)
-bun run test:coverage:tui          # ≥80% threshold (packages/cli/src/tui — TUI components)
-bun run test:coverage:mcp          # ≥70% threshold (mcp-connectors)
-bun run test:coverage:sdk          # ≥80% threshold (@nimbus-dev/sdk)
-# Phase 4 WS4 coverage gates
-bun run test:coverage:updater      # ≥80% threshold (updater state machine + manifest fetcher)
-bun run test:coverage:lan          # ≥80% threshold (lan-crypto, lan-pairing, lan-rate-limit, lan-rpc, lan-server)
-bun run test:coverage:perf         # ≥80% threshold (perf bench harness)
-
-# Phase 4 WS5-A UI coverage gate (Vitest — separate runner)
-cd packages/ui && bunx vitest run --coverage  # ≥80% lines / ≥75% branches
-
-# Integration tests
-bun run test:integration
-
-# E2E CLI tests
-bun run test:e2e:cli
-
-# UI component tests (Vitest — separate from bun test)
-cd packages/ui && bunx vitest run
-cd packages/ui && bunx vitest run --coverage  # with branch/line coverage report
-
-# Build all packages
-bun run build
-
-# Full validate-and-build (runs CI test suite first, then builds)
-bun run build:debug    # debug build with sourcemaps (also: scripts/linux/build-debug.sh, scripts/windows/build-debug.ps1)
-bun run build:release  # production build (also: scripts/linux/build-release.sh, scripts/windows/build-release.ps1)
-
-# Clean all build outputs
-bun run clean
-
-# Workspace-aware deep clean (root + per-package node_modules + bun.lock)
-bun run clean-deep
-
-# Contributor environment health check (Bun version, node_modules, Rust, gcloud, libsecret on Linux)
-bun run dev-doctor
-
-# Security audit
-bun audit --audit-level high
-bun run audit:high                 # same as above (root script)
-
-# Phase 4 B3 — Structure audit (Phase 1 tooling complete; Phase 2 ranking pending)
-bun run audit:structure         # full pack via orchestrator (writes run-<ts>.json)
-bun run audit:boundaries        # dep-cruiser: D1 cross-pkg / D2 cycles / D3 PAL leakage
-bun run audit:duplication       # jscpd token-level duplication (D6)
-bun run audit:dead-code         # knip unused exports / orphan files (D7)
-bun run audit:any               # D8 any-count print mode
-bun scripts/structure-audit/count-any-usage.ts --check    # D8 CI gate (fails on regression OR reduction without --update)
-bun scripts/structure-audit/count-any-usage.ts --update   # rewrite docs/structure-audit/any-baseline.json
-bun run audit:invariants        # D10 spawn rule + D11 vault-key allow-list (binary, --binary-only)
-# Baselines: docs/structure-audit/{any-baseline.json,db-run-census.json,churn-90d.json,baseline.md}
-# CI gate (reusable workflow): .github/workflows/_structure.yml — wired into ci.yml after Phase 3 top-5 fixes land
-
-# Headless binary bundle + Linux .deb / tarball (after compiling gateway + CLI to dist/)
-# Optional: set NIMBUS_EMBEDDING_MODEL_DIR to pre-downloaded MiniLM weights (or pass --embedding-model-dir) to embed them in the bundle output
-bun run package:headless
-bun run package:installers:linux -- --version 0.1.0
-
-# Phase 3.5 CLI commands (reference — not bun scripts)
-# nimbus query --service github --type pr --since 7d --json
-# nimbus query --sql "SELECT title FROM items WHERE pinned = 1" --pretty
-# nimbus config get <key> / set <key> <value> / list / validate / edit
-# nimbus profile create <name> / list / switch <name> / delete <name>
-# nimbus diag [--json]
-# nimbus diag slow-queries [--limit N] [--since <duration>]
-# nimbus doctor
-# nimbus db verify
-# nimbus db repair [--yes]
-# nimbus db snapshot
-# nimbus db restore <snapshot>
-# nimbus db snapshots list / backups list
-# nimbus db prune [--yes]
-# nimbus telemetry show
-# nimbus telemetry disable
-# nimbus serve [--port 7474]
-# nimbus docs [topic]
-# nimbus connector history <name>
-# nimbus connector reindex <name> [--depth <metadata_only|summary|full>]
-
-# Phase 4 WS3 — Data Sovereignty
-# nimbus data export --output <path.tar.gz> --passphrase <pw> [--no-index]
-# nimbus data import <path.tar.gz> [--passphrase <pw> | --recovery-seed <mnemonic>]
-# nimbus data delete --service <name> [--dry-run] [--yes]
-# nimbus audit verify [--full] [--since <id>]
-# nimbus audit export --output <path.json>
-
-# Phase 4 B2 — Perf bench (Phase 1A scaffolding)
-# nimbus bench --surface S2-a --runs 5 --corpus small --gha
-# nimbus bench --all --reference                     # interactive protocol confirmation required
-
-# Phase 4 WS4 — Release Infrastructure
-# nimbus update --check              # check for update; exit 1 if available, 0 if current
-# nimbus update [--yes]              # download, verify Ed25519 signature, invoke platform installer
-# nimbus lan enable [--allow-pairing]  # start LAN server; open 5-min pairing window (optional)
-# nimbus lan disable                 # stop LAN server
-# nimbus lan pair <host-ip> <code>   # exchange X25519 keys with a host using pairing code
-# nimbus lan status                  # show LAN server state and paired peers
-# nimbus lan list-peers              # list paired peers with id, direction, write-allowed
-# nimbus lan grant-write <peer-id>   # allow peer to call write/HITL methods
-# nimbus lan revoke-write <peer-id>  # remove write grant
-# nimbus lan remove-peer <peer-id>   # unpair a peer
-
-# Phase 5 T3 — Team Intelligence built-in agents
-# nimbus expert <topic-or-file>      # ranked list of team members with most context on a topic / file;
-#                                    # IPC: agents.expert; emits agents.expert.briefReady notification
-# nimbus impact <file-or-PR-url>     # reverse-dependency blast radius across services / pipelines / dashboards / oncall;
-#                                    # IPC: agents.impact; emits agents.impact.briefReady notification
-
-# Phase 4 env-var overrides (multi-agent loop guards)
-# NIMBUS_MAX_AGENT_DEPTH=3          max sub-agent recursion depth (1–10; default 3)
-# NIMBUS_MAX_TOOL_CALLS_PER_SESSION=20  hard cap on tool calls per session (1–200; default 20)
-# Exceeding either fires agent.gasLimitReached and halts new decomposition.
-
-# Phase 4 WS4 env-var overrides
-# NIMBUS_UPDATER_URL=<url>           override update manifest URL (default: official endpoint)
-# NIMBUS_UPDATER_DISABLE=true        disable auto-update checks entirely
-# NIMBUS_LAN_PORT=<port>             override LAN TCP listen port (default: 7475)
-# NIMBUS_DEV_UPDATER_PUBLIC_KEY=<base64>  override embedded Ed25519 public key (tests only)
-
-# LLM model selection — resolution priority: env > [llm] TOML > hardcoded default.
-# Bare model ids work; the engine auto-prefixes for Mastra (claude-* → anthropic/..., gpt-* / o1-* / o3-* / o4-* → openai/...).
-# NIMBUS_AGENT_MODEL=claude-sonnet-4-6              overrides [llm].remote_model       (Mastra agent)
-# NIMBUS_CLASSIFIER_MODEL=claude-haiku-4-5-20251001 overrides [llm].classifier_model   (Anthropic intent classifier)
-# NIMBUS_OPENAI_CLASSIFIER_MODEL=gpt-4o-mini        OpenAI classifier when ANTHROPIC_API_KEY is unset
-
-# Docs site (packages/docs)
-bun run docs:build                     # from repo root (workspace filter)
-cd packages/docs && bunx astro build   # build static docs site
-cd packages/docs && bunx astro dev     # local dev server
-
-# Extension author CI template (copy into extension repo `.github/workflows/`)
-# docs/templates/nimbus-extension-ci.yml
-
-# Publish @nimbus-dev/client (triggered by git tag client-v*)
-# git tag client-v0.1.0 && git push origin client-v0.1.0
-
-# Publish Nimbus VS Code extension (triggered by git tag vscode-v*)
-# Pushes to VS Code Marketplace + Open VSX + GitHub Release.
-# Requires repo secrets VSCE_PAT (Marketplace) + OVSX_PAT (Open VSX).
-# git tag vscode-v0.1.0 && git push origin vscode-v0.1.0
-```
-
----
-
-## Architecture Summary
-
-```
-[CLI]  [Tauri UI]
-  |         |
-  └────┬────┘
-       │ JSON-RPC 2.0 IPC
-       │ (domain socket / named pipe)
-       ▼
-[Gateway Process]
-  ├── Engine (Mastra)
-  │     ├── Intent Router (LLM classification)
-  │     ├── Task Planner (step decomposition)
-  │     ├── HITL Consent Gate  ←── structural, frozen whitelist
-  │     └── Tool Executor      ←── dispatches to MCP connectors only
-  ├── Platform Abstraction Layer (PAL)
-  │     ├── win32.ts   (Named Pipe, DPAPI, Registry autostart)
-  │     ├── darwin.ts  (Unix Socket, Keychain, LaunchAgents)
-  │     └── linux.ts   (Unix Socket, libsecret, systemd/XDG)
-  ├── Secure Vault  (NimbusVault interface → PAL implementation)
-  ├── Local Index   (bun:sqlite metadata + sqlite-vec embeddings)
-  ├── Connector Mesh (MCPClient → MCP server processes)
-  └── Extension Registry (sandboxed child processes, SHA-256 verified)
-```
+**Prerequisites:** Bun v1.2+; Rust for building the Tauri UI (`packages/ui/src-tauri`).
 
 ---
 
@@ -442,69 +87,32 @@ Circular dependencies are forbidden. The CLI and UI never import Gateway TypeScr
 
 ## Testing Philosophy
 
-A system that orchestrates real actions against real data cannot rely on developer confidence. Every behavioral contract is verified by automated tests on all three platforms.
+- **HITL tests** prove the gate fires for every action type in the whitelist, before the connector is called.
+- **Vault tests** prove no secret value is exposed through any interface.
+- **Integration tests** use real SQLite, real Bun subprocesses, fresh temp dirs per test — no mocks at the DB layer.
+- **E2E CLI tests** use a real Gateway subprocess + mock MCP servers — no real cloud calls.
+- **Coverage gates** are enforced in CI (Engine ≥85%, Vault ≥90%, Embedding ≥80%, plus scheduler/rate-limiter/people thresholds — see `.github/workflows/_test-suite.yml` and the `nimbus-commands` skill).
 
-- **HITL tests** prove the gate fires for every action type in the whitelist, before the connector is called
-- **Vault tests** prove no secret value is exposed through any interface
-- **Integration tests** use real SQLite, real Bun subprocesses, fresh temp dirs per test — no mocks at the DB layer
-- **E2E CLI tests** use a real Gateway subprocess + mock MCP servers (wire protocol, no real cloud calls)
-- **Coverage gates** are enforced in CI: Engine ≥85%, Vault ≥90%, Embedding ≥80%, plus scheduler, rate limiter, and people thresholds (see `.github/workflows/_test-suite.yml`)
+PRs gate on Ubuntu (`pr-quality`); pushes run the full Windows / macOS / Linux matrix.
 
----
-
-## Roadmap Context
-
-> Full roadmap with acceptance criteria and inter-quarter dependencies: [`docs/roadmap.md`](./docs/roadmap.md)
-
-| Phase | Theme | Status |
-|---|---|---|
-| Phase 1 | Foundation — Gateway, PAL, Vault, filesystem connector, HITL, CLI, CI | ✅ Complete |
-| Phase 2 | The Bridge — 15 MCP connectors, unified index, people graph, context ranker, installers | ✅ Complete |
-| Phase 3 | Intelligence — Semantic layer, extensions, CI/CD + cloud MCPs, workflows, watchers | ✅ Complete |
-| Phase 3.5 | Observability — Connector health model, `nimbus query` / `diag` / `doctor` / `db`, config profiles, `@nimbus-dev/client`, telemetry, docs site | ✅ Complete |
-| Phase 4 | Presence — Tauri UI, VS Code ext, local LLM (Ollama), multi-agent, data portability | ✅ Complete |
-| Phase 5 | The Extended Surface — browser/reading, IMAP, finance, CRM, HR, design connectors; Marketplace v2 | 🔵 Active |
-| Phase 6 | Team — federation, Team Vault, shared namespaces, SSO/SCIM, multi-user HITL, org policy | Planned |
-| Phase 7 | The Autonomous Agent — standing approvals, scheduled tasks, incident correlation, fine-tuning, SRE loop | Planned |
-| Phase 8 | Sovereign Mesh — P2P sync, mobile companion, hardware vault, DIDs, Digital Executor | Planned |
-| Phase 9 | Enterprise — Docker/Helm, SIEM, compliance, SCIM, admin console, security audit, SLA | Planned |
-| Phase 10 | Desktop Distribution — `desktop-v0.1.0` Tauri installers + signing (deferred from `v0.1.0`) | Planned |
-
-When implementing, focus only on the current phase. Do not add Phase N+1 features in Phase N code.
+When implementing, focus on the current phase. Do not add Phase N+1 features in Phase N code.
 
 ---
 
-## Subsystems (monorepo)
+## Development Workflow
 
-- `packages/gateway` — Engine, MCP mesh, Vault, local index, IPC
-- `packages/cli` — Terminal client
-- `packages/ui` — Tauri 2.0 + React (desktop)
-- `packages/sdk` — `@nimbus-dev/sdk` for extensions (MIT)
-- `packages/mcp-connectors/*` — First-party MCP servers (AGPL)
+**Worktree directory:** `.worktrees/` (project-local, git-ignored). When setting up isolated workspaces for feature branches, use `.worktrees/<branch-name>`.
 
-**PAL:** All OS-specific logic lives under `packages/gateway/src/platform/` and is accessed via `PlatformServices` — never import `win32` / `darwin` / `linux` from business logic.
-
-**Prerequisites:** Bun v1.2+; Rust for building the Tauri UI (`packages/ui/src-tauri`).
+**Pre-flight before pushing a PR:** `bun run test:ci` (full CI parity). Full command catalogue + coverage thresholds + env-var overrides live in the [`nimbus-commands`](./.claude/commands/nimbus-commands.md) skill. File-location pointers live in [`nimbus-file-map`](./.claude/commands/nimbus-file-map.md).
 
 ---
 
-## Dependency Safety
+## See Also
 
-Before suggesting any `bun add` (or `bun add -d`) command, run:
-
-```bash
-bun run check-package <name>
-```
-
-The script fetches the package metadata from `registry.npmjs.org` and prints the author, maintainers, created date, and version count.
-
-Verify the result before proposing the install. **Do not propose `bun add`** if any of the following are true:
-
-- The script exits with code `1` (the package does not exist on npm)
-- The script emits the `< 7 days old` warning — newly-published packages are a common slopsquatting / typosquatting vector
-- The author/maintainer is unfamiliar for a name that resembles a well-known package (e.g. `expresss`, `lodahs`, `react-domm`)
-
-When all three checks pass, include the package's published age and maintainer in your suggestion so the user can confirm before installing.
+- [`docs/architecture.md`](./docs/architecture.md) — full subsystem design, IPC method catalogue, schema reference. Read before modifying any subsystem.
+- [`docs/roadmap.md`](./docs/roadmap.md) — phases, acceptance criteria, delivered summaries.
+- [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md) — I1–I12 rationale + anti-patterns.
+- [`docs/cli-reference.md`](./docs/cli-reference.md) — full CLI subcommand reference.
 
 ---
 
@@ -512,8 +120,10 @@ When all three checks pass, include the package's published age and maintainer i
 
 @.claude/commands/nimbus-agent-patterns.md
 @.claude/commands/nimbus-architecture.md
+@.claude/commands/nimbus-commands.md
 @.claude/commands/nimbus-connector-authoring.md
 @.claude/commands/nimbus-db-migrations.md
+@.claude/commands/nimbus-file-map.md
 @.claude/commands/nimbus-ipc.md
 @.claude/commands/nimbus-phase-4.md
 @.claude/commands/nimbus-security-invariants.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,15 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 
 These constraints are architectural, not preferences. Do not suggest changes that violate them:
 
-| # | Constraint | Implementation |
-|---|---|---|
-| 1 | **Local-first** | Machine is the source of truth; cloud is a connector |
-| 2 | **HITL is structural** | Consent gate is in the executor, not the prompt; cannot be bypassed or configured away |
-| 3 | **No plaintext credentials** | Vault only (DPAPI/Keychain/libsecret); never in logs/IPC/config |
-| 4 | **MCP as connector standard** | Engine never calls cloud APIs directly |
-| 5 | **Platform equality** | Windows/macOS/Linux are equally supported; PRs gate on Ubuntu (`pr-quality`); pushes run the full 3-OS matrix |
-| 6 | **AGPL-3.0 core / MIT SDK** | Dual license is intentional; do not change license fields |
-| 7 | **No `any`** | Use `unknown` for external data; TypeScript strict mode is non-negotiable |
+| #   | Constraint                    | Implementation                                                                                                |
+| --- | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| 1   | **Local-first**               | Machine is the source of truth; cloud is a connector                                                          |
+| 2   | **HITL is structural**        | Consent gate is in the executor, not the prompt; cannot be bypassed or configured away                        |
+| 3   | **No plaintext credentials**  | Vault only (DPAPI/Keychain/libsecret); never in logs/IPC/config                                               |
+| 4   | **MCP as connector standard** | Engine never calls cloud APIs directly                                                                        |
+| 5   | **Platform equality**         | Windows/macOS/Linux are equally supported; PRs gate on Ubuntu (`pr-quality`); pushes run the full 3-OS matrix |
+| 6   | **AGPL-3.0 core / MIT SDK**   | Dual license is intentional; do not change license fields                                                     |
+| 7   | **No `any`**                  | Use `unknown` for external data; TypeScript strict mode is non-negotiable                                     |
 
 ---
 
@@ -33,20 +33,20 @@ These constraints are architectural, not preferences. Do not suggest changes tha
 
 Each invariant has a production wiring site and an enforcement test in `packages/gateway/src/security-invariants.test.ts`. Full rationale, anti-patterns, and audit cross-references in [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md).
 
-| # | Invariant | Wired at | Anti-pattern that regresses it |
-|---|---|---|---|
-| I1 | Child-process env scoping via `extensionProcessEnv()` | `connectors/lazy-mesh/` (every spawn across `mesh.ts`, `connector-spawns.ts`, `phase3-config.ts`, `user-mcp.ts`) | `spawn(..., { env: { ...process.env } })` anywhere under `connectors/` |
-| I2 | HITL frozen-set membership; `HITL_REQUIRED_BACKING` is module-private | `engine/executor.ts` `ToolExecutor.gate()` | New destructive RPC that skips `ToolExecutor` or omits the action type from the set |
-| I3 | HITL gate consults `action.type` only (NOT `payload.mcpToolId`) | `engine/executor.ts` `ToolExecutor.gate()` | Gating on `mcpToolId` or `resolvedToolId` — the set holds logical types, not MCP ids |
-| I4 | `hitlStatus` is set only by the consent gate | `engine/executor.ts` `ToolExecutor.gate()` | Hardcoding `hitlStatus: "approved"` in any handler |
-| I5 | `checkLanMethodAllowed` is intrinsic to `LanServer` | `ipc/lan-server.ts` `LanServer.handleEncryptedMessage()` | Moving the check into the dispatcher or any caller |
-| I6 | LAN bind defaults to `127.0.0.1` | `config/nimbus-toml.ts` | Defaulting to `0.0.0.0` or auto-binding all interfaces from an env var |
-| I7 | Tauri `ALLOWED_METHODS` matches gateway handlers; no RCE-class methods exposed to renderer | `ui/src-tauri/src/gateway_bridge.rs` | Adding `extension.install` / `connector.addMcp` to the renderer allowlist |
-| I8 | Tauri renderer CSP is restrictive (no `unsafe-inline`, no `unsafe-eval`) | `ui/src-tauri/tauri.conf.json` | `"csp": null` or loosening with `unsafe-*` |
-| I9 | All SQL uses bound parameters; identifiers go through `escapeIdentifier` | `db/write.ts`, `db/repair.ts`, `people/person-store.ts` | Template-literal SQL on caller-supplied data |
-| I10 | Constant-time compare for hashes / MACs / pairing codes | `extensions/verify-extensions.ts`, `updater/updater.ts`, `ipc/lan-pairing.ts` | `===` / `!==` on hash bytes |
-| I11 | LLM-facing tool results wrapped via `wrapToolOutput` | `engine/agent.ts`, `engine/tool-output-envelope.ts` | New agent surface that feeds raw tool results to the LLM |
-| I12 | DPAPI calls pass `pOptionalEntropy` from `<configDir>/vault/.entropy` | `vault/win32.ts` | Dropping the entropy parameter "for compatibility" |
+| #   | Invariant                                                                                  | Wired at                                                                                                         | Anti-pattern that regresses it                                                       |
+| --- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| I1  | Child-process env scoping via `extensionProcessEnv()`                                      | `connectors/lazy-mesh/` (every spawn across `mesh.ts`, `connector-spawns.ts`, `phase3-config.ts`, `user-mcp.ts`) | `spawn(..., { env: { ...process.env } })` anywhere under `connectors/`               |
+| I2  | HITL frozen-set membership; `HITL_REQUIRED_BACKING` is module-private                      | `engine/executor.ts` `ToolExecutor.gate()`                                                                       | New destructive RPC that skips `ToolExecutor` or omits the action type from the set  |
+| I3  | HITL gate consults `action.type` only (NOT `payload.mcpToolId`)                            | `engine/executor.ts` `ToolExecutor.gate()`                                                                       | Gating on `mcpToolId` or `resolvedToolId` — the set holds logical types, not MCP ids |
+| I4  | `hitlStatus` is set only by the consent gate                                               | `engine/executor.ts` `ToolExecutor.gate()`                                                                       | Hardcoding `hitlStatus: "approved"` in any handler                                   |
+| I5  | `checkLanMethodAllowed` is intrinsic to `LanServer`                                        | `ipc/lan-server.ts` `LanServer.handleEncryptedMessage()`                                                         | Moving the check into the dispatcher or any caller                                   |
+| I6  | LAN bind defaults to `127.0.0.1`                                                           | `config/nimbus-toml.ts`                                                                                          | Defaulting to `0.0.0.0` or auto-binding all interfaces from an env var               |
+| I7  | Tauri `ALLOWED_METHODS` matches gateway handlers; no RCE-class methods exposed to renderer | `ui/src-tauri/src/gateway_bridge.rs`                                                                             | Adding `extension.install` / `connector.addMcp` to the renderer allowlist            |
+| I8  | Tauri renderer CSP is restrictive (no `unsafe-inline`, no `unsafe-eval`)                   | `ui/src-tauri/tauri.conf.json`                                                                                   | `"csp": null` or loosening with `unsafe-*`                                           |
+| I9  | All SQL uses bound parameters; identifiers go through `escapeIdentifier`                   | `db/write.ts`, `db/repair.ts`, `people/person-store.ts`                                                          | Template-literal SQL on caller-supplied data                                         |
+| I10 | Constant-time compare for hashes / MACs / pairing codes                                    | `extensions/verify-extensions.ts`, `updater/updater.ts`, `ipc/lan-pairing.ts`                                    | `===` / `!==` on hash bytes                                                          |
+| I11 | LLM-facing tool results wrapped via `wrapToolOutput`                                       | `engine/agent.ts`, `engine/tool-output-envelope.ts`                                                              | New agent surface that feeds raw tool results to the LLM                             |
+| I12 | DPAPI calls pass `pOptionalEntropy` from `<configDir>/vault/.entropy`                      | `vault/win32.ts`                                                                                                 | Dropping the entropy parameter "for compatibility"                                   |
 
 When changing a wiring site, update both the test and `SECURITY-INVARIANTS.md` in the same commit. When retiring an invariant, delete the row — never leave it as documentation drift.
 
@@ -125,7 +125,6 @@ When implementing, focus on the current phase. Do not add Phase N+1 features in 
 @.claude/commands/nimbus-db-migrations.md
 @.claude/commands/nimbus-file-map.md
 @.claude/commands/nimbus-ipc.md
-@.claude/commands/nimbus-phase-4.md
 @.claude/commands/nimbus-security-invariants.md
 @.claude/commands/nimbus-tauri-allowlist.md
 @.claude/commands/nimbus-testing.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,11 +1,11 @@
 # Nimbus — Gemini CLI Context
 
-Nimbus is a **local-first AI agent framework** — a headless Bun Gateway process that maintains a private SQLite index of the user's data across cloud services (Google Drive, Gmail, OneDrive, Outlook, Google Photos, Microsoft Teams, GitHub, GitLab, Bitbucket, Slack, Linear, Jira, Notion, Confluence, Discord opt-in, Jenkins, GitHub Actions, CircleCI, GitLab CI, PagerDuty, Kubernetes, AWS, Azure, GCP, IaC CLIs, Grafana, Sentry, New Relic, Datadog, optional filesystem roots, and other first-party MCP connectors) and executes multi-step agentic workflows on their behalf. Clients (CLI and Tauri 2.0 desktop app) communicate with the Gateway exclusively over JSON-RPC 2.0 IPC.
+Nimbus is a **local-first AI agent framework** — a headless Bun Gateway process that maintains a private SQLite index of the user's data across cloud services (Google Drive, Gmail, Google Photos, OneDrive, Outlook, Microsoft Teams, GitHub, GitLab, Bitbucket, Slack, Linear, Jira, Notion, Confluence, Discord opt-in, Jenkins, GitHub Actions, CircleCI, GitLab CI, PagerDuty, Kubernetes, AWS, Azure, GCP, IaC CLIs, Grafana, Sentry, New Relic, Datadog, optional `[[filesystem.roots]]` indexing, and the local filesystem via first-party MCP connectors) and executes multi-step agentic workflows on their behalf. Clients (CLI and Tauri 2.0 desktop app) communicate with the Gateway exclusively over JSON-RPC 2.0 IPC.
 
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict  
 **Linter:** Biome  
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)  
-**Status:** Phase 3.5 ✅ Complete; **Phase 4** — Presence ✅ Complete (WS1–4 ✅ · WS5-A ✅ · WS5-B ✅ · WS5-C ✅ · WS5-D ✅ · WS6 ✅ · S2 graph-aware watchers ✅ · B3 Phase 1 ✅ · B3 Phase 2 ✅); **`v0.1.0` released 2026-05-09** (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 10); **Phase 5** — Extended Surface 🔵 Active (T1 sequencing spec ✅ · T3 PR 1 coordinator parallelism + `nimbus expert` ✅ · T3 PR 2 `nimbus impact` ✅ · T3 PR 3 `nimbus catchup` ✅ · Wave A PR 1 OpenAPI / AsyncAPI spec indexer ✅ · Wave A PR 2 Obsidian vault connector ✅)
+**Status:** Phase 4 ✅ Complete · Phase 5 (Extended Surface) 🔵 Active · `v0.1.0` released 2026-05-09 (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 13). Workstream-level status is in [`docs/roadmap.md`](./docs/roadmap.md).
 
 Companion context for other agents: [`CLAUDE.md`](./CLAUDE.md) (same project facts; keep both files aligned when changing commands, roadmap rows, or non-negotiables).
 
@@ -29,7 +29,7 @@ These constraints are architectural, not preferences. Do not suggest changes tha
 
 ## Security Invariants
 
-These are the structural defenses Nimbus relies on. Each one has a production wiring site and an enforcement test in `packages/gateway/src/security-invariants.test.ts` that fails if the defense is removed or orphaned. Full rationale, anti-patterns, and audit cross-references in [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md).
+Each invariant has a production wiring site and an enforcement test in `packages/gateway/src/security-invariants.test.ts`. Full rationale, anti-patterns, and audit cross-references in [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md).
 
 | # | Invariant | Wired at | Anti-pattern that regresses it |
 |---|---|---|---|
@@ -46,341 +46,26 @@ These are the structural defenses Nimbus relies on. Each one has a production wi
 | I11 | LLM-facing tool results wrapped via `wrapToolOutput` | `engine/agent.ts`, `engine/tool-output-envelope.ts` | New agent surface that feeds raw tool results to the LLM |
 | I12 | DPAPI calls pass `pOptionalEntropy` from `<configDir>/vault/.entropy` | `vault/win32.ts` | Dropping the entropy parameter "for compatibility" |
 
-When changing a wiring site referenced above, update both the test and `SECURITY-INVARIANTS.md` in the same commit. When retiring an invariant, delete the row — never leave it as documentation drift.
+When changing a wiring site, update both the test and `SECURITY-INVARIANTS.md` in the same commit. When retiring an invariant, delete the row — never leave it as documentation drift.
 
-**Static-time complement:** Phase 1 of the B3 structure audit added
-`scripts/structure-audit/check-nimbus-invariants.ts` which enforces I1
-(`spawn` under `connectors/` must use `extensionProcessEnv()`) and the
-vault-key allow-list at static time. The runtime tests in
-`packages/gateway/src/security-invariants.test.ts` remain authoritative
-for invariant wiring; the static checks catch regressions before the test
-runs. See `docs/structure-audit/baseline.md` for current findings.
+**Static-time complement:** `scripts/structure-audit/check-nimbus-invariants.ts` enforces I1 (`spawn` under `connectors/` must use `extensionProcessEnv()`) and the vault-key allow-list at static time. Runtime tests remain authoritative; the static checks fail before the test suite runs.
 
 ---
 
-## Key File Locations
+## Subsystems (monorepo)
 
-| File | Purpose |
-|---|---|
-| `packages/gateway/src/engine/executor.ts` | HITL gate — `HITL_REQUIRED` frozen set; most security-critical file |
-| `packages/gateway/src/platform/index.ts` | PAL — `createPlatformServices()` dispatch |
-| `packages/gateway/src/platform/win32.ts` | Windows platform implementation |
-| `packages/gateway/src/platform/darwin.ts` | macOS platform implementation |
-| `packages/gateway/src/platform/linux.ts` | Linux platform implementation |
-| `packages/gateway/src/vault/index.ts` | `NimbusVault` interface |
-| `packages/gateway/src/auth/google-access-token.ts` | Google per-service OAuth token resolution — `resolveGoogleOAuthVaultKey()`, `anyGoogleOAuthVaultPresent()` |
-| `packages/gateway/src/auth/oauth-vault-tokens.ts` | Generic OAuth token storage/refresh helpers — `getValidVaultOAuthAccessToken()`, `microsoftOAuthAccessFromConfig()` |
-| `packages/gateway/src/connectors/` | MCP connector mesh (`lazy-mesh/` — Phase 3 bundle spawns AWS/Azure/GCP/IaC/observability MCPs when vault keys exist) |
-| `packages/gateway/src/connectors/health.ts` | Connector health state machine — `transitionHealth()`, `ConnectorHealthSnapshot` |
-| `packages/gateway/src/connectors/connector-vault.ts` | Per-service OAuth vault key helpers + typed connector-secret reader — `perServiceOAuthVaultKey()`, `writePerServiceOAuthKey()`, `migrateToPerServiceOAuthKeys()`, `readConnectorSecret()` (Phase 4 / D11 Bucket B) |
-| `packages/gateway/src/connectors/connector-secrets-manifest.ts` | `CONNECTOR_VAULT_SECRET_KEYS` — per-connector PAT/API-key vault manifest; `clearConnectorVaultSecretKeys()` |
-| `packages/gateway/src/connectors/remove-intent.ts` | Connector removal — cascade vault + index cleanup via `executeRemoveIntent()` |
-| `packages/gateway/src/automation/graph-predicate.ts` | Graph predicate types, parser, evaluator; `parseGraphPredicate` / `itemMatchesGraphPredicate` / `countItemsMatchingGraphPredicate` / `listCandidateGraphRelations` |
-| `packages/gateway/src/automation/watcher-engine.ts` | Watcher evaluation loop; applies `graph_predicate_json` as a post-filter when `[automation].graph_conditions = true` |
-| `packages/gateway/src/index/watcher-graph-v22-sql.ts` | V22 migration — `watcher.graph_predicate_json` column |
-| `packages/gateway/src/index/workflow-run-columns-v23-sql.ts` | V23 migration — `dry_run` and `params_override_json` columns |
-| `packages/gateway/src/index/audit-session-v24-sql.ts` | V24 migration — `audit_log.session_id` column |
-| `packages/gateway/src/sync/connectivity.ts` | Network connectivity probe — guards the sync scheduler against consuming backoff on offline events |
-| `packages/gateway/src/db/verify.ts` | `nimbus db verify` — non-destructive index integrity checks (integrity_check, FTS5, vec rowid, FK, schema version) |
-| `packages/gateway/src/db/repair.ts` | `nimbus db repair` — targeted recovery actions; writes audit log entry |
-| `packages/gateway/src/db/snapshot.ts` | Manual and scheduled snapshot management |
-| `packages/gateway/src/db/metrics.ts` | `IndexMetrics` — item counts, embedding coverage, query latency percentiles |
-| `packages/gateway/src/db/latency-ring-buffer.ts` | In-memory ring buffer for query latency samples; async batch flush to `query_latency_log` |
-| `packages/gateway/src/db/write.ts` | Central DB write wrapper — catches `SQLITE_FULL`, re-throws `DiskFullError` |
-| `packages/gateway/src/perf/` | B2 bench harness — `BenchHarness`, `PerfFixture`, `HistoryLine`, `bench-cli.ts`; one S2-a driver under `surfaces/` |
-| `packages/cli/src/commands/bench.ts` | `nimbus bench` CLI command — thin `Bun.spawn` wrapper around `bench-runner.ts` |
-| `scripts/structure-audit/lib.ts` | Shared B3 audit helpers — `REPO_ROOT`, `stripComments`, `countAnyInSource`, `iterateSourceFiles`, `auditOutputPath`; imported by every audit driver |
-| `docs/structure-audit/baseline.md` | Phase 1 baseline reference for the B3 structure audit; per-dimension starting state + Phase 2 thresholds |
-| `packages/gateway/src/telemetry/collector.ts` | Opt-in telemetry — aggregate counters only, no content, configurable endpoint |
-| `packages/gateway/src/config/profiles.ts` | Named configuration profiles (`work`, `personal`); Vault key prefixing |
-| `packages/gateway/src/llm/types.ts` | LLM provider interfaces — `LlmProvider`, `LlmTaskType`, `LlmModelInfo`, `LlmGenerateOptions/Result` |
-| `packages/gateway/src/llm/gpu-arbiter.ts` | `GpuArbiter` — single-slot GPU VRAM mutex with activity-aware timeout |
-| `packages/gateway/src/llm/ollama-provider.ts` | `OllamaProvider` — Ollama HTTP API wrapper (batch + streaming) |
-| `packages/gateway/src/llm/llamacpp-provider.ts` | `LlamaCppProvider` — llama-server HTTP API wrapper |
-| `packages/gateway/src/llm/router.ts` | `LlmRouter` — task-to-provider routing, air-gap enforcement, local/remote preference |
-| `packages/gateway/src/llm/registry.ts` | `LlmRegistry` — model discovery, `llm_models` DB sync, availability checks |
-| `packages/gateway/src/ipc/llm-rpc.ts` | `dispatchLlmRpc` — `llm.listModels` / `llm.getStatus` IPC handlers |
-| `packages/gateway/src/voice/service.ts` | `VoiceService` — STT (`whisper-cli`), TTS, wake-word loop |
-| `packages/gateway/src/voice/tts.ts` | `NativeTtsProvider` — `say` (macOS), PowerShell SAPI (Windows), `espeak-ng`/`spd-say` (Linux) |
-| `packages/gateway/src/ipc/voice-rpc.ts` | `dispatchVoiceRpc` — `voice.*` IPC handlers |
-| `packages/gateway/src/engine/coordinator.ts` | `AgentCoordinator` — multi-agent sub-task orchestration, depth + tool-call guards |
-| `packages/gateway/src/engine/sub-agent.ts` | `runSubAgent` — single sub-task executor with `sub_task_results` DB lifecycle |
-| `packages/gateway/src/index/llm-models-v16-sql.ts` | V16 migration SQL — `llm_models` table + `sync_state.context_window_tokens` |
-| `packages/gateway/src/index/sub-task-results-v17-sql.ts` | V17 migration SQL — `sub_task_results` table for multi-agent persistence |
-| `packages/gateway/src/ipc/http-server.ts` | Read-only local HTTP API (`localhost` only, `SQLITE_OPEN_READONLY` connection) |
-| `packages/gateway/src/ipc/metrics-server.ts` | Prometheus-compatible metrics endpoint (`localhost` only, off by default) |
-| `packages/gateway/src/ipc/lan-crypto.ts` | NaCl box keypair generation, `sealBoxFrame` / `openBoxFrame` for LAN E2E encryption |
-| `packages/gateway/src/ipc/lan-pairing.ts` | `PairingWindow` — single-use base58 pairing code with 5-minute expiry |
-| `packages/gateway/src/ipc/lan-rate-limit.ts` | `LanRateLimiter` — per-IP sliding-window failure tracking and lockout |
-| `packages/gateway/src/ipc/lan-rpc.ts` | `LanError`, `checkLanMethodAllowed` — forbidden-method and write-grant enforcement for LAN peers |
-| `packages/gateway/src/ipc/lan-server.ts` | `LanServer` — `Bun.listen` TCP server; length-framed, NaCl box encrypted RPC after pairing handshake |
-| `packages/gateway/src/ipc/updater-rpc.ts` | `dispatchUpdaterRpc` — `updater.getStatus`, `updater.checkNow`, `updater.applyUpdate`, `updater.rollback` |
-| `packages/gateway/src/updater/updater.ts` | `Updater` state machine — manifest fetch, semver compare, download, Ed25519 verify, install |
-| `packages/gateway/src/updater/manifest-fetcher.ts` | `fetchUpdateManifest` — typed manifest fetch with `AbortController` timeout |
-| `packages/gateway/src/updater/signature-verifier.ts` | `verifyBinarySignature` — Ed25519 over SHA-256 of binary |
-| `packages/gateway/src/updater/public-key.ts` | Embedded Ed25519 updater public key; `NIMBUS_DEV_UPDATER_PUBLIC_KEY` override for tests |
-| `packages/gateway/src/index/lan-peers-v19-sql.ts` | V19 migration SQL — `lan_peers` table |
-| `packages/gateway/src/ipc/` | JSON-RPC 2.0 IPC server |
-| `packages/cli/src/index.ts` | CLI entry point |
-| `packages/cli/src/ipc-client/` | IPC client + consent channel |
-| `packages/cli/src/commands/query.ts` | `nimbus query` — structured index query with `--sql` guard |
-| `packages/cli/src/commands/config.ts` | `nimbus config get/set/list/validate/edit` |
-| `packages/cli/src/commands/profile.ts` | `nimbus profile create/list/switch/delete` |
-| `packages/cli/src/commands/diag.ts` | `nimbus diag` — full diagnostic snapshot; `slow-queries` subcommand |
-| `packages/cli/src/commands/doctor.ts` | `nimbus doctor` — environment health checks, actionable remediation output |
-| `packages/cli/src/commands/telemetry.ts` | `nimbus telemetry show/disable` |
-| `packages/cli/src/commands/tui.tsx` | `nimbus tui` entry — gateway check, fallback detection, Ink render orchestration |
-| `packages/cli/src/tui/App.tsx` | TUI root — state machine + Option-1 layout + narrow/short-terminal behavior |
-| `packages/cli/src/tui/state.ts` | Top-level state reducer: `idle` / `streaming` / `awaiting-hitl` / `disconnected` |
-| `packages/sdk/src/index.ts` | `@nimbus-dev/sdk` public API |
-| `packages/client/src/index.ts` | `@nimbus-dev/client` public API — `NimbusClient`, `MockClient` |
-| `packages/ui/src/ipc/client.ts` | `NimbusIpcClient` singleton, `createIpcClient()`, `parseError()` — includes credential redaction (5 forbidden keys) |
-| `packages/ui/src/ipc/types.ts` | Shared IPC types — `ConnectionState`, `DiagSnapshot`, `ConnectorSummary`, `ProfileListResult`, `TelemetryStatus`, `RouterDecision`/`RouterStatusResult`, `LlmModelInfo`/`LlmListModelsResult`, `LlmAvailabilityResult`, `LlmPullStartedResult`/`LlmPullProgressPayload`/`LlmPullTerminalPayload`, error types |
-| `packages/ui/src/store/index.ts` | `useNimbusStore` — Zustand v5 store with `persist` middleware; 11 slices composed; `partialize` whitelist excludes secrets |
-| `packages/ui/src/store/partialize.ts` | `persistPartialize` — 5-key whitelist + 5-key forbidden deep-scrub for Zustand persist |
-| `packages/ui/src/providers/GatewayConnectionProvider.tsx` | `onConnectionState` mirror + first-run routing logic |
-| `packages/ui/src/App.tsx` | `createBrowserRouter` — all UI routes including nested `/settings/*` |
-| `packages/ui/src/pages/QuickQuery.tsx` | Quick Query popup page — stream + auto-close |
-| `packages/ui/src/pages/Onboarding.tsx` | Onboarding wizard frame + step pills |
-| `packages/ui/src/pages/Dashboard.tsx` | Dashboard page (metrics strip + connector grid + audit feed) |
-| `packages/ui/src/pages/HitlPopup.tsx` | HITL popup page hosted inside the `hitl-popup` Tauri window |
-| `packages/ui/src/pages/Settings.tsx` | Settings layout — `SettingsSidebar` + `<Outlet />` for nested panel routes |
-| `packages/ui/src/pages/settings/ProfilesPanel.tsx` | Profiles panel — list, create, switch, delete with typed-name confirm guard |
-| `packages/ui/src/pages/settings/TelemetryPanel.tsx` | Telemetry panel — toggle, counter cards, payload sample expander |
-| `packages/ui/src/pages/settings/ConnectorsPanel.tsx` | Connectors panel — interval editor (60 s min inline-validated), depth selector, enable toggle, `connector.configChanged` reconcile, Dashboard deep-link highlight |
-| `packages/ui/src/pages/settings/connectors/interval-parts.ts` | Interval input parser/formatter shared by `ConnectorsPanel` |
-| `packages/ui/src/pages/settings/ModelPanel.tsx` | Model panel — `RouterStatus` cards, per-task default pickers, load/unload row actions, `PullDialog` launcher, re-attaches to in-flight pull via persisted `activePullId` |
-| `packages/ui/src/components/settings/model/RouterStatus.tsx` | Per-task router decision cards driven by `llm.getRouterStatus`; emits `llm.setDefault` |
-| `packages/ui/src/components/settings/model/PullDialog.tsx` | Streaming model pull dialog — provider radio filtered by `llm.getStatus`, 15 s stall detection via `setTimeout`, cancel via `llm.cancelPull` |
-| `packages/ui/src/components/hitl/HitlPopupPage.tsx` | Head-of-queue consent dialog; Approve / Reject → `consent.respond` |
-| `packages/ui/src/components/hitl/StructuredPreview.tsx` | Recursive, XSS-safe preview of `consent.request` details |
-| `packages/ui/src/components/chrome/Sidebar.tsx` | Labelled sidebar nav with pending-HITL badge |
-| `packages/ui/src/components/chrome/PageHeader.tsx` | Page title + profile/health pill |
-| `packages/ui/src/components/dashboard/ConnectorTile.tsx` | Single connector card with health dot + degradation tooltip |
-| `packages/ui/src/components/settings/SettingsSidebar.tsx` | Settings secondary nav — 7 panel entries with `NavLink` active styling |
-| `packages/ui/src/components/settings/PanelHeader.tsx` | Shared panel title + description + optional live-status pill |
-| `packages/ui/src/components/settings/PanelError.tsx` | Error state with optional Retry button |
-| `packages/ui/src/components/settings/StaleChip.tsx` | Offline / stale indicator chip |
-| `packages/ui/src/components/settings/PanelComingSoon.tsx` | Placeholder for panels not yet implemented |
-| `packages/ui/src/hooks/useIpcQuery.ts` | Typed polling hook (pauses on hidden / disconnected) |
-| `packages/ui/src/hooks/useIpcSubscription.ts` | Typed Tauri event listener hook |
-| `packages/ui/src/hooks/useConfirm.tsx` | Inline confirm dialog hook — supports typed-name confirmation |
-| `packages/ui/src/lib/restart.ts` | `restartApp()` — invokes Tauri `plugin:app\|restart`; fallback to `location.reload()` |
-| `packages/ui/src/store/slices/dashboard.ts` | Dashboard store slice (metrics / connectors / audit / highlight) |
-| `packages/ui/src/store/slices/hitl.ts` | HITL pending-request FIFO queue |
-| `packages/ui/src/store/slices/settings.ts` | Settings slice — `activePanel` navigation state |
-| `packages/ui/src/store/slices/profile.ts` | Profile slice — list, active, `lastFetchAt`, `actionInFlight`; persisted |
-| `packages/ui/src/store/slices/telemetry.ts` | Telemetry slice — `TelemetryStatus` + `telemetryActionInFlight`; transient |
-| `packages/ui/src/store/slices/connectors.ts` | Connectors slice — `PersistedConnectorRow[]` (persisted) + transient `perServiceInFlight` + `highlightService` + `patchConnectorRow` |
-| `packages/ui/src/store/slices/model.ts` | Model slice — `installedModels` + `activePullId` (persisted) + transient `routerStatus`, `pullProgress`, `pullStalled`, `loadedKeys` |
-| `packages/ui/src-tauri/src/gateway_bridge.rs` | Rust IPC bridge — `ALLOWED_METHODS` (38), `NO_TIMEOUT_METHODS` (4), `GLOBAL_BROADCAST_METHODS` (`profile.switched`), `rpc_call`, reconnect loop |
-| `packages/ui/src-tauri/src/tray.rs` | System tray icon, menu, state forwarding |
-| `packages/ui/src-tauri/src/quick_query.rs` | Quick Query window lifecycle — spawn/focus, focus-loss close |
-| `packages/ui/src-tauri/src/hitl_popup.rs` | HITL popup window lifecycle — spawn / focus / close |
-| `packages/ui/src-tauri/src/lib.rs` | Tauri app entry — plugins, tray init, global shortcut, macOS accessory mode |
-| `packages/ui/src-tauri/capabilities/default.json` | Tauri capability set — windows, permissions |
-| `docs/release/manual-smoke-headless.md` | Reusable manual smoke checklist for headless Gateway + CLI + VS Code releases; per-platform results matrix; companion Windows run sheet at `manual-smoke-headless-windows.md` |
-| `packages/ui/src/pages/settings/DataPanel.tsx` | Data panel — Export/Import/Delete wizard launcher with preflight stats |
-| `packages/ui/src/components/settings/data/ExportWizard.tsx` | Export wizard — passphrase gate, zxcvbn, overwrite confirm, progress, seed display |
-| `packages/ui/src/components/settings/data/ImportWizard.tsx` | Import wizard — passphrase + recovery-seed auth, version-compat error handling |
-| `packages/ui/src/components/settings/data/DeleteServiceDialog.tsx` | Delete service dialog — preflight preview, typed-name confirm, `data.delete` call |
-| `packages/ui/src/store/slices/data.ts` | Data store slice — exportFlow / importFlow / deleteFlow state machines + markDisconnected |
-| `docs/architecture.md` | Full subsystem design — read before modifying any subsystem |
-| `docs/roadmap.md` | Phases, acceptance criteria, Phase 3 delivered summary |
+- `packages/gateway` — Engine, MCP mesh, Vault, local index, IPC
+- `packages/cli` — Terminal client (CLI + Ink TUI)
+- `packages/ui` — Tauri 2.0 + React (desktop)
+- `packages/sdk` — `@nimbus-dev/sdk` for extensions (MIT)
+- `packages/client` — `@nimbus-dev/client` (typed IPC wrapper, MIT)
+- `packages/mcp-connectors/*` — First-party MCP servers (AGPL)
+- `packages/vscode-extension` — `nimbus-vscode` (Marketplace + Open VSX)
+- `packages/docs` — Astro Starlight documentation site
 
----
+**PAL:** All OS-specific logic lives under `packages/gateway/src/platform/` and is accessed via `PlatformServices` — never import `win32` / `darwin` / `linux` from business logic.
 
-## Development Workflow
-
-**Worktree directory:** `.worktrees/` (project-local, git-ignored)
-
-When setting up isolated workspaces for feature branches, use `.worktrees/<branch-name>`.
-
----
-
-## Commands
-
-```bash
-# Install all dependencies
-bun install
-
-# Type check all packages
-bun run typecheck
-
-# Lint (Biome — format + lint)
-bun run lint
-bun run lint:fix
-
-# Run all unit tests
-bun test
-
-# Run with coverage
-bun run test:coverage
-
-# Coverage gates (enforced in CI) — run all: bun run test:ci
-bun run test:coverage:engine       # ≥85% threshold (engine)
-bun run test:coverage:agents       # ≥80% threshold (built-in agents)
-bun run test:coverage:vault        # ≥90% threshold (vault)
-bun run test:coverage:sync         # ≥80% threshold (sync scheduler)
-bun run test:coverage:rate-limiter # ≥85% threshold (per-provider rate limiter)
-bun run test:coverage:people       # ≥80% threshold (people graph + cross-service linker)
-bun run test:coverage:embedding    # ≥80% threshold (embedding)
-bun run test:coverage:workflow     # ≥80% threshold (workflow runner + store)
-bun run test:coverage:watcher      # ≥80% threshold (watcher engine + store + anomaly stub)
-bun run test:coverage:extensions   # ≥85% threshold (extension registry + manifest + verify)
-bun run test:coverage:config       # ≥80% threshold (config loader, profiles, env overrides)
-bun run test:coverage:client       # ≥80% threshold (@nimbus-dev/client)
-bun run test:coverage:telemetry    # ≥85% threshold (telemetry collector — payload safety gate)
-bun run test:coverage:db           # ≥85% threshold (verify, repair, migrations, metrics, latency buffer)
-bun run test:coverage:health       # ≥85% threshold (connectors/health.ts)
-bun run test:coverage:doctor       # ≥80% threshold (nimbus doctor checks)
-bun run test:coverage:tui          # ≥80% threshold (packages/cli/src/tui — TUI components)
-bun run test:coverage:mcp          # ≥70% threshold (mcp-connectors)
-bun run test:coverage:sdk          # ≥80% threshold (@nimbus-dev/sdk)
-# Phase 4 WS4 coverage gates
-bun run test:coverage:updater      # ≥80% threshold (updater state machine + manifest fetcher)
-bun run test:coverage:lan          # ≥80% threshold (lan-crypto, lan-pairing, lan-rate-limit, lan-rpc, lan-server)
-bun run test:coverage:perf      # ≥80% threshold (perf bench harness)
-
-# Phase 4 WS5-A UI coverage gate (Vitest — separate runner)
-cd packages/ui && bunx vitest run --coverage  # ≥80% lines / ≥75% branches
-
-# Integration tests
-bun run test:integration
-
-# E2E CLI tests
-bun run test:e2e:cli
-
-# UI component tests (Vitest — separate from bun test)
-cd packages/ui && bunx vitest run
-cd packages/ui && bunx vitest run --coverage  # with branch/line coverage report
-
-# Build all packages
-bun run build
-
-# Full validate-and-build (runs CI test suite first, then builds)
-bun run build:debug    # debug build with sourcemaps (use --skip-tests for fast build)
-bun run build:release  # production build (use --skip-tests for fast build)
-
-# Docs site (Starlight — static output under packages/docs/dist)
-bun run docs:build
-
-# Extension author CI template (copy into extension repo `.github/workflows/`)
-# docs/templates/nimbus-extension-ci.yml
-
-# Clean all build outputs
-bun run clean
-bun run clean:deep     # wipe node_modules + lockfile
-
-# Dev health check
-bun run dev:doctor
-
-# Security audit
-bun audit --audit-level high
-bun run audit:high                 # same (root script)
-
-# Phase 4 B3 — Structure audit (Phase 1 tooling complete; Phase 2 ranking pending)
-bun run audit:structure         # full pack via orchestrator (writes run-<ts>.json)
-bun run audit:boundaries        # dep-cruiser: D1 cross-pkg / D2 cycles / D3 PAL leakage
-bun run audit:duplication       # jscpd token-level duplication (D6)
-bun run audit:dead-code         # knip unused exports / orphan files (D7)
-bun run audit:any               # D8 any-count print mode
-bun scripts/structure-audit/count-any-usage.ts --check    # D8 CI gate (fails on regression OR reduction without --update)
-bun scripts/structure-audit/count-any-usage.ts --update   # rewrite docs/structure-audit/any-baseline.json
-bun run audit:invariants        # D10 spawn rule + D11 vault-key allow-list (binary, --binary-only)
-# Baselines: docs/structure-audit/{any-baseline.json,db-run-census.json,churn-90d.json,baseline.md}
-# CI gate (reusable workflow): .github/workflows/_structure.yml — wired into ci.yml after Phase 3 top-5 fixes land
-
-# Phase 3.5 CLI commands (reference — not bun scripts)
-# nimbus query --service github --type pr --since 7d --json
-# nimbus query --sql "SELECT title FROM items WHERE pinned = 1" --pretty
-# nimbus config get <key> / set <key> <value> / list / validate / edit
-# nimbus profile create <name> / list / switch <name> / delete <name>
-# nimbus diag [--json]
-# nimbus diag slow-queries [--limit N] [--since <duration>]
-# nimbus doctor
-# nimbus db verify
-# nimbus db repair [--yes]
-# nimbus db snapshot
-# nimbus db restore <snapshot>
-# nimbus db snapshots list / backups list
-# nimbus db prune [--yes]
-# nimbus telemetry show
-# nimbus telemetry disable
-# nimbus serve [--port 7474]
-# nimbus docs [topic]
-# nimbus connector history <name>
-# nimbus connector reindex <name> [--depth <metadata_only|summary|full>]
-
-# Phase 4 WS3 — Data Sovereignty
-# nimbus data export --output <path.tar.gz> --passphrase <pw> [--no-index]
-# nimbus data import <path.tar.gz> [--passphrase <pw> | --recovery-seed <mnemonic>]
-# nimbus data delete --service <name> [--dry-run] [--yes]
-# nimbus audit verify [--full] [--since <id>]
-# nimbus audit export --output <path.json>
-
-# Phase 4 B2 — Perf bench (Phase 1A scaffolding)
-# nimbus bench --surface S2-a --runs 5 --corpus small --gha
-# nimbus bench --all --reference                     # interactive protocol confirmation required
-
-# Phase 4 WS4 — Release Infrastructure
-# nimbus update --check              # check for update; exit 1 if available, 0 if current
-# nimbus update [--yes]              # download, verify Ed25519 signature, invoke platform installer
-# nimbus lan enable [--allow-pairing]  # start LAN server; open 5-min pairing window (optional)
-# nimbus lan disable                 # stop LAN server
-# nimbus lan pair <host-ip> <code>   # exchange X25519 keys with a host using pairing code
-# nimbus lan status                  # show LAN server state and paired peers
-# nimbus lan list-peers              # list paired peers with id, direction, write-allowed
-# nimbus lan grant-write <peer-id>   # allow peer to call write/HITL methods
-# nimbus lan revoke-write <peer-id>  # remove write grant
-# nimbus lan remove-peer <peer-id>   # unpair a peer
-
-# Phase 4 env-var overrides (multi-agent loop guards)
-# NIMBUS_MAX_AGENT_DEPTH=3          max sub-agent recursion depth (1–10; default 3)
-# NIMBUS_MAX_TOOL_CALLS_PER_SESSION=20  hard cap on tool calls per session (1–200; default 20)
-# Exceeding either fires agent.gasLimitReached and halts new decomposition.
-
-# Phase 4 WS4 env-var overrides
-# NIMBUS_UPDATER_URL=<url>           override update manifest URL
-# NIMBUS_UPDATER_DISABLE=true        disable auto-update checks entirely
-# NIMBUS_LAN_PORT=<port>             override LAN TCP listen port (default: 7475)
-# NIMBUS_DEV_UPDATER_PUBLIC_KEY=<base64>  override embedded Ed25519 public key (tests only)
-
-# LLM model selection — resolution priority: env > [llm] TOML > hardcoded default.
-# Bare model ids work; the engine auto-prefixes for Mastra (claude-* → anthropic/..., gpt-* / o1-* / o3-* / o4-* → openai/...).
-# NIMBUS_AGENT_MODEL=claude-sonnet-4-6              overrides [llm].remote_model       (Mastra agent)
-# NIMBUS_CLASSIFIER_MODEL=claude-haiku-4-5-20251001 overrides [llm].classifier_model   (Anthropic intent classifier)
-# NIMBUS_OPENAI_CLASSIFIER_MODEL=gpt-4o-mini        OpenAI classifier when ANTHROPIC_API_KEY is unset
-
-# Headless binary bundle + Linux .deb / tarball (after compiling gateway + CLI to dist/)
-# Optional: NIMBUS_EMBEDDING_MODEL_DIR or bun run package:headless -- --embedding-model-dir <path>
-bun run package:headless
-bun run package:installers:linux -- --version 0.1.0
-```
-
----
-
-## Architecture Summary
-
-```
-[CLI]  [Tauri UI]
-  |         |
-  └────┬────┘
-       │ JSON-RPC 2.0 IPC
-       │ (domain socket / named pipe)
-       ▼
-[Gateway Process]
-  ├── Engine (Mastra)
-  │     ├── Intent Router (LLM classification)
-  │     ├── Task Planner (step decomposition)
-  │     ├── HITL Consent Gate  ←── structural, frozen whitelist
-  │     └── Tool Executor      ←── dispatches to MCP connectors only
-  ├── Platform Abstraction Layer (PAL)
-  ├── Secure Vault  (NimbusVault → PAL)
-  ├── Local Index   (bun:sqlite metadata + sqlite-vec embeddings)
-  ├── Connector Mesh (MCPClient → MCP server processes)
-  └── Extension Registry (sandboxed child processes, SHA-256 verified)
-```
+**Prerequisites:** Bun v1.2+; Rust for building the Tauri UI (`packages/ui/src-tauri`).
 
 ---
 
@@ -394,48 +79,36 @@ sdk        ← no imports from gateway, cli, or ui
 mcp-connectors/*  ← depend on @nimbus-dev/sdk only
 ```
 
+Circular dependencies are forbidden. The CLI and UI never import Gateway TypeScript.
+
 ---
 
 ## Testing Philosophy
 
-- **HITL tests** — consent before connector dispatch; rejected consent → no connector call; audit with `hitlStatus: "rejected"`
-- **Vault tests** — `get()` returns `null` for missing keys; secrets never in errors; `listKeys()` returns names only
-- **Integration tests** — real SQLite, real Bun subprocesses, fresh temp dirs
-- **E2E CLI tests** — real Gateway subprocess + mock MCP wire protocol
-- **Coverage gates** — Engine ≥85%, Vault ≥90%, Embedding ≥80% (see `_test-suite.yml` for full matrix)
+- **HITL tests** prove the gate fires for every action type in the whitelist, before the connector is called.
+- **Vault tests** prove no secret value is exposed through any interface.
+- **Integration tests** use real SQLite, real Bun subprocesses, fresh temp dirs per test — no mocks at the DB layer.
+- **E2E CLI tests** use a real Gateway subprocess + mock MCP servers — no real cloud calls.
+- **Coverage gates** are enforced in CI (Engine ≥85%, Vault ≥90%, Embedding ≥80%, plus scheduler/rate-limiter/people thresholds — see `.github/workflows/_test-suite.yml` and the `nimbus-commands` skill).
+
+PRs gate on Ubuntu (`pr-quality`); pushes run the full Windows / macOS / Linux matrix.
+
+When implementing, focus on the current phase. Do not add Phase N+1 features in Phase N code.
 
 ---
 
-## Roadmap Context
+## Development Workflow
 
-> Full roadmap: [`docs/roadmap.md`](./docs/roadmap.md)
+**Worktree directory:** `.worktrees/` (project-local, git-ignored). When setting up isolated workspaces for feature branches, use `.worktrees/<branch-name>`.
 
-| Phase | Theme | Status |
-|---|---|---|
-| Phase 1 | Foundation — Gateway, PAL, Vault, filesystem connector, HITL, CLI, CI | ✅ Complete |
-| Phase 2 | The Bridge — 15 MCP connectors, unified index, people graph, context ranker, installers | ✅ Complete |
-| Phase 3 | Intelligence — Semantic layer, extensions, CI/CD + cloud MCPs, workflows, watchers | ✅ Complete |
-| Phase 3.5 | Observability — Health model, `nimbus query`, `diag`, recovery, telemetry, docs site | ✅ Complete |
-| Phase 4 | Presence — Tauri UI, VS Code ext, local LLM (Ollama), multi-agent, data portability | ✅ Complete |
-| Phase 5 | The Extended Surface — browser/reading, IMAP, finance, CRM, HR, design connectors; Marketplace v2 | 🔵 Active |
-| Phase 6 | Team — federation, Team Vault, shared namespaces, SSO/SCIM, multi-user HITL, org policy | Planned |
-| Phase 7 | The Autonomous Agent — standing approvals, scheduled tasks, incident correlation, fine-tuning, SRE loop | Planned |
-| Phase 8 | Sovereign Mesh — P2P sync, mobile companion, hardware vault, DIDs, Digital Executor | Planned |
-| Phase 9 | Enterprise — Docker/Helm, SIEM, compliance, SCIM, admin console, security audit, SLA | Planned |
-| Phase 10 | Desktop Distribution — `desktop-v0.1.0` Tauri installers + signing (deferred from `v0.1.0`) | Planned |
-
-When implementing, focus only on the current phase. Do not add Phase N+1 features in Phase N code.
+**Pre-flight before pushing a PR:** `bun run test:ci` (full CI parity). Full command catalogue + coverage thresholds + env-var overrides live in the [`nimbus-commands`](./.claude/commands/nimbus-commands.md) skill. File-location pointers live in [`nimbus-file-map`](./.claude/commands/nimbus-file-map.md).
 
 ---
 
-## Subsystems (monorepo)
+## See Also
 
-- `packages/gateway` — Engine, MCP mesh, Vault, local index, IPC
-- `packages/cli` — Terminal client
-- `packages/ui` — Tauri 2.0 + React (desktop)
-- `packages/sdk` — `@nimbus-dev/sdk` for extensions (MIT)
-- `packages/mcp-connectors/*` — First-party MCP servers (AGPL)
-
-**PAL:** All OS-specific logic lives under `packages/gateway/src/platform/` and is accessed via `PlatformServices` — never import `win32` / `darwin` / `linux` from business logic.
-
-**Prerequisites:** Bun v1.2+; Rust for building the Tauri UI (`packages/ui/src-tauri`).
+- [`docs/architecture.md`](./docs/architecture.md) — full subsystem design, IPC method catalogue, schema reference. Read before modifying any subsystem.
+- [`docs/roadmap.md`](./docs/roadmap.md) — phases, acceptance criteria, delivered summaries.
+- [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md) — I1–I12 rationale + anti-patterns.
+- [`docs/cli-reference.md`](./docs/cli-reference.md) — full CLI subcommand reference.
+- `.claude/commands/nimbus-*.md` — domain skills (architecture, IPC, file-map, commands, testing, agents, connectors, migrations, security invariants, Tauri allowlist, tool-output envelope, Phase 4 reference). The Gemini CLI activates these on demand via `activate_skill`.

--- a/docs/superpowers/plans/2026-05-11-phase-5-t4-pr2-dora-metrics-review.md
+++ b/docs/superpowers/plans/2026-05-11-phase-5-t4-pr2-dora-metrics-review.md
@@ -1,0 +1,40 @@
+# Review: Phase 5 T4 PR 2 — DORA Metrics Implementation Plan
+
+**Reviewer:** Gemini CLI  
+**Date:** 2026-05-11  
+**Status:** ✅ Approved with minor suggestions
+
+The plan for DORA Metrics implementation is comprehensive, well-structured, and aligns perfectly with Nimbus's architectural patterns (pure calculators, local-first index, strict TDD).
+
+## Strengths
+- **Empirical Gap Analysis:** Correctly identified that `merged_at` and `merge_commit_sha` were missing from the current schema/connectors and added tasks (1 & 2) to resolve this.
+- **Pure Calculators:** Keeping the metrics logic in `packages/gateway/src/metrics/dora.ts` I/O-free (taking `Database` and `config`) ensures high testability.
+- **Config Validation:** Comprehensive validation in the TOML parser (Task 3) prevents the Gateway from starting with a broken config.
+- **Fixture-Driven Integration:** Using a synthetic 30-day window fixture (Task 5) is the right way to verify metric correctness before the connectors are fully enriched.
+
+## Suggestions / Observations
+
+### 1. Security & Invariants
+- The plan focuses on `SELECT` queries, so **I2 (HITL)** is not triggered.
+- Ensure that the new `metrics.dora` RPC method is correctly excluded from HITL requirements in `ToolExecutor.gate()` if the gateway defaults to "deny-all" for new namespaces (it currently gates on a whitelist, so verify `metrics.dora` isn't accidentally blocked or requires consent if it's read-only).
+
+### 2. Lead Time Logic
+- The "exact-SHA" join is a solid first step. The plan notes that transitive commit walking is out of scope. This is a reasonable trade-off for PR 2.
+- **Observation:** If a PR is merged via "Rebase and Merge", the `merge_commit_sha` might not exist or might point to a commit that isn't the one deployed if the CI runs on the source branch. The fallback to `approximate_lead_time` is a good way to handle these edge cases.
+
+### 3. PagerDuty Connector Enrichment
+- Task 4 correctly identifies that `metadata.opened_at_ms` and `metadata.pagerduty_service_id` are missing from the current connector.
+- Since the fixture seeds these, the tests will pass. Ensure the follow-up task for the PagerDuty connector is tracked in the project's backlog (or `docs/roadmap.md`).
+
+### 4. CLI Output
+- The `formatPretty` function in Task 8 uses manual padding. Consider if existing CLI table helpers (if any) should be used for consistency, though manual padding is fine for a simple card view.
+
+### 5. Performance
+- `selectDeploys` and `selectResolvedIncidents` use `JSON.parse` in a loop. For very large indexes (e.g., thousands of CI runs), this might become a bottleneck. Since DORA is typically run on-demand for a specific service and window, this is likely fine for now, but something to watch.
+
+## Questions for Implementation
+- **Task 9 Step 1:** Does `test:ci` already exist in the root `package.json`? If not, ensure it's created or the aggregate command is updated correctly.
+- **Task 7 Step 3:** Is `json` helper already available in `http-server.ts`? If not, it should be defined or the standard `Response` constructor used.
+
+## Final Verdict
+The plan is ready for execution. Recommend using **Subagent-Driven Development** for the implementation phase due to the distinct boundaries between DB, Gateway, and CLI tasks.

--- a/docs/superpowers/plans/2026-05-11-phase-5-t4-pr2-dora-metrics.md
+++ b/docs/superpowers/plans/2026-05-11-phase-5-t4-pr2-dora-metrics.md
@@ -1,0 +1,2624 @@
+# Phase 5 T4 PR 2 — DORA Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `nimbus metrics dora --service <id>` end-to-end (CLI → `metrics.dora` IPC → `GET /v1/metrics/dora` → four pure calculators reading `pr` / `ci_run` / `incident` items) so any indexed service with a `[metrics.dora.<id>]` config produces the four canonical DORA values.
+
+**Architecture:** Pure-SELECT calculators in `packages/gateway/src/metrics/dora.ts` read from the existing local index. A new `[metrics.dora.<service-id>]` TOML table maps a service id to repo URNs, PagerDuty service ids, deploy-workflow regex, and behaviour overrides. The DORA functions are I/O-free below `db`. CLI / IPC / HTTP layers all serialise the same `DoraMetricsResult` envelope.
+
+**Scope expansion (vs. spec):** Spec assumes `pr.metadata.merge_commit_sha` + `merged_at` + a `pr → commit` graph edge exist. They do not (verified 2026-05-11). PR 2 therefore also enriches `github-sync.ts` with `merged_at`, `merge_commit_sha`, and `labels`, adds a V27 migration seeding a `merged_as` `graph_relation_type`, and emits the edge from `graph-populator.ts`. Other providers (GitLab / Bitbucket) get the same enrichment shape opportunistically (best-effort field extraction), but Lead Time on them carries `gap: "approximate_lead_time"` when the field is absent. Transitive commit-to-commit walking is **out of scope**; Lead Time falls back to exact `pr.merge_commit_sha === ci_run.metadata.headSha` and emits `gap: "approximate_lead_time"` when no exact match.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6.x strict, `bun:sqlite`, hand-written TOML parser pattern, `js-yaml` (already in PR 1), the existing `[Bun.serve]` HTTP server, JSON-RPC 2.0 over Unix socket / named pipe.
+
+---
+
+## File Structure
+
+### Files created
+
+| Path | Responsibility |
+|---|---|
+| `packages/gateway/src/index/pr-commit-relation-v27-sql.ts` | V27 migration — seeds `merged_as` row in `graph_relation_type`. Schema-only; no shadow table. |
+| `packages/gateway/src/metrics/dora.ts` | Four pure metric calculators: `deploymentFrequency`, `leadTimeForChanges`, `changeFailureRate`, `mttr`. Each takes `(db, config, nowMs, sinceMs)` and returns `DoraMetricValue`. Plus `computeDoraMetrics` wrapper returning the full envelope. |
+| `packages/gateway/src/metrics/dora-config.ts` | `DoraServiceConfig` type + URN parsing + repo-provider-to-`service`-column mapping. Standalone so unit tests don't need a DB. |
+| `packages/gateway/src/ipc/metrics-rpc.ts` | `dispatchMetricsRpc` + `MetricsRpcError`; validates params, emits the envelope. Same shape as `agents-rpc.ts`. |
+| `packages/gateway/test/fixtures/dora/payment-service/seed.ts` | Programmatic fixture seeder: 30 days of synthetic `pr`, `ci_run`, `incident` items spanning GitHub Actions / GitLab / Jenkins, hand-computed via `expected-metrics.json`. |
+| `packages/gateway/test/fixtures/dora/payment-service/expected-metrics.json` | The four expected metric values for the fixture window. |
+| `packages/gateway/test/unit/metrics/dora.test.ts` | Per-metric unit tests (every gap case + multi-provider + revert exclusion + most-recent-preceding CFR + MTTR low-sample). |
+| `packages/gateway/test/unit/metrics/dora-config.test.ts` | TOML parse: missing fields, bad types, unknown keys, malformed URNs, unparseable regex. |
+| `packages/gateway/test/integration/metrics/dora-real-db.test.ts` | Fresh SQLite + fixture + assert all four metrics within ±5%. |
+| `packages/gateway/test/unit/ipc/metrics-rpc.test.ts` | Method dispatch + param validation. |
+| `packages/gateway/test/integration/http/metrics-dora-route.test.ts` | `GET /v1/metrics/dora` round-trip. |
+| `packages/cli/src/commands/metrics.ts` | `nimbus metrics dora --service X [--since 30d] [--json]`; pretty card + JSON modes; `NO_COLOR` respected. |
+| `packages/cli/test/commands/metrics.test.ts` | CLI arg parsing + pretty-vs-json switch. |
+| `packages/gateway/test/e2e/scenarios/metrics-dora.e2e.test.ts` | Gateway subprocess + seeded fixture + `nimbus metrics dora --service X --json` → assert envelope. |
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `packages/gateway/src/connectors/github-sync.ts` | Add `merged_at`, `merge_commit_sha`, `labels` to PR upsert metadata. |
+| `packages/gateway/src/graph/graph-populator.ts` | Extend `syncPrGraph` to emit `merged_as` edge from PR entity → commit entity when `merged === true` and `merge_commit_sha` set. |
+| `packages/gateway/src/index/migrations/runner.ts` | Register V26→V27 migration. |
+| `packages/gateway/src/index/local-index.ts` | Bump `CURRENT_SCHEMA_VERSION` 26 → 27. |
+| `packages/gateway/src/config/nimbus-toml.ts` | Add `NimbusDoraToml` types + `parseNimbusDoraToml` + `loadNimbusDoraFromConfigDir`. |
+| `packages/gateway/src/ipc/http-routes.ts` | Append `{ method: "GET", path: "/v1/metrics/dora" }`. |
+| `packages/gateway/src/ipc/http-server.ts` | Add `handleMetricsDora` + route dispatch. |
+| `packages/gateway/src/ipc/server/dispatchers.ts` | Add `tryDispatchMetricsRpc`; wire into `tryDispatchPhase4Rpc` chain. |
+| `packages/gateway/openapi/v1.yaml` | Replace `/v1/metrics/dora` reserved stub with full schema. |
+| `packages/gateway/src/ipc/types.ts` (gateway) and `packages/ui/src/ipc/types.ts` (UI) | Export `DoraMetricValue`, `DoraMetricsResult`. UI mirror is just types — no UI wiring in PR 2. |
+| `packages/cli/src/index.ts` | Register `metrics` subcommand. |
+| `package.json` (root) | Add `test:coverage:metrics` script; wire into `test:ci`. |
+| `.github/workflows/_test-suite.yml` | Add `test:coverage:metrics` step. |
+| `.claude/commands/nimbus-file-map.md` | Add `packages/gateway/src/metrics/dora.ts`, `metrics-rpc.ts`, `metrics.ts` CLI rows. |
+| `.claude/commands/nimbus-commands.md` | Add `test:coverage:metrics` row + `nimbus metrics dora` reference. |
+| `CLAUDE.md` and `GEMINI.md` | Bump status line: T4 PR 2 ✅ in flight / shipped (depending on merge timing). |
+| `docs/roadmap.md` | Flip the `nimbus metrics dora` DORA bullet to `[x]` on merge. |
+
+---
+
+## Task 1: V27 migration — `merged_as` graph_relation_type seed
+
+**Files:**
+- Create: `packages/gateway/src/index/pr-commit-relation-v27-sql.ts`
+- Modify: `packages/gateway/src/index/migrations/runner.ts`
+- Modify: `packages/gateway/src/index/local-index.ts:267` (bump `CURRENT_SCHEMA_VERSION`)
+- Test: `packages/gateway/test/integration/index/migration-v27.test.ts`
+
+- [ ] **Step 1: Write the failing migration test**
+
+```ts
+// packages/gateway/test/integration/index/migration-v27.test.ts
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "../../../src/index/local-index.ts";
+
+describe("V27 migration — merged_as graph_relation_type", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-v27-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("seeds the merged_as relation type idempotently", () => {
+    const index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+    const db = index.getDatabase();
+    const row = db
+      .query("SELECT name, directed FROM graph_relation_type WHERE name = 'merged_as'")
+      .get() as { name: string; directed: number } | undefined;
+    expect(row).toBeDefined();
+    expect(row?.directed).toBe(1);
+    index.close();
+  });
+
+  it("does not fail when applied to a DB already at V27 (idempotency)", () => {
+    const index1 = new LocalIndex(join(dir, "nimbus.db"));
+    index1.open();
+    index1.close();
+    const index2 = new LocalIndex(join(dir, "nimbus.db"));
+    index2.open(); // should be a no-op for V27
+    index2.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/integration/index/migration-v27.test.ts`
+Expected: FAIL with "Expected row to be defined" (V27 doesn't exist yet).
+
+- [ ] **Step 3: Create the V27 SQL module**
+
+Create `packages/gateway/src/index/pr-commit-relation-v27-sql.ts`:
+
+```ts
+/**
+ * V27 migration — seeds the `merged_as` row in `graph_relation_type`
+ * so the graph populator can emit `pr → commit` edges produced by the
+ * github PR connector (Phase 5 T4 PR 2). Append-only; no shadow table.
+ *
+ * The relation links the `pr` graph entity to the `commit` graph entity
+ * created when `pr.metadata.merge_commit_sha` is present. Used by the
+ * DORA Lead Time calculator's exact-SHA join.
+ */
+
+export const PR_COMMIT_RELATION_V27_SEED_SQL = `
+INSERT OR IGNORE INTO graph_relation_type (name, directed) VALUES
+  ('merged_as', 1);
+`;
+```
+
+- [ ] **Step 4: Register the migration in the runner**
+
+Modify `packages/gateway/src/index/migrations/runner.ts`:
+
+After the V26 import block (~line 39), add:
+
+```ts
+import { PR_COMMIT_RELATION_V27_SEED_SQL } from "../pr-commit-relation-v27-sql.ts";
+```
+
+After `migrateIndexedV25ToV26` (~line 365), add:
+
+```ts
+function migrateIndexedV26ToV27(db: Database, _now: number): void {
+  db.transaction(() => {
+    db.exec(PR_COMMIT_RELATION_V27_SEED_SQL);
+  })();
+}
+```
+
+In the `INDEXED_SCHEMA_STEPS` array (~line 395), append:
+
+```ts
+  { fromVersion: 26, toVersion: 27, apply: migrateIndexedV26ToV27 },
+```
+
+Modify `packages/gateway/src/index/local-index.ts:267`:
+
+```ts
+export const CURRENT_SCHEMA_VERSION = 27;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test packages/gateway/test/integration/index/migration-v27.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 6: Run the full migration test suite to confirm no regression**
+
+Run: `bun test packages/gateway/test/integration/index/`
+Expected: PASS (all migration tests green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/index/pr-commit-relation-v27-sql.ts \
+        packages/gateway/src/index/migrations/runner.ts \
+        packages/gateway/src/index/local-index.ts \
+        packages/gateway/test/integration/index/migration-v27.test.ts
+git commit -m "feat(db): V27 migration seeds merged_as graph_relation_type
+
+Adds the relation type used by github-sync to link a merged PR entity
+to its merge-commit entity. Single source of truth for the DORA Lead
+Time exact-SHA join (Phase 5 T4 PR 2)."
+```
+
+---
+
+## Task 2: Enrich `github-sync.ts` PR metadata + emit `pr → commit` graph edge
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/github-sync.ts:100-140` (`upsertFromPullRequest`)
+- Modify: `packages/gateway/src/graph/graph-populator.ts` (`syncPrGraph`)
+- Test: `packages/gateway/test/unit/connectors/github-sync-pr-metadata.test.ts`
+- Test: `packages/gateway/test/integration/graph/pr-commit-edge.test.ts`
+
+- [ ] **Step 1: Write the failing metadata test**
+
+```ts
+// packages/gateway/test/unit/connectors/github-sync-pr-metadata.test.ts
+import { describe, expect, it } from "bun:test";
+import { extractPrMetadataForIndex } from "../../../src/connectors/github-sync.ts";
+
+describe("github-sync: PR metadata enrichment", () => {
+  it("captures merged_at, merge_commit_sha, labels on a merged PR", () => {
+    const pr = {
+      number: 42,
+      state: "closed",
+      merged: true,
+      merged_at: "2026-05-10T12:34:56Z",
+      merge_commit_sha: "abc123def456",
+      labels: [{ name: "bug" }, { name: "backend" }],
+      user: { login: "alice" },
+      draft: false,
+    };
+    const out = extractPrMetadataForIndex("nimbus-agent/payments", pr);
+    expect(out.merged_at).toBe(Date.parse("2026-05-10T12:34:56Z"));
+    expect(out.merge_commit_sha).toBe("abc123def456");
+    expect(out.labels).toEqual(["bug", "backend"]);
+    expect(out.merged).toBe(true);
+  });
+
+  it("omits merged_at and merge_commit_sha when PR is open", () => {
+    const pr = {
+      number: 7,
+      state: "open",
+      merged: false,
+      labels: [],
+      user: { login: "bob" },
+      draft: false,
+    };
+    const out = extractPrMetadataForIndex("nimbus-agent/payments", pr);
+    expect(out.merged_at).toBeUndefined();
+    expect(out.merge_commit_sha).toBeUndefined();
+    expect(out.labels).toEqual([]);
+  });
+
+  it("tolerates a labels array of strings (defensive)", () => {
+    const pr = {
+      number: 9,
+      state: "closed",
+      merged: true,
+      merged_at: "2026-05-10T12:00:00Z",
+      merge_commit_sha: "deadbeef",
+      labels: ["revert", "hotfix"],
+      user: { login: "alice" },
+    };
+    const out = extractPrMetadataForIndex("nimbus-agent/payments", pr);
+    expect(out.labels).toEqual(["revert", "hotfix"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/unit/connectors/github-sync-pr-metadata.test.ts`
+Expected: FAIL — `extractPrMetadataForIndex` is not exported.
+
+- [ ] **Step 3: Extract a pure helper and use it from `upsertFromPullRequest`**
+
+Modify `packages/gateway/src/connectors/github-sync.ts`. Replace the `meta` block in `upsertFromPullRequest` (lines ~117-124) with a call to a new exported helper. Add at the top of the file (export so the unit test can hit it):
+
+```ts
+export function extractPrMetadataForIndex(
+  repoFull: string,
+  pr: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = pr["merged"] === true;
+  const out: Record<string, unknown> = {
+    number: numberField(pr, "number"),
+    repo: repoFull,
+    state: stringField(pr, "state"),
+    draft: pr["draft"] === true,
+    merged,
+    user: (() => {
+      const user = asRecord(pr["user"]);
+      return user === undefined ? undefined : stringField(user, "login");
+    })(),
+    labels: extractLabelNames(pr["labels"]),
+  };
+  if (merged) {
+    const mergedAtIso = stringField(pr, "merged_at");
+    if (mergedAtIso !== undefined) {
+      const ms = Date.parse(mergedAtIso);
+      if (Number.isFinite(ms)) out.merged_at = ms;
+    }
+    const sha = stringField(pr, "merge_commit_sha");
+    if (sha !== undefined && sha.length > 0) out.merge_commit_sha = sha;
+  }
+  return out;
+}
+
+function extractLabelNames(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string") {
+      out.push(entry);
+      continue;
+    }
+    const r = asRecord(entry);
+    if (r === undefined) continue;
+    const name = stringField(r, "name");
+    if (name !== undefined && name.length > 0) out.push(name);
+  }
+  return out;
+}
+```
+
+Then replace the original `meta` block inside `upsertFromPullRequest` so it reads:
+
+```ts
+  const meta = extractPrMetadataForIndex(repoFull, pr);
+```
+
+(removes the duplicated inline construction, calls the pure helper).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/gateway/test/unit/connectors/github-sync-pr-metadata.test.ts`
+Expected: PASS (3 cases).
+
+- [ ] **Step 5: Write the failing graph-edge test**
+
+```ts
+// packages/gateway/test/integration/graph/pr-commit-edge.test.ts
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "../../../src/index/local-index.ts";
+import { populateGraphForIndexedItem } from "../../../src/graph/graph-populator.ts";
+
+describe("graph-populator: pr → commit merged_as edge", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-pr-edge-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("emits a merged_as relation from PR entity to commit entity on merge", () => {
+    const index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+    const db = index.getDatabase();
+    const now = Date.now();
+    populateGraphForIndexedItem(db, {
+      id: "github:pr_nimbus-agent/payments#42",
+      service: "github",
+      type: "pr",
+      externalId: "nimbus-agent/payments#42",
+      title: "Add retry logic",
+      modifiedAt: now,
+      authorId: null,
+      metadata: {
+        repo: "nimbus-agent/payments",
+        merged: true,
+        merged_at: now,
+        merge_commit_sha: "abc123",
+      },
+    }, now);
+    const rows = db
+      .query(
+        `SELECT rt.name FROM graph_relation r
+         JOIN graph_relation_type rt ON rt.name = r.type
+         JOIN graph_entity src ON src.id = r.source_id
+         JOIN graph_entity dst ON dst.id = r.target_id
+         WHERE src.type = 'pr' AND dst.type = 'commit' AND rt.name = 'merged_as'`,
+      )
+      .all() as { name: string }[];
+    expect(rows.length).toBe(1);
+    index.close();
+  });
+
+  it("emits no merged_as edge when PR is not merged", () => {
+    const index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+    const db = index.getDatabase();
+    const now = Date.now();
+    populateGraphForIndexedItem(db, {
+      id: "github:pr_nimbus-agent/payments#7",
+      service: "github",
+      type: "pr",
+      externalId: "nimbus-agent/payments#7",
+      title: "WIP",
+      modifiedAt: now,
+      authorId: null,
+      metadata: { repo: "nimbus-agent/payments", merged: false },
+    }, now);
+    const rows = db
+      .query(
+        `SELECT 1 FROM graph_relation r
+         JOIN graph_relation_type rt ON rt.name = r.type
+         WHERE rt.name = 'merged_as'`,
+      )
+      .all();
+    expect(rows.length).toBe(0);
+    index.close();
+  });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/integration/graph/pr-commit-edge.test.ts`
+Expected: FAIL — `syncPrGraph` doesn't emit the edge yet.
+
+- [ ] **Step 7: Extend `syncPrGraph` in `graph-populator.ts`**
+
+Find `syncPrGraph` in `packages/gateway/src/graph/graph-populator.ts`. After the existing entity upserts, before the function returns, add:
+
+```ts
+  const merged = row.metadata !== undefined && (row.metadata as Record<string, unknown>)["merged"] === true;
+  const mergeSha = stringField(row.metadata, "merge_commit_sha");
+  if (merged && mergeSha !== undefined && mergeSha.length > 0) {
+    const commitEntityId = upsertGraphEntity(db, {
+      type: "commit",
+      externalId: `${row.service}:${mergeSha}`,
+      label: mergeSha.slice(0, 12),
+      service: row.service,
+      metadata: { sha: mergeSha },
+    });
+    upsertGraphRelation(db, prEntityId, commitEntityId, "merged_as", now);
+  }
+```
+
+(Use the existing `prEntityId` variable created earlier in the function. `stringField` is already imported. If the metadata read pattern in the file uses a different helper, mirror it exactly — `stringField(row.metadata, "merge_commit_sha")` works because metadata is already a `Record<string, unknown>` after the populator's normalisation.)
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `bun test packages/gateway/test/integration/graph/pr-commit-edge.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 9: Run github-sync.ts existing tests to confirm no regression**
+
+Run: `bun test packages/gateway/test/unit/connectors/github-sync`
+Expected: PASS (all existing github-sync tests still green).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/gateway/src/connectors/github-sync.ts \
+        packages/gateway/src/graph/graph-populator.ts \
+        packages/gateway/test/unit/connectors/github-sync-pr-metadata.test.ts \
+        packages/gateway/test/integration/graph/pr-commit-edge.test.ts
+git commit -m "feat(github): enrich PR metadata with merged_at + merge_commit_sha + labels
+
+Adds extractPrMetadataForIndex as a pure helper used by upsertFromPullRequest.
+graph-populator emits a merged_as edge from the PR entity to the merge
+commit entity when the PR is merged with a merge_commit_sha. The DORA
+Lead Time calculator joins on this edge."
+```
+
+---
+
+## Task 3: `[metrics.dora.<service-id>]` TOML parser
+
+**Files:**
+- Create: `packages/gateway/src/metrics/dora-config.ts`
+- Modify: `packages/gateway/src/config/nimbus-toml.ts` (append at end)
+- Test: `packages/gateway/test/unit/metrics/dora-config.test.ts`
+
+- [ ] **Step 1: Write the failing config-parsing test**
+
+```ts
+// packages/gateway/test/unit/metrics/dora-config.test.ts
+import { describe, expect, it } from "bun:test";
+import {
+  DEFAULT_DEPLOY_WORKFLOW_PATTERN,
+  parseDoraRepoUrn,
+  type ParsedDoraRepoUrn,
+} from "../../../src/metrics/dora-config.ts";
+import { parseNimbusDoraToml } from "../../../src/config/nimbus-toml.ts";
+
+describe("DORA TOML parser", () => {
+  it("parses one service entry with all keys", () => {
+    const raw = `
+[metrics.dora.payment-service]
+repos = ["github:nimbus-agent/payments", "jenkins:payment-service/deploy-prod"]
+pagerduty_services = ["P12ABCD"]
+deploy_workflow_pattern = "^Release"
+incident_window_minutes = 90
+exclude_pr_labels = ["revert", "rollback"]
+`;
+    const parsed = parseNimbusDoraToml(raw);
+    expect(parsed.size).toBe(1);
+    const cfg = parsed.get("payment-service");
+    if (cfg === undefined) throw new Error("payment-service missing");
+    expect(cfg.repos.map((r) => `${r.provider}:${r.providerId}`)).toEqual([
+      "github:nimbus-agent/payments",
+      "jenkins:payment-service/deploy-prod",
+    ]);
+    expect(cfg.pagerdutyServices).toEqual(["P12ABCD"]);
+    expect(cfg.deployWorkflowPattern.source).toBe("^Release");
+    expect(cfg.incidentWindowMinutes).toBe(90);
+    expect(cfg.excludePrLabels).toEqual(["revert", "rollback"]);
+  });
+
+  it("uses defaults for omitted keys", () => {
+    const raw = `
+[metrics.dora.svc-a]
+repos = ["github:org/svc-a"]
+`;
+    const cfg = parseNimbusDoraToml(raw).get("svc-a");
+    if (cfg === undefined) throw new Error("svc-a missing");
+    expect(cfg.deployWorkflowPattern.source).toBe(DEFAULT_DEPLOY_WORKFLOW_PATTERN);
+    expect(cfg.incidentWindowMinutes).toBe(60);
+    expect(cfg.excludePrLabels).toEqual(["revert"]);
+    expect(cfg.pagerdutyServices).toEqual([]);
+  });
+
+  it("rejects an unknown provider prefix", () => {
+    expect(() => parseDoraRepoUrn("svn:my-repo")).toThrow(/unknown provider/i);
+  });
+
+  it("rejects URN with no separator", () => {
+    expect(() => parseDoraRepoUrn("github")).toThrow(/invalid urn/i);
+  });
+
+  it("parses URN with provider-id containing colons", () => {
+    const out = parseDoraRepoUrn("circleci:gh/nimbus-agent/payments");
+    expect(out.provider).toBe("circleci");
+    expect(out.providerId).toBe("gh/nimbus-agent/payments");
+  });
+
+  it("rejects unparseable deploy_workflow_pattern", () => {
+    const raw = `
+[metrics.dora.bad-service]
+repos = ["github:org/svc"]
+deploy_workflow_pattern = "["
+`;
+    expect(() => parseNimbusDoraToml(raw)).toThrow(/regex/i);
+  });
+
+  it("rejects out-of-range incident_window_minutes", () => {
+    const raw = `
+[metrics.dora.bad]
+repos = ["github:org/svc"]
+incident_window_minutes = 0
+`;
+    expect(() => parseNimbusDoraToml(raw)).toThrow(/incident_window_minutes/);
+  });
+
+  it("rejects unknown keys", () => {
+    const raw = `
+[metrics.dora.bad]
+repos = ["github:org/svc"]
+mystery = "yes"
+`;
+    expect(() => parseNimbusDoraToml(raw)).toThrow(/unknown key/i);
+  });
+
+  it("returns an empty Map when no [metrics.dora.*] tables present", () => {
+    const parsed = parseNimbusDoraToml("[user]\nme_person_id = \"alice\"\n");
+    expect(parsed.size).toBe(0);
+  });
+
+  it("parses multiple service entries independently", () => {
+    const raw = `
+[metrics.dora.svc-a]
+repos = ["github:org/a"]
+
+[metrics.dora.svc-b]
+repos = ["gitlab:org/b"]
+pagerduty_services = ["PXYZ"]
+`;
+    const parsed = parseNimbusDoraToml(raw);
+    expect(parsed.size).toBe(2);
+    expect(parsed.get("svc-a")?.pagerdutyServices).toEqual([]);
+    expect(parsed.get("svc-b")?.pagerdutyServices).toEqual(["PXYZ"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/unit/metrics/dora-config.test.ts`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Create `dora-config.ts`**
+
+Create `packages/gateway/src/metrics/dora-config.ts`:
+
+```ts
+/**
+ * DORA service-config types + URN helpers.
+ *
+ * `[metrics.dora.<service-id>]` in nimbus.toml maps an abstract service id
+ * to: a list of repo URNs (multi-provider), PagerDuty service ids, a deploy
+ * workflow name regex, and behaviour overrides.
+ *
+ * Provider URN format: `<provider>:<provider-specific-id>`. The provider
+ * prefix is used to compute the `service` column filter on the unified
+ * `item` table (verified 2026-05-10 against the four CI connectors).
+ */
+
+export type DoraProvider = "github" | "gitlab" | "bitbucket" | "jenkins" | "circleci";
+
+export type ParsedDoraRepoUrn = {
+  readonly provider: DoraProvider;
+  readonly providerId: string;
+};
+
+export type DoraServiceConfig = {
+  /** Stable service id from the table key. */
+  readonly serviceId: string;
+  readonly repos: readonly ParsedDoraRepoUrn[];
+  readonly pagerdutyServices: readonly string[];
+  readonly deployWorkflowPattern: RegExp;
+  readonly incidentWindowMinutes: number;
+  readonly excludePrLabels: readonly string[];
+};
+
+export const DEFAULT_DEPLOY_WORKFLOW_PATTERN = "^[Dd]eploy";
+export const DEFAULT_INCIDENT_WINDOW_MINUTES = 60;
+export const DEFAULT_EXCLUDE_PR_LABELS: readonly string[] = ["revert"];
+
+const KNOWN_PROVIDERS: readonly DoraProvider[] = [
+  "github",
+  "gitlab",
+  "bitbucket",
+  "jenkins",
+  "circleci",
+];
+
+export function parseDoraRepoUrn(raw: string): ParsedDoraRepoUrn {
+  const colon = raw.indexOf(":");
+  if (colon <= 0) {
+    throw new Error(`invalid URN '${raw}': missing 'provider:id' separator`);
+  }
+  const provider = raw.slice(0, colon);
+  const providerId = raw.slice(colon + 1);
+  if (!(KNOWN_PROVIDERS as readonly string[]).includes(provider)) {
+    throw new Error(
+      `unknown provider '${provider}' in URN '${raw}'. Known: ${KNOWN_PROVIDERS.join(", ")}`,
+    );
+  }
+  if (providerId.length === 0) {
+    throw new Error(`invalid URN '${raw}': empty provider-specific id`);
+  }
+  return { provider: provider as DoraProvider, providerId };
+}
+
+/**
+ * Maps a provider URN prefix to the `service` column values it covers
+ * on the indexed `item` table. Asymmetric for GitHub: PRs live under
+ * `github`, CI runs under `github_actions`.
+ */
+export function providerServiceColumns(
+  provider: DoraProvider,
+): { prServices: readonly string[]; ciServices: readonly string[] } {
+  switch (provider) {
+    case "github":
+      return { prServices: ["github"], ciServices: ["github_actions"] };
+    case "gitlab":
+      return { prServices: ["gitlab"], ciServices: ["gitlab"] };
+    case "bitbucket":
+      return { prServices: ["bitbucket"], ciServices: ["bitbucket"] };
+    case "jenkins":
+      return { prServices: [], ciServices: ["jenkins"] };
+    case "circleci":
+      return { prServices: [], ciServices: ["circleci"] };
+  }
+}
+```
+
+- [ ] **Step 4: Append parser to `nimbus-toml.ts`**
+
+Append at the very end of `packages/gateway/src/config/nimbus-toml.ts`:
+
+```ts
+// ---------------------------------------------------------------------------
+// [metrics.dora.<service-id>] — DORA service map (Phase 5 T4 PR 2)
+// ---------------------------------------------------------------------------
+
+import {
+  DEFAULT_DEPLOY_WORKFLOW_PATTERN,
+  DEFAULT_EXCLUDE_PR_LABELS,
+  DEFAULT_INCIDENT_WINDOW_MINUTES,
+  type DoraServiceConfig,
+  parseDoraRepoUrn,
+} from "../metrics/dora-config.ts";
+
+const DORA_TABLE_PREFIX = "[metrics.dora.";
+const DORA_KNOWN_KEYS: ReadonlySet<string> = new Set([
+  "repos",
+  "pagerduty_services",
+  "deploy_workflow_pattern",
+  "incident_window_minutes",
+  "exclude_pr_labels",
+]);
+
+function parseStringArray(raw: string): string[] {
+  const t = raw.trim();
+  if (!t.startsWith("[") || !t.endsWith("]")) {
+    throw new Error(`expected array, got: ${raw}`);
+  }
+  const inner = t.slice(1, -1).trim();
+  if (inner.length === 0) return [];
+  const out: string[] = [];
+  // Naive split — repos / pagerduty ids don't contain commas or quotes.
+  for (const part of inner.split(",")) {
+    const v = parseString(part);
+    if (v.length > 0) out.push(v);
+  }
+  return out;
+}
+
+export function parseNimbusDoraToml(raw: string): Map<string, DoraServiceConfig> {
+  const lines = raw.split(/\r?\n/);
+  const accum: Map<string, Record<string, string>> = new Map();
+  let currentId: string | undefined;
+  for (const line of lines) {
+    const trimmed = stripComment(line).trim();
+    if (trimmed === "") continue;
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      if (trimmed.startsWith(DORA_TABLE_PREFIX) && trimmed.endsWith("]")) {
+        const id = trimmed.slice(DORA_TABLE_PREFIX.length, -1);
+        if (id.length === 0) throw new Error("empty service id in [metrics.dora.<id>]");
+        currentId = id;
+        if (!accum.has(id)) accum.set(id, {});
+      } else {
+        currentId = undefined;
+      }
+      continue;
+    }
+    if (currentId === undefined) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    if (!DORA_KNOWN_KEYS.has(key)) {
+      throw new Error(`unknown key '${key}' in [metrics.dora.${currentId}]`);
+    }
+    accum.get(currentId)![key] = trimmed.slice(eq + 1).trim();
+  }
+  const out: Map<string, DoraServiceConfig> = new Map();
+  for (const [serviceId, kv] of accum.entries()) {
+    const reposRaw = kv["repos"];
+    if (reposRaw === undefined) {
+      throw new Error(`[metrics.dora.${serviceId}] missing required 'repos'`);
+    }
+    const repos = parseStringArray(reposRaw).map(parseDoraRepoUrn);
+    const pagerdutyServices =
+      kv["pagerduty_services"] === undefined ? [] : parseStringArray(kv["pagerduty_services"]);
+    const patternSrc =
+      kv["deploy_workflow_pattern"] === undefined
+        ? DEFAULT_DEPLOY_WORKFLOW_PATTERN
+        : parseString(kv["deploy_workflow_pattern"]);
+    let deployWorkflowPattern: RegExp;
+    try {
+      deployWorkflowPattern = new RegExp(patternSrc);
+    } catch (e) {
+      throw new Error(
+        `[metrics.dora.${serviceId}].deploy_workflow_pattern is not a valid regex: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+    }
+    const windowMins =
+      kv["incident_window_minutes"] === undefined
+        ? DEFAULT_INCIDENT_WINDOW_MINUTES
+        : parseIntDec(kv["incident_window_minutes"]);
+    if (windowMins === undefined || windowMins < 1 || windowMins > 1440) {
+      throw new Error(
+        `[metrics.dora.${serviceId}].incident_window_minutes must be 1..1440, got '${kv["incident_window_minutes"]}'`,
+      );
+    }
+    const excludePrLabels =
+      kv["exclude_pr_labels"] === undefined
+        ? Array.from(DEFAULT_EXCLUDE_PR_LABELS)
+        : parseStringArray(kv["exclude_pr_labels"]);
+    out.set(serviceId, {
+      serviceId,
+      repos,
+      pagerdutyServices,
+      deployWorkflowPattern,
+      incidentWindowMinutes: windowMins,
+      excludePrLabels,
+    });
+  }
+  return out;
+}
+
+export function loadNimbusDoraFromPath(tomlPath: string): Map<string, DoraServiceConfig> {
+  if (!existsSync(tomlPath)) return new Map();
+  const raw = readFileSync(tomlPath, "utf8");
+  return parseNimbusDoraToml(raw);
+}
+
+export function loadNimbusDoraFromConfigDir(configDir: string): Map<string, DoraServiceConfig> {
+  return loadNimbusDoraFromPath(join(configDir, "nimbus.toml"));
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test packages/gateway/test/unit/metrics/dora-config.test.ts`
+Expected: PASS (all 10 cases).
+
+- [ ] **Step 6: Run config tests to confirm no regression**
+
+Run: `bun test packages/gateway/test/unit/config/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/metrics/dora-config.ts \
+        packages/gateway/src/config/nimbus-toml.ts \
+        packages/gateway/test/unit/metrics/dora-config.test.ts
+git commit -m "feat(config): parse [metrics.dora.<id>] TOML table
+
+URN parsing supports github/gitlab/bitbucket/jenkins/circleci. Regex,
+range, and unknown-key validation all run at parse time so the Gateway
+refuses to start on a malformed config. Phase 5 T4 PR 2."
+```
+
+---
+
+## Task 4: `metrics/dora.ts` — pure metric calculators
+
+**Files:**
+- Create: `packages/gateway/src/metrics/dora.ts`
+- Test: `packages/gateway/test/unit/metrics/dora.test.ts`
+
+- [ ] **Step 1: Write the failing test (deploymentFrequency)**
+
+```ts
+// packages/gateway/test/unit/metrics/dora.test.ts
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "../../../src/index/local-index.ts";
+import { computeDoraMetrics, deploymentFrequency } from "../../../src/metrics/dora.ts";
+import type { DoraServiceConfig } from "../../../src/metrics/dora-config.ts";
+
+function seedCiRun(db: Database, id: string, opts: {
+  service: string;
+  title: string;
+  conclusion: string;
+  headSha?: string;
+  modifiedAt: number;
+}) {
+  const meta = JSON.stringify({ conclusion: opts.conclusion, headSha: opts.headSha ?? null });
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, url, canonical_url,
+                       modified_at, author_id, metadata, synced_at, pinned)
+     VALUES (?, ?, 'ci_run', ?, ?, '', NULL, NULL, ?, NULL, ?, ?, 0)`,
+    [id, opts.service, id, opts.title, opts.modifiedAt, meta, opts.modifiedAt],
+  );
+}
+
+function cfg(overrides: Partial<DoraServiceConfig> = {}): DoraServiceConfig {
+  return {
+    serviceId: "payment-service",
+    repos: [{ provider: "github", providerId: "nimbus-agent/payments" }],
+    pagerdutyServices: ["P1"],
+    deployWorkflowPattern: /^[Dd]eploy/,
+    incidentWindowMinutes: 60,
+    excludePrLabels: ["revert"],
+    ...overrides,
+  };
+}
+
+describe("deploymentFrequency", () => {
+  let dir: string;
+  let index: LocalIndex;
+  let db: Database;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-dora-"));
+    index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+    db = index.getDatabase();
+  });
+  afterEach(() => {
+    index.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("counts only successful deploys matching the regex on a matching repo", () => {
+    const now = 1_715_000_000_000;
+    const day = 86_400_000;
+    seedCiRun(db, "github_actions:r1", {
+      service: "github_actions",
+      title: "Deploy production",
+      conclusion: "success",
+      modifiedAt: now - 5 * day,
+    });
+    seedCiRun(db, "github_actions:r2", {
+      service: "github_actions",
+      title: "Deploy production",
+      conclusion: "failure",
+      modifiedAt: now - 4 * day,
+    });
+    seedCiRun(db, "github_actions:r3", {
+      service: "github_actions",
+      title: "CI lint",
+      conclusion: "success",
+      modifiedAt: now - 3 * day,
+    });
+    seedCiRun(db, "github_actions:r4", {
+      service: "github_actions",
+      title: "deploy",
+      conclusion: "success",
+      modifiedAt: now - 2 * day,
+    });
+    const result = deploymentFrequency(db, cfg(), now, 30 * day);
+    expect(result.sample).toBe(2);
+    expect(result.unit).toBe("deploys_per_day");
+    // 2 deploys / 30 days
+    expect(result.value).toBeCloseTo(2 / 30, 3);
+    expect(result.gap).toBeNull();
+  });
+
+  it("returns null with gap='no_repos' when repos is empty", () => {
+    const result = deploymentFrequency(db, cfg({ repos: [] }), Date.now(), 30 * 86_400_000);
+    expect(result.value).toBeNull();
+    expect(result.gap).toBe("no_repos");
+    expect(result.sample).toBe(0);
+  });
+
+  it("returns null with gap='no_deployment_data' when zero ci_run titles match the regex", () => {
+    const now = Date.now();
+    seedCiRun(db, "github_actions:lint", {
+      service: "github_actions",
+      title: "CI lint",
+      conclusion: "success",
+      modifiedAt: now - 1000,
+    });
+    const result = deploymentFrequency(db, cfg(), now, 7 * 86_400_000);
+    expect(result.value).toBeNull();
+    expect(result.gap).toBe("no_deployment_data");
+  });
+
+  it("emits gap='low_sample' when fewer than 3 deploys in window", () => {
+    const now = Date.now();
+    seedCiRun(db, "github_actions:r1", {
+      service: "github_actions",
+      title: "Deploy",
+      conclusion: "success",
+      modifiedAt: now - 1000,
+    });
+    seedCiRun(db, "github_actions:r2", {
+      service: "github_actions",
+      title: "Deploy",
+      conclusion: "success",
+      modifiedAt: now - 2000,
+    });
+    const result = deploymentFrequency(db, cfg(), now, 7 * 86_400_000);
+    expect(result.value).toBeGreaterThan(0);
+    expect(result.gap).toBe("low_sample");
+  });
+});
+
+describe("computeDoraMetrics envelope", () => {
+  let dir: string;
+  let index: LocalIndex;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-dora-env-"));
+    index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+  });
+  afterEach(() => {
+    index.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the four-metric envelope with computed_at set", () => {
+    const out = computeDoraMetrics(index.getDatabase(), cfg(), Date.now(), 30 * 86_400_000);
+    expect(out.metrics).toHaveProperty("deployment_frequency");
+    expect(out.metrics).toHaveProperty("lead_time_for_changes");
+    expect(out.metrics).toHaveProperty("change_failure_rate");
+    expect(out.metrics).toHaveProperty("mttr");
+    expect(out.service).toBe("payment-service");
+    expect(out.computed_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+```
+
+Add the rest of the test file covering: `leadTimeForChanges`, `changeFailureRate` (including the most-recent-preceding rule), `mttr` (N=1, N=2 → `low_sample`; N=0 → null), revert exclusion, multi-provider repos, `no_pagerduty_mapping` gap. Mirror the seeding helper for `pr` and `incident`. Use the same fixture-style seeding (16+ test cases total).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/unit/metrics/dora.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `metrics/dora.ts`**
+
+Create `packages/gateway/src/metrics/dora.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+import type { DoraServiceConfig, ParsedDoraRepoUrn } from "./dora-config.ts";
+import { providerServiceColumns } from "./dora-config.ts";
+
+export type DoraGap =
+  | null
+  | "no_pagerduty_mapping"
+  | "no_repos"
+  | "no_deployment_data"
+  | "low_sample"
+  | "approximate_lead_time";
+
+export type DoraMetricValue = {
+  readonly value: number | null;
+  readonly unit: string;
+  readonly sample: number;
+  readonly gap: DoraGap;
+};
+
+export type DoraMetricsResult = {
+  readonly service: string;
+  readonly since_ms: number;
+  readonly computed_at: string;
+  readonly metrics: {
+    readonly deployment_frequency: DoraMetricValue;
+    readonly lead_time_for_changes: DoraMetricValue;
+    readonly change_failure_rate: DoraMetricValue;
+    readonly mttr: DoraMetricValue;
+  };
+};
+
+const LOW_SAMPLE_THRESHOLD = 3;
+
+function gapOrNull(metric: DoraMetricValue): DoraMetricValue {
+  if (metric.value !== null && metric.sample < LOW_SAMPLE_THRESHOLD && metric.gap === null) {
+    return { ...metric, gap: "low_sample" };
+  }
+  return metric;
+}
+
+function distinctCiServiceColumns(repos: readonly ParsedDoraRepoUrn[]): string[] {
+  const out = new Set<string>();
+  for (const r of repos) {
+    for (const s of providerServiceColumns(r.provider).ciServices) out.add(s);
+  }
+  return Array.from(out);
+}
+
+function distinctPrServiceColumns(repos: readonly ParsedDoraRepoUrn[]): string[] {
+  const out = new Set<string>();
+  for (const r of repos) {
+    for (const s of providerServiceColumns(r.provider).prServices) out.add(s);
+  }
+  return Array.from(out);
+}
+
+/**
+ * Matches `metadata.repo` (GitHub / Bitbucket), `metadata.project` (GitLab),
+ * `metadata.jobName` (Jenkins), or `external_id` fallback. Combined per provider.
+ */
+function repoLikeMatchesUrn(
+  metadata: Record<string, unknown> | null,
+  externalId: string,
+  urn: ParsedDoraRepoUrn,
+): boolean {
+  if (metadata === null) return false;
+  switch (urn.provider) {
+    case "github":
+    case "bitbucket":
+      return metadata["repo"] === urn.providerId;
+    case "gitlab":
+      return metadata["project"] === urn.providerId || metadata["repo"] === urn.providerId;
+    case "jenkins":
+      return metadata["jobName"] === urn.providerId;
+    case "circleci":
+      return externalId.includes(urn.providerId);
+  }
+}
+
+type CiRunRow = {
+  id: string;
+  external_id: string;
+  title: string;
+  modified_at: number;
+  metadata: string | null;
+};
+
+function selectDeploys(
+  db: Database,
+  cfg: DoraServiceConfig,
+  nowMs: number,
+  sinceMs: number,
+): CiRunRow[] {
+  const ciServices = distinctCiServiceColumns(cfg.repos);
+  if (ciServices.length === 0) return [];
+  const placeholders = ciServices.map(() => "?").join(",");
+  const rows = db
+    .query(
+      `SELECT id, external_id, title, modified_at, metadata
+       FROM item
+       WHERE service IN (${placeholders})
+         AND type = 'ci_run'
+         AND modified_at >= ?
+         AND modified_at <= ?`,
+    )
+    .all(...ciServices, nowMs - sinceMs, nowMs) as CiRunRow[];
+  const out: CiRunRow[] = [];
+  for (const row of rows) {
+    if (!cfg.deployWorkflowPattern.test(row.title)) continue;
+    const meta = row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null;
+    if (meta?.["conclusion"] !== "success") continue;
+    if (!cfg.repos.some((u) => repoLikeMatchesUrn(meta, row.external_id, u))) continue;
+    out.push(row);
+  }
+  return out;
+}
+
+export function deploymentFrequency(
+  db: Database,
+  cfg: DoraServiceConfig,
+  nowMs: number,
+  sinceMs: number,
+): DoraMetricValue {
+  if (cfg.repos.length === 0) {
+    return { value: null, unit: "deploys_per_day", sample: 0, gap: "no_repos" };
+  }
+  const deploys = selectDeploys(db, cfg, nowMs, sinceMs);
+  if (deploys.length === 0) {
+    return { value: null, unit: "deploys_per_day", sample: 0, gap: "no_deployment_data" };
+  }
+  const days = sinceMs / 86_400_000;
+  const value = deploys.length / days;
+  return gapOrNull({ value, unit: "deploys_per_day", sample: deploys.length, gap: null });
+}
+
+type PrRow = {
+  id: string;
+  modified_at: number;
+  metadata: string | null;
+};
+
+export function leadTimeForChanges(
+  db: Database,
+  cfg: DoraServiceConfig,
+  nowMs: number,
+  sinceMs: number,
+): DoraMetricValue {
+  if (cfg.repos.length === 0) {
+    return { value: null, unit: "seconds_median", sample: 0, gap: "no_repos" };
+  }
+  const deploys = selectDeploys(db, cfg, nowMs, sinceMs);
+  if (deploys.length === 0) {
+    return { value: null, unit: "seconds_median", sample: 0, gap: "no_deployment_data" };
+  }
+  const prServices = distinctPrServiceColumns(cfg.repos);
+  if (prServices.length === 0) {
+    return { value: null, unit: "seconds_median", sample: 0, gap: "approximate_lead_time" };
+  }
+  const placeholders = prServices.map(() => "?").join(",");
+  const prRows = db
+    .query(
+      `SELECT id, modified_at, metadata FROM item
+       WHERE service IN (${placeholders})
+         AND type = 'pr'
+         AND modified_at >= ?
+         AND modified_at <= ?`,
+    )
+    .all(...prServices, nowMs - sinceMs, nowMs) as PrRow[];
+  const leadTimes: number[] = [];
+  let anyApproximate = false;
+  // Build deploy index by headSha + chronological order on same repo (for fallback).
+  type DeployIdx = { headSha: string | null; modifiedAt: number; meta: Record<string, unknown> | null };
+  const deployIdx: DeployIdx[] = deploys.map((d) => {
+    const meta = d.metadata ? (JSON.parse(d.metadata) as Record<string, unknown>) : null;
+    const headSha = meta && typeof meta["headSha"] === "string" ? meta["headSha"] : null;
+    return { headSha, modifiedAt: d.modified_at, meta };
+  });
+  for (const pr of prRows) {
+    const meta = pr.metadata ? (JSON.parse(pr.metadata) as Record<string, unknown>) : null;
+    if (meta === null || meta["merged"] !== true) continue;
+    const mergedAt = typeof meta["merged_at"] === "number" ? meta["merged_at"] : null;
+    if (mergedAt === null) continue;
+    const labels = Array.isArray(meta["labels"]) ? (meta["labels"] as unknown[]) : [];
+    if (labels.some((l) => typeof l === "string" && cfg.excludePrLabels.includes(l))) continue;
+    const mergeSha = typeof meta["merge_commit_sha"] === "string" ? meta["merge_commit_sha"] : null;
+    if (mergeSha === null) {
+      anyApproximate = true;
+      continue;
+    }
+    const match = deployIdx.find((d) => d.headSha === mergeSha && d.modifiedAt >= mergedAt);
+    if (match === undefined) {
+      anyApproximate = true;
+      continue;
+    }
+    leadTimes.push(Math.floor((match.modifiedAt - mergedAt) / 1000));
+  }
+  if (leadTimes.length === 0) {
+    return {
+      value: null,
+      unit: "seconds_median",
+      sample: 0,
+      gap: anyApproximate ? "approximate_lead_time" : "no_deployment_data",
+    };
+  }
+  leadTimes.sort((a, b) => a - b);
+  const median =
+    leadTimes.length % 2 === 1
+      ? leadTimes[(leadTimes.length - 1) / 2]
+      : Math.floor((leadTimes[leadTimes.length / 2 - 1] + leadTimes[leadTimes.length / 2]) / 2);
+  return gapOrNull({
+    value: median,
+    unit: "seconds_median",
+    sample: leadTimes.length,
+    gap: anyApproximate ? "approximate_lead_time" : null,
+  });
+}
+
+type IncidentRow = {
+  id: string;
+  modified_at: number;
+  metadata: string | null;
+};
+
+function selectResolvedIncidents(
+  db: Database,
+  cfg: DoraServiceConfig,
+  nowMs: number,
+  sinceMs: number,
+): { opened: number; resolved: number; pdService: string }[] {
+  if (cfg.pagerdutyServices.length === 0) return [];
+  const placeholders = cfg.pagerdutyServices.map(() => "?").join(",");
+  // The pagerduty connector stores status + incidentId on metadata; we need
+  // opened_at + resolved_at via the upstream API. Schema gap: incidents land
+  // in `item` with modified_at = updated_at (latest update). For DORA we use
+  // modified_at as resolved_at when status is 'resolved' and seed `opened_at`
+  // from metadata when the connector starts populating it (planned in a
+  // follow-up). Current behaviour: incident is "resolved" iff metadata.status
+  // === 'resolved'; opened_at falls back to the earliest known synced_at.
+  const rows = db
+    .query(
+      `SELECT i.id, i.modified_at, i.metadata, i.synced_at
+       FROM item i
+       JOIN json_each(i.metadata, '$.pagerduty_service_id') p ON 1
+       WHERE i.service = 'pagerduty'
+         AND i.type = 'incident'
+         AND p.value IN (${placeholders})
+         AND i.modified_at >= ?
+         AND i.modified_at <= ?`,
+    )
+    .all(...cfg.pagerdutyServices, nowMs - sinceMs, nowMs) as (IncidentRow & { synced_at: number })[];
+  const out: { opened: number; resolved: number; pdService: string }[] = [];
+  for (const r of rows) {
+    const meta = r.metadata ? (JSON.parse(r.metadata) as Record<string, unknown>) : null;
+    if (meta === null || meta["status"] !== "resolved") continue;
+    const opened =
+      typeof meta["opened_at_ms"] === "number" ? (meta["opened_at_ms"] as number) : r.synced_at;
+    out.push({
+      opened,
+      resolved: r.modified_at,
+      pdService:
+        typeof meta["pagerduty_service_id"] === "string"
+          ? (meta["pagerduty_service_id"] as string)
+          : "",
+    });
+  }
+  return out;
+}
+
+export function changeFailureRate(
+  db: Database,
+  cfg: DoraServiceConfig,
+  nowMs: number,
+  sinceMs: number,
+): DoraMetricValue {
+  if (cfg.repos.length === 0) {
+    return { value: null, unit: "ratio", sample: 0, gap: "no_repos" };
+  }
+  const deploys = selectDeploys(db, cfg, nowMs, sinceMs);
+  if (deploys.length === 0) {
+    return { value: null, unit: "ratio", sample: 0, gap: "no_deployment_data" };
+  }
+  if (cfg.pagerdutyServices.length === 0) {
+    return { value: null, unit: "ratio", sample: deploys.length, gap: "no_pagerduty_mapping" };
+  }
+  const incidents = selectResolvedIncidents(db, cfg, nowMs, sinceMs);
+  const windowMs = cfg.incidentWindowMinutes * 60_000;
+  // Most-recent-preceding attribution: each incident → the single most recent
+  // preceding deploy within `windowMs`.
+  const sortedDeploys = deploys
+    .map((d) => ({ id: d.id, t: d.modified_at }))
+    .sort((a, b) => a.t - b.t);
+  const failedDeployIds = new Set<string>();
+  for (const inc of incidents) {
+    let attributed: string | undefined;
+    for (const d of sortedDeploys) {
+      if (d.t <= inc.opened && inc.opened - d.t <= windowMs) attributed = d.id;
+      if (d.t > inc.opened) break;
+    }
+    if (attributed !== undefined) failedDeployIds.add(attributed);
+  }
+  const value = failedDeployIds.size / deploys.length;
+  return gapOrNull({ value, unit: "ratio", sample: deploys.length, gap: null });
+}
+
+export function mttr(
+  db: Database,
+  cfg: DoraServiceConfig,
+  nowMs: number,
+  sinceMs: number,
+): DoraMetricValue {
+  if (cfg.pagerdutyServices.length === 0) {
+    return { value: null, unit: "seconds_median", sample: 0, gap: "no_pagerduty_mapping" };
+  }
+  const incidents = selectResolvedIncidents(db, cfg, nowMs, sinceMs);
+  if (incidents.length === 0) {
+    return { value: null, unit: "seconds_median", sample: 0, gap: "low_sample" };
+  }
+  const durations = incidents.map((i) => Math.max(0, Math.floor((i.resolved - i.opened) / 1000)));
+  durations.sort((a, b) => a - b);
+  const median =
+    durations.length % 2 === 1
+      ? durations[(durations.length - 1) / 2]
+      : Math.floor((durations[durations.length / 2 - 1] + durations[durations.length / 2]) / 2);
+  const lowSampleGap: DoraGap = durations.length < LOW_SAMPLE_THRESHOLD ? "low_sample" : null;
+  return { value: median, unit: "seconds_median", sample: durations.length, gap: lowSampleGap };
+}
+
+export function computeDoraMetrics(
+  db: Database,
+  cfg: DoraServiceConfig,
+  nowMs: number,
+  sinceMs: number,
+): DoraMetricsResult {
+  return {
+    service: cfg.serviceId,
+    since_ms: sinceMs,
+    computed_at: new Date(nowMs).toISOString(),
+    metrics: {
+      deployment_frequency: deploymentFrequency(db, cfg, nowMs, sinceMs),
+      lead_time_for_changes: leadTimeForChanges(db, cfg, nowMs, sinceMs),
+      change_failure_rate: changeFailureRate(db, cfg, nowMs, sinceMs),
+      mttr: mttr(db, cfg, nowMs, sinceMs),
+    },
+  };
+}
+```
+
+> **Note on incident metadata:** `selectResolvedIncidents` reads `metadata.pagerduty_service_id`, `metadata.status`, and `metadata.opened_at_ms`. Two of those (`pagerduty_service_id`, `opened_at_ms`) are **not** populated by the current PagerDuty connector (verified 2026-05-11). Add to the github-sync.ts follow-up tracker — but in PR 2, the tests pass because the fixture seeds these fields directly. Document the gap in the acceptance criteria: real CFR / MTTR data depends on a PagerDuty connector enrichment landed in a follow-up. The metrics ship with a correct calculator + a real-data-shaped fixture; the connector gap blocks production accuracy until enriched.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/test/unit/metrics/dora.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/metrics/dora.ts \
+        packages/gateway/test/unit/metrics/dora.test.ts
+git commit -m "feat(metrics): four pure DORA calculators
+
+Reads pr / ci_run / incident from the local index; no I/O below db.
+Returns the documented gap notes (no_repos, no_deployment_data,
+no_pagerduty_mapping, low_sample, approximate_lead_time). CFR uses
+the most-recent-preceding attribution rule so two close-together
+deploys followed by one incident attribute only to the second."
+```
+
+---
+
+## Task 5: Fixture + integration test
+
+**Files:**
+- Create: `packages/gateway/test/fixtures/dora/payment-service/seed.ts`
+- Create: `packages/gateway/test/fixtures/dora/payment-service/expected-metrics.json`
+- Create: `packages/gateway/test/integration/metrics/dora-real-db.test.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+// packages/gateway/test/integration/metrics/dora-real-db.test.ts
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "../../../src/index/local-index.ts";
+import { computeDoraMetrics } from "../../../src/metrics/dora.ts";
+import { seedPaymentServiceFixture, FIXTURE_NOW_MS } from "../../fixtures/dora/payment-service/seed.ts";
+
+describe("DORA metrics — payment-service fixture (real SQLite)", () => {
+  let dir: string;
+  let index: LocalIndex;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-dora-int-"));
+    index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+  });
+  afterEach(() => {
+    index.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("computes all four metrics within ±5% of hand-computed values", () => {
+    const { config } = seedPaymentServiceFixture(index.getDatabase());
+    const result = computeDoraMetrics(
+      index.getDatabase(),
+      config,
+      FIXTURE_NOW_MS,
+      30 * 86_400_000,
+    );
+    const expected = JSON.parse(
+      readFileSync(
+        join(import.meta.dir, "..", "..", "fixtures", "dora", "payment-service", "expected-metrics.json"),
+        "utf8",
+      ),
+    ) as Record<string, { value: number; sample: number }>;
+    for (const key of [
+      "deployment_frequency",
+      "lead_time_for_changes",
+      "change_failure_rate",
+      "mttr",
+    ] as const) {
+      const got = result.metrics[key];
+      const want = expected[key];
+      expect(got.sample).toBe(want.sample);
+      expect(got.value).not.toBeNull();
+      const pct = Math.abs((got.value as number) - want.value) / Math.max(want.value, 0.001);
+      expect(pct).toBeLessThan(0.05);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/integration/metrics/dora-real-db.test.ts`
+Expected: FAIL — fixture not found.
+
+- [ ] **Step 3: Create the fixture seeder**
+
+Create `packages/gateway/test/fixtures/dora/payment-service/seed.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+import type { DoraServiceConfig } from "../../../../src/metrics/dora-config.ts";
+
+export const FIXTURE_NOW_MS = 1_715_000_000_000;
+const DAY = 86_400_000;
+
+function ins(db: Database, row: {
+  id: string;
+  service: string;
+  type: string;
+  external_id: string;
+  title: string;
+  modified_at: number;
+  metadata: Record<string, unknown>;
+  synced_at?: number;
+}) {
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, url, canonical_url,
+                       modified_at, author_id, metadata, synced_at, pinned)
+     VALUES (?, ?, ?, ?, ?, '', NULL, NULL, ?, NULL, ?, ?, 0)`,
+    [
+      row.id,
+      row.service,
+      row.type,
+      row.external_id,
+      row.title,
+      row.modified_at,
+      JSON.stringify(row.metadata),
+      row.synced_at ?? row.modified_at,
+    ],
+  );
+}
+
+export function seedPaymentServiceFixture(db: Database): { config: DoraServiceConfig } {
+  // 8 GitHub Actions deploys + 4 GitLab deploys + 1 Jenkins deploy = 13 total.
+  // 22 merged PRs (3 with `revert` label, excluded from lead time → 19 candidates).
+  // 4 PagerDuty incidents (3 inside 60-min CFR window, 1 outside).
+
+  // Deploys: spaced over 30 days starting 5 days back.
+  let t = FIXTURE_NOW_MS - 5 * DAY;
+  for (let i = 0; i < 8; i++) {
+    ins(db, {
+      id: `github_actions:gha_deploy_${i}`,
+      service: "github_actions",
+      type: "ci_run",
+      external_id: `gha_deploy_${i}`,
+      title: "Deploy production",
+      modified_at: t,
+      metadata: { conclusion: "success", repo: "nimbus-agent/payments", headSha: `sha_gha_${i}` },
+    });
+    t -= 2 * DAY;
+  }
+  t = FIXTURE_NOW_MS - 1 * DAY;
+  for (let i = 0; i < 4; i++) {
+    ins(db, {
+      id: `gitlab:gl_deploy_${i}`,
+      service: "gitlab",
+      type: "ci_run",
+      external_id: `gl_deploy_${i}`,
+      title: "Deploy production",
+      modified_at: t,
+      metadata: { conclusion: "success", project: "nimbus-agent/payments", headSha: `sha_gl_${i}` },
+    });
+    t -= 3 * DAY;
+  }
+  ins(db, {
+    id: "jenkins:jen_deploy_0",
+    service: "jenkins",
+    type: "ci_run",
+    external_id: "jen_deploy_0",
+    title: "Deploy to prod",
+    modified_at: FIXTURE_NOW_MS - 15 * DAY,
+    metadata: { conclusion: "success", jobName: "payment-service/deploy-prod", headSha: "sha_jen_0" },
+  });
+
+  // 22 merged PRs — 19 match exact-SHA to a deploy, 3 reverts excluded.
+  for (let i = 0; i < 8; i++) {
+    ins(db, {
+      id: `github:pr_${i}`,
+      service: "github",
+      type: "pr",
+      external_id: `nimbus-agent/payments#${i}`,
+      title: `PR ${i}`,
+      modified_at: FIXTURE_NOW_MS - (5 * DAY + i * 2 * DAY) - 3600_000,
+      metadata: {
+        repo: "nimbus-agent/payments",
+        merged: true,
+        merged_at: FIXTURE_NOW_MS - (5 * DAY + i * 2 * DAY) - 3600_000,
+        merge_commit_sha: `sha_gha_${i}`,
+        labels: [],
+      },
+    });
+  }
+  for (let i = 0; i < 4; i++) {
+    ins(db, {
+      id: `gitlab:pr_${i}`,
+      service: "gitlab",
+      type: "pr",
+      external_id: `nimbus-agent/payments!${i}`,
+      title: `MR ${i}`,
+      modified_at: FIXTURE_NOW_MS - (1 * DAY + i * 3 * DAY) - 7200_000,
+      metadata: {
+        project: "nimbus-agent/payments",
+        merged: true,
+        merged_at: FIXTURE_NOW_MS - (1 * DAY + i * 3 * DAY) - 7200_000,
+        merge_commit_sha: `sha_gl_${i}`,
+        labels: [],
+      },
+    });
+  }
+  for (let i = 0; i < 7; i++) {
+    ins(db, {
+      id: `github:pr_extra_${i}`,
+      service: "github",
+      type: "pr",
+      external_id: `nimbus-agent/payments#extra${i}`,
+      title: `extra PR ${i}`,
+      modified_at: FIXTURE_NOW_MS - (10 * DAY + i * 1 * DAY) - 1800_000,
+      metadata: {
+        repo: "nimbus-agent/payments",
+        merged: true,
+        merged_at: FIXTURE_NOW_MS - (10 * DAY + i * 1 * DAY) - 1800_000,
+        merge_commit_sha: `sha_gha_${i}`, // shares with first 7 deploys → counted via dedup, OK
+        labels: [],
+      },
+    });
+  }
+  for (let i = 0; i < 3; i++) {
+    ins(db, {
+      id: `github:pr_revert_${i}`,
+      service: "github",
+      type: "pr",
+      external_id: `nimbus-agent/payments#revert${i}`,
+      title: `Revert ${i}`,
+      modified_at: FIXTURE_NOW_MS - (4 * DAY + i * DAY),
+      metadata: {
+        repo: "nimbus-agent/payments",
+        merged: true,
+        merged_at: FIXTURE_NOW_MS - (4 * DAY + i * DAY),
+        merge_commit_sha: `sha_gha_${i}`,
+        labels: ["revert"],
+      },
+    });
+  }
+
+  // PagerDuty incidents: 4 resolved; 3 within 60-min window of a deploy.
+  for (let i = 0; i < 3; i++) {
+    const deployIdx = i;
+    const deployAt = FIXTURE_NOW_MS - 5 * DAY - deployIdx * 2 * DAY;
+    const openedAt = deployAt + 10 * 60_000; // 10 min after deploy
+    const resolvedAt = openedAt + (20 + i * 5) * 60_000;
+    ins(db, {
+      id: `pagerduty:inc_${i}`,
+      service: "pagerduty",
+      type: "incident",
+      external_id: `inc_${i}`,
+      title: `Incident ${i}`,
+      modified_at: resolvedAt,
+      metadata: {
+        status: "resolved",
+        pagerduty_service_id: "P12ABCD",
+        opened_at_ms: openedAt,
+      },
+    });
+  }
+  // 1 incident outside CFR window
+  ins(db, {
+    id: "pagerduty:inc_outside",
+    service: "pagerduty",
+    type: "incident",
+    external_id: "inc_outside",
+    title: "Late alert",
+    modified_at: FIXTURE_NOW_MS - 7 * DAY,
+    metadata: {
+      status: "resolved",
+      pagerduty_service_id: "P12ABCD",
+      opened_at_ms: FIXTURE_NOW_MS - 7 * DAY - 90 * 60_000, // 90 min before nearest deploy
+    },
+  });
+
+  const config: DoraServiceConfig = {
+    serviceId: "payment-service",
+    repos: [
+      { provider: "github", providerId: "nimbus-agent/payments" },
+      { provider: "gitlab", providerId: "nimbus-agent/payments" },
+      { provider: "jenkins", providerId: "payment-service/deploy-prod" },
+    ],
+    pagerdutyServices: ["P12ABCD"],
+    deployWorkflowPattern: /^[Dd]eploy/,
+    incidentWindowMinutes: 60,
+    excludePrLabels: ["revert"],
+  };
+  return { config };
+}
+```
+
+Create `packages/gateway/test/fixtures/dora/payment-service/expected-metrics.json`:
+
+```json
+{
+  "deployment_frequency": { "value": 0.4333, "sample": 13 },
+  "lead_time_for_changes": { "value": 3600, "sample": 12 },
+  "change_failure_rate": { "value": 0.231, "sample": 13 },
+  "mttr": { "value": 1800, "sample": 4 }
+}
+```
+
+> Re-derive these values before committing — run the integration test once, capture the actual outputs from a console.log, hand-verify each row against the fixture, then commit. The exact numbers above are illustrative; they MUST be reconciled with the seeder's actual outputs before this task is marked done.
+
+- [ ] **Step 2 (now): Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/integration/metrics/dora-real-db.test.ts`
+Expected: FAIL on first run — outputs will diverge from the placeholder JSON.
+
+- [ ] **Step 3: Re-derive `expected-metrics.json`**
+
+Add a temporary `console.log(JSON.stringify(result.metrics, null, 2))` to the integration test. Run the test, capture the four values, hand-verify each:
+
+- Deployment Frequency: count deploys matching the regex on matching repos, divide by 30.
+- Lead Time: for each PR with `merge_commit_sha` matching a deploy's `headSha` where `deploy.modified_at >= pr.merged_at` and not in `exclude_pr_labels`, compute `(deploy.modified_at - pr.merged_at) / 1000`; take the median.
+- CFR: incidents within 60 min after a deploy → count distinct deploys with ≥1 attributed incident, divide by deploy count.
+- MTTR: median of `resolved - opened` in seconds, across resolved incidents matching `pagerduty_service_id`.
+
+Update `expected-metrics.json` with the verified numbers. Remove the temporary console.log.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/gateway/test/integration/metrics/dora-real-db.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/test/fixtures/dora/ \
+        packages/gateway/test/integration/metrics/dora-real-db.test.ts
+git commit -m "test(metrics): payment-service fixture + integration test
+
+30-day synthetic window: 13 deploys across GitHub Actions/GitLab/Jenkins,
+22 merged PRs (3 reverts excluded), 4 PagerDuty incidents (3 inside the
+60-min CFR window). Hand-computed expected values asserted within ±5%."
+```
+
+---
+
+## Task 6: `metrics-rpc.ts` IPC handler
+
+**Files:**
+- Create: `packages/gateway/src/ipc/metrics-rpc.ts`
+- Modify: `packages/gateway/src/ipc/server/dispatchers.ts`
+- Modify: `packages/gateway/src/ipc/server/context.ts` (add `metricsRpcSkipped` constant, mirror existing pattern)
+- Test: `packages/gateway/test/unit/ipc/metrics-rpc.test.ts`
+
+- [ ] **Step 1: Write the failing IPC test**
+
+```ts
+// packages/gateway/test/unit/ipc/metrics-rpc.test.ts
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "../../../src/index/local-index.ts";
+import { dispatchMetricsRpc, MetricsRpcError } from "../../../src/ipc/metrics-rpc.ts";
+import { seedPaymentServiceFixture, FIXTURE_NOW_MS } from "../../fixtures/dora/payment-service/seed.ts";
+
+describe("metrics-rpc", () => {
+  let dir: string;
+  let index: LocalIndex;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-metrics-rpc-"));
+    index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+  });
+  afterEach(() => {
+    index.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("dispatches metrics.dora with a fixture-seeded service", async () => {
+    const { config } = seedPaymentServiceFixture(index.getDatabase());
+    const out = await dispatchMetricsRpc(
+      "metrics.dora",
+      { service: "payment-service", since: "30d" },
+      {
+        db: index.getDatabase(),
+        loadConfig: () => new Map([[config.serviceId, config]]),
+        nowMs: () => FIXTURE_NOW_MS,
+      },
+    );
+    if (out.kind !== "hit") throw new Error("expected hit");
+    const result = out.value as { service: string };
+    expect(result.service).toBe("payment-service");
+  });
+
+  it("returns null-everywhere envelope when service id has no config", async () => {
+    const out = await dispatchMetricsRpc(
+      "metrics.dora",
+      { service: "unknown", since: "30d" },
+      {
+        db: index.getDatabase(),
+        loadConfig: () => new Map(),
+        nowMs: () => FIXTURE_NOW_MS,
+      },
+    );
+    if (out.kind !== "hit") throw new Error("expected hit");
+    const result = out.value as { metrics: Record<string, { value: number | null; gap: string }> };
+    expect(result.metrics.deployment_frequency.value).toBeNull();
+    expect(result.metrics.deployment_frequency.gap).toBe("no_repos");
+  });
+
+  it("rejects array params with -32602", async () => {
+    await expect(
+      dispatchMetricsRpc("metrics.dora", [{ service: "x" }], {
+        db: index.getDatabase(),
+        loadConfig: () => new Map(),
+        nowMs: () => FIXTURE_NOW_MS,
+      }),
+    ).rejects.toThrow(MetricsRpcError);
+  });
+
+  it("rejects missing service param", async () => {
+    await expect(
+      dispatchMetricsRpc("metrics.dora", { since: "30d" }, {
+        db: index.getDatabase(),
+        loadConfig: () => new Map(),
+        nowMs: () => FIXTURE_NOW_MS,
+      }),
+    ).rejects.toThrow(/service/);
+  });
+
+  it("returns miss for an unknown method", async () => {
+    const out = await dispatchMetricsRpc("metrics.unknown", {}, {
+      db: index.getDatabase(),
+      loadConfig: () => new Map(),
+      nowMs: () => FIXTURE_NOW_MS,
+    });
+    expect(out.kind).toBe("miss");
+  });
+
+  it("parses since='7d' and '24h' correctly", async () => {
+    const { config } = seedPaymentServiceFixture(index.getDatabase());
+    const sevenDay = await dispatchMetricsRpc(
+      "metrics.dora",
+      { service: "payment-service", since: "7d" },
+      {
+        db: index.getDatabase(),
+        loadConfig: () => new Map([[config.serviceId, config]]),
+        nowMs: () => FIXTURE_NOW_MS,
+      },
+    );
+    if (sevenDay.kind !== "hit") throw new Error("expected hit");
+    expect((sevenDay.value as { since_ms: number }).since_ms).toBe(7 * 86_400_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/unit/ipc/metrics-rpc.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `metrics-rpc.ts`**
+
+Create `packages/gateway/src/ipc/metrics-rpc.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+import type { DoraServiceConfig } from "../metrics/dora-config.ts";
+import { computeDoraMetrics, type DoraMetricsResult } from "../metrics/dora.ts";
+
+export class MetricsRpcError extends Error {
+  readonly rpcCode: number;
+  constructor(rpcCode: number, message: string) {
+    super(message);
+    this.name = "MetricsRpcError";
+    this.rpcCode = rpcCode;
+  }
+}
+
+export type MetricsRpcContext = {
+  db: Database;
+  loadConfig: () => Map<string, DoraServiceConfig>;
+  nowMs?: () => number;
+};
+
+const MIN_SERVICE_LEN = 1;
+const MAX_SERVICE_LEN = 64;
+const DEFAULT_SINCE = "30d";
+
+function parseSinceToMs(raw: string): number {
+  const m = /^(\d+)([dh])$/.exec(raw);
+  if (m === null) {
+    throw new MetricsRpcError(-32602, `since must match \\d+(d|h), got '${raw}'`);
+  }
+  const n = Number(m[1]);
+  if (!Number.isInteger(n) || n < 1 || n > 365) {
+    throw new MetricsRpcError(-32602, `since duration must be 1..365 ${m[2]}`);
+  }
+  return m[2] === "d" ? n * 86_400_000 : n * 3_600_000;
+}
+
+function requireDoraParams(params: unknown): { service: string; since: string } {
+  if (params === null || typeof params !== "object" || Array.isArray(params)) {
+    throw new MetricsRpcError(-32602, "metrics.dora requires { service: string }");
+  }
+  const p = params as { service?: unknown; since?: unknown };
+  if (typeof p.service !== "string") {
+    throw new MetricsRpcError(-32602, "service must be a string");
+  }
+  const service = p.service.trim();
+  if (service.length < MIN_SERVICE_LEN || service.length > MAX_SERVICE_LEN) {
+    throw new MetricsRpcError(
+      -32602,
+      `service must be ${MIN_SERVICE_LEN}..${MAX_SERVICE_LEN} chars`,
+    );
+  }
+  const since = p.since === undefined ? DEFAULT_SINCE : p.since;
+  if (typeof since !== "string") {
+    throw new MetricsRpcError(-32602, "since must be a string");
+  }
+  return { service, since };
+}
+
+function unconfiguredEnvelope(service: string, sinceMs: number, nowMs: number): DoraMetricsResult {
+  const placeholder = (unit: string) =>
+    ({ value: null, unit, sample: 0, gap: "no_repos" as const });
+  return {
+    service,
+    since_ms: sinceMs,
+    computed_at: new Date(nowMs).toISOString(),
+    metrics: {
+      deployment_frequency: placeholder("deploys_per_day"),
+      lead_time_for_changes: placeholder("seconds_median"),
+      change_failure_rate: placeholder("ratio"),
+      mttr: placeholder("seconds_median"),
+    },
+  };
+}
+
+export async function dispatchMetricsRpc(
+  method: string,
+  params: unknown,
+  ctx: MetricsRpcContext,
+): Promise<{ kind: "miss" } | { kind: "hit"; value: DoraMetricsResult }> {
+  if (method !== "metrics.dora") return { kind: "miss" };
+  const { service, since } = requireDoraParams(params);
+  const sinceMs = parseSinceToMs(since);
+  const nowMs = (ctx.nowMs ?? (() => Date.now()))();
+  const configMap = ctx.loadConfig();
+  const cfg = configMap.get(service);
+  if (cfg === undefined) {
+    return { kind: "hit", value: unconfiguredEnvelope(service, sinceMs, nowMs) };
+  }
+  return { kind: "hit", value: computeDoraMetrics(ctx.db, cfg, nowMs, sinceMs) };
+}
+```
+
+- [ ] **Step 4: Wire the dispatcher**
+
+Modify `packages/gateway/src/ipc/server/context.ts` to add a sentinel (mirror the existing `phase4RpcSkipped` pattern; the file already has them — add `metricsRpcSkipped` next to them):
+
+```ts
+export const metricsRpcSkipped = Symbol("metricsRpcSkipped");
+```
+
+Modify `packages/gateway/src/ipc/server/dispatchers.ts`. Add import:
+
+```ts
+import { dispatchMetricsRpc, MetricsRpcError } from "../metrics-rpc.ts";
+import { loadNimbusDoraFromConfigDir } from "../../config/nimbus-toml.ts";
+```
+
+Add a `tryDispatchMetricsRpc` function after `tryDispatchAgentsRpc`:
+
+```ts
+export async function tryDispatchMetricsRpc(
+  ctx: ServerCtx,
+  method: string,
+  params: unknown,
+): Promise<unknown> {
+  if (!method.startsWith("metrics.") || ctx.options.localIndex === undefined) {
+    return phase4RpcSkipped;
+  }
+  try {
+    const configDir = ctx.options.configDir;
+    const out = await dispatchMetricsRpc(method, params, {
+      db: ctx.options.localIndex.getDatabase(),
+      loadConfig: () => (configDir === undefined ? new Map() : loadNimbusDoraFromConfigDir(configDir)),
+    });
+    if (out.kind === "hit") return out.value;
+  } catch (e) {
+    if (e instanceof MetricsRpcError) {
+      throw new RpcMethodError(e.rpcCode, e.message);
+    }
+    throw e;
+  }
+  throw new RpcMethodError(-32601, `Method not found: ${method}`);
+}
+```
+
+Add to the chain in `tryDispatchPhase4Rpc` (right after `tryDispatchAgentsRpc`):
+
+```ts
+  const metricsOutcome = await tryDispatchMetricsRpc(ctx, method, params);
+  if (metricsOutcome !== phase4RpcSkipped) return metricsOutcome;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/test/unit/ipc/metrics-rpc.test.ts`
+Expected: PASS (6 cases).
+
+Run: `bun test packages/gateway/test/unit/ipc/`
+Expected: PASS (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/ipc/metrics-rpc.ts \
+        packages/gateway/src/ipc/server/dispatchers.ts \
+        packages/gateway/src/ipc/server/context.ts \
+        packages/gateway/test/unit/ipc/metrics-rpc.test.ts
+git commit -m "feat(ipc): metrics.dora JSON-RPC method
+
+Validates params (service: string, since: \"<n>d|h\"); resolves the
+[metrics.dora.<id>] config via the active profile's configDir; falls
+back to a null-everywhere envelope with gap='no_repos' when the service
+has no config. Wired into tryDispatchPhase4Rpc."
+```
+
+---
+
+## Task 7: `/v1/metrics/dora` HTTP route + OpenAPI schema fill-in
+
+**Files:**
+- Modify: `packages/gateway/src/ipc/http-routes.ts`
+- Modify: `packages/gateway/src/ipc/http-server.ts`
+- Modify: `packages/gateway/openapi/v1.yaml`
+- Test: `packages/gateway/test/integration/http/metrics-dora-route.test.ts`
+
+- [ ] **Step 1: Write the failing HTTP route test**
+
+```ts
+// packages/gateway/test/integration/http/metrics-dora-route.test.ts
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "../../../src/index/local-index.ts";
+import { startReadOnlyHttpServer } from "../../../src/ipc/http-server.ts";
+import { seedPaymentServiceFixture, FIXTURE_NOW_MS } from "../../fixtures/dora/payment-service/seed.ts";
+
+describe("GET /v1/metrics/dora", () => {
+  let dir: string;
+  let index: LocalIndex;
+  let handle: ReturnType<typeof startReadOnlyHttpServer>;
+  let port: number;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-dora-http-"));
+    index = new LocalIndex(join(dir, "nimbus.db"));
+    index.open();
+    seedPaymentServiceFixture(index.getDatabase());
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      `[metrics.dora.payment-service]
+repos = ["github:nimbus-agent/payments", "gitlab:nimbus-agent/payments", "jenkins:payment-service/deploy-prod"]
+pagerduty_services = ["P12ABCD"]
+`,
+    );
+    index.close();
+    port = 30000 + Math.floor(Math.random() * 30000);
+    handle = startReadOnlyHttpServer(join(dir, "nimbus.db"), port, { configDir: dir, nowMs: () => FIXTURE_NOW_MS });
+  });
+  afterEach(() => {
+    handle.stop();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the four-metric envelope for a configured service", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${port}/v1/metrics/dora?service=payment-service&since=30d`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { service: string; metrics: Record<string, unknown> };
+    expect(body.service).toBe("payment-service");
+    expect(body.metrics).toHaveProperty("deployment_frequency");
+    expect(body.metrics).toHaveProperty("change_failure_rate");
+  });
+
+  it("returns 400 when service param is missing", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/v1/metrics/dora`);
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/test/integration/http/metrics-dora-route.test.ts`
+Expected: FAIL — `startReadOnlyHttpServer` doesn't accept `configDir`/`nowMs`, route returns 404.
+
+- [ ] **Step 3: Extend `http-server.ts`**
+
+Modify `packages/gateway/src/ipc/http-server.ts`. The current signature is `startReadOnlyHttpServer(dbPath, port)`. Widen to accept optional context:
+
+```ts
+export type ReadOnlyHttpServerOptions = {
+  configDir?: string;
+  nowMs?: () => number;
+};
+
+export function startReadOnlyHttpServer(
+  dbPath: string,
+  port: number,
+  opts: ReadOnlyHttpServerOptions = {},
+): ReadOnlyHttpServerHandle { ... }
+```
+
+Add a handler. Above `dispatchReadOnlyGet`, define:
+
+```ts
+import { loadNimbusDoraFromConfigDir } from "../config/nimbus-toml.ts";
+import { dispatchMetricsRpc } from "./metrics-rpc.ts";
+
+async function handleMetricsDora(
+  url: URL,
+  db: Database,
+  opts: ReadOnlyHttpServerOptions,
+): Promise<Response> {
+  const service = url.searchParams.get("service");
+  if (service === null) {
+    return json({ error: "missing required query param: service" }, 400);
+  }
+  const since = url.searchParams.get("since") ?? "30d";
+  try {
+    const configMap =
+      opts.configDir === undefined ? new Map() : loadNimbusDoraFromConfigDir(opts.configDir);
+    const out = await dispatchMetricsRpc(
+      "metrics.dora",
+      { service, since },
+      { db, loadConfig: () => configMap, nowMs: opts.nowMs },
+    );
+    if (out.kind === "miss") return json({ error: "method miss" }, 500);
+    // Reuse the existing `json` helper (defined at http-server.ts:16) so all
+    // responses share the same content-type + serialisation path.
+    return json(out.value, 200);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "internal_error";
+    return json({ error: msg }, 400);
+  }
+}
+```
+
+In `dispatchReadOnlyGet`, before the `return new Response("Not Found", { status: 404 });` line, add:
+
+```ts
+  if (path === "/v1/metrics/dora") {
+    return handleMetricsDora(url, db, opts);
+  }
+```
+
+The route table:
+
+Modify `packages/gateway/src/ipc/http-routes.ts`:
+
+```ts
+export const READ_ONLY_HTTP_ROUTES: readonly ReadOnlyHttpRoute[] = Object.freeze([
+  { method: "GET", path: "/v1/audit" },
+  { method: "GET", path: "/v1/connectors" },
+  { method: "GET", path: "/v1/health" },
+  { method: "GET", path: "/v1/items" },
+  { method: "GET", path: "/v1/items/{id}" },
+  { method: "GET", path: "/v1/metrics/dora" },
+  { method: "GET", path: "/v1/openapi.json" },
+  { method: "GET", path: "/v1/people" },
+  { method: "GET", path: "/v1/people/{id}" },
+] as const);
+```
+
+Update `packages/gateway/openapi/v1.yaml`. Replace the `/v1/metrics/dora` block (lines 172-176) with:
+
+```yaml
+  /v1/metrics/dora:
+    get:
+      operationId: getDoraMetrics
+      summary: Compute the four DORA metrics for a configured service
+      parameters:
+        - { in: query, name: service, required: true, schema: { type: string } }
+        - { in: query, name: since, required: false, schema: { type: string, default: "30d" }, description: "Window: '<N>d' or '<N>h' (1..365)." }
+      responses:
+        "200":
+          description: Four-metric envelope.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoraMetricsResult"
+        "400":
+          description: Bad request (missing/invalid service, malformed since).
+```
+
+Add to `components.schemas`:
+
+```yaml
+    DoraMetricsResult:
+      type: object
+      required: [service, since_ms, computed_at, metrics]
+      properties:
+        service: { type: string }
+        since_ms: { type: integer }
+        computed_at: { type: string, format: date-time }
+        metrics:
+          type: object
+          required: [deployment_frequency, lead_time_for_changes, change_failure_rate, mttr]
+          properties:
+            deployment_frequency: { $ref: "#/components/schemas/DoraMetricValue" }
+            lead_time_for_changes: { $ref: "#/components/schemas/DoraMetricValue" }
+            change_failure_rate: { $ref: "#/components/schemas/DoraMetricValue" }
+            mttr: { $ref: "#/components/schemas/DoraMetricValue" }
+    DoraMetricValue:
+      type: object
+      required: [value, unit, sample, gap]
+      properties:
+        value: { type: number, nullable: true }
+        unit: { type: string }
+        sample: { type: integer }
+        gap:
+          nullable: true
+          type: string
+          enum: [no_pagerduty_mapping, no_repos, no_deployment_data, low_sample, approximate_lead_time]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/test/integration/http/metrics-dora-route.test.ts`
+Expected: PASS (2 cases).
+
+Run: `bun run audit:openapi-drift`
+Expected: PASS — the route is in both `READ_ONLY_HTTP_ROUTES` and `v1.yaml`.
+
+- [ ] **Step 5: Verify no callers break**
+
+Find all callers of `startReadOnlyHttpServer` and confirm the new third arg is optional:
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/ipc/http-routes.ts \
+        packages/gateway/src/ipc/http-server.ts \
+        packages/gateway/openapi/v1.yaml \
+        packages/gateway/test/integration/http/metrics-dora-route.test.ts
+git commit -m "feat(http): GET /v1/metrics/dora + OpenAPI schema fill-in
+
+Replaces the reserved stub from PR 1 with the full schema referencing
+DoraMetricsResult / DoraMetricValue. Drift CI gate verifies the route
+list and the YAML agree."
+```
+
+---
+
+## Task 8: CLI `nimbus metrics dora`
+
+**Files:**
+- Create: `packages/cli/src/commands/metrics.ts`
+- Modify: `packages/cli/src/index.ts` (register subcommand)
+- Test: `packages/cli/test/commands/metrics.test.ts`
+- Test: `packages/gateway/test/e2e/scenarios/metrics-dora.e2e.test.ts`
+
+- [ ] **Step 1: Write the failing CLI arg-parser test**
+
+```ts
+// packages/cli/test/commands/metrics.test.ts
+import { describe, expect, it } from "bun:test";
+import { parseMetricsDoraArgs } from "../../src/commands/metrics.ts";
+
+describe("nimbus metrics dora arg parser", () => {
+  it("parses service + since + json", () => {
+    const out = parseMetricsDoraArgs(["--service", "payment-service", "--since", "7d", "--json"]);
+    expect(out).toEqual({ service: "payment-service", since: "7d", json: true });
+  });
+
+  it("defaults since to 30d and json to false", () => {
+    const out = parseMetricsDoraArgs(["--service", "x"]);
+    expect(out).toEqual({ service: "x", since: "30d", json: false });
+  });
+
+  it("throws on missing --service", () => {
+    expect(() => parseMetricsDoraArgs(["--since", "7d"])).toThrow(/--service/);
+  });
+
+  it("throws on malformed --since", () => {
+    expect(() => parseMetricsDoraArgs(["--service", "x", "--since", "lol"])).toThrow(/--since/);
+  });
+
+  it("accepts --since 24h", () => {
+    const out = parseMetricsDoraArgs(["--service", "x", "--since", "24h"]);
+    expect(out.since).toBe("24h");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/cli && bun test test/commands/metrics.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the CLI command**
+
+Create `packages/cli/src/commands/metrics.ts`:
+
+```ts
+import { IPCClient } from "../ipc-client/index.ts";
+import { readGatewayState } from "../lib/gateway-process.ts";
+import { getCliPlatformPaths } from "../paths.ts";
+
+export type MetricsDoraArgs = {
+  service: string;
+  since: string;
+  json: boolean;
+};
+
+const SINCE_RE = /^\d+[dh]$/;
+
+export function parseMetricsDoraArgs(args: string[]): MetricsDoraArgs {
+  let service: string | undefined;
+  let since = "30d";
+  let json = false;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--service") {
+      const v = args[i + 1];
+      if (typeof v !== "string" || v.trim().length === 0) {
+        throw new Error("--service requires a non-empty value");
+      }
+      service = v.trim();
+      i += 1;
+      continue;
+    }
+    if (a === "--since") {
+      const v = args[i + 1];
+      if (typeof v !== "string" || !SINCE_RE.test(v)) {
+        throw new Error("--since must match \\d+(d|h), e.g. '30d' or '24h'");
+      }
+      since = v;
+      i += 1;
+      continue;
+    }
+    if (a === "--json") {
+      json = true;
+      continue;
+    }
+  }
+  if (service === undefined) {
+    throw new Error("Usage: nimbus metrics dora --service <id> [--since 30d] [--json]");
+  }
+  return { service, since, json };
+}
+
+type DoraEnvelope = {
+  service: string;
+  since_ms: number;
+  computed_at: string;
+  metrics: Record<
+    string,
+    { value: number | null; unit: string; sample: number; gap: string | null }
+  >;
+};
+
+function formatPretty(env: DoraEnvelope, useColor: boolean): string {
+  const lines: string[] = [];
+  lines.push(`DORA metrics — ${env.service} (since ${Math.floor(env.since_ms / 86_400_000)}d)`);
+  lines.push("");
+  const labels: Record<string, string> = {
+    deployment_frequency: "Deployment Frequency",
+    lead_time_for_changes: "Lead Time",
+    change_failure_rate: "Change Failure Rate",
+    mttr: "MTTR",
+  };
+  for (const key of [
+    "deployment_frequency",
+    "lead_time_for_changes",
+    "change_failure_rate",
+    "mttr",
+  ]) {
+    const m = env.metrics[key];
+    if (m === undefined) continue;
+    const value = m.value === null ? "—" : m.value.toFixed(3);
+    const gap = m.gap === null ? "" : useColor ? `\x1b[33m[${m.gap}]\x1b[0m` : `[${m.gap}]`;
+    lines.push(`  ${labels[key].padEnd(20)} ${value.padStart(10)} ${m.unit.padEnd(20)} n=${m.sample}  ${gap}`);
+  }
+  return lines.join("\n");
+}
+
+const TIMEOUT_MS = 30_000;
+
+export async function runMetricsCli(args: string[]): Promise<void> {
+  if (args[0] !== "dora") {
+    process.stderr.write("Usage: nimbus metrics dora --service <id>\n");
+    process.exit(1);
+  }
+  const parsed = parseMetricsDoraArgs(args.slice(1));
+  const paths = getCliPlatformPaths();
+  const state = await readGatewayState(paths);
+  if (state === undefined) {
+    process.stderr.write("Gateway is not running. Start with: nimbus start\n");
+    process.exit(1);
+  }
+  const client = new IPCClient(state.socketPath);
+  await client.connect();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const responsePromise = client.call<DoraEnvelope>(
+      "metrics.dora",
+      { service: parsed.service, since: parsed.since },
+    );
+    timeout = setTimeout(() => {
+      throw new Error("metrics.dora timed out after 30 s");
+    }, TIMEOUT_MS);
+    const result = await responsePromise;
+    if (parsed.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return;
+    }
+    const useColor = process.env.NO_COLOR === undefined && process.stdout.isTTY === true;
+    process.stdout.write(`${formatPretty(result, useColor)}\n`);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(2);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+    await client.disconnect();
+  }
+}
+```
+
+Modify `packages/cli/src/index.ts` to register the subcommand. Find the existing command dispatch block (look for `impact` / `expert` registration) and add:
+
+```ts
+  if (cmd === "metrics") {
+    const { runMetricsCli } = await import("./commands/metrics.ts");
+    await runMetricsCli(args);
+    return;
+  }
+```
+
+- [ ] **Step 4: Run unit tests to verify they pass**
+
+Run: `cd packages/cli && bun test test/commands/metrics.test.ts`
+Expected: PASS (5 cases).
+
+- [ ] **Step 5: Write the failing e2e test**
+
+```ts
+// packages/gateway/test/e2e/scenarios/metrics-dora.e2e.test.ts
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnGatewaySubprocess, type GatewayHandle } from "../helpers/gateway-subprocess.ts";
+import { seedPaymentServiceFixture, FIXTURE_NOW_MS } from "../../fixtures/dora/payment-service/seed.ts";
+
+describe("E2E: nimbus metrics dora", () => {
+  let dir: string;
+  let gw: GatewayHandle;
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-dora-e2e-"));
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      `[metrics.dora.payment-service]
+repos = ["github:nimbus-agent/payments", "gitlab:nimbus-agent/payments", "jenkins:payment-service/deploy-prod"]
+pagerduty_services = ["P12ABCD"]
+`,
+    );
+    gw = await spawnGatewaySubprocess({ configDir: dir, dataDir: dir, nowMs: FIXTURE_NOW_MS });
+    seedPaymentServiceFixture(gw.getDatabaseConnection());
+  });
+  afterEach(async () => {
+    await gw.stop();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the four-metric envelope via CLI", async () => {
+    const out = await gw.runCli(["metrics", "dora", "--service", "payment-service", "--json"]);
+    expect(out.exitCode).toBe(0);
+    const result = JSON.parse(out.stdout) as { service: string; metrics: Record<string, unknown> };
+    expect(result.service).toBe("payment-service");
+    expect(Object.keys(result.metrics).sort()).toEqual([
+      "change_failure_rate",
+      "deployment_frequency",
+      "lead_time_for_changes",
+      "mttr",
+    ]);
+  });
+
+  it("exits 2 with a useful error when service is not configured", async () => {
+    const out = await gw.runCli(["metrics", "dora", "--service", "unknown-svc", "--json"]);
+    // Calls succeed: server returns null-everywhere envelope with gap='no_repos'.
+    expect(out.exitCode).toBe(0);
+    const result = JSON.parse(out.stdout) as { metrics: Record<string, { gap: string | null }> };
+    expect(result.metrics["deployment_frequency"]?.gap).toBe("no_repos");
+  });
+});
+```
+
+(`spawnGatewaySubprocess` is the existing helper used by impact / catchup e2e tests at `packages/gateway/test/e2e/helpers/`. Reuse it. If it does not accept `nowMs`, add an env-var pass-through `NIMBUS_TEST_NOW_MS` that the Gateway reads at startup and threads to `http-server.ts` / metrics-rpc. The pattern matches how the test fixture seeder takes `FIXTURE_NOW_MS`.)
+
+- [ ] **Step 6: Run e2e to verify it passes**
+
+Run: `bun test packages/gateway/test/e2e/scenarios/metrics-dora.e2e.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/commands/metrics.ts \
+        packages/cli/src/index.ts \
+        packages/cli/test/commands/metrics.test.ts \
+        packages/gateway/test/e2e/scenarios/metrics-dora.e2e.test.ts
+git commit -m "feat(cli): nimbus metrics dora --service <id>
+
+Pretty mode renders the four metrics as a labelled card (NO_COLOR /
+non-TTY → plain ASCII). --json mode emits the IPC envelope verbatim.
+E2E test seeds the payment-service fixture and asserts the envelope
+shape against a real Gateway subprocess."
+```
+
+---
+
+> **Why `metrics.dora` doesn't pass through the HITL gate** (review clarification): `ToolExecutor.gate()` checks `HITL_REQUIRED.has(action.type)` on a `PlannedAction` — i.e., engine intents emitted by the planner during an `engine.ask` flow. JSON-RPC method dispatch never constructs a `PlannedAction`, so a read-only handler like `metrics.dora` bypasses the gate by design. Verified at `packages/gateway/src/engine/executor.ts:200-201` (the gate's only entry point reads `action.type`, not the IPC method name).
+
+---
+
+## Task 9: Coverage gate + skills + status updates
+
+**Files:**
+- Modify: `package.json` (root)
+- Modify: `.github/workflows/_test-suite.yml`
+- Modify: `.claude/commands/nimbus-file-map.md`
+- Modify: `.claude/commands/nimbus-commands.md`
+- Modify: `CLAUDE.md`
+- Modify: `GEMINI.md`
+- Modify: `docs/roadmap.md`
+
+- [ ] **Step 1: Add the coverage script**
+
+Modify `package.json`. Find the block of `test:coverage:*` scripts and add:
+
+```json
+    "test:coverage:metrics": "bun test --coverage --coverage-dir=coverage/metrics packages/gateway/src/metrics/ packages/gateway/test/unit/metrics/ packages/gateway/test/integration/metrics/",
+```
+
+`test:ci` exists in the root `package.json` (`"test:ci": "bun scripts/run-tests.ts"`) — verified 2026-05-11. The aggregator is `scripts/run-tests.ts`, not a shell `&&` chain. Open `scripts/run-tests.ts`, find the list of coverage-gate names already invoked (e.g. `test:coverage:agents`, `test:coverage:engine`), and append `"test:coverage:metrics"` in the same position the other Phase 5 gates use. Verify the local-run command:
+
+Run: `bun run test:coverage:metrics`
+Expected: PASS with the line coverage report showing ≥80% for `packages/gateway/src/metrics/`.
+
+If under 80%, add unit tests until the gate is satisfied — every branch in `dora.ts` must be exercised (gap paths included).
+
+- [ ] **Step 2: Wire into CI**
+
+Modify `.github/workflows/_test-suite.yml`. Find the existing `test:coverage:agents` step and append a parallel `test:coverage:metrics` step with the same shape (cross-platform matrix, fail-fast off).
+
+- [ ] **Step 3: Update skills**
+
+Modify `.claude/commands/nimbus-file-map.md`. Add under the "Built-in Agents" section or a new "Metrics" subsection:
+
+```markdown
+## Metrics
+
+| File | Purpose |
+|---|---|
+| `packages/gateway/src/metrics/dora.ts` | Four pure DORA calculators: `deploymentFrequency`, `leadTimeForChanges`, `changeFailureRate`, `mttr`. Returns `DoraMetricsResult` envelope. |
+| `packages/gateway/src/metrics/dora-config.ts` | `DoraServiceConfig` type + URN parser + provider→service-column map. |
+| `packages/gateway/src/ipc/metrics-rpc.ts` | `dispatchMetricsRpc` — `metrics.dora` JSON-RPC handler. |
+| `packages/cli/src/commands/metrics.ts` | `nimbus metrics dora --service <id> [--since 30d] [--json]`. |
+```
+
+Modify `.claude/commands/nimbus-commands.md`. Add under the coverage gates section:
+
+```
+bun run test:coverage:metrics      # ≥80% threshold (DORA calculators + IPC)
+```
+
+Add under the CLI commands reference:
+
+```
+nimbus metrics dora --service <id> [--since 30d] [--json]   # four DORA metrics from the local index
+```
+
+- [ ] **Step 4: Update top-level status**
+
+Modify `CLAUDE.md` line ~10 (the Status line). Append `· T4 PR 2 DORA metrics ✅` to the Phase 5 entry. Mirror into `GEMINI.md`.
+
+Modify `docs/roadmap.md`. Find the `- [ ] **DORA Metrics** — ...` bullet in the "Nimbus as a CI/CD Data Layer" section and flip to `- [x] **DORA Metrics** (2026-05-MM, Phase 5 T4 PR 2)` — fill in the merge date.
+
+In the same `docs/roadmap.md`, under Phase 5 § "New Connector Categories" (or the closest deferred-followups section per the roadmap's current structure), add a follow-up bullet so the PagerDuty enrichment dependency is tracked, not buried in PR 2's prose:
+
+```markdown
+- [ ] **PagerDuty connector enrichment** — populate `metadata.opened_at_ms` and `metadata.pagerduty_service_id` on indexed `incident` items so DORA CFR / MTTR compute against real data (Phase 5 T4 PR 2 ships against fixture-seeded incidents; production accuracy depends on this follow-up). No new credentials; reuses the existing PagerDuty OAuth.
+```
+
+- [ ] **Step 5: Run the full CI suite locally**
+
+Run: `bun run test:ci`
+Expected: PASS — every existing gate plus the new metrics gate.
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+Run: `bun run lint`
+Expected: PASS.
+
+Run: `bun run audit:openapi-drift`
+Expected: PASS.
+
+Run: `bun scripts/structure-audit/check-doc-references.ts --check`
+Expected: PASS — no broken doc references.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json \
+        .github/workflows/_test-suite.yml \
+        .claude/commands/nimbus-file-map.md \
+        .claude/commands/nimbus-commands.md \
+        CLAUDE.md GEMINI.md \
+        docs/roadmap.md
+git commit -m "chore(t4 pr 2): wire coverage gate + update skills + flip roadmap
+
+Adds test:coverage:metrics (≥80%) to CI, points the nimbus-file-map
+and nimbus-commands skills at the new files, flips the roadmap DORA
+bullet to shipped."
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Spec requirement | Task |
+|---|---|
+| `nimbus metrics dora --service X --since 30d --json` envelope | Tasks 4, 6, 8 |
+| `audit:openapi-drift` validates `/v1/metrics/dora` parity | Task 7 |
+| `GET /v1/openapi.json` round-trips through validator | Already shipped in PR 1; Task 7 only adds the new path |
+| Action P1-incident block (CFR computation correctness) | Task 4 + 5 (CFR unit + fixture integration) |
+| Hook template runs cleanly (PR 1 deliverable, not PR 2) | — out of scope |
+| `--service` with no config returns null + gap='no_repos', exit 0 | Task 6 + 8 |
+| Multi-provider repos counted | Task 4 + 5 |
+| Most-recent-preceding CFR attribution | Task 4 |
+| MTTR N=1, N=2 → low_sample | Task 4 |
+| Coverage gate ≥ 80% | Task 9 |
+| CLAUDE.md / GEMINI.md status update | Task 9 |
+
+Lead Time enrichment (`merged_at`, `merge_commit_sha`, `labels`, `merged_as` edge) added as Tasks 1 + 2 — necessary because the spec assumed data that doesn't exist yet.
+
+CFR depends on PagerDuty `metadata.opened_at_ms` and `metadata.pagerduty_service_id`, which the current PagerDuty connector does **not** populate (verified 2026-05-11). The plan ships correct calculators + a fixture that seeds the fields directly; a PagerDuty connector follow-up is **out of PR 2 scope** but listed in Task 4's note for visibility. CFR and MTTR will compute against the fixture and against a future enriched connector without code changes.
+
+### Placeholder scan
+
+- No "TBD" / "TODO" / "fill in details" left in steps.
+- `expected-metrics.json` placeholder values are explicitly flagged to re-derive in Task 5 step 3 before committing.
+- "If a `test:ci` aggregate script exists" in Task 9 step 1 is conditional; the agent should grep `package.json` to verify.
+
+### Type consistency
+
+- `DoraServiceConfig` shape stable across `dora-config.ts`, `dora.ts`, `metrics-rpc.ts`, the seeder, and the e2e harness — checked.
+- `DoraMetricValue` / `DoraMetricsResult` exported only from `dora.ts`; re-imported by `metrics-rpc.ts` and the CLI's local type alias matches.
+- `parseDoraRepoUrn` returns `ParsedDoraRepoUrn` (not a raw string) — Task 3's tests and Task 4's helpers agree.
+- The `merged_as` graph relation name is identical in the V27 SQL seed, the graph-populator emission, and the integration test's `WHERE rt.name = 'merged_as'` filter — checked.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-11-phase-5-t4-pr2-dora-metrics.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, two-stage review on each. Best fit because this PR spans nine self-contained tasks across DB / config / metrics / IPC / HTTP / CLI / CI surfaces.
+
+2. **Inline Execution** — execute tasks in this session using executing-plans, batching with manual checkpoints. Faster if no review feedback is expected between tasks; less safe.
+
+Which approach?


### PR DESCRIPTION
## Summary

Three doc/meta changes that don't touch any production code:

- **Roadmap Expansion II** (commits `49b0bd2` / `81fc046` / `c6f5d72`) — Phase 7 Engineering Excellence, Phase 8 Security Engineering, Phase 9 AI Engineering Loop, and Phase 14 Agent Evolution inserted; original phases renumbered (Desktop Distribution → Phase 13). Phase 5 agent triad + Phase 10 autonomous trio design specs added.
- **Slim CLAUDE.md / GEMINI.md** (merge `48bd66a` of `dev/asafgolombek/optimize-claude-md`) — moved the long Key File Locations table and the Commands catalogue into two new `.claude/commands/nimbus-*.md` skills. `CLAUDE.md` shrinks 533 → 132 lines; `GEMINI.md` 498 → 114. The T4 PR 1 file pointers (`openapi/v1.yaml`, `http-routes.ts`, `openapi-loader.ts`, `check-openapi-drift.ts`, `use-in-ci.md`, `nimbus-pre-commit.sh`) survive in `nimbus-file-map.md`; `audit:openapi-drift` is documented in `nimbus-commands.md`.
- **T4 PR 2 (DORA metrics) implementation plan** (commit `6b4e34b`) — nine-task plan + the Gemini CLI review with per-item dispositions. The plan expands scope to enrich `github-sync.ts` PR metadata + emit a `pr → commit` graph edge, because the spec assumed `merged_at` / `merge_commit_sha` / `labels` existed (they do not — verified 2026-05-11).

## Test plan

- [ ] CI `pr-quality` green (Ubuntu lint + typecheck + tests)
- [ ] `bun run audit:openapi-drift` green
- [ ] `bun scripts/structure-audit/check-doc-references.ts --check` green
- [ ] Visual sanity-check that `CLAUDE.md` skill references resolve and the slim version still loads in Claude Code (skills auto-discovered by the `Skill` tool)

No production code changes; no migrations; no new IPC surface. Pure docs + skill index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)