### PR TITLE
test(gateway): de-flake bench S2-b + platform IPC-path tests

### DIFF
--- a/packages/gateway/src/perf/bench-cli.test.ts
+++ b/packages/gateway/src/perf/bench-cli.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LINUX_ONLY_THRESHOLDS, runBenchCli } from "./bench-cli.ts";
+import { runQueryLatency100kOnce } from "./surfaces/bench-query-latency-100k.ts";
 
 let dir = "";
 let historyPath = "";
@@ -85,10 +86,19 @@ describe("runBenchCli — PR-B-2a registrations", () => {
   });
 
   test("--surface S2-b on --gha measures the medium tier (override to small for test speed)", async () => {
-    const exitCode = await runBenchCli(
-      ["--surface", "S2-b", "--runs", "1", "--corpus", "small", "--gha"],
-      { runId: "s2b-test", historyPath, fixtureCacheDir: dir, stdout: () => {} },
-    );
+    // S2-b pins to the medium (100k-row) tier in production; `--corpus` does
+    // not override it. Use the wrapper's documented test-only `overrideTier`
+    // escape hatch to keep the fixture small so the test fits its budget.
+    const exitCode = await runBenchCli(["--surface", "S2-b", "--runs", "1", "--gha"], {
+      runId: "s2b-test",
+      historyPath,
+      fixtureCacheDir: dir,
+      stdout: () => {},
+      surfaceDriverOverrides: {
+        "S2-b": (opts, runOpts) =>
+          runQueryLatency100kOnce(opts, { ...runOpts, overrideTier: "small" }),
+      },
+    });
     expect(exitCode).toBe(0);
     const line = readHistoryLine();
     expect(line.surfaces["S2-b"]?.samples_count).toBe(100);

--- a/packages/gateway/src/platform/platform.test.ts
+++ b/packages/gateway/src/platform/platform.test.ts
@@ -105,27 +105,26 @@ describe("Platform Abstraction Layer", () => {
     }
   }, 15000); // 15s timeout to allow for migrations on fresh DB
 
-  it("uses the documented IPC path pattern per OS", async () => {
-    const { createPlatformServices } = await import("./index.ts");
-    const services = await createPlatformServices();
-    try {
-      const { paths } = services;
-      const os = platform();
-      if (os === "win32") {
-        expect(paths.socketPath.toLowerCase()).toBe(
-          String.raw`\\.\pipe\nimbus-gateway`.toLowerCase(),
-        );
-      } else {
-        expect(paths.socketPath).toContain("nimbus-gateway.sock");
-      }
-    } finally {
-      await services.syncScheduler?.stop().catch(() => {});
-      await services.connectorMesh?.disconnect().catch(() => {});
-      services.disposeSidecars?.();
-      services.localIndex?.close();
-      await new Promise((r) => setTimeout(r, 100));
+  it("uses the documented IPC path pattern per OS", () => {
+    // The socket path is determined entirely by the per-OS PlatformPaths
+    // factory — no need to assemble the full PlatformServices stack (DB
+    // migrations, vault, connector mesh, sync scheduler) just to read one
+    // string. The end-to-end shape is covered by the sibling test above.
+    const os = platform();
+    const paths =
+      os === "win32"
+        ? createWindowsPaths()
+        : os === "darwin"
+          ? createDarwinPaths()
+          : createLinuxPaths();
+    if (os === "win32") {
+      expect(paths.socketPath.toLowerCase()).toBe(
+        String.raw`\\.\pipe\nimbus-gateway`.toLowerCase(),
+      );
+    } else {
+      expect(paths.socketPath).toContain("nimbus-gateway.sock");
     }
-  }, 15000); // 15s timeout to allow for migrations on fresh DB (matches sibling test above)
+  });
 
   it("throws PlatformInitError for missing Linux secret-tool (subprocess)", () => {
     if (platform() !== "linux") {


### PR DESCRIPTION
## Summary

Two recurring CI-flake fixes — both root-cause, no timeout bumps.

- **`runBenchCli — S2-b`** (5s timeout, observed 7.3s). The S2-b wrapper pins to the medium (100k-row) tier and ignores `opts.corpus`, so `--corpus small` in the test never took effect; each run rebuilt a fresh 100k-row fixture (each test uses a fresh `mkdtempSync` cache dir → no reuse). Switched to inject the wrapper's documented test-only `overrideTier: "small"` via `surfaceDriverOverrides`. No production change.
- **`Platform Abstraction Layer > uses the documented IPC path pattern per OS`** (15s timeout, observed 19s; previously bumped from a smaller budget in `fffc4bf`). The assertion only inspects `paths.socketPath`, which is determined entirely by the per-OS `PlatformPaths` factory. The test was spinning up the full `createPlatformServices()` stack (vault, DB migrations, connector mesh, sync scheduler, sidecars) just to read one string. Switched to call the factory directly; sibling test on the same `describe` still covers full assembly.

After: 21/21 in ~1.2s on this branch (was timing out).

## Test plan

- [x] `bun test packages/gateway/src/platform/platform.test.ts packages/gateway/src/perf/bench-cli.test.ts` — 21/21 pass locally
- [x] `bunx tsc --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)