### PR TITLE
feat(docs): Sub-project B - Docs Publish and Package READMEs

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,41 @@
+name: docs-publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/docs/**"
+      - ".github/workflows/docs-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-publish
+  cancel-in-progress: false   # never cancel a deploy mid-flight
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: "1.2" }
+      - run: bun install --frozen-lockfile
+      - run: bun --cwd packages/docs run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: packages/docs/dist }
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "docs/**"
+      - "packages/docs/**"
       - "**/*.md"
       - ".github/workflows/docs-quality.yml"
       - ".markdownlint-cli2.jsonc"
@@ -12,6 +13,7 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "packages/docs/**"
       - "**/*.md"
       - ".markdownlint-cli2.jsonc"
 
@@ -134,3 +136,51 @@ jobs:
 
       - name: Run README CLI-command tripwire
         run: bun run audit:readme-cli
+
+  package-readmes:
+    name: Package READMEs audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Nimbus CI
+        uses: ./.github/actions/setup-nimbus-ci
+
+      - name: Run package READMEs audit
+        run: bun run audit:package-readmes
+
+  docs-build:
+    name: Starlight build test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Nimbus CI
+        uses: ./.github/actions/setup-nimbus-ci
+
+      - name: Run build
+        run: bun --cwd packages/docs run build

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ nimbus
 
 # Per-run audit-orchestrator output (committed artifacts are tracked separately)
 docs/structure-audit/run-*.json
+
+packages/docs/src/assets/nimbus-wordmark-*.svg
+packages/docs/src/assets/architecture-*.svg

--- a/bun.lock
+++ b/bun.lock
@@ -5,13 +5,13 @@
     "": {
       "name": "nimbus",
       "devDependencies": {
-        "@biomejs/biome": "^2.4.14",
+        "@biomejs/biome": "^2.4.15",
         "@resvg/resvg-js": "^2.6.2",
         "@types/bun": "^1.3.13",
         "dependency-cruiser": "^17.4.0",
         "js-yaml": "^4.1.1",
-        "jscpd": "^4.0.9",
-        "knip": "^6.12.0",
+        "jscpd": "^4.1.1",
+        "knip": "^6.13.1",
         "markdownlint-cli2": "^0.22.1",
         "tweetnacl": "^1.0.3",
         "typescript": "^6.0.3",
@@ -31,7 +31,7 @@
         "ink-text-input": "^6.0.0",
         "pino": "^10.3.1",
         "react": "^19.2.5",
-        "yaml": "^2.8.4",
+        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -519,7 +519,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.3",
-        "@tauri-apps/cli": "^2.11.0",
+        "@tauri-apps/cli": "^2.11.1",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.0.0",
@@ -528,11 +528,11 @@
         "@types/react-window": "^2.0.0",
         "@types/zxcvbn": "^4.4.5",
         "@vitejs/plugin-react": "^5.0.4",
-        "@vitest/coverage-v8": "^4.1.5",
+        "@vitest/coverage-v8": "^4.1.6",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4.2.3",
         "vite": "^7.0.0",
-        "vitest": "^4.1.5",
+        "vitest": "^4.1.6",
       },
     },
     "packages/vscode-extension": {
@@ -545,7 +545,7 @@
       },
       "devDependencies": {
         "@types/dompurify": "^3.0.0",
-        "@types/node": "^25.6.0",
+        "@types/node": "^25.7.0",
         "@types/vscode": "^1.90.0",
         "@vitest/coverage-v8": "^2.0.0",
         "@vscode/test-electron": "^2.4.0",
@@ -684,23 +684,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -898,15 +898,15 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@jscpd/badge-reporter": ["@jscpd/badge-reporter@4.0.5", "", { "dependencies": { "badgen": "^3.2.3", "colors": "^1.4.0", "fs-extra": "^11.2.0" } }, "sha512-SLVhP00R9lkQ//Ivaanfm7k0L9sewpBven670kk1uGec2SWUOa7MVQcuad/TV59KEZ73UIC1lXvi6O9hAnbpUw=="],
+    "@jscpd/badge-reporter": ["@jscpd/badge-reporter@4.1.1", "", { "dependencies": { "badgen": "^3.2.3", "colors": "^1.4.0", "fs-extra": "^11.2.0" } }, "sha512-vRTrzYpmc8SlNLcE0YTO3wE8uZ2BeEPX5Jo17zITuuhOwQ/T9qamXBk504/6Y/gkt21lon/jb7dnEFE59TrCEw=="],
 
-    "@jscpd/core": ["@jscpd/core@4.0.5", "", { "dependencies": { "eventemitter3": "^5.0.1" } }, "sha512-Udvym21nWzxjYRVXwwpYNBqZ6b50QV2zHN3fFNzOPPg4cfQVYOZerILB7xNDUsXHC1PCr/N52Tq3q7AElvjWWA=="],
+    "@jscpd/core": ["@jscpd/core@4.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1" } }, "sha512-oRGAA+jwm9PNOm4gpIbeWAi1ryPq4usKBtPPzMLJUn/egmh4W1T0RvwLwAuFJTbhy+o0hgqlS8X3OMkCOFKaHg=="],
 
-    "@jscpd/finder": ["@jscpd/finder@4.0.5", "", { "dependencies": { "@jscpd/core": "4.0.5", "@jscpd/tokenizer": "4.0.5", "blamer": "^1.0.6", "bytes": "^3.1.2", "cli-table3": "^0.6.5", "colors": "^1.4.0", "fast-glob": "^3.3.2", "fs-extra": "^11.2.0", "markdown-table": "^2.0.0", "pug": "^3.0.3" } }, "sha512-/2VkRoVrrfya+51sitZo5I9MdwsRaPKB8X3L3khAYoHFXk4L/mUuG81RmGazDHjUIGg22ItlkQtwzorNZ2+aPw=="],
+    "@jscpd/finder": ["@jscpd/finder@4.1.1", "", { "dependencies": { "@jscpd/core": "4.1.1", "@jscpd/tokenizer": "4.1.1", "blamer": "^1.0.6", "bytes": "^3.1.2", "cli-table3": "^0.6.5", "colors": "^1.4.0", "fast-glob": "^3.3.2", "fs-extra": "^11.2.0", "markdown-table": "^2.0.0", "pug": "^3.0.3" } }, "sha512-6QTmZ8ruvYBUnAs3FXxF8zqT/x6MNfjDAw6PiYPdIG58G4GeIRLMNdjw7kFDjQo07FTnHKidToKNek3dN2jKAQ=="],
 
-    "@jscpd/html-reporter": ["@jscpd/html-reporter@4.0.5", "", { "dependencies": { "colors": "1.4.0", "fs-extra": "^11.2.0", "pug": "^3.0.3" } }, "sha512-drK2J8KyPIW9wvaElSIobZFp4dBO9GA++JW4gx3oihvLdDSp8qSo/CNqH47Dw0XkjQTxND3j/+Wz5JWvYRBgFQ=="],
+    "@jscpd/html-reporter": ["@jscpd/html-reporter@4.1.1", "", { "dependencies": { "colors": "1.4.0", "fs-extra": "^11.2.0", "pug": "^3.0.3" } }, "sha512-mlwmHjAlDbyXVy4Wdjsb0V4cj8xnKeW3nNLPV4VSkRhZcYBFdBlMznyMuFqzkhKLQeWv6Ux9JdB3AW+IoStQ9w=="],
 
-    "@jscpd/tokenizer": ["@jscpd/tokenizer@4.0.5", "", { "dependencies": { "@jscpd/core": "4.0.5", "reprism": "^0.0.11", "spark-md5": "^3.0.2" } }, "sha512-WzRujQtN5WedxZVDKuoanxmKAFrxcLrHpcA6kaM4z8AhGtWXZ325yseqgL5TZ8OK7Auwu7kQLlqhfk05fGYG7A=="],
+    "@jscpd/tokenizer": ["@jscpd/tokenizer@4.1.1", "", { "dependencies": { "@jscpd/core": "4.1.1", "prismjs": "^1.30.0", "spark-md5": "^3.0.2" } }, "sha512-1Qg8kcUzWyn+JJTv18P7MsNgpMDaKvnQrrV4onpiVVy1tcgolK8TN2fho247JedK5MjfGzeX+RU+s5SSp011dA=="],
 
     "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
 
@@ -986,47 +986,47 @@
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
-    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.128.0", "", { "os": "android", "cpu": "arm" }, "sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA=="],
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.130.0", "", { "os": "android", "cpu": "arm" }, "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw=="],
 
-    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.128.0", "", { "os": "android", "cpu": "arm64" }, "sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ=="],
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.130.0", "", { "os": "android", "cpu": "arm64" }, "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg=="],
 
-    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.128.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA=="],
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.130.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig=="],
 
-    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.128.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ=="],
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.130.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg=="],
 
-    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.128.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg=="],
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.130.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw=="],
 
-    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.128.0", "", { "os": "linux", "cpu": "arm" }, "sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng=="],
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.130.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA=="],
 
-    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.128.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g=="],
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.130.0", "", { "os": "linux", "cpu": "arm" }, "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w=="],
 
-    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.128.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ=="],
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.130.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q=="],
 
-    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.128.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA=="],
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.130.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw=="],
 
-    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.128.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg=="],
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.130.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA=="],
 
-    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.128.0", "", { "os": "linux", "cpu": "none" }, "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ=="],
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.130.0", "", { "os": "linux", "cpu": "none" }, "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw=="],
 
-    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.128.0", "", { "os": "linux", "cpu": "none" }, "sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA=="],
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.130.0", "", { "os": "linux", "cpu": "none" }, "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw=="],
 
-    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.128.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA=="],
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.130.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw=="],
 
-    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.128.0", "", { "os": "linux", "cpu": "x64" }, "sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q=="],
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.130.0", "", { "os": "linux", "cpu": "x64" }, "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg=="],
 
-    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.128.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw=="],
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.130.0", "", { "os": "linux", "cpu": "x64" }, "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A=="],
 
-    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.128.0", "", { "os": "none", "cpu": "arm64" }, "sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg=="],
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.130.0", "", { "os": "none", "cpu": "arm64" }, "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw=="],
 
-    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.128.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA=="],
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.130.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA=="],
 
-    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.128.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw=="],
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.130.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA=="],
 
-    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.128.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA=="],
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.130.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA=="],
 
-    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.128.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw=="],
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.130.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
 
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.19.1", "", { "os": "android", "cpu": "arm" }, "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg=="],
 
@@ -1326,29 +1326,29 @@
 
     "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
-    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.0", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.0", "@tauri-apps/cli-darwin-x64": "2.11.0", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.0", "@tauri-apps/cli-linux-arm64-gnu": "2.11.0", "@tauri-apps/cli-linux-arm64-musl": "2.11.0", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.0", "@tauri-apps/cli-linux-x64-gnu": "2.11.0", "@tauri-apps/cli-linux-x64-musl": "2.11.0", "@tauri-apps/cli-win32-arm64-msvc": "2.11.0", "@tauri-apps/cli-win32-ia32-msvc": "2.11.0", "@tauri-apps/cli-win32-x64-msvc": "2.11.0" }, "bin": { "tauri": "tauri.js" } }, "sha512-W5Wbuqsb2pHFPTj4TaRNKTj5rwXhDShPiLSY9T18y4ouSR/NNCptAEFxFsBtyNRgL6Vs1a/q9LzfqqYzEwC+Jw=="],
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.1", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.1", "@tauri-apps/cli-darwin-x64": "2.11.1", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.1", "@tauri-apps/cli-linux-arm64-gnu": "2.11.1", "@tauri-apps/cli-linux-arm64-musl": "2.11.1", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.1", "@tauri-apps/cli-linux-x64-gnu": "2.11.1", "@tauri-apps/cli-linux-x64-musl": "2.11.1", "@tauri-apps/cli-win32-arm64-msvc": "2.11.1", "@tauri-apps/cli-win32-ia32-msvc": "2.11.1", "@tauri-apps/cli-win32-x64-msvc": "2.11.1" }, "bin": { "tauri": "tauri.js" } }, "sha512-rpEbaJ/HzNb6fwsquwoAbq29/Vt4gADhS423A8fdkwL4edJ0wZmoB8ar7O6JPDL834MUKOCm/rrJ7c9oAaEaYQ=="],
 
-    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UfMeDNlgIP252rm/KSTuu8yHatPua5TjtUEUf+jyIzVwBNcIl7Ywkdpfj+e5jVVg3EfCTp+4gwuL1dNpgF8clg=="],
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6eEKMBXsQPCuM1EmvrjT2+aBuxWQuFdKdW8pzNuNQtpq45nEEpBlD5gr8pUeAyOU1DQKlkFaEc/MPBxb/Pfjtg=="],
 
-    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-lY1+aPlgyMN7vgjtCdQ3+WODfZkebAcxnrCrO0HjqDpKSXieDkrJbimqeaoM4RwhTSrCLRHfVYiYrfE5E131tg=="],
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-LQUO7exfRWjWALNhetph5guWpMeHphRpokOLk0OIbTTExaNwJNFu3I4vb+CCM/4G/QGoZe/5XikZOJdNEFP1ig=="],
 
-    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.0", "", { "os": "linux", "cpu": "arm" }, "sha512-5uCP0AusgN3NrKC8EpkuJwjek1k8pEffBdugJSpXPey/QGbPEb8vZ542n/giJ2mZPjMSllDkdhG2QIDpBY4PpQ=="],
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.1", "", { "os": "linux", "cpu": "arm" }, "sha512-5i/awiBCRRhOUG8yjn0fMHXIWD5Ez8eEk5LtvOxyQrKuJkRaZDvnbIjZbE183blAwkoA4xN3aO/prJiqscl02Q=="],
 
-    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-loDPqtRHMSbIcrH2VBd4GgHoQlF7jJnrZj7MxA2lj1cixS/jEgMAPFqj83U6Wvjete4HfYplbE/gCpSFifA9jw=="],
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-9LrwDw3S9Fygtw/Q6WDhOP+3svJRGAsejeE+GKrc0eO1ThMVhwi2LL6hw4dlKw93IfS7VY1G19sWGxJ/NcU4nA=="],
 
-    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-DtSE8ZBlB9H+L+eHkfZ3myt00EVEyAB3e41juEHoE2qT88fgVlJvyrwa9SZYc/xTwCS9TnmK+R84tpg+ZsAg7Q=="],
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg=="],
 
-    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.0", "", { "os": "linux", "cpu": "none" }, "sha512-5QdgS4LD+kntClI1aj2JmwjW38LosNXxwCe8viIHEwqYIWuMPdNEIau6/cLogI38Yzx9DnfCPRfEWLyI+5li8Q=="],
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.1", "", { "os": "linux", "cpu": "none" }, "sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw=="],
 
-    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5UynPXo3Zq9khjVdAbD+YogeLltdVUeOah2ioSIM3tu6H7wY9vMy6rgGJhv9r5R8ZXmk9GttMippdqYJWrnLnA=="],
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw=="],
 
-    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-CNz7fHbApz1Zyhhq73jtGn9JqgNEV/lIWnTnUo6h6ujw+mHsTmkLszvJSM8W6JBaDjNpTTFr/RSNoVL5FMwcTg=="],
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA=="],
 
-    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-K+br+VXZ+Xx0n/9FdWohpW5Ugq+2FQUpJScqcPl1hTxXfh3fgjYgt4qA2NgrjlJo+zZPNrmUMl+NLvm0ufEqBQ=="],
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ=="],
 
-    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-OFV+s3MLZnd75zl0ZAFU5riMpGK4waUEA8ZDuijDsnkU0btz/gHhqh5jVlOn8thyvgdtT3Xyoxqo099MMifH3g=="],
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-VBGkuH0eB9K9LLSMv361Gzr5Ou72sCS4+ztpmkWEQ+wd/amhcYOsf3X6qn1RJZDzIhiOYHJEOysZUC3baD01rA=="],
 
-    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-AeDTWBd2cOZ6TX133BWsoo+LutG9o0JRcgjMsIfLE13ZugpgCMv/2dJbUiBGeRvbPOGin5A3aYmsArPVV6ZSHQ=="],
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-b3ORhIAKgp9ZYY+zBt7b7r0kLU2kjvyGF0+MS2SBym3emsweGPybEqocJcmtMuxyBhkOKHP4CiuEJEDuAlTx6A=="],
 
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
 
@@ -1420,7 +1420,7 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
@@ -1458,21 +1458,21 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
-    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.5", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.5", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.5", "vitest": "4.1.5" }, "optionalPeers": ["@vitest/browser"] }, "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A=="],
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.6", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.6", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.6", "vitest": "4.1.6" }, "optionalPeers": ["@vitest/browser"] }, "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+    "@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.6", "", { "dependencies": { "@vitest/utils": "4.1.6", "pathe": "^2.0.3" } }, "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "@vitest/utils": "4.1.6", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+    "@vitest/spy": ["@vitest/spy@4.1.6", "", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+    "@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 
@@ -2194,7 +2194,7 @@
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
-    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
@@ -2206,9 +2206,9 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "jscpd": ["jscpd@4.0.9", "", { "dependencies": { "@jscpd/badge-reporter": "4.0.5", "@jscpd/core": "4.0.5", "@jscpd/finder": "4.0.5", "@jscpd/html-reporter": "4.0.5", "@jscpd/tokenizer": "4.0.5", "colors": "^1.4.0", "commander": "^5.0.0", "fs-extra": "^11.2.0", "jscpd-sarif-reporter": "4.0.7" }, "bin": { "jscpd": "bin/jscpd" } }, "sha512-fp6Sh42W3mIPoQgZmgYmKDLQzEDnnX2vaGlTN4haILkB2vsi+ewcCHEtWR/2CR/QbsBvAvsNo8U5Sa+p9aHiGw=="],
+    "jscpd": ["jscpd@4.1.1", "", { "dependencies": { "@jscpd/badge-reporter": "4.1.1", "@jscpd/core": "4.1.1", "@jscpd/finder": "4.1.1", "@jscpd/html-reporter": "4.1.1", "@jscpd/tokenizer": "4.1.1", "colors": "^1.4.0", "commander": "^5.0.0", "fs-extra": "^11.2.0", "jscpd-sarif-reporter": "4.1.1" }, "bin": { "jscpd": "bin/jscpd" } }, "sha512-Z+BkeNF1lEO1RQlon59rDx0uzmE3VRqi+4hjTnGj7GDkwYjwdVqFW8tiVvQ3dJ2myUQSrT3mAsFWDMlFEArJXA=="],
 
-    "jscpd-sarif-reporter": ["jscpd-sarif-reporter@4.0.7", "", { "dependencies": { "colors": "^1.4.0", "fs-extra": "^11.2.0", "node-sarif-builder": "^3.4.0" } }, "sha512-Q/VlfTI/Nbjc8dZ/2pDVIf1aRi2bM2CTYujcAoeYr7brRnS4o5ZeW86W8q7MM7cQu40gezlNckl+E9wKFSMFiA=="],
+    "jscpd-sarif-reporter": ["jscpd-sarif-reporter@4.1.1", "", { "dependencies": { "colors": "^1.4.0", "fs-extra": "^11.2.0", "node-sarif-builder": "^3.4.0" } }, "sha512-ipT2Qr9WTEb/r51FMdHy/U1Z1HTChzpxj8/9csqq2eIizEBeY8vRk8xw9m9blBa/WajsmQmnwuCdZiHYe0YNLg=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
@@ -2250,7 +2250,7 @@
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
-    "knip": ["knip@6.12.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-parser": "^0.128.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-nRg8+DOFcfBD6NjmNzu9+3D35QnEmMsnojJGOHQUqv+70r1aOx99wpSUXvEV7syQVOL5E6tNXXkoyG1Fuz8BWg=="],
+    "knip": ["knip@6.13.1", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.130.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
@@ -2624,7 +2624,7 @@
 
     "ovsx": ["ovsx@0.10.11", "", { "dependencies": { "@vscode/vsce": "^3.7.1", "commander": "^6.2.1", "follow-redirects": "^1.14.6", "is-ci": "^2.0.0", "leven": "^3.1.0", "semver": "^7.6.0", "tmp": "^0.2.3", "yauzl-promise": "^4.0.0" }, "bin": { "ovsx": "bin/ovsx" } }, "sha512-VYYlAWO7hvcrP0EIM/Q5lCdXTumXIiGyDnSXm8ztNbGN9zCSNW6iGiJMMMUNhPRWqJjNKpo/Vc2+B4uFRy8ACg=="],
 
-    "oxc-parser": ["oxc-parser@0.128.0", "", { "dependencies": { "@oxc-project/types": "^0.128.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.128.0", "@oxc-parser/binding-android-arm64": "0.128.0", "@oxc-parser/binding-darwin-arm64": "0.128.0", "@oxc-parser/binding-darwin-x64": "0.128.0", "@oxc-parser/binding-freebsd-x64": "0.128.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.128.0", "@oxc-parser/binding-linux-arm64-gnu": "0.128.0", "@oxc-parser/binding-linux-arm64-musl": "0.128.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.128.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.128.0", "@oxc-parser/binding-linux-riscv64-musl": "0.128.0", "@oxc-parser/binding-linux-s390x-gnu": "0.128.0", "@oxc-parser/binding-linux-x64-gnu": "0.128.0", "@oxc-parser/binding-linux-x64-musl": "0.128.0", "@oxc-parser/binding-openharmony-arm64": "0.128.0", "@oxc-parser/binding-wasm32-wasi": "0.128.0", "@oxc-parser/binding-win32-arm64-msvc": "0.128.0", "@oxc-parser/binding-win32-ia32-msvc": "0.128.0", "@oxc-parser/binding-win32-x64-msvc": "0.128.0" } }, "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw=="],
+    "oxc-parser": ["oxc-parser@0.130.0", "", { "dependencies": { "@oxc-project/types": "^0.130.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.130.0", "@oxc-parser/binding-android-arm64": "0.130.0", "@oxc-parser/binding-darwin-arm64": "0.130.0", "@oxc-parser/binding-darwin-x64": "0.130.0", "@oxc-parser/binding-freebsd-x64": "0.130.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.130.0", "@oxc-parser/binding-linux-arm64-gnu": "0.130.0", "@oxc-parser/binding-linux-arm64-musl": "0.130.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.130.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.130.0", "@oxc-parser/binding-linux-riscv64-musl": "0.130.0", "@oxc-parser/binding-linux-s390x-gnu": "0.130.0", "@oxc-parser/binding-linux-x64-gnu": "0.130.0", "@oxc-parser/binding-linux-x64-musl": "0.130.0", "@oxc-parser/binding-openharmony-arm64": "0.130.0", "@oxc-parser/binding-wasm32-wasi": "0.130.0", "@oxc-parser/binding-win32-arm64-msvc": "0.130.0", "@oxc-parser/binding-win32-ia32-msvc": "0.130.0", "@oxc-parser/binding-win32-x64-msvc": "0.130.0" } }, "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw=="],
 
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
@@ -2869,8 +2869,6 @@
     "remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
 
     "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
-
-    "reprism": ["reprism@0.0.11", "", {}, "sha512-VsxDR5QxZo08M/3nRypNlScw5r3rKeSOPdU/QhDmu3Ai3BJxHn/qgfXGWQp/tAxUtzwYNo9W6997JZR0tPLZsA=="],
 
     "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
 
@@ -3166,7 +3164,7 @@
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
@@ -3232,7 +3230,7 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
+    "vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
@@ -3320,7 +3318,7 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yaml-language-server": ["yaml-language-server@1.20.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "prettier": "^3.5.0", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.7.1" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA=="],
 
@@ -3413,6 +3411,8 @@
     "@sindresorhus/transliterate/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
+
+    "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -3572,6 +3572,8 @@
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
+    "protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
@@ -3647,8 +3649,6 @@
     "vite-node/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
-
-    "vitest/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -3835,6 +3835,8 @@
     "parse5-htmlparser2-tree-adapter/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "parse5-parser-stream/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "protobufjs/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "secretlint/globby/@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "@astrojs/check": "^0.9.9",
         "@astrojs/starlight": "^0.38.4",
         "astro": "^6.2.1",
+        "sharp": "^0.34.5",
         "starlight-links-validator": "0.24.0",
         "typescript": "^6.0.3",
       },
@@ -741,7 +742,7 @@
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
@@ -3381,8 +3382,6 @@
 
     "@expressive-code/plugin-shiki/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
-    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
-
     "@inquirer/core/mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
@@ -3396,6 +3395,8 @@
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
     "@node-rs/crc32-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@protobufjs/fetch/@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
 
@@ -3684,6 +3685,8 @@
     "@expressive-code/plugin-shiki/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
 
     "@expressive-code/plugin-shiki/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@node-rs/crc32-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@secretlint/formatter/terminal-link/supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
 

--- a/docs/templates/package-README.md
+++ b/docs/templates/package-README.md
@@ -1,0 +1,42 @@
+<!--
+Nimbus Package README Template
+
+This template applies to every package in the monorepo. 
+Sections required by the lint vary by tier:
+
+**Public tier** (client, sdk, vscode-extension, mcp-connectors/*):
+## What this is
+## Install
+## Quickstart
+## See also
+## License
+
+**Internal tier** (docs, installers, gateway/src/perf/fixtures):
+## What this is
+## See also
+## License
+-->
+
+# nimbus-package-name
+
+<!-- Short description of the package -->
+
+## What this is
+
+<!-- Explanation of the package's role in the architecture -->
+
+## Install
+
+<!-- Instructions for installation -->
+
+## Quickstart
+
+<!-- Minimal code example or usage -->
+
+## See also
+
+<!-- Links to docs site or other references -->
+
+## License
+
+<!-- License info -->

--- a/installers/README.md
+++ b/installers/README.md
@@ -1,5 +1,7 @@
 # Nimbus headless installers (Q2 §7.9)
 
+## What this is
+
 Ship the **CLI** (`nimbus`) and **Gateway** (`nimbus-gateway`) as siblings — the same layout produced by `bun run package:headless` and expected by `packages/cli/src/lib/resolve-gateway-launch.ts` (`NIMBUS_GATEWAY_EXECUTABLE` override optional).
 
 | Platform | Mechanism | CI / release |
@@ -39,6 +41,10 @@ export NIMBUS_RELEASE_VERSION=1.2.3
 bash installers/macos/build-pkg.sh dist/headless-bundle
 ```
 
-## Out of scope
+## See also
 
-Bundling MCP connector server binaries inside these installers is a future follow-up (see [`docs/roadmap.md`](../docs/roadmap.md)).
+- [`docs/roadmap.md`](../docs/roadmap.md) (Bundling MCP connector server binaries inside these installers is a future follow-up)
+
+## License
+
+MIT

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,6 +20,7 @@ exclude = [
   "npmjs\\.com",           # 403 to non-browser UAs
   "opengraph\\.xyz",       # aggressive 429 rate limit
   "tauri\\.app",           # intermittent connection failures from runners
+  "nimbus-agent\\.dev",    # exclude until PR 1 DNS propagates
 ]
 accept = ["200", "203", "204", "206", "301", "302", "304"]
 max_redirects = 5

--- a/package.json
+++ b/package.json
@@ -112,13 +112,13 @@
     "clean": "bun run --filter '*' clean && rm -rf node_modules"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.14",
+    "@biomejs/biome": "^2.4.15",
     "@resvg/resvg-js": "^2.6.2",
     "@types/bun": "^1.3.13",
     "dependency-cruiser": "^17.4.0",
     "js-yaml": "^4.1.1",
-    "jscpd": "^4.0.9",
-    "knip": "^6.12.0",
+    "jscpd": "^4.1.1",
+    "knip": "^6.13.1",
     "markdownlint-cli2": "^0.22.1",
     "tweetnacl": "^1.0.3",
     "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "audit:js-licenses": "bun scripts/structure-audit/check-js-licenses.ts --check",
     "audit:svg-assets": "bun scripts/audit/svg-assets.ts",
     "audit:readme-cli": "bun scripts/audit/readme-cli-commands.ts",
+    "audit:package-readmes": "bun scripts/audit/package-readmes.ts",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "lint:markdown": "markdownlint-cli2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "ink-text-input": "^6.0.0",
     "pino": "^10.3.1",
     "react": "^19.2.5",
-    "yaml": "^2.8.4"
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,6 +1,18 @@
 # @nimbus-dev/client
 
-MIT-licensed JSON-RPC IPC client for the Nimbus Gateway (`nimbus start`). Published to npm as **`@nimbus-dev/client`**: **`import`** loads `dist/index.js` (ESM); **`require`** loads `dist/index.cjs` (bundled CommonJS). Run `bun run build` in this package before publishing (`prepublishOnly` does this automatically).
+## What this is
+
+MIT-licensed JSON-RPC IPC client for the Nimbus Gateway (`nimbus start`). Published to npm as **`@nimbus-dev/client`**: **`import`** loads `dist/index.js` (ESM); **`require`** loads `dist/index.cjs` (bundled CommonJS).
+
+## Install
+
+```bash
+npm install @nimbus-dev/client
+```
+
+Run `bun run build` in this package before publishing (`prepublishOnly` does this automatically).
+
+## Quickstart
 
 ```typescript
 import { NimbusClient, IPCClient } from "@nimbus-dev/client";
@@ -22,3 +34,11 @@ Example:
 git tag client-v0.1.0
 git push origin client-v0.1.0
 ```
+
+## See also
+
+- [Nimbus Developer Guide](https://nimbus-agent.dev/)
+
+## License
+
+MIT

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,0 +1,20 @@
+# Nimbus Docs
+
+## What this is
+
+This directory contains the source for `https://nimbus-agent.dev`, built with [Starlight](https://starlight.astro.build/). It serves as the primary documentation for both users and developers of the Nimbus ecosystem.
+
+To run the site locally:
+
+```bash
+bun --cwd packages/docs run dev
+```
+
+## See also
+
+- [Starlight Documentation](https://starlight.astro.build/getting-started/)
+- [Project Roadmap](../../docs/roadmap.md)
+
+## License
+
+MIT

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "bun ../../scripts/copy-shared-docs-assets.ts",
+    "prebuild": "bun ../../scripts/copy-shared-docs-assets.ts",
     "astro": "astro",
     "dev": "astro dev",
     "build": "astro check && astro build",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,6 +15,7 @@
     "@astrojs/check": "^0.9.9",
     "@astrojs/starlight": "^0.38.4",
     "astro": "^6.2.1",
+    "sharp": "^0.34.5",
     "starlight-links-validator": "0.24.0",
     "typescript": "^6.0.3"
   }

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -1,62 +1,48 @@
 ---
-title: What is Nimbus
-description: Local-first AI agent framework for engineers running production systems.
+title: Nimbus
+description: On-call intelligence. Local-first.
 template: splash
 hero:
-  tagline: On-call intelligence for engineers who run systems in production. Local-first, consent-gated, MCP-native.
+  tagline: |
+    Cross-service incident context in under 100 ms. Consent-gated automation.
+    Your credentials never leave the machine.
+  image:
+    light: ../../assets/architecture-light.svg
+    dark: ../../assets/architecture-dark.svg
+    alt: 30 connectors → local SQLite index → engine + HITL → CLI · UI · voice
   actions:
     - text: Install
       link: /user-guide/install/
-      icon: right-arrow
+      icon: rocket
       variant: primary
-    - text: View on GitHub
-      link: https://github.com/nimbus-agent/Nimbus
+    - text: Watch the cast
+      link: https://asciinema.org/a/MnH4zEtmLxgfOGoy
       icon: external
+      variant: secondary
 ---
 
-## Why Nimbus
+import { CardGrid, Card } from "@astrojs/starlight/components";
 
-Nimbus is a headless agent that runs on **your** machine. It maintains a
-private SQLite index of your data across the services your on-call rotation
-already depends on — Google Drive, Gmail, GitHub, Slack, Linear, Jira,
-PagerDuty, Datadog, Kubernetes, AWS, GCP, and more — and executes multi-step
-workflows on your behalf.
+## What it does
 
-Three things make it different:
-
-- **Local-first.** Your machine is the source of truth. The cloud is a
-  connector, never a backend. Nimbus runs offline; cross-service queries
-  resolve from the local index in under 100 ms.
-- **HITL is structural.** Any action that writes data — sending a message,
-  deleting a file, creating an issue, triggering a deploy — pauses for your
-  explicit consent. The consent gate is in the executor, not the prompt; it
-  cannot be bypassed.
-- **No plaintext credentials.** Vault-only storage (Windows DPAPI, macOS
-  Keychain, Linux libsecret). Credentials never appear in logs, config files,
-  or IPC payloads.
-
-## Available today (`v0.1.0`)
-
-Headless Gateway, CLI, and VS Code extension. Optional fully local LLM via
-Ollama or llama.cpp — no cloud API key required, no outbound HTTP during a
-query when air-gap mode is on.
-
-Two built-in read-only agents shipped in Phase 5: **`nimbus expert`** (who has
-context on this file or topic) and **`nimbus impact`** (reverse-dependency
-blast radius across services, pipelines, dashboards, and on-call). See
-[Built-in agents](/user-guide/agents/).
-
-## Get started
-
-import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+Three things, in one query:
 
 <CardGrid>
-  <LinkCard title="Install" href="/user-guide/install/" description="Windows, macOS, Linux. Per-user, no admin." />
-  <LinkCard title="Connect a service" href="/user-guide/connect-your-first-service/" description="OAuth into your first cloud service in under a minute." />
-  <LinkCard title="Your first query" href="/user-guide/your-first-query/" description="CLI and Tauri desktop, side-by-side." />
-  <LinkCard title="Built-in agents" href="/user-guide/agents/" description="nimbus expert and nimbus impact — parallel sub-agents over your local index." />
+  <Card title="Incident response" icon="warning">
+    PagerDuty alert → deploy → commit → author, correlated locally.
+  </Card>
+  <Card title="CVE exposure" icon="seti:lock">
+    Indexed code search across every connected repo, no fan-out network calls.
+  </Card>
+  <Card title="Data lineage" icon="bars">
+    Tableau → Looker → dbt → Airflow → the renamed column.
+  </Card>
 </CardGrid>
 
-## License
+## Three load-bearing words
 
-Gateway, CLI, and connectors: AGPL-3.0. SDK and client library: MIT.
+- **local** — the SQLite index, the Vault, the audit log all live on your machine.
+- **consent-gated** — every destructive or outbound action is intercepted before it runs.
+- **MCP** — every connector speaks the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+[Get started →](/user-guide/install/) · [Architecture →](/architecture-overview/) · [Source on GitHub →](https://github.com/nimbus-agent/Nimbus)

--- a/packages/gateway/src/perf/fixtures/README.md
+++ b/packages/gateway/src/perf/fixtures/README.md
@@ -1,5 +1,7 @@
 # Perf bench fixtures
 
+## What this is
+
 Synthetic HTTP-trace generators + MSW v2 handlers used by the S6 sync-throughput drivers. The verification table below documents which connector traffic each fixture intercepts.
 
 ## Connector HTTP-layer verification (PR-B-2b-1, Task 2)
@@ -28,3 +30,11 @@ Tests register `setupServer` with `onUnhandledRequest: "error"`
 (sentinel against connector drift). Driver runtime uses `"warn"`
 because the spawned gateway emits unrelated outbound HTTP
 (telemetry, update-manifest probe, etc.).
+
+## See also
+
+- [Nimbus Developer Guide](https://nimbus-agent.dev/)
+
+## License
+
+MIT

--- a/packages/mcp-connectors/aws/README.md
+++ b/packages/mcp-connectors/aws/README.md
@@ -1,0 +1,26 @@
+# Aws Connector
+
+## What this is
+
+Nimbus MCP connector for Aws. Indexes and provides context from Aws to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth aws
+nimbus ask "Summarize my recent activity in Aws"
+```
+
+## See also
+
+- [Aws Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/azure/README.md
+++ b/packages/mcp-connectors/azure/README.md
@@ -1,0 +1,26 @@
+# Azure Connector
+
+## What this is
+
+Nimbus MCP connector for Azure. Indexes and provides context from Azure to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth azure
+nimbus ask "Summarize my recent activity in Azure"
+```
+
+## See also
+
+- [Azure Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/bitbucket/README.md
+++ b/packages/mcp-connectors/bitbucket/README.md
@@ -1,0 +1,26 @@
+# Bitbucket Connector
+
+## What this is
+
+Nimbus MCP connector for Bitbucket. Indexes and provides context from Bitbucket to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth bitbucket
+nimbus ask "Summarize my recent activity in Bitbucket"
+```
+
+## See also
+
+- [Bitbucket Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/circleci/README.md
+++ b/packages/mcp-connectors/circleci/README.md
@@ -1,0 +1,26 @@
+# Circleci Connector
+
+## What this is
+
+Nimbus MCP connector for Circleci. Indexes and provides context from Circleci to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth circleci
+nimbus ask "Summarize my recent activity in Circleci"
+```
+
+## See also
+
+- [Circleci Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/confluence/README.md
+++ b/packages/mcp-connectors/confluence/README.md
@@ -1,0 +1,26 @@
+# Confluence Connector
+
+## What this is
+
+Nimbus MCP connector for Confluence. Indexes and provides context from Confluence to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth confluence
+nimbus ask "Summarize my recent activity in Confluence"
+```
+
+## See also
+
+- [Confluence Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/datadog/README.md
+++ b/packages/mcp-connectors/datadog/README.md
@@ -1,0 +1,26 @@
+# Datadog Connector
+
+## What this is
+
+Nimbus MCP connector for Datadog. Indexes and provides context from Datadog to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth datadog
+nimbus ask "Summarize my recent activity in Datadog"
+```
+
+## See also
+
+- [Datadog Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/discord/README.md
+++ b/packages/mcp-connectors/discord/README.md
@@ -1,0 +1,26 @@
+# Discord Connector
+
+## What this is
+
+Nimbus MCP connector for Discord. Indexes and provides context from Discord to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth discord
+nimbus ask "Summarize my recent activity in Discord"
+```
+
+## See also
+
+- [Discord Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/gcp/README.md
+++ b/packages/mcp-connectors/gcp/README.md
@@ -1,0 +1,26 @@
+# Gcp Connector
+
+## What this is
+
+Nimbus MCP connector for Gcp. Indexes and provides context from Gcp to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth gcp
+nimbus ask "Summarize my recent activity in Gcp"
+```
+
+## See also
+
+- [Gcp Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/github-actions/README.md
+++ b/packages/mcp-connectors/github-actions/README.md
@@ -1,0 +1,26 @@
+# Github Actions Connector
+
+## What this is
+
+Nimbus MCP connector for Github Actions. Indexes and provides context from Github Actions to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth github-actions
+nimbus ask "Summarize my recent activity in Github Actions"
+```
+
+## See also
+
+- [Github Actions Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/github/README.md
+++ b/packages/mcp-connectors/github/README.md
@@ -1,0 +1,26 @@
+# Github Connector
+
+## What this is
+
+Nimbus MCP connector for Github. Indexes and provides context from Github to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth github
+nimbus ask "Summarize my recent activity in Github"
+```
+
+## See also
+
+- [Github Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/gitlab/README.md
+++ b/packages/mcp-connectors/gitlab/README.md
@@ -1,0 +1,26 @@
+# Gitlab Connector
+
+## What this is
+
+Nimbus MCP connector for Gitlab. Indexes and provides context from Gitlab to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth gitlab
+nimbus ask "Summarize my recent activity in Gitlab"
+```
+
+## See also
+
+- [Gitlab Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/gmail/README.md
+++ b/packages/mcp-connectors/gmail/README.md
@@ -1,0 +1,26 @@
+# Gmail Connector
+
+## What this is
+
+Nimbus MCP connector for Gmail. Indexes and provides context from Gmail to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth gmail
+nimbus ask "Summarize my recent activity in Gmail"
+```
+
+## See also
+
+- [Gmail Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/google-drive/README.md
+++ b/packages/mcp-connectors/google-drive/README.md
@@ -1,0 +1,26 @@
+# Google Drive Connector
+
+## What this is
+
+Nimbus MCP connector for Google Drive. Indexes and provides context from Google Drive to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth google-drive
+nimbus ask "Summarize my recent activity in Google Drive"
+```
+
+## See also
+
+- [Google Drive Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/google-photos/README.md
+++ b/packages/mcp-connectors/google-photos/README.md
@@ -1,0 +1,26 @@
+# Google Photos Connector
+
+## What this is
+
+Nimbus MCP connector for Google Photos. Indexes and provides context from Google Photos to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth google-photos
+nimbus ask "Summarize my recent activity in Google Photos"
+```
+
+## See also
+
+- [Google Photos Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/grafana/README.md
+++ b/packages/mcp-connectors/grafana/README.md
@@ -1,0 +1,26 @@
+# Grafana Connector
+
+## What this is
+
+Nimbus MCP connector for Grafana. Indexes and provides context from Grafana to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth grafana
+nimbus ask "Summarize my recent activity in Grafana"
+```
+
+## See also
+
+- [Grafana Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/iac/README.md
+++ b/packages/mcp-connectors/iac/README.md
@@ -1,0 +1,26 @@
+# Iac Connector
+
+## What this is
+
+Nimbus MCP connector for Iac. Indexes and provides context from Iac to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth iac
+nimbus ask "Summarize my recent activity in Iac"
+```
+
+## See also
+
+- [Iac Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/jenkins/README.md
+++ b/packages/mcp-connectors/jenkins/README.md
@@ -1,0 +1,26 @@
+# Jenkins Connector
+
+## What this is
+
+Nimbus MCP connector for Jenkins. Indexes and provides context from Jenkins to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth jenkins
+nimbus ask "Summarize my recent activity in Jenkins"
+```
+
+## See also
+
+- [Jenkins Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/jira/README.md
+++ b/packages/mcp-connectors/jira/README.md
@@ -1,0 +1,26 @@
+# Jira Connector
+
+## What this is
+
+Nimbus MCP connector for Jira. Indexes and provides context from Jira to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth jira
+nimbus ask "Summarize my recent activity in Jira"
+```
+
+## See also
+
+- [Jira Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/kubernetes/README.md
+++ b/packages/mcp-connectors/kubernetes/README.md
@@ -1,0 +1,26 @@
+# Kubernetes Connector
+
+## What this is
+
+Nimbus MCP connector for Kubernetes. Indexes and provides context from Kubernetes to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth kubernetes
+nimbus ask "Summarize my recent activity in Kubernetes"
+```
+
+## See also
+
+- [Kubernetes Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/linear/README.md
+++ b/packages/mcp-connectors/linear/README.md
@@ -1,0 +1,26 @@
+# Linear Connector
+
+## What this is
+
+Nimbus MCP connector for Linear. Indexes and provides context from Linear to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth linear
+nimbus ask "Summarize my recent activity in Linear"
+```
+
+## See also
+
+- [Linear Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/newrelic/README.md
+++ b/packages/mcp-connectors/newrelic/README.md
@@ -1,0 +1,26 @@
+# Newrelic Connector
+
+## What this is
+
+Nimbus MCP connector for Newrelic. Indexes and provides context from Newrelic to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth newrelic
+nimbus ask "Summarize my recent activity in Newrelic"
+```
+
+## See also
+
+- [Newrelic Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/notion/README.md
+++ b/packages/mcp-connectors/notion/README.md
@@ -1,0 +1,26 @@
+# Notion Connector
+
+## What this is
+
+Nimbus MCP connector for Notion. Indexes and provides context from Notion to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth notion
+nimbus ask "Summarize my recent activity in Notion"
+```
+
+## See also
+
+- [Notion Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/obsidian/README.md
+++ b/packages/mcp-connectors/obsidian/README.md
@@ -1,0 +1,26 @@
+# Obsidian Connector
+
+## What this is
+
+Nimbus MCP connector for Obsidian. Indexes and provides context from Obsidian to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth obsidian
+nimbus ask "Summarize my recent activity in Obsidian"
+```
+
+## See also
+
+- [Obsidian Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/onedrive/README.md
+++ b/packages/mcp-connectors/onedrive/README.md
@@ -1,0 +1,26 @@
+# Onedrive Connector
+
+## What this is
+
+Nimbus MCP connector for Onedrive. Indexes and provides context from Onedrive to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth onedrive
+nimbus ask "Summarize my recent activity in Onedrive"
+```
+
+## See also
+
+- [Onedrive Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/outlook/README.md
+++ b/packages/mcp-connectors/outlook/README.md
@@ -1,0 +1,26 @@
+# Outlook Connector
+
+## What this is
+
+Nimbus MCP connector for Outlook. Indexes and provides context from Outlook to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth outlook
+nimbus ask "Summarize my recent activity in Outlook"
+```
+
+## See also
+
+- [Outlook Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/pagerduty/README.md
+++ b/packages/mcp-connectors/pagerduty/README.md
@@ -1,0 +1,26 @@
+# Pagerduty Connector
+
+## What this is
+
+Nimbus MCP connector for Pagerduty. Indexes and provides context from Pagerduty to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth pagerduty
+nimbus ask "Summarize my recent activity in Pagerduty"
+```
+
+## See also
+
+- [Pagerduty Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/sentry/README.md
+++ b/packages/mcp-connectors/sentry/README.md
@@ -1,0 +1,26 @@
+# Sentry Connector
+
+## What this is
+
+Nimbus MCP connector for Sentry. Indexes and provides context from Sentry to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth sentry
+nimbus ask "Summarize my recent activity in Sentry"
+```
+
+## See also
+
+- [Sentry Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/slack/README.md
+++ b/packages/mcp-connectors/slack/README.md
@@ -1,0 +1,26 @@
+# Slack Connector
+
+## What this is
+
+Nimbus MCP connector for Slack. Indexes and provides context from Slack to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth slack
+nimbus ask "Summarize my recent activity in Slack"
+```
+
+## See also
+
+- [Slack Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/mcp-connectors/teams/README.md
+++ b/packages/mcp-connectors/teams/README.md
@@ -1,0 +1,26 @@
+# Teams Connector
+
+## What this is
+
+Nimbus MCP connector for Teams. Indexes and provides context from Teams to the Nimbus agent.
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+```bash
+nimbus connector auth teams
+nimbus ask "Summarize my recent activity in Teams"
+```
+
+## See also
+
+- [Teams Connector Documentation](https://nimbus-agent.dev/user-guide/connectors/)
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,34 @@
+# @nimbus-dev/sdk
+
+## What this is
+
+MIT-licensed SDK for authoring Nimbus Model Context Protocol (MCP) connectors. This library provides TypeScript types, base classes, and request-routing primitives to build connectors that run on the Nimbus Gateway.
+
+## Install
+
+```bash
+npm install @nimbus-dev/sdk
+```
+
+## Quickstart
+
+```typescript
+import { McpServer } from "@nimbus-dev/sdk";
+
+const server = new McpServer("my-connector");
+
+server.registerTool("echo", "Echoes input", async (input) => {
+  return { result: input };
+});
+
+server.start();
+```
+
+## See also
+
+- [Nimbus Developer Guide](https://nimbus-agent.dev/developer/)
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/)
+
+## License
+
+MIT

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -26,7 +26,7 @@ server.start();
 
 ## See also
 
-- [Nimbus Developer Guide](https://nimbus-agent.dev/developer/)
+- [Nimbus Developer Guide](https://nimbus-agent.dev/)
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/)
 
 ## License

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.3",
-    "@tauri-apps/cli": "^2.11.0",
+    "@tauri-apps/cli": "^2.11.1",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.0.0",
@@ -43,10 +43,10 @@
     "@types/react-window": "^2.0.0",
     "@types/zxcvbn": "^4.4.5",
     "@vitejs/plugin-react": "^5.0.4",
-    "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/coverage-v8": "^4.1.6",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.2.3",
     "vite": "^7.0.0",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/ui/src-tauri/Cargo.lock
+++ b/packages/ui/src-tauri/Cargo.lock
@@ -275,6 +275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1474,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1769,7 +1778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1803,16 +1812,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -1908,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2419,9 +2418,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "dunce",
  "is-wsl",
@@ -2756,9 +2755,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -2999,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -3246,11 +3245,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3379,9 +3379,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3557,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
@@ -3734,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d5f58bfd0cdcfdbc0a68dc08b354eea2afc551b421de91b07b69e0dd769d57"
+checksum = "eefb2c18e8a605c23edb48fc56bb77381199e1a1e7f6ff0c9b970afe7b3cb8ee"
 dependencies = [
  "anyhow",
  "glob",
@@ -4087,9 +4087,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4261,20 +4261,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4556,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4569,9 +4569,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4579,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4589,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4602,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4728,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5419,9 +5419,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.55.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3013fd6116aac351dd2e18f349b28b2cfef3a5ff3253a9d0ce2d7193bb1b4429"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -5559,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,8 +1,8 @@
 # Nimbus for VS Code
 
-Local-first AI agent for the editor. Ask, search, and run workflows against your private Nimbus index — all running on your machine.
+## What this is
 
-## What it does
+Local-first AI agent for the editor. Ask, search, and run workflows against your private Nimbus index — all running on your machine.
 
 - **Ask** — chat with the Nimbus agent in a side panel; results stream token-by-token.
 - **Search** — query your local Nimbus index across every connected service from the command palette.
@@ -14,9 +14,17 @@ VS Code Marketplace: `ext install nimbus-agent.nimbus-vscode`
 Open VSX (Cursor, VSCodium): `ext install nimbus-agent.nimbus-vscode`
 Manual: download the `.vsix` from the GitHub Release and run `code --install-extension nimbus-<ver>.vsix`.
 
+## Quickstart
+
+After installing, click the Nimbus icon in the sidebar or run `Nimbus: Open Chat` from the command palette.
+
 ## Requires
 
 A running Nimbus Gateway. See https://nimbus-agent.dev/install for setup.
+
+## See also
+
+- [Nimbus User Guide](https://nimbus-agent.dev/user-guide/)
 
 ## License
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -24,7 +24,7 @@ A running Nimbus Gateway. See https://nimbus-agent.dev/install for setup.
 
 ## See also
 
-- [Nimbus User Guide](https://nimbus-agent.dev/user-guide/)
+- [Nimbus User Guide](https://nimbus-agent.dev/user-guide/vscode-extension/)
 
 ## License
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -161,7 +161,7 @@
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.7.0",
     "@types/vscode": "^1.90.0",
     "@vitest/coverage-v8": "^2.0.0",
     "@vscode/test-electron": "^2.4.0",

--- a/scripts/audit/generate-connector-readme.ts
+++ b/scripts/audit/generate-connector-readme.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SLUGS = [
+  "aws", "azure", "bitbucket", "circleci", "confluence", "datadog", "discord", 
+  "gcp", "github", "github-actions", "gitlab", "gmail", "google-drive", 
+  "google-photos", "grafana", "iac", "jenkins", "jira", "kubernetes", 
+  "linear", "newrelic", "notion", "obsidian", "onedrive", "outlook", 
+  "pagerduty", "sentry", "slack", "teams"
+];
+
+function toDisplayName(slug: string) {
+  return slug.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}
+
+async function main() {
+  const rootDir = process.cwd();
+
+  for (const slug of SLUGS) {
+    const dirPath = join(rootDir, "packages", "mcp-connectors", slug);
+    if (!existsSync(dirPath)) continue;
+
+    const displayName = toDisplayName(slug);
+    const description = `Nimbus MCP connector for ${displayName}. Indexes and provides context from ${displayName} to the Nimbus agent.`;
+
+    const docPathMdx = join(rootDir, "packages", "docs", "src", "content", "docs", "connectors", `${slug}.mdx`);
+    const docPathMd = join(rootDir, "packages", "docs", "src", "content", "docs", "connectors", `${slug}.md`);
+
+    let seeAlsoUrl = "https://nimbus-agent.dev/user-guide/connectors/";
+    if (existsSync(docPathMdx) || existsSync(docPathMd)) {
+      seeAlsoUrl = `https://nimbus-agent.dev/user-guide/connectors/${slug}/`;
+    }
+
+    const readmeContent = `# ${displayName} Connector
+
+## What this is
+
+${description}
+
+## Install
+
+Bundled with Nimbus — no separate install required.
+
+## Quickstart
+
+\`\`\`bash
+nimbus connector auth ${slug}
+nimbus ask "Summarize my recent activity in ${displayName}"
+\`\`\`
+
+## See also
+
+- [${displayName} Connector Documentation](${seeAlsoUrl})
+- [Nimbus Architecture Overview](https://nimbus-agent.dev/architecture-overview/)
+- [HITL and Safety](https://nimbus-agent.dev/user-guide/hitl-and-safety/)
+
+## License
+
+AGPL-3.0
+`;
+
+    await writeFile(join(dirPath, "README.md"), readmeContent, "utf-8");
+    console.log(`Generated README for ${slug}`);
+  }
+}
+
+main().catch(console.error);

--- a/scripts/audit/generate-connector-readme.ts
+++ b/scripts/audit/generate-connector-readme.ts
@@ -3,15 +3,42 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const SLUGS = [
-  "aws", "azure", "bitbucket", "circleci", "confluence", "datadog", "discord", 
-  "gcp", "github", "github-actions", "gitlab", "gmail", "google-drive", 
-  "google-photos", "grafana", "iac", "jenkins", "jira", "kubernetes", 
-  "linear", "newrelic", "notion", "obsidian", "onedrive", "outlook", 
-  "pagerduty", "sentry", "slack", "teams"
+  "aws",
+  "azure",
+  "bitbucket",
+  "circleci",
+  "confluence",
+  "datadog",
+  "discord",
+  "gcp",
+  "github",
+  "github-actions",
+  "gitlab",
+  "gmail",
+  "google-drive",
+  "google-photos",
+  "grafana",
+  "iac",
+  "jenkins",
+  "jira",
+  "kubernetes",
+  "linear",
+  "newrelic",
+  "notion",
+  "obsidian",
+  "onedrive",
+  "outlook",
+  "pagerduty",
+  "sentry",
+  "slack",
+  "teams",
 ];
 
 function toDisplayName(slug: string) {
-  return slug.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+  return slug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
 }
 
 async function main() {
@@ -24,8 +51,26 @@ async function main() {
     const displayName = toDisplayName(slug);
     const description = `Nimbus MCP connector for ${displayName}. Indexes and provides context from ${displayName} to the Nimbus agent.`;
 
-    const docPathMdx = join(rootDir, "packages", "docs", "src", "content", "docs", "connectors", `${slug}.mdx`);
-    const docPathMd = join(rootDir, "packages", "docs", "src", "content", "docs", "connectors", `${slug}.md`);
+    const docPathMdx = join(
+      rootDir,
+      "packages",
+      "docs",
+      "src",
+      "content",
+      "docs",
+      "connectors",
+      `${slug}.mdx`,
+    );
+    const docPathMd = join(
+      rootDir,
+      "packages",
+      "docs",
+      "src",
+      "content",
+      "docs",
+      "connectors",
+      `${slug}.md`,
+    );
 
     let seeAlsoUrl = "https://nimbus-agent.dev/user-guide/connectors/";
     if (existsSync(docPathMdx) || existsSync(docPathMd)) {

--- a/scripts/audit/package-readmes.test.ts
+++ b/scripts/audit/package-readmes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { extractH2Headings, validatePackageReadme } from "./package-readmes.ts";
+
+describe("extractH2Headings", () => {
+  it("extracts and lowercases H2 headings", () => {
+    const markdown = `
+# Title
+## What this is
+Some text.
+## InSTaLl
+More text.
+### Not an H2
+## See also
+`;
+    expect(extractH2Headings(markdown)).toEqual(["what this is", "install", "see also"]);
+  });
+});
+
+describe("validatePackageReadme", () => {
+  it("passes public tier when all required sections are present", () => {
+    const content = `
+## What this is
+## Install
+## Quickstart
+## See also
+## License
+`;
+    expect(validatePackageReadme(content, "public", "test.md")).toBeNull();
+  });
+
+  it("fails public tier on missing section", () => {
+    const content = `
+## What this is
+## Install
+## Quickstart
+## License
+`;
+    const error = validatePackageReadme(content, "public", "test.md");
+    expect(error).toContain("Missing required section in 'test.md': '## See also'");
+    expect(error).toContain("What this is, Install, Quickstart, See also, License");
+  });
+
+  it("passes internal tier", () => {
+    const content = `
+## What this is
+## See also
+## License
+`;
+    expect(validatePackageReadme(content, "internal", "test.md")).toBeNull();
+  });
+
+  it("fails internal tier on missing section", () => {
+    const content = `
+## What this is
+## License
+`;
+    const error = validatePackageReadme(content, "internal", "test.md");
+    expect(error).toContain("Missing required section in 'test.md': '## See also'");
+    expect(error).toContain("What this is, See also, License");
+  });
+});

--- a/scripts/audit/package-readmes.ts
+++ b/scripts/audit/package-readmes.ts
@@ -1,0 +1,87 @@
+import { readFile, readdir, access } from "node:fs/promises";
+import { join } from "node:path";
+
+const SCOPE: readonly { path: string; tier: "public" | "internal" }[] = [
+  { path: "packages/client", tier: "public" },
+  { path: "packages/sdk", tier: "public" },
+  { path: "packages/vscode-extension", tier: "public" },
+  { path: "packages/docs", tier: "internal" },
+  { path: "installers", tier: "internal" },
+  { path: "packages/gateway/src/perf/fixtures", tier: "internal" },
+];
+
+const REQUIRED_SECTIONS = {
+  public: ["what this is", "install", "quickstart", "see also", "license"],
+  internal: ["what this is", "see also", "license"],
+} as const;
+
+export function extractH2Headings(content: string): string[] {
+  const headings: string[] = [];
+  const regex = /^##\s+(.+)$/gm;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    if (match[1]) headings.push(match[1].trim().toLowerCase());
+  }
+  return headings;
+}
+
+export function validatePackageReadme(content: string, tier: "public" | "internal", filePath: string): string | null {
+  const headings = extractH2Headings(content);
+  const required = REQUIRED_SECTIONS[tier];
+  
+  for (const req of required) {
+    if (!headings.includes(req)) {
+      const expectedOriginalCase = tier === "public" 
+        ? "What this is, Install, Quickstart, See also, License"
+        : "What this is, See also, License";
+      return `Missing required section in '${filePath}': '## ${req.charAt(0).toUpperCase() + req.slice(1)}'. Expected H2 headings for tier '${tier}' (case-insensitive): ${expectedOriginalCase}.`;
+    }
+  }
+  return null;
+}
+
+async function discoverConnectors(rootDir: string): Promise<{ path: string; tier: "public" | "internal" }[]> {
+  const connectorsPath = join(rootDir, "packages", "mcp-connectors");
+  try {
+    const entries = await readdir(connectorsPath, { withFileTypes: true });
+    const connectors: { path: string; tier: "public" | "internal" }[] = [];
+    for (const entry of entries) {
+      if (entry.isDirectory() && entry.name !== "shared") {
+        connectors.push({ path: `packages/mcp-connectors/${entry.name}`, tier: "public" });
+      }
+    }
+    return connectors;
+  } catch {
+    return [];
+  }
+}
+
+async function main() {
+  const rootDir = process.cwd();
+  const dynamicScope = await discoverConnectors(rootDir);
+  const fullScope = [...SCOPE, ...dynamicScope];
+  let failed = false;
+
+  for (const pkg of fullScope) {
+    const readmePath = join(rootDir, pkg.path, "README.md");
+    try {
+      const content = await readFile(readmePath, "utf-8");
+      const error = validatePackageReadme(content, pkg.tier, `${pkg.path}/README.md`);
+      if (error) {
+        console.error(error);
+        failed = true;
+      }
+    } catch (e) {
+      console.error(`Missing README.md in '${pkg.path}'`);
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/audit/package-readmes.ts
+++ b/scripts/audit/package-readmes.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, access } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const SCOPE: readonly { path: string; tier: "public" | "internal" }[] = [
@@ -18,29 +18,35 @@ const REQUIRED_SECTIONS = {
 export function extractH2Headings(content: string): string[] {
   const headings: string[] = [];
   const regex = /^##\s+(.+)$/gm;
-  let match;
-  while ((match = regex.exec(content)) !== null) {
+  for (const match of content.matchAll(regex)) {
     if (match[1]) headings.push(match[1].trim().toLowerCase());
   }
   return headings;
 }
 
-export function validatePackageReadme(content: string, tier: "public" | "internal", filePath: string): string | null {
+export function validatePackageReadme(
+  content: string,
+  tier: "public" | "internal",
+  filePath: string,
+): string | null {
   const headings = extractH2Headings(content);
   const required = REQUIRED_SECTIONS[tier];
-  
+
   for (const req of required) {
     if (!headings.includes(req)) {
-      const expectedOriginalCase = tier === "public" 
-        ? "What this is, Install, Quickstart, See also, License"
-        : "What this is, See also, License";
+      const expectedOriginalCase =
+        tier === "public"
+          ? "What this is, Install, Quickstart, See also, License"
+          : "What this is, See also, License";
       return `Missing required section in '${filePath}': '## ${req.charAt(0).toUpperCase() + req.slice(1)}'. Expected H2 headings for tier '${tier}' (case-insensitive): ${expectedOriginalCase}.`;
     }
   }
   return null;
 }
 
-async function discoverConnectors(rootDir: string): Promise<{ path: string; tier: "public" | "internal" }[]> {
+async function discoverConnectors(
+  rootDir: string,
+): Promise<{ path: string; tier: "public" | "internal" }[]> {
   const connectorsPath = join(rootDir, "packages", "mcp-connectors");
   try {
     const entries = await readdir(connectorsPath, { withFileTypes: true });
@@ -71,7 +77,7 @@ async function main() {
         console.error(error);
         failed = true;
       }
-    } catch (e) {
+    } catch (_e) {
       console.error(`Missing README.md in '${pkg.path}'`);
       failed = true;
     }

--- a/scripts/copy-shared-docs-assets.ts
+++ b/scripts/copy-shared-docs-assets.ts
@@ -1,8 +1,8 @@
 import { copyFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 async function main() {
-  const rootDir = process.cwd();
+  const rootDir = resolve(import.meta.dir, "..");
   const srcDir = join(rootDir, "docs", "assets");
   const destDir = join(rootDir, "packages", "docs", "src", "assets");
 

--- a/scripts/copy-shared-docs-assets.ts
+++ b/scripts/copy-shared-docs-assets.ts
@@ -1,0 +1,28 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+async function main() {
+  const rootDir = process.cwd();
+  const srcDir = join(rootDir, "docs", "assets");
+  const destDir = join(rootDir, "packages", "docs", "src", "assets");
+
+  await mkdir(destDir, { recursive: true });
+
+  const files = [
+    "architecture-light.svg",
+    "architecture-dark.svg",
+    "nimbus-wordmark-light.svg",
+    "nimbus-wordmark-dark.svg"
+  ];
+
+  for (const file of files) {
+    try {
+      await copyFile(join(srcDir, file), join(destDir, file));
+      console.log(`Copied ${file}`);
+    } catch (err) {
+      console.warn(`Warning: Could not copy ${file}: ${(err as Error).message}`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/scripts/copy-shared-docs-assets.ts
+++ b/scripts/copy-shared-docs-assets.ts
@@ -12,7 +12,7 @@ async function main() {
     "architecture-light.svg",
     "architecture-dark.svg",
     "nimbus-wordmark-light.svg",
-    "nimbus-wordmark-dark.svg"
+    "nimbus-wordmark-dark.svg",
   ];
 
   for (const file of files) {


### PR DESCRIPTION
This PR implements Sub-project B in its entirety (PRs 1 through 5).

### Manual Configuration Checklist
- [ ] **Settings → Pages → Source:** Set to **GitHub Actions** (not "Deploy from a branch").
- [ ] **Settings → Pages → Custom domain:** Enter `nimbus-agent.dev`.
- [ ] **Settings → Pages → Enforce HTTPS:** Ensure this is **enabled**.
- [ ] **Settings → Pages → Verified domains:** Verify `nimbus-agent.dev` via TXT record.
- [ ] **Settings → Features → Wikis:** Ensure this is **disabled**.
- [ ] **DNS at the registrar:** Ensure apex `A` records point at `185.199.108.153 / 185.199.109.153 / 185.199.110.153 / 185.199.111.153`.

### Contents
- **PR 1:** GitHub Pages publish workflow and PR gate.
- **PR 2:** Per-package README template and CI lint script.
- **PR 3:** Fleshed-out marketplace content for `@nimbus-dev/client` and `@nimbus-dev/sdk`.
- **PR 4:** Automatically generated docs for 29 first-party MCP connectors, compliant with the public tier.
- **PR 5:** Starlight splash page refresh mirroring the new README hero design.
