### PR TITLE
feat(community): Sub-project C PR 2 - Discussions infra + reshape ops

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,41 @@
+title: "Idea: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ideas are how the roadmap gets shaped. Large features get discussed
+        here before a PR. The local-first and structural-HITL constraints
+        are non-negotiable — be explicit about how your idea respects them.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem you're solving
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    id: local_first_fit
+    attributes:
+      label: How does this fit the local-first / HITL model?
+      description: |
+        Local-first means no user data or credentials leave the machine without an explicit user action.
+        Structural HITL means any destructive or outgoing action goes through the consent gate.
+        How does your idea respect both?
+
+  - type: dropdown
+    id: willing_to_build
+    attributes:
+      label: Are you willing to build this?
+      options:
+        - "Yes — I want to build it and would like guidance"
+        - "Maybe — depends on complexity"
+        - "No — requesting for someone else to build"

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,30 @@
+title: "Q&A: "
+labels: ["question", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking — the more context you give, the faster a maintainer
+        or community member can help. The FAQ pinned at the top of this
+        category answers many common questions; check it first.
+
+  - type: textarea
+    id: trying_to_do
+    attributes:
+      label: What are you trying to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Commands run, configuration tried, output observed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "OS, Bun version, Nimbus version/commit"


### PR DESCRIPTION
## Summary

PR 2 of Sub-project C (community pack). Adds Discussion templates for Q&A and Ideas, and carries an operational checklist for restructuring Discussions categories and publishing 4 pinned seed threads.

- Adds `.github/DISCUSSION_TEMPLATE/q-a.yml`
- Adds `.github/DISCUSSION_TEMPLATE/ideas.yml`

## Related Issue

Closes # (no tracking issue; tracked in the design spec)

## Linked Discussion

(none — this is the spec-driven sub-project)

## Type of Change

- [x] New feature (Discussion templates + ops)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Test improvement
- [ ] Documentation only
- [ ] CI / tooling

## Spec reference

Implements `docs/superpowers/specs/2026-05-12-sub-project-C-community-pack-design.md` §5.3.

## Operational checklist (perform after merge; requires repo admin access)

### 1. Restructure Discussions categories

Settings → Discussions → "Manage categories":

- [ ] Snapshot the current category state for record:
  ```bash
  gh api graphql -f query='{repository(owner:"nimbus-agent",name:"Nimbus"){discussionCategories(first:20){nodes{name slug description emoji isAnswerable}}}}' > /tmp/discussion-categories-before.json
  cat /tmp/discussion-categories-before.json
  ```
- [ ] Delete the `Polls` category. (Current discussion count: 0. Verify before deletion.)
- [ ] Rename `Show and tell` → `Show your workflow`. **In the rename dialog, edit the slug field to keep `show-and-tell`** so the one existing discussion thread and any future external links don't break.
- [ ] Verify `Q&A` is set to **Answerable** (default — should already be).
- [ ] Toggle `Ideas` to **Answerable** (lets maintainers mark ideas as built / declined / duplicate).
- [ ] Confirm the final category set: `Announcements`, `General`, `Q&A` (answerable), `Ideas` (answerable), `Show your workflow` (slug `show-and-tell`). 5 categories total.
- [ ] Snapshot the resulting category state:
  ```bash
  gh api graphql -f query='{repository(owner:"nimbus-agent",name:"Nimbus"){discussionCategories(first:20){nodes{name slug description emoji isAnswerable}}}}' > /tmp/discussion-categories-after.json
  diff /tmp/discussion-categories-before.json /tmp/discussion-categories-after.json
  ```
  Expected diff: only the Polls category removed, Show-and-tell renamed (slug preserved), Ideas isAnswerable flipped to true.

### 2. Publish & pin 4 seed threads

All four are authored by a maintainer.

- [ ] **Welcome to Nimbus Discussions** (category: Announcements). Pin at the top. Body content covers: what each of the 5 categories is for; links to `CONTRIBUTING.md`, `SUPPORT.md`, `CODE_OF_CONDUCT.md`. ~30 lines. Markdown only — no template applies to Announcements.
- [ ] **FAQ — common questions** (category: Q&A). Pin second. 8–10 Q&As covering:
  - Where does my data live? (local SQLite index)
  - How does HITL work? (consent gate in executor.ts; not bypassable)
  - Does Nimbus call external LLMs? (depends on config; local-first by default)
  - How do I add a connector? (`nimbus scaffold extension`)
  - What platforms are supported? (Windows 10+, macOS 13+, Ubuntu 22.04+)
  - What's the difference between Issues and Discussions? (links to SUPPORT.md)
  - How do I report a vulnerability? (links to SECURITY.md)
  - Where's the roadmap? (links to docs/roadmap.md)
  - How do I update? (`nimbus update`)
  - How do I run a remote query over LAN? (links to LAN remote-access docs)
- [ ] **Roadmap input — what should Phase 6+ look like?** (category: Ideas). Pin third. Links to `docs/roadmap.md`. Body solicits Phase 6+ direction; explicitly notes Phase 5 is in progress so ideas land in Phase 6.
- [ ] **Show your workflow — starter** (category: Show your workflow, slug `show-and-tell`). Pin fourth. Maintainer-authored example titled something like "How I use Nimbus for on-call handoffs" — describes a real workflow with HITL touchpoints. Invites others to share theirs.

### 3. Move the one existing discussion if needed

- [ ] Check whether the one pre-existing discussion (count was 1 at design time) is in a category that still exists. If it was in Polls, move it to General. If in Show-and-tell (now "Show your workflow"), no action needed — slug preserved.

### 4. Smoke-test discussion templates

- [ ] Open a draft discussion in **Q&A**. Verify the `q-a.yml` template auto-populates with the 4 prompts (markdown intro + 3 textareas).
- [ ] Open a draft discussion in **Ideas**. Verify the `ideas.yml` template auto-populates with the 5 prompts (markdown intro + 3 textareas + 1 dropdown).
- [ ] **Required-field check (Q1 from design review):** in the Q&A draft, leave all 3 textareas blank and click submit. Note the outcome:
  - If GitHub blocks submit with a "required field" error → `validations.required` enforces on discussions same as Issue Forms. Good.
  - If submit succeeds → `validations.required` is prompt-only on discussions. Accept this; do NOT change the template.
  Record the result in this PR as a comment.

## Verification

- [x] `bun run typecheck` — N/A
- [x] `bun run lint` — N/A
- [x] All existing tests pass — N/A
- [x] No `any`, no credentials, HITL not touched
- Smoke tests in operational checklist sections 1, 2, 4 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
