### PR TITLE
chore: post-PR-293 CI hygiene (Biome lint + devalue advisory + CHANGELOG markdownlint)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -37,6 +37,7 @@
     "!docs/perf/slo.md",
     "!.claude/worktrees/**",
     "!node_modules/**",
-    "!packages/docs/dist/**"
+    "!packages/docs/dist/**",
+    "!CHANGELOG.md"
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -560,6 +560,7 @@
     },
   },
   "overrides": {
+    "devalue": "5.8.1",
     "fast-uri": "3.1.2",
     "protobufjs": "7.5.8",
     "sharp": "0.34.5",
@@ -1794,7 +1795,7 @@
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
-    "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "sharp": "0.34.5",
     "protobufjs": "7.5.8",
     "fast-uri": "3.1.2",
-    "vite": "7.3.3"
+    "vite": "7.3.3",
+    "devalue": "5.8.1"
   },
   "workspaces": [
     "packages/gateway",

--- a/scripts/cast-driver/driver.test.ts
+++ b/scripts/cast-driver/driver.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runDriver } from "./driver.ts";

--- a/scripts/cast-driver/fake-gateway.test.ts
+++ b/scripts/cast-driver/fake-gateway.test.ts
@@ -25,7 +25,7 @@ async function rpc(method: string, params: unknown): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const client = connect(socketPath);
     client.on("connect", () => {
-      const msg = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
+      const msg = `${JSON.stringify({ jsonrpc: "2.0", id: 1, method, params })}\n`;
       client.write(msg);
     });
     let buf = "";
@@ -78,12 +78,12 @@ describe("FakeGateway", () => {
       const client = connect(socketPath);
       client.on("connect", () => {
         client.write(
-          JSON.stringify({
+          `${JSON.stringify({
             jsonrpc: "2.0",
             id: 1,
             method: "engine.askStream",
             params: { prompt: "hi" },
-          }) + "\n",
+          })}\n`,
         );
       });
       let buf = "";
@@ -131,12 +131,12 @@ describe("FakeGateway", () => {
       const client = connect(socketPath);
       client.on("connect", () => {
         client.write(
-          JSON.stringify({
+          `${JSON.stringify({
             jsonrpc: "2.0",
             id: 1,
             method: "engine.askStream",
             params: { prompt: "x" },
-          }) + "\n",
+          })}\n`,
         );
       });
       let buf = "";
@@ -152,12 +152,12 @@ describe("FakeGateway", () => {
             if (parsed.method === "consent.request") {
               setTimeout(() => {
                 client.write(
-                  JSON.stringify({
+                  `${JSON.stringify({
                     jsonrpc: "2.0",
                     id: 2,
                     method: "consent.respond",
                     params: { requestId: "r1", approved: true },
-                  }) + "\n",
+                  })}\n`,
                 );
                 respondedAfterConsent = true;
               }, 50);
@@ -193,7 +193,7 @@ describe("FakeGateway", () => {
       const client = connect(socketPath);
       client.on("connect", () => {
         client.write(
-          JSON.stringify({ jsonrpc: "2.0", id: 1, method: "engine.askStream", params: {} }) + "\n",
+          `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "engine.askStream", params: {} })}\n`,
         );
       });
       let buf = "";
@@ -202,12 +202,12 @@ describe("FakeGateway", () => {
         const nl = buf.indexOf("\n");
         if (nl !== -1) {
           client.write(
-            JSON.stringify({
+            `${JSON.stringify({
               jsonrpc: "2.0",
               id: 2,
               method: "consent.respond",
               params: { requestId: "r1", approved: false },
-            }) + "\n",
+            })}\n`,
           );
           setTimeout(() => {
             client.end();
@@ -259,12 +259,12 @@ describe("FakeGateway", () => {
       const client = connect(socketPath);
       client.on("connect", () => {
         client.write(
-          JSON.stringify({
+          `${JSON.stringify({
             jsonrpc: "2.0",
             id: 1,
             method: "agents.expert",
             params: { topicOrFile: "latency" },
-          }) + "\n",
+          })}\n`,
         );
       });
       let buf = "";
@@ -318,7 +318,7 @@ describe("FakeGateway", () => {
       const client = connect(socketPath);
       client.on("connect", () => {
         client.write(
-          JSON.stringify({ jsonrpc: "2.0", id: 1, method: "agent.invoke", params: {} }) + "\n",
+          `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "agent.invoke", params: {} })}\n`,
         );
       });
       let buf = "";

--- a/scripts/cast-driver/fake-gateway.ts
+++ b/scripts/cast-driver/fake-gateway.ts
@@ -89,11 +89,12 @@ export class FakeGateway {
   constructor(private readonly opts: FakeGatewayOptions) {}
 
   async start(): Promise<void> {
-    this.server = createServer((socket) => this.handleConnection(socket));
+    const server = createServer((socket) => this.handleConnection(socket));
+    this.server = server;
     await new Promise<void>((resolve, reject) => {
-      this.server!.once("listening", () => resolve());
-      this.server!.once("error", reject);
-      this.server!.listen(this.opts.socketPath);
+      server.once("listening", () => resolve());
+      server.once("error", reject);
+      server.listen(this.opts.socketPath);
     });
   }
 
@@ -262,10 +263,10 @@ export class FakeGateway {
         if (typeof p.requestId === "string") {
           const rid = p.requestId;
           // Check whether consent.respond already arrived early (async race).
-          if (this.earlyConsents.has(rid)) {
-            const approved = this.earlyConsents.get(rid)!;
+          const earlyApproved = this.earlyConsents.get(rid);
+          if (earlyApproved !== undefined) {
             this.earlyConsents.delete(rid);
-            this.consentDecisions.push({ requestId: rid, approved });
+            this.consentDecisions.push({ requestId: rid, approved: earlyApproved });
             // No pause needed — response is already here.
           } else {
             // Wait for the client's consent.respond to arrive.

--- a/scripts/cast-driver/normalize.ts
+++ b/scripts/cast-driver/normalize.ts
@@ -16,7 +16,9 @@ export interface Rule {
   readonly apply: (text: string, ctx: NormalizationContext) => string;
 }
 
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI CSI parsing requires the literal ESC (\x1b) byte
 const ANSI_CSI = /\x1b\[[?]?[0-9;]*[A-Za-z]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI OSC parsing requires the literal ESC (\x1b) and BEL (\x07) bytes
 const ANSI_OSC = /\x1b\][^\x07\x1b]*(\x07|\x1b\\)/g;
 const ISO_8601 = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?/g;
 const EPOCH_MS = /\b\d{13}\b/g;
@@ -49,7 +51,7 @@ export const NORMALIZATION_RULES: ReadonlyArray<Rule> = [
       let text = t.replace(/\r\n/g, "\n");
       // (c) Lone trailing \r at EOF becomes \n
       if (text.endsWith("\r")) {
-        text = text.slice(0, -1) + "\n";
+        text = `${text.slice(0, -1)}\n`;
       }
       // (b) Within each line, keep only substring after last \r
       const lines = text.split("\n");
@@ -117,7 +119,7 @@ export const NORMALIZATION_RULES: ReadonlyArray<Rule> = [
         // If it's a labeled SHA (sha=abc123), replace just the hex part
         const labelMatch = match.match(/^(sha=|commit=|SHA=|COMMIT=)/i);
         if (labelMatch) {
-          return labelMatch[1] + "<SHA>";
+          return `${labelMatch[1]}<SHA>`;
         }
         // Otherwise it's a bare long hex, replace entirely
         return "<SHA>";

--- a/scripts/cast-driver/run.ts
+++ b/scripts/cast-driver/run.ts
@@ -13,8 +13,7 @@ function parseArgs(argv: ReadonlyArray<string>): {
     const a = argv[i];
     if (a === "--check") mode = "check";
     else if (a === "--update-snapshots") mode = "update";
-    else if (a !== undefined && a.startsWith("--artifacts-dir="))
-      artifactsDir = a.slice("--artifacts-dir=".length);
+    else if (a?.startsWith("--artifacts-dir=")) artifactsDir = a.slice("--artifacts-dir=".length);
     else if (a === "--artifacts-dir") {
       const next = argv[i + 1];
       if (next !== undefined) {


### PR DESCRIPTION
## Summary

Three independent CI failures landed on main alongside / after #293 (sub-project D Phase 3, cast tripwire). All three block every subsequent PR via the merge-ref. This PR clears all three.

### 1. `fix(cast-driver): satisfy Biome lint` (1d50b387)
#293 admin-merged with `PR quality / Test (ubuntu-24.04)` red: 11 Biome errors + 10 fixable infos in `scripts/cast-driver/`.

- `normalize.ts:19–22` — 2 ANSI-strip regexes legitimately need literal `\x1b` / `\x07`. Added `// biome-ignore lint/suspicious/noControlCharactersInRegex` with rationale.
- `fake-gateway.ts start()` — replaced 3× `this.server!` with a captured local before the Promise.
- `fake-gateway.ts` early-consent branch — replaced `Map.has + get + !` with `get + undefined check`, dropping the 4th non-null assertion.
- 10 fixable style infos auto-applied: 10× `useTemplate`, 1× `useOptionalChain`, 1× `noUnusedImports`.

**Cast hash unchanged** (no normalization-rule semantics changed).

### 2. `chore(deps): force devalue@5.8.1 via override (GHSA-77vg-94rm-hx3p)` (0a69bf83)
`astro@6.2.2` declares `devalue: "^5.6.3"`; Bun resolved 5.7.1, inside the advisory range (>=5.6.3 <=5.8.0, DoS via sparse array deserialization, **HIGH**). `astro@6.3.3` keeps the same `^5.6.3` constraint — plain `bun update astro` does not lift devalue out of the range.

- Add `"devalue": "5.8.1"` to root `overrides` (mirroring the existing sharp / protobufjs / fast-uri / vite pins). Bun re-resolves transitively to 5.8.1.
- `bun audit --audit-level high` → 0 vulnerabilities locally.
- Should also clear the `Trivy vulnerability scan` job (same advisory).

### 3. `chore(lint): exclude CHANGELOG.md from markdownlint (release-please owns)` (014af7a5)
PR #290 (release-please 0.2.0) prepended an entry to root `CHANGELOG.md` whose `*` bullets + double-blank separators violate MD012 / MD004 (the pre-existing manual 0.1.x entries use `-` bullets; once `*` and `-` coexist, MD004 fails on the dashes). 0.3.0 (open release PR) compounds it.

- Add `"!CHANGELOG.md"` to `.markdownlint-cli2.jsonc` globs. The file is machine-generated; prose-quality rules don't apply. The three package-level `CHANGELOG.md`s were already outside scope.

## Test plan

- [x] `bun run lint` → 0 errors
- [x] `bun run lint:markdown` → 0 errors (37 files linted, down from 38)
- [x] `bun audit --audit-level high` → 0 vulnerabilities
- [ ] CI: `PR quality / Test (ubuntu-24.04)` green
- [ ] CI: `Dependency audit` green
- [ ] CI: `Trivy vulnerability scan` green
- [ ] CI: `markdownlint-cli2` green
- [ ] CI: `Cast transcript tripwire` stays green (proves cast hash unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)