### PR TITLE
docs(architecture): add Contents section to docs/architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,27 @@
 
 ---
 
+## Contents
+
+- [Overview](#overview)
+- [Cross-Platform Architecture](#cross-platform-architecture)
+- [Package Dependency Rules](#package-dependency-rules)
+- [Data Flow Diagram](#data-flow-diagram)
+- [Subsystem 1: The Nimbus Engine](#subsystem-1-the-nimbus-engine)
+- [Subsystem 2: The MCP Connector Mesh](#subsystem-2-the-mcp-connector-mesh)
+- [Subsystem 3: The Secure Vault](#subsystem-3-the-secure-vault)
+- [Subsystem 4: The Extension Registry](#subsystem-4-the-extension-registry)
+- [Phase 4 Subsystems](#phase-4-subsystems)
+- [Built-in Agents Pattern](#built-in-agents-pattern)
+- [Phase 6+ Subsystems (Planned)](#phase-6-subsystems-planned)
+- [Nimbus Gateway: Process Lifecycle](#nimbus-gateway-process-lifecycle)
+- [Local Database Schema](#local-database-schema)
+- [Testing Architecture](#testing-architecture)
+- [Security Model](#security-model)
+- [Directory Structure](#directory-structure)
+
+---
+
 ## Overview
 
 Nimbus is a local-first AI agent for DevOps engineers, security practitioners, and senior developers who run systems in production. It is composed of four primary subsystems, all hosted inside a single headless **Nimbus Gateway** process. Clients — the CLI, the Tauri 2.0 desktop app, or the VS Code extension — communicate with the Gateway exclusively over a local IPC socket. No subsystem is directly accessible from the client tier.


### PR DESCRIPTION
## Summary

- Adds a Contents list near the top of [`docs/architecture.md`](docs/architecture.md) covering all 16 `##`-level sections
- Closes #245
- No other content changes — pure additive TOC

## Why

`architecture.md` is **1 607 lines** with 16 top-level sections. Readers landing from a roadmap or external link had no quick way to jump to the subsystem they cared about without scrolling.

## Anchor verification

Each anchor uses GitHub's slug convention (lowercase, hyphenated, special chars stripped). The `Phase 6+ Subsystems (Planned)` slug (`#phase-6-subsystems-planned`) reuses an existing in-doc cross-reference, so it's already verified to work in GitHub-rendered Markdown.

## Test plan

- [ ] Hover each Contents link in the GitHub PR diff view; each should jump to the corresponding `##` heading
- [ ] No other links in `docs/architecture.md` regress (lychee CI gate covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)