### PR TITLE
docs(verify-your-download): bump example version to v0.2.0

### DIFF
--- a/packages/docs/src/content/docs/user-guide/verify-your-download.mdx
+++ b/packages/docs/src/content/docs/user-guide/verify-your-download.mdx
@@ -72,7 +72,7 @@ curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbu
 chmod +x nimbus-verify.sh
 
 # Verify the latest release artefacts
-./nimbus-verify.sh --version 0.1.0
+./nimbus-verify.sh --version 0.2.0
 ```
 
 **Windows (PowerShell):**
@@ -82,7 +82,7 @@ Invoke-WebRequest `
   -Uri "https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-verify.ps1" `
   -OutFile "nimbus-verify.ps1"
 
-.\nimbus-verify.ps1 -Version 0.1.0
+.\nimbus-verify.ps1 -Version 0.2.0
 ```
 
 The helper script:
@@ -202,10 +202,10 @@ gpg --verify Nimbus.AppImage.asc Nimbus.AppImage
 
 ## macOS and Windows note
 
-v0.1.0 ships **without** platform-native code-signing (no notarised macOS
-`.pkg`, no Authenticode-signed Windows installer). This is an explicit project
-decision deferred to a later point release — see `docs/SECURITY.md` in the
-repository for the full rationale.
+v0.1.0+ releases ship **without** platform-native code-signing (no notarised
+macOS `.pkg`, no Authenticode-signed Windows installer). This is an explicit
+project decision deferred to a later point release — see `docs/SECURITY.md`
+in the repository for the full rationale.
 
 The GPG-signed `SHA256SUMS.asc` manifest is the cross-platform integrity
 proof for all platforms. When you first run the Nimbus binary on macOS,


### PR DESCRIPTION
## Summary

- Bumps the two `--version 0.1.0` example invocations to `0.2.0` in [`packages/docs/src/content/docs/user-guide/verify-your-download.mdx`](packages/docs/src/content/docs/user-guide/verify-your-download.mdx)
- Reworks the macOS/Windows code-signing note from "v0.1.0 ships without" to "v0.1.0+ releases ship without" to match the existing `v0.1.0+ releases` phrasing used in the fingerprint section
- Partially closes #246

## Verification done

Cross-checked against the live v0.2.0 release asset list:

- ✓ `nimbus-verify.sh` and `nimbus-verify.ps1` still ship as release assets
- ✓ `SHA256SUMS` + `SHA256SUMS.asc` still present
- ✓ No `.pkg` (macOS) or signed Windows installer in v0.2.0 → code-signing note still accurate
- ✓ Fingerprint `5A20 457C CD8B 53FF AA94 5240 886A DA6B 487C AB6E` unchanged across `docs/SECURITY.md`

## Out of scope for this PR

The full acceptance criterion in #246 — running every command end-to-end against a fresh v0.2.0 download on Linux + macOS + Windows — needs hands-on platform access. This PR fixes the documentable drift; the per-platform e2e walkthrough remains open on #246 for whoever can run `nimbus-verify.sh` against the actual v0.2.0 artefacts on each OS.

## Test plan

- [ ] Open the rendered Starlight page locally (`cd packages/docs && bunx astro dev`) and confirm the Bash + PowerShell code blocks now show `0.2.0`
- [ ] Confirm the macOS/Windows note reads "v0.1.0+ releases ship without"
- [ ] No other links regress (lychee CI gate covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)