### PR TITLE
docs(site): add per-connector docs pages for all 29 first-party connectors

### DIFF
--- a/packages/docs/src/content/docs/connectors/aws.mdx
+++ b/packages/docs/src/content/docs/connectors/aws.mdx
@@ -1,0 +1,49 @@
+---
+title: AWS
+description: Index Lambda functions, ECS services, and EC2 inventory from AWS through the local AWS CLI credential chain.
+---
+
+The AWS connector indexes a thin slice of your AWS account into the local SQLite index and exposes a small read + HITL-gated write surface to the agent. The MCP server shells out to the `aws` CLI v2, so it inherits whatever credential chain the CLI uses (vault-supplied access keys, `AWS_PROFILE`, or default `~/.aws/credentials`).
+
+---
+
+## What's indexed
+
+- **Service id:** `aws`
+- **Item types:** `lambda_function`
+
+## Authenticate
+
+```bash
+nimbus connector auth aws
+```
+
+The Gateway resolves credentials from the Vault keys `aws.access_key_id`, `aws.secret_access_key`, `aws.default_region`, and `aws.profile`. They are injected into the connector spawn environment as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE`. If you'd rather use the AWS CLI default credential chain (e.g. an SSO session) leave the vault keys empty — the spawn inherits the parent process's `AWS_*` environment.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `aws_ecs_service_list` | List ECS services in a cluster. |
+| `aws_lambda_list` | List Lambda functions (first page). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `aws_ec2_instance_start` | Start EC2 instances. |
+| `aws_ec2_instance_stop` | Stop EC2 instances. |
+| `aws_ecs_service_update` | Update an ECS service (e.g. new task definition). |
+| `aws_lambda_invoke` | Invoke a Lambda function. |
+
+## Platform notes
+
+- Requires the **`aws` CLI v2** on `PATH` — the MCP server invokes it via `Bun.spawn(["aws", ...])`.
+- Credentials are resolved from the Vault and injected as environment variables at spawn time. They are never written to the index, never logged, and never reach the LLM context.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/azure.mdx
+++ b/packages/docs/src/content/docs/connectors/azure.mdx
@@ -1,0 +1,46 @@
+---
+title: Azure
+description: Index Azure subscription metadata and act on App Services and AKS node pools through the Azure CLI.
+---
+
+The Azure connector indexes basic subscription metadata into the local SQLite index and exposes a small read + HITL-gated write surface. The MCP server shells out to the `az` CLI, using either a service-principal session seeded from the Vault or a pre-existing `az login` session.
+
+---
+
+## What's indexed
+
+- **Service id:** `azure`
+- **Item types:** `subscription`
+
+## Authenticate
+
+```bash
+nimbus connector auth azure
+```
+
+The Gateway resolves credentials from the Vault keys `azure.tenant_id`, `azure.client_id`, and `azure.client_secret`. They are injected into the connector spawn environment as `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`, and the spawn opens a service-principal session against `az`. If you'd rather use a pre-existing `az login` session, leave the vault keys empty.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `azure_app_service_list` | List App Services in a resource group. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `azure_aks_node_pool_scale` | Scale an AKS node pool. |
+| `azure_app_service_restart` | Restart an App Service. |
+
+## Platform notes
+
+- Requires the **`az` CLI** on `PATH` — the MCP server invokes it via `Bun.spawn(["az", ...])`.
+- The sync handler runs `az account show` once per cycle to seed the indexed subscription item.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/bitbucket.mdx
+++ b/packages/docs/src/content/docs/connectors/bitbucket.mdx
@@ -1,0 +1,45 @@
+---
+title: Bitbucket
+description: Index Bitbucket pull requests and read repository metadata, issues, and Pipelines runs.
+---
+
+The Bitbucket connector indexes pull requests into the local SQLite index and exposes read tools across repositories, PRs, issues, and Pipelines runs. Authentication is via your Bitbucket username plus an [app password](https://bitbucket.org/account/settings/app-passwords/).
+
+---
+
+## What's indexed
+
+- **Service id:** `bitbucket`
+- **Item types:** `pr`
+
+## Authenticate
+
+```bash
+nimbus connector auth bitbucket
+```
+
+Stored in the Vault as `bitbucket.username` and `bitbucket.app_password` and injected at spawn as `BITBUCKET_USERNAME` / `BITBUCKET_APP_PASSWORD`. The MCP server uses HTTP Basic auth against `api.bitbucket.org/2.0`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `bitbucket_issue_list` | List issues for a repository (issue tracker must be enabled). |
+| `bitbucket_pipeline_get` | Get a single pipeline run by UUID. |
+| `bitbucket_pipeline_list` | List Pipelines runs for a repository. |
+| `bitbucket_pr_get` | Get a single pull request by numeric id. |
+| `bitbucket_pr_list` | List pull requests for a repository. |
+| `bitbucket_repo_list` | List repositories where the authenticated user is a member. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `bitbucket_pr_merge` | Merge a pull request. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/circleci.mdx
+++ b/packages/docs/src/content/docs/connectors/circleci.mdx
@@ -1,0 +1,45 @@
+---
+title: CircleCI
+description: Index CircleCI pipelines and read workflow + job + artefact metadata across your projects.
+---
+
+The CircleCI connector indexes pipeline runs into the local SQLite index and exposes read tools across pipelines, workflows, jobs, and artefacts. Authentication is via a personal API token.
+
+---
+
+## What's indexed
+
+- **Service id:** `circleci`
+- **Item types:** `ci_run`
+
+## Authenticate
+
+```bash
+nimbus connector auth circleci
+```
+
+Stored in the Vault as `circleci.api_token` and injected at spawn as `CIRCLECI_API_TOKEN`. The MCP server uses the `Circle-Token` header against `circleci.com/api/v2`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `circleci_job_artifacts` | List artifact metadata for a job number under a project. |
+| `circleci_job_list` | List jobs for a workflow. |
+| `circleci_pipeline_get` | Get a pipeline by UUID. |
+| `circleci_pipeline_list` | List pipelines for a CircleCI project. |
+| `circleci_workflow_list` | List workflows for a pipeline. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `circleci_job_cancel` | Cancel a running job by project slug and job number. |
+| `circleci_pipeline_trigger` | Trigger a new pipeline on a branch (or tag). |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/confluence.mdx
+++ b/packages/docs/src/content/docs/connectors/confluence.mdx
@@ -1,0 +1,51 @@
+---
+title: Confluence
+description: Index Confluence pages and blog posts and read + write content across spaces. Cloud only.
+---
+
+The Confluence connector indexes pages into the local SQLite index and exposes read tools across pages, blog posts, comments, and spaces, plus a small set of HITL-gated write tools for creating and updating content. Confluence Cloud only.
+
+---
+
+## What's indexed
+
+- **Service id:** `confluence`
+- **Item types:** `page`
+
+## Authenticate
+
+```bash
+nimbus connector auth confluence
+```
+
+Stored in the Vault as `confluence.base_url`, `confluence.email`, and `confluence.api_token` and injected at spawn as `CONFLUENCE_BASE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`. The MCP server uses Atlassian Basic auth (email + API token). Generate an API token at [id.atlassian.com → Security → API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `confluence_blogpost_get` | Get a blog post by id (`GET /content/{id}`). |
+| `confluence_blogpost_list` | List blog posts in a space (`GET /content?type=blogpost`). |
+| `confluence_comment_list` | List footer comments on a page (`GET /content/{id}/child/comment`). |
+| `confluence_page_get` | Get a Confluence page with `body.storage` (`GET /content/{id}`). |
+| `confluence_page_list` | List pages in a space (`GET /content?type=page`). |
+| `confluence_space_list` | List Confluence spaces (`GET /space`). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `confluence_comment_add` | Add a footer comment to a page. |
+| `confluence_page_create` | Create a page in a space (optional `parentPageId`). |
+| `confluence_page_update` | Update page body and bump version (pass current version + title). |
+
+## Platform notes
+
+- **Confluence Cloud only.** The base URL must be the `*.atlassian.net` site root; the connector appends `/wiki` automatically.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/datadog.mdx
+++ b/packages/docs/src/content/docs/connectors/datadog.mdx
@@ -1,0 +1,41 @@
+---
+title: Datadog
+description: Index Datadog monitors and read incident metadata. Read-only.
+---
+
+The Datadog connector indexes monitor definitions into the local SQLite index and exposes read tools for monitors and incidents. Read-only — there are no write tools today.
+
+---
+
+## What's indexed
+
+- **Service id:** `datadog`
+- **Item types:** `monitor`
+
+## Authenticate
+
+```bash
+nimbus connector auth datadog
+```
+
+Stored in the Vault as `datadog.api_key`, `datadog.app_key`, and `datadog.site` and injected at spawn as `DD_API_KEY`, `DD_APP_KEY`, `DD_SITE`. The MCP server uses the `DD-API-KEY` and `DD-APPLICATION-KEY` headers.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `datadog_incident_list` | List incidents (Incidents v2 API). |
+| `datadog_monitor_list` | List monitors. |
+
+## Write tools (HITL-gated)
+
+_No write tools — this connector is read-only._
+
+## Platform notes
+
+- **`DD_SITE` selects the regional API host.** Defaults to `datadoghq.com`. Set it to `datadoghq.eu`, `us3.datadoghq.com`, etc. for non-US regions. The sync handler reads the site from the Vault; the MCP server reads it from the env var.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/discord.mdx
+++ b/packages/docs/src/content/docs/connectors/discord.mdx
@@ -1,0 +1,46 @@
+---
+title: Discord
+description: Index Discord channel messages from a bot you control. Opt-in — disabled by default.
+---
+
+The Discord connector indexes channel messages and threads from servers your bot is a member of into the local SQLite index. Read-only by design. Discord is an **opt-in** connector — the Gateway sync stays a no-op until you explicitly flip the vault switch.
+
+---
+
+## What's indexed
+
+- **Service id:** `discord`
+- **Item types:** `message`
+
+## Authenticate
+
+```bash
+# Opt in first
+nimbus vault set discord.enabled 1
+nimbus vault set discord.bot_token <your-bot-token>
+nimbus connector sync discord
+```
+
+Stored in the Vault as `discord.bot_token` and `discord.enabled` (must equal `"1"`) and injected at spawn as `DISCORD_BOT_TOKEN`. The MCP server authenticates against the Discord REST API as the bot. Without **both** the `enabled=1` flag and a non-empty `bot_token`, the Gateway syncable returns a no-op on every cycle.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `discord_channel_list` | List channels in a guild (id, type, name). |
+| `discord_channel_messages` | List recent messages in a channel (newest first). Optional `after` snowflake for incremental fetch. |
+| `discord_guild_list` | List guilds the bot is a member of. |
+| `discord_thread_list` | List active threads in a guild (includes public threads the bot can see). |
+
+## Write tools (HITL-gated)
+
+_No write tools — this connector is read-only._
+
+## Platform notes
+
+- **Opt-in.** The Gateway sync is gated on `discord.enabled == "1"` AND a non-empty `discord.bot_token` in the Vault. Without both, the syncable returns a no-op on every cycle and no Discord data is ever indexed.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/gcp.mdx
+++ b/packages/docs/src/content/docs/connectors/gcp.mdx
@@ -1,0 +1,46 @@
+---
+title: Google Cloud Platform
+description: Index GCP project metadata and act on Cloud Run + GKE through gcloud Application Default Credentials.
+---
+
+The GCP connector indexes project metadata into the local SQLite index and exposes a small read + HITL-gated write surface for Cloud Run and GKE. The MCP server shells out to the `gcloud` CLI using Application Default Credentials.
+
+---
+
+## What's indexed
+
+- **Service id:** `gcp`
+- **Item types:** `project`
+
+## Authenticate
+
+```bash
+nimbus connector auth gcp
+```
+
+Stored in the Vault as `gcp.credentials_json_path` and `gcp.project_id`. The credentials JSON path is exported into the connector spawn as `GOOGLE_APPLICATION_CREDENTIALS`, which `gcloud` (and any Google client library) picks up as ADC.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `gcp_cloud_run_service_list` | List Cloud Run services in a region. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `gcp_cloud_run_deploy` | Deploy a container image to Cloud Run. |
+| `gcp_gke_workload_restart` | Restart a GKE deployment rollout via `kubectl` (uses current cluster credentials). |
+
+## Platform notes
+
+- Requires the **`gcloud` CLI** on `PATH` — the MCP server invokes it via `Bun.spawn(["gcloud", ...])`.
+- `gcp_gke_workload_restart` additionally requires **`kubectl`** on `PATH` and a configured cluster context.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/github-actions.mdx
+++ b/packages/docs/src/content/docs/connectors/github-actions.mdx
@@ -1,0 +1,46 @@
+---
+title: GitHub Actions
+description: Index GitHub Actions workflow runs and trigger or cancel runs via the same PAT used for the GitHub connector.
+---
+
+The GitHub Actions connector is a deeper read surface on top of the same `GITHUB_PAT` used by the [GitHub connector](./github), focused on workflows, runs, jobs, and logs. It also exposes two HITL-gated write tools for triggering and cancelling runs.
+
+---
+
+## What's indexed
+
+- **Service id:** `github_actions`
+- **Item types:** `ci_run`
+
+## Authenticate
+
+The GitHub Actions connector reuses the same Vault key as the [GitHub connector](./github) — `github.pat` — and is injected at spawn as `GITHUB_PAT`. Authenticate once; both connectors work.
+
+```bash
+nimbus connector auth github
+```
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `gha_run_get` | Get a single workflow run by id. |
+| `gha_run_jobs` | List jobs for a workflow run. |
+| `gha_run_list` | List workflow runs for a repository. |
+| `gha_run_log` | Download console log text for a job (truncated). |
+| `gha_workflow_list` | List GitHub Actions workflows for a repository. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `gha_run_cancel` | Cancel a workflow run. |
+| `gha_run_trigger` | Dispatch a workflow (`workflow_dispatch`). |
+
+## See also
+
+- [GitHub connector](./github) — shares the same PAT
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/github.mdx
+++ b/packages/docs/src/content/docs/connectors/github.mdx
@@ -1,0 +1,52 @@
+---
+title: GitHub
+description: Index GitHub PRs, issues, and CI runs and act on PRs, issues, branches, and tags via personal access token.
+---
+
+The GitHub connector is the canonical first-party connector. It indexes pull requests and issues into the local SQLite index and exposes a wide read surface across repositories, PRs, issues, and Actions runs, plus a HITL-gated write surface for the operations on-call engineers reach for most: merging PRs, creating issues, deleting branches.
+
+---
+
+## What's indexed
+
+- **Service id:** `github`
+- **Item types:** `pr`, `issue`
+
+## Authenticate
+
+```bash
+nimbus connector auth github
+```
+
+Stored in the Vault as `github.pat` and injected at spawn as `GITHUB_PAT`. Use a [fine-grained personal access token](https://github.com/settings/personal-access-tokens) scoped to the repositories you want indexed.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `github_ci_run_get` | Get a single workflow run including jobs URL reference. |
+| `github_ci_runs` | List GitHub Actions workflow runs for a repository. |
+| `github_issue_get` | Get a single issue by number. |
+| `github_issue_list` | List issues for a repository. |
+| `github_pr_get` | Get a single pull request by number. |
+| `github_pr_list` | List pull requests for a repository. |
+| `github_repo_get` | Get repository metadata (owner/repo). |
+| `github_repo_list` | List repositories the authenticated user owns or collaborates on. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `github_branch_delete` | Delete a branch by ref name. |
+| `github_issue_create` | Create a new issue in a repository. |
+| `github_pr_close` | Close a pull request without merging. |
+| `github_pr_merge` | Merge a pull request. |
+| `github_tag_create` | Create a lightweight tag pointing at a commit SHA. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [GitHub Actions connector](./github-actions) — separate connector for deeper Actions read surface
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/gitlab.mdx
+++ b/packages/docs/src/content/docs/connectors/gitlab.mdx
@@ -1,0 +1,55 @@
+---
+title: GitLab
+description: Index GitLab merge requests, issues, and CI pipelines. Works against gitlab.com or self-hosted.
+---
+
+The GitLab connector indexes merge requests, issues, and CI pipeline runs into the local SQLite index and exposes a wide read surface across projects, MRs, issues, pipelines, and job traces, plus three HITL-gated write tools.
+
+---
+
+## What's indexed
+
+- **Service id:** `gitlab`
+- **Item types:** `pr`, `issue`, `ci_run`
+
+## Authenticate
+
+```bash
+nimbus connector auth gitlab
+```
+
+Stored in the Vault as `gitlab.pat` (and optionally `gitlab.api_base_url` for self-hosted instances) and injected at spawn as `GITLAB_PAT` / `GITLAB_API_BASE_URL`. The MCP server uses the `PRIVATE-TOKEN` header.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `gitlab_issue_get` | Get a single issue by IID. |
+| `gitlab_issue_list` | List issues for a project. |
+| `gitlab_job_log_tail` | Download job trace text, optionally keeping only the last N characters. |
+| `gitlab_job_trace` | Download plain-text trace for a CI job (by job id). |
+| `gitlab_mr_get` | Get a single merge request by IID. |
+| `gitlab_mr_list` | List merge requests for a project. |
+| `gitlab_pipeline_get` | Get a single pipeline by id. |
+| `gitlab_pipeline_jobs_get` | List jobs for a CI pipeline (by pipeline id). |
+| `gitlab_pipeline_list` | List CI pipelines for a project. |
+| `gitlab_project_list` | List projects visible to the authenticated user (membership). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `gitlab_mr_merge` | Merge a merge request. |
+| `gitlab_pipeline_cancel` | Cancel a pipeline. |
+| `gitlab_pipeline_retry` | Retry failed jobs in a pipeline. |
+
+## Platform notes
+
+- For **self-hosted GitLab**, set `gitlab.api_base_url` in the Vault (e.g. `https://gitlab.example.com/api/v4`). Defaults to `https://gitlab.com/api/v4`.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/gmail.mdx
+++ b/packages/docs/src/content/docs/connectors/gmail.mdx
@@ -1,0 +1,45 @@
+---
+title: Gmail
+description: Index Gmail messages and threads, and send/draft mail through HITL-gated write tools.
+---
+
+The Gmail connector indexes message metadata into the local SQLite index and exposes read tools for labels, messages, and threads, plus three HITL-gated write tools for drafting and sending mail.
+
+---
+
+## What's indexed
+
+- **Service id:** `gmail`
+- **Item types:** `email`
+
+## Authenticate
+
+```bash
+nimbus connector auth gmail
+```
+
+OAuth (Google). The Gateway resolves a short-lived access token per service via the per-service Google OAuth flow and injects it into the connector spawn as `GOOGLE_OAUTH_ACCESS_TOKEN`. Tokens are never logged and never reach the LLM context.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `gmail_label_list` | List all Gmail labels. |
+| `gmail_message_list` | List Gmail message ids (metadata). Supports a Gmail search `q` (same syntax as the Gmail UI). |
+| `gmail_message_read` | Read a single Gmail message (`format`: `minimal` \| `metadata` \| `full` \| `raw`). |
+| `gmail_thread_read` | Read a Gmail thread and its messages. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `gmail_draft_create` | Create a Gmail draft. |
+| `gmail_draft_send` | Send an existing Gmail draft by id. |
+| `gmail_message_send` | Send a new Gmail message (not a draft). |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/google-drive.mdx
+++ b/packages/docs/src/content/docs/connectors/google-drive.mdx
@@ -1,0 +1,46 @@
+---
+title: Google Drive
+description: Index Drive files and folders, download content, and create / move / rename / trash files via HITL-gated write tools.
+---
+
+The Google Drive connector indexes file and folder metadata into the local SQLite index and exposes read tools for listing, searching, and downloading files, plus four HITL-gated write tools for create / move / rename / trash.
+
+---
+
+## What's indexed
+
+- **Service id:** `google_drive`
+- **Item types:** `file`, `folder`
+
+## Authenticate
+
+```bash
+nimbus connector auth google-drive
+```
+
+OAuth (Google). The Gateway resolves a short-lived access token per service via the per-service Google OAuth flow and injects it into the connector spawn as `GOOGLE_OAUTH_ACCESS_TOKEN`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `gdrive_file_download` | Download file bytes (base64) or text (utf-8 for `text/*`). Google Docs export to plain text; Sheets to CSV. Capped by `maxBytes` (default 256 KiB, max 16 MiB). |
+| `gdrive_file_list` | List Drive files (metadata only). Supports pagination via `pageToken`. |
+| `gdrive_file_metadata` | Get metadata for a single Drive file or folder (owners, parents, links, mimeType, description). |
+| `gdrive_file_search` | Full-text search over Drive (`fullText contains`). Non-trashed files only. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `gdrive_file_create` | Create a Drive file. Optional text `content` uses multipart upload. |
+| `gdrive_file_move` | Move a file or folder to another parent folder. |
+| `gdrive_file_rename` | Rename a Drive file or folder. |
+| `gdrive_file_trash` | Move a Drive file or folder to trash (recoverable). |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/google-photos.mdx
+++ b/packages/docs/src/content/docs/connectors/google-photos.mdx
@@ -1,0 +1,40 @@
+---
+title: Google Photos
+description: Index Google Photos albums and media item metadata. Read-only.
+---
+
+The Google Photos connector indexes album and media-item metadata into the local SQLite index and exposes read tools for listing and searching photos. Read-only — there are no write tools.
+
+---
+
+## What's indexed
+
+- **Service id:** `google_photos`
+- **Item types:** `photo`
+
+## Authenticate
+
+```bash
+nimbus connector auth google-photos
+```
+
+OAuth (Google). The Gateway resolves a short-lived access token per service via the per-service Google OAuth flow and injects it into the connector spawn as `GOOGLE_OAUTH_ACCESS_TOKEN`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `gphotos_album_get` | Get a single album by id (title, mediaItemsCount, coverPhotoBaseUrl). |
+| `gphotos_album_list` | List Google Photos albums (metadata). Supports pagination. |
+| `gphotos_media_get` | Get a single media item by id. |
+| `gphotos_media_list` | List media items (metadata + `baseUrl` / `productUrl` only). Optional `albumId` scopes to one album. |
+| `gphotos_media_search` | Search media items. Optional album filter; supports pagination. |
+
+## Write tools (HITL-gated)
+
+_No write tools — this connector is read-only._
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/grafana.mdx
+++ b/packages/docs/src/content/docs/connectors/grafana.mdx
@@ -1,0 +1,37 @@
+---
+title: Grafana
+description: Index Grafana dashboards and read alert rules. Read-only.
+---
+
+The Grafana connector indexes dashboard metadata into the local SQLite index and exposes read tools for dashboards and alert rules. Read-only — there are no write tools.
+
+---
+
+## What's indexed
+
+- **Service id:** `grafana`
+- **Item types:** `dashboard`
+
+## Authenticate
+
+```bash
+nimbus connector auth grafana
+```
+
+Stored in the Vault as `grafana.url` and `grafana.api_token` and injected at spawn as `GRAFANA_URL` / `GRAFANA_API_TOKEN`. The MCP server uses Bearer auth against the Grafana API.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `grafana_alert_list` | List alert rules (Ruler API). |
+| `grafana_dashboard_list` | Search dashboards. |
+
+## Write tools (HITL-gated)
+
+_No write tools — this connector is read-only._
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/iac.mdx
+++ b/packages/docs/src/content/docs/connectors/iac.mdx
@@ -1,0 +1,53 @@
+---
+title: Infrastructure as Code (Terraform / OpenTofu / Pulumi)
+description: Run terraform / pulumi / cloudformation plans and applies in a working directory. Opt-in.
+---
+
+The IaC connector exposes a small set of CLI-driven tools for `terraform`, OpenTofu, Pulumi, and AWS CloudFormation against a caller-supplied working directory. Reads (`plan`, `preview`) are no-HITL; every state-mutating tool (`apply`, `destroy`, `up`, `deploy`) is HITL-gated. Opt-in.
+
+---
+
+## What's indexed
+
+- **Service id:** `iac`
+- **Item types:** `sync_heartbeat`
+
+The IaC connector does not scan repositories. The sync emits a heartbeat with indexed AWS Lambda counts (consumed by `nimbus status --drift`); all other operation is on-demand against a `workingDirectory` you pass at call time.
+
+## Authenticate
+
+```bash
+# Opt in
+nimbus vault set iac.enabled 1
+```
+
+The connector inherits the ambient process environment, so cloud credentials come from your usual `terraform` / `pulumi` / `aws` setup (`AWS_PROFILE`, `~/.aws/credentials`, `gcloud auth`, etc.). Without `iac.enabled = "1"` in the Vault, the syncable returns a no-op.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `iac_pulumi_preview` | Run `pulumi preview` in a stack directory. |
+| `iac_terraform_plan` | Run `terraform plan` in a directory. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `iac_cloudformation_deploy` | Deploy a CloudFormation stack via AWS CLI. |
+| `iac_pulumi_up` | Run `pulumi up`. |
+| `iac_terraform_apply` | Run `terraform apply`. |
+| `iac_terraform_destroy` | Run `terraform destroy`. |
+
+## Platform notes
+
+- Requires the relevant CLI on `PATH`: **`terraform`** (or **`tofu`**) for terraform tools, **`pulumi`** for pulumi tools, **`aws`** for `cloudformation_deploy`.
+- All operations take a `workingDirectory` argument and execute there with the caller's ambient cloud credentials.
+
+## See also
+
+- [AWS connector](./aws), [GCP connector](./gcp), [Azure connector](./azure) — for cloud credential setup
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/jenkins.mdx
+++ b/packages/docs/src/content/docs/connectors/jenkins.mdx
@@ -1,0 +1,45 @@
+---
+title: Jenkins
+description: Index Jenkins builds and trigger / abort builds with HITL-gated write tools.
+---
+
+The Jenkins connector indexes build metadata into the local SQLite index and exposes read tools for jobs and builds, plus two HITL-gated write tools for triggering and aborting builds.
+
+---
+
+## What's indexed
+
+- **Service id:** `jenkins`
+- **Item types:** `ci_run`
+
+## Authenticate
+
+```bash
+nimbus connector auth jenkins
+```
+
+Stored in the Vault as `jenkins.base_url`, `jenkins.username`, and `jenkins.api_token`. The MCP server uses HTTP Basic auth and fetches a CSRF crumb for write operations.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `jenkins_build_get` | Get a single build by job name and build number. |
+| `jenkins_build_list` | List recent builds for a job. |
+| `jenkins_build_log_tail` | Fetch console text for a build (full log; tail client-side). |
+| `jenkins_job_get` | Get Jenkins job metadata by full name. |
+| `jenkins_job_list` | List Jenkins jobs (nested folders, limited depth). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `jenkins_build_abort` | Abort/stop a running build. |
+| `jenkins_build_trigger` | Trigger a new build for a job. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/jira.mdx
+++ b/packages/docs/src/content/docs/connectors/jira.mdx
@@ -1,0 +1,51 @@
+---
+title: Jira
+description: Index Jira issues, search via JQL, and create / update / comment with HITL-gated write tools. Cloud only.
+---
+
+The Jira connector indexes issues into the local SQLite index and exposes read tools for issues, boards, sprints, and epics, plus three HITL-gated write tools for creating, updating, and commenting. Jira Cloud only.
+
+---
+
+## What's indexed
+
+- **Service id:** `jira`
+- **Item types:** `issue`
+
+## Authenticate
+
+```bash
+nimbus connector auth jira
+```
+
+Stored in the Vault as `jira.base_url`, `jira.email`, and `jira.api_token` and injected at spawn as `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`. The MCP server uses Atlassian Basic auth (email + API token). Generate an API token at [id.atlassian.com → Security → API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `jira_board_list` | List Jira boards (`GET /rest/agile/1.0/board`). |
+| `jira_epic_list` | List epics in a project via JQL search. |
+| `jira_issue_get` | Get a Jira issue by key or id. |
+| `jira_issue_list` | Search Jira issues with JQL (`POST /rest/api/3/search`). |
+| `jira_sprint_list` | List sprints for a board. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `jira_comment_add` | Add a comment to a Jira issue. |
+| `jira_issue_create` | Create a Jira issue (requires project key + summary). |
+| `jira_issue_update` | Update summary and/or description on a Jira issue. |
+
+## Platform notes
+
+- **Jira Cloud only.** The base URL must be a `*.atlassian.net` site.
+
+## See also
+
+- [Confluence connector](./confluence) — Atlassian sibling, same auth pattern
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/kubernetes.mdx
+++ b/packages/docs/src/content/docs/connectors/kubernetes.mdx
@@ -1,0 +1,50 @@
+---
+title: Kubernetes
+description: Index workload state and act on deployments / pods through your existing kubeconfig.
+---
+
+The Kubernetes connector indexes deployment state into the local SQLite index and exposes a small read + HITL-gated write surface against whatever cluster your kubeconfig points at. The MCP server shells out to `kubectl`.
+
+---
+
+## What's indexed
+
+- **Service id:** `kubernetes`
+- **Item types:** `k8s_workload`
+
+## Authenticate
+
+```bash
+nimbus connector auth kubernetes
+```
+
+Stored in the Vault as `kubernetes.kubeconfig` (path) and optionally `kubernetes.context`. The kubeconfig path is exported into the connector spawn as `KUBECONFIG`; the optional context is passed via `--context`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `k8s_deployment_list` | List deployments in a namespace. |
+| `k8s_event_list` | List events in a namespace. |
+| `k8s_pod_list` | List pods in a namespace (default: `default`). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `k8s_deployment_scale` | Scale a deployment. |
+| `k8s_pod_delete` | Delete a pod. |
+| `k8s_rollout_restart` | Restart a rollout (e.g. deployment). |
+
+## Platform notes
+
+- Requires the **`kubectl` CLI** on `PATH` and a valid kubeconfig file.
+- The sync handler runs `kubectl get deployments -A -o json` once per cycle.
+- The MCP server throws on startup if `KUBECONFIG` is unset.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/linear.mdx
+++ b/packages/docs/src/content/docs/connectors/linear.mdx
@@ -1,0 +1,48 @@
+---
+title: Linear
+description: Index Linear issues and act on issues + comments via HITL-gated write tools.
+---
+
+The Linear connector indexes issues into the local SQLite index and exposes read tools for issues, projects, cycles, members, and roadmap initiatives, plus three HITL-gated write tools for creating issues, updating issues, and adding comments.
+
+---
+
+## What's indexed
+
+- **Service id:** `linear`
+- **Item types:** `issue`
+
+## Authenticate
+
+```bash
+nimbus connector auth linear
+```
+
+Stored in the Vault as `linear.api_key` and injected at spawn as `LINEAR_API_KEY`. Generate a personal API key at [linear.app/settings/api](https://linear.app/settings/api).
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `linear_cycle_list` | List Linear cycles for a team. |
+| `linear_issue_get` | Get a single Linear issue by UUID id. |
+| `linear_issue_list` | List Linear issues with optional filters (team id, state name, assignee id). |
+| `linear_member_list` | List users in the workspace. |
+| `linear_project_get` | Get a Linear project by id. |
+| `linear_project_list` | List Linear projects. |
+| `linear_roadmap_list` | List Linear initiatives (roadmap). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `linear_comment_create` | Add a comment to a Linear issue. |
+| `linear_issue_create` | Create a Linear issue (requires `teamId` and `title`). |
+| `linear_issue_update` | Update a Linear issue by id. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/newrelic.mdx
+++ b/packages/docs/src/content/docs/connectors/newrelic.mdx
@@ -1,0 +1,41 @@
+---
+title: New Relic
+description: Index APM applications and read alert violations. Read-only. US region only today.
+---
+
+The New Relic connector indexes APM applications into the local SQLite index and exposes read tools for applications and alert violations. Read-only — there are no write tools.
+
+---
+
+## What's indexed
+
+- **Service id:** `newrelic`
+- **Item types:** `application`
+
+## Authenticate
+
+```bash
+nimbus connector auth newrelic
+```
+
+Stored in the Vault as `newrelic.api_key` and injected at spawn as `NEW_RELIC_API_KEY`. The MCP server uses the `X-Api-Key` header.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `newrelic_alert_violations` | List recent alert violations. |
+| `newrelic_application_list` | List APM applications. |
+
+## Write tools (HITL-gated)
+
+_No write tools — this connector is read-only._
+
+## Platform notes
+
+- The API host is hardcoded to `api.newrelic.com` (US region only). EU region (`api.eu.newrelic.com`) is not configurable through the current connector.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/notion.mdx
+++ b/packages/docs/src/content/docs/connectors/notion.mdx
@@ -1,0 +1,48 @@
+---
+title: Notion
+description: Index Notion pages and databases and act on pages, blocks, and comments via HITL-gated write tools.
+---
+
+The Notion connector indexes pages into the local SQLite index and exposes read tools for pages, databases, blocks, and comments, plus four HITL-gated write tools for creating pages, appending blocks, and posting comments.
+
+---
+
+## What's indexed
+
+- **Service id:** `notion`
+- **Item types:** `page`
+
+## Authenticate
+
+```bash
+nimbus connector auth notion
+```
+
+OAuth (Notion). The Gateway resolves a Bearer access token via the Notion OAuth flow (refreshed via `getValidNotionAccessToken`) and injects it into the connector spawn as `NOTION_ACCESS_TOKEN`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `notion_block_children` | List child blocks of a block or page. |
+| `notion_comment_list` | List comments for a block or page. |
+| `notion_database_list` | Search Notion databases (`POST /v1/search`, object filter `database`). |
+| `notion_database_query` | Query a Notion database. |
+| `notion_page_get` | Retrieve a Notion page and its direct child blocks. |
+| `notion_page_list` | Search Notion pages the integration can access (`POST /v1/search`, object filter `page`). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `notion_block_append` | Append blocks to a parent block. `childrenJson` is a JSON array of block objects. |
+| `notion_comment_create` | Create a comment thread on a page. |
+| `notion_page_create` | Create a page under a parent page. |
+| `notion_page_update` | Update page properties. Pass properties JSON as a string. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/obsidian.mdx
+++ b/packages/docs/src/content/docs/connectors/obsidian.mdx
@@ -1,0 +1,47 @@
+---
+title: Obsidian
+description: Index local Obsidian vaults — notes, frontmatter tags, and wikilink graph. Filesystem-only, no network.
+---
+
+The Obsidian connector indexes notes from local Obsidian vaults into the local SQLite index, including frontmatter tags and wikilink graph edges. It exposes read tools for listing, reading, and substring-searching notes across all configured vaults, plus one HITL-gated write tool for appending to today's daily note.
+
+This is a **filesystem-only** connector — no network call, no remote credential. Vault roots come from `[[filesystem.roots]]` in your `nimbus.toml`.
+
+---
+
+## What's indexed
+
+- **Service id:** `obsidian`
+- **Item types:** `obsidian_note`
+- **Graph:** wikilink edges are also written to `graph_entity` / `graph_relation` for cross-note traversal.
+
+## Authenticate
+
+No credential. The Gateway discovers vaults by walking each `[[filesystem.roots]]` path for a `.obsidian/` marker directory and exposes the discovered vault list to the MCP server as `OBSIDIAN_VAULT_PATHS_JSON` (a JSON array of absolute paths).
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `obsidian_get` | Read a single Obsidian note by id, or by `(vault, path)` pair. |
+| `obsidian_list` | List Obsidian notes (optionally filtered by vault id, vault path, or frontmatter tag). |
+| `obsidian_search` | Substring-match against note title and body across all configured vaults. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `obsidian_append_to_daily_note` | Append text to today's daily note. Creates the file if it does not exist. **Always appends — never overwrites.** Adds a leading newline when the existing file does not end in one. |
+
+## Platform notes
+
+- **Local-only.** Vault roots come from `[[filesystem.roots]]` in `nimbus.toml`. Vaults are auto-discovered by walking each root for a `.obsidian/` marker.
+- All paths are validated by `assertWithinVault` against directory traversal — `..` segments and absolute paths outside the vault root are rejected.
+- The sync also writes to the `obsidian_notes` table and the graph tables (`graph_entity` / `graph_relation`) so wikilink follows work in agent searches.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/onedrive.mdx
+++ b/packages/docs/src/content/docs/connectors/onedrive.mdx
@@ -1,0 +1,44 @@
+---
+title: OneDrive
+description: Index OneDrive files and folders, download content, and act on items via HITL-gated write tools.
+---
+
+The OneDrive connector indexes file and folder metadata into the local SQLite index and exposes read tools for listing, searching, and downloading items, plus two HITL-gated write tools for moving and deleting.
+
+---
+
+## What's indexed
+
+- **Service id:** `onedrive`
+- **Item types:** `file`, `folder`
+
+## Authenticate
+
+```bash
+nimbus connector auth onedrive
+```
+
+OAuth (Microsoft Graph). The Gateway resolves a short-lived access token via the Microsoft OAuth flow (`getValidMicrosoftAccessToken`) and injects it into the connector spawn as `MICROSOFT_OAUTH_ACCESS_TOKEN`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `onedrive_item_download` | Download file content as base64 (capped by `maxBytes`, default 256 KiB). Folders are rejected. |
+| `onedrive_item_get` | Get OneDrive item metadata by id (file or folder). |
+| `onedrive_item_list` | List drive items under root or a folder (by `parentId`). Use `nextLink` from prior response for pagination. |
+| `onedrive_item_search` | Search OneDrive under `/me/drive/root/search`. |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `onedrive_item_delete` | Permanently delete a OneDrive item. |
+| `onedrive_item_move` | Move (and optionally rename) a drive item. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/outlook.mdx
+++ b/packages/docs/src/content/docs/connectors/outlook.mdx
@@ -1,0 +1,54 @@
+---
+title: Outlook
+description: Index Outlook mail and read mail / calendar / contacts. Tools register conditionally on granted Microsoft Graph scopes.
+---
+
+The Outlook connector indexes mail messages into the local SQLite index and exposes read tools across mail, calendar, and contacts, plus three HITL-gated write tools for sending mail and creating / deleting calendar events.
+
+Tools are **registered conditionally** based on the granted Microsoft Graph scopes — if a tool's required scope is not in `MICROSOFT_OAUTH_SCOPES`, it is not registered and the agent cannot call it.
+
+---
+
+## What's indexed
+
+- **Service id:** `outlook`
+- **Item types:** `email` (sync only indexes mail; calendar and contacts are MCP-only surfaces)
+
+## Authenticate
+
+```bash
+nimbus connector auth outlook
+```
+
+OAuth (Microsoft Graph). The Gateway resolves a short-lived access token via the Microsoft OAuth flow and injects it into the connector spawn as `MICROSOFT_OAUTH_ACCESS_TOKEN`. The granted scope set is also injected as `MICROSOFT_OAUTH_SCOPES` (space-separated) and gates which tools register at startup.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `outlook_calendar_get` | Get a single calendar event by id. |
+| `outlook_calendar_list` | List calendar events in a time window (ISO 8601 `startDateTime` / `endDateTime`). |
+| `outlook_contact_get` | Get a single contact by id. |
+| `outlook_contact_list` | List contacts from the default folder. |
+| `outlook_mail_folders` | List mail folders (pagination via `nextLink`). |
+| `outlook_mail_list` | List mail messages (default folder `inbox` if `folderId` omitted). Pagination via `nextLink`. |
+| `outlook_mail_read` | Read a single message (body, headers, attachments metadata). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `outlook_calendar_create` | Create a calendar event. |
+| `outlook_calendar_delete` | Delete a calendar event. |
+| `outlook_mail_send` | Send an email via Microsoft Graph. |
+
+## Platform notes
+
+- **Scope-gated tool registration.** Tools whose required Microsoft Graph scope is not in `MICROSOFT_OAUTH_SCOPES` are not registered at startup. Re-authenticate with broader scopes if you want more tools available.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/overview.mdx
+++ b/packages/docs/src/content/docs/connectors/overview.mdx
@@ -1,6 +1,8 @@
 ---
 title: First-party connectors
 description: Built-in MCP connectors — authenticate with nimbus connector auth
+sidebar:
+  order: 0
 ---
 
 Nimbus ships first-party MCP servers under `packages/mcp-connectors/` in the repository. Each connector syncs metadata into your local SQLite index; the Engine talks to connectors **only over MCP** (never direct cloud SDK calls from the Gateway).

--- a/packages/docs/src/content/docs/connectors/pagerduty.mdx
+++ b/packages/docs/src/content/docs/connectors/pagerduty.mdx
@@ -1,0 +1,52 @@
+---
+title: PagerDuty
+description: Index PagerDuty incidents (with metadata for DORA MTTR) and act on incidents via HITL-gated write tools.
+---
+
+The PagerDuty connector indexes incidents into the local SQLite index — including the metadata fields used by DORA MTTR calculations — and exposes read tools for incidents plus three HITL-gated write tools for acknowledging, escalating, and resolving.
+
+---
+
+## What's indexed
+
+- **Service id:** `pagerduty`
+- **Item types:** `incident`
+- **DORA-relevant metadata** (written into `metadata` on every incident upsert):
+  - `opened_at_ms` — parsed from `created_at`; the X axis for MTTR
+  - `pagerduty_service_id` — from `service.id`; lets DORA group incidents per service
+  - `severity` — from `priority.name`; used for severity-aware filtering
+
+## Authenticate
+
+```bash
+nimbus connector auth pagerduty
+```
+
+Stored in the Vault as `pagerduty.api_token` and injected at spawn as `PAGERDUTY_API_TOKEN`. The MCP server uses the `Authorization: Token token=...` header.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `pd_incident_get` | Get a single incident by id. |
+| `pd_incident_list` | List PagerDuty incidents (open and recently resolved). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `pd_incident_acknowledge` | Acknowledge an incident. |
+| `pd_incident_escalate` | Escalate an incident. |
+| `pd_incident_resolve` | Resolve an incident. |
+
+## Platform notes
+
+- **Sync watermark.** The cursor is the `updated_at` watermark (`{ lastUpdated }`); initial sync depth is 30 days; the API call uses `sort_by=updated_at`.
+- The API host is hardcoded to `https://api.pagerduty.com` (no EU/region knob today).
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/sentry.mdx
+++ b/packages/docs/src/content/docs/connectors/sentry.mdx
@@ -1,0 +1,41 @@
+---
+title: Sentry
+description: Index Sentry projects and read unresolved issues + releases. Read-only.
+---
+
+The Sentry connector indexes project metadata into the local SQLite index and exposes read tools for unresolved issues and releases. Read-only — there are no write tools.
+
+---
+
+## What's indexed
+
+- **Service id:** `sentry`
+- **Item types:** `project`
+
+## Authenticate
+
+```bash
+nimbus connector auth sentry
+```
+
+Stored in the Vault as `sentry.url`, `sentry.org_slug`, and `sentry.auth_token` and injected at spawn as `SENTRY_URL`, `SENTRY_ORG_SLUG`, `SENTRY_AUTH_TOKEN`. The MCP server uses Bearer auth.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `sentry_issue_list` | List unresolved issues for a project. |
+| `sentry_release_list` | List releases for a project. |
+
+## Write tools (HITL-gated)
+
+_No write tools — this connector is read-only._
+
+## Platform notes
+
+- **`SENTRY_URL` is optional** and defaults to `https://sentry.io`. Set it for self-hosted Sentry instances.
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/slack.mdx
+++ b/packages/docs/src/content/docs/connectors/slack.mdx
@@ -1,0 +1,48 @@
+---
+title: Slack
+description: Index Slack messages from your channels + DMs and post messages with HITL-gated write tools.
+---
+
+The Slack connector indexes channel and DM messages into the local SQLite index and exposes read tools across channels, DMs, threads, search, and users, plus two HITL-gated write tools for posting messages.
+
+---
+
+## What's indexed
+
+- **Service id:** `slack`
+- **Item types:** `message`
+
+## Authenticate
+
+```bash
+nimbus connector auth slack
+```
+
+OAuth (Slack user access token). The Gateway resolves a short-lived user access token via the Slack OAuth flow (refreshed via `getValidSlackAccessToken`) and injects it into the connector spawn as `SLACK_USER_ACCESS_TOKEN`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `slack_channel_history` | Fetch message history for a channel, DM, or mpim. |
+| `slack_channel_list` | List channels the user is a member of (public, private, mpim, im). |
+| `slack_dm_history` | Fetch DM / mpim history (alias of `channel_history`). |
+| `slack_dm_list` | List direct message conversations (im + mpim). |
+| `slack_search` | Search messages (workspace search). |
+| `slack_thread_replies` | Fetch replies in a thread (channel + thread parent ts). |
+| `slack_user_get` | Get a single user profile by ID. |
+| `slack_user_list` | List users in the workspace (paginated). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `slack_message_post` | Post a message to a channel. |
+| `slack_message_post_dm` | Open or find a DM with user id(s) and send a message. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)

--- a/packages/docs/src/content/docs/connectors/teams.mdx
+++ b/packages/docs/src/content/docs/connectors/teams.mdx
@@ -1,0 +1,45 @@
+---
+title: Microsoft Teams
+description: Index Teams channel messages and post to channels + chats with HITL-gated write tools.
+---
+
+The Microsoft Teams connector indexes channel messages into the local SQLite index and exposes read tools for teams, channels, chats, and messages, plus two HITL-gated write tools for posting to channels and chats.
+
+---
+
+## What's indexed
+
+- **Service id:** `teams`
+- **Item types:** `message` (channel messages; external id format `<teamId>:<channelId>:<messageId>`)
+
+## Authenticate
+
+```bash
+nimbus connector auth teams
+```
+
+OAuth (Microsoft Graph). The Gateway resolves a short-lived access token via the Microsoft OAuth flow (`getValidMicrosoftAccessToken`) and injects it into the connector spawn as `MICROSOFT_OAUTH_ACCESS_TOKEN`.
+
+## Read tools (no HITL)
+
+| Tool | Purpose |
+|---|---|
+| `teams_channel_list` | List channels in a team (standard + private the app can read). |
+| `teams_channel_messages` | List recent messages in a team channel (not delta; for interactive reads). |
+| `teams_chat_list` | List 1:1 and group chats for the signed-in user. |
+| `teams_chat_messages` | List messages in a chat. |
+| `teams_team_list` | List Microsoft Teams the signed-in user has joined (pagination via `nextLink`). |
+
+## Write tools (HITL-gated)
+
+Every tool below requires interactive consent through the Gateway HITL gate before it executes.
+
+| Tool | Purpose |
+|---|---|
+| `teams_message_post` | Post a message to a team channel. |
+| `teams_message_post_chat` | Post a message to a chat. |
+
+## See also
+
+- [Connectors overview](./overview)
+- [HITL and safety](../user-guide/hitl-and-safety/)


### PR DESCRIPTION
## Summary

- Closes #243
- Adds dedicated MDX pages under [`packages/docs/src/content/docs/connectors/`](packages/docs/src/content/docs/connectors/) for **every** first-party connector under `packages/mcp-connectors/`
- Pinned `overview.mdx` first in the sidebar via `sidebar.order: 0`
- Picked up automatically by the existing `autogenerate: { directory: \"connectors\" }` sidebar entry in `astro.config.mjs`

## Coverage (29 new files)

| Category | Connectors |
|---|---|
| Dev / Code | `bitbucket`, `circleci`, `github`, `github-actions`, `gitlab`, `jenkins` |
| Google | `gmail`, `google-drive`, `google-photos` |
| Microsoft | `onedrive`, `outlook`, `teams` |
| Work tracking | `confluence`, `jira`, `linear`, `notion` |
| Chat / notes | `discord` (opt-in), `obsidian` (filesystem-only), `slack` |
| Cloud / IaC | `aws`, `azure`, `gcp`, `iac`, `kubernetes` |
| Observability | `datadog`, `grafana`, `newrelic`, `pagerduty`, `sentry` |

## Page structure

Every page covers the four sections the issue asked for:

1. **What's indexed** — service id and the exact `item_type` values written to the SQLite index
2. **Authenticate** — the `nimbus connector auth <id>` command, the Vault keys the Gateway reads, and the env vars injected into the connector spawn
3. **Read tools (no HITL)** — the full read surface as a table
4. **Write tools (HITL-gated)** — every mutating tool, or an explicit \"read-only\" note when the connector has none
5. **Platform notes** — only when there's something OS-specific, CLI-prerequisite, region-gated, opt-in, or scope-gated

## Data source

Everything was extracted directly from each connector's `src/server.ts` (tool names + descriptions, env vars) and the matching `packages/gateway/src/connectors/<name>-sync.ts` (item types). No invented tool names. No invented auth env vars. Where a sync handler does not write items (`iac`), the item type is documented as such (`sync_heartbeat`).

## Acceptance against #243

- ✅ At least the six required connectors (`github`, `gmail`, `google-drive`, `slack`, `linear`, `jira`) have dedicated pages — plus 23 more
- ✅ Each page follows the structure of the user-guide pages (frontmatter + sections separated by `---`)
- ✅ The `connectors` sidebar entry already uses `autogenerate: { directory: \"connectors\" }` (in `packages/docs/astro.config.mjs:44`) so all 30 files are picked up automatically; `overview.mdx` pinned first via `sidebar.order: 0`

## Test plan

- [ ] `cd packages/docs && bunx astro build` — confirm the build is green (links validator)
- [ ] `cd packages/docs && bunx astro dev` — open the local site, confirm 30 pages render under the \"Connectors (per-service)\" sidebar group, overview first
- [ ] Lychee CI gate (Docs Quality workflow) verifies no broken internal/external links

🤖 Generated with [Claude Code](https://claude.com/claude-code)