### PR TITLE
ci: wire structure audit into ci.yml

### DIFF
--- a/.github/workflows/_structure.yml
+++ b/.github/workflows/_structure.yml
@@ -2,15 +2,16 @@ name: Structure audit
 
 # Reusable workflow — fast PR check (≤30 s budget) for the binary subset of
 # audit:* gates: D1/D2/D3 (boundaries), D8 (any-count ratchet), D10/D11
-# (Nimbus invariants).
+# (Nimbus invariants), and release-please manifest drift.
 #
 # Ubuntu-only by design: every gate is static analysis with zero OS variance.
 # The platform-equality non-negotiable is a runtime property
 # (B3 structure audit design § 6.1).
 #
-# NOT YET wired into ci.yml — current main has 5 D10 + 56 D11 violations
-# (Phase 2 missed.md). The last top-5 fix PR (Phase 3) wires this once
-# D10/D11 are clean.
+# Wired into ci.yml as `pr-quality-structure` (PR side) and `ci-structure`
+# (push side). Failures block PRs — the D8 any-count ratchet and the D10/D11
+# nimbus-invariant checks are the static-time complement to runtime
+# enforcement in `security-invariants.test.ts`.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,16 @@ jobs:
         # Exclude dependencies and tests to avoid false positives.
         run: bunx jscpd --min-lines 10 --min-tokens 50 --threshold 5 --reporters console -i "**/node_modules/**,**/*.test.ts,**/*.test.tsx,**/*.vitest.tsx" packages/
 
+  # Structure audit — D1/D2/D3 boundaries, D8 any-count ratchet, D10/D11
+  # nimbus-invariants, release-please manifest drift. Static-time complement
+  # to runtime enforcement in `security-invariants.test.ts`.
+  pr-quality-structure:
+    name: PR quality — Structure audit
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/_structure.yml
+    permissions:
+      contents: read
+
   # ── Push: full cross-platform matrix (two parallel matrix jobs) ────────────
 
   # TS/Bun suite — all 3 OSes, runs in parallel with ci-rust
@@ -242,6 +252,15 @@ jobs:
 
       - name: Setup Rust + Tauri checks
         uses: ./.github/actions/setup-rust-tauri
+
+  # Structure audit on push — same gates as `pr-quality-structure`. Cheap to
+  # re-run; catches the case where a force-push or merge bypasses the PR gate.
+  ci-structure:
+    if: github.event_name == 'push'
+    name: CI — Structure audit
+    uses: ./.github/workflows/_structure.yml
+    permissions:
+      contents: read
 
   # ── E2E Desktop ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- The `_structure.yml` reusable workflow has existed since Phase 4 B3 but **had no caller** — D1/D2/D3 boundaries, D8 any-count ratchet, D10/D11 nimbus-invariant checks, and release-please manifest drift were not gating PRs at all
- The deferral comment cited "5 D10 + 56 D11 violations" on main; those have since been fixed (`audit:invariants` exits 0 locally on this branch's base)
- Wire as `pr-quality-structure` (PR side, parallel with existing PR-quality jobs) and `ci-structure` (push side, matches the matrix pattern); strip the stale "NOT YET wired" header comment

## Why now
Discovered during a CI/CD audit. The static-time invariant checks are the complement to runtime enforcement in `security-invariants.test.ts`. Leaving the static side dark means a future change that breaks D10 (spawn rule) or D11 (vault-key allow-list) only fails at test runtime — and would silently regress if someone adds an `if/else` that bypasses the runtime path.

## Verified locally
- `bun run audit:boundaries` → 0 violations (621 modules cruised)
- `bun scripts/structure-audit/count-any-usage.ts --check` → 2 (matches baseline)
- `bun run audit:invariants` → exit 0
- `bun run audit:release-please` → OK
- Both YAML files parse cleanly

## Test plan
- [ ] PR-side: `pr-quality-structure` job appears in checks and passes
- [ ] Push side (after merge): `ci-structure` job appears and passes
- [ ] No regression in existing `pr-quality-*` jobs (parallel, no shared resources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)