### PR TITLE
ci: pin release-please to ubuntu-24.04 + propagate retry exit codes

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -117,10 +117,27 @@ jobs:
       - name: Unit tests (with coverage) — macOS/Windows (retry once)
         if: runner.os != 'Linux'
         shell: bash
+        # Retry-once tolerates the cold-runner timeout outliers in
+        # `packages/gateway/src/perf/` and `packages/gateway/src/platform/` on
+        # Windows/macOS that come in under budget on a warm second attempt.
+        # Critically, attempt 2's exit code MUST propagate — without that, two
+        # consecutive genuine failures look identical to two transient flakes
+        # and the job exits 0 (silent flake hiding). Mirrors the same shape
+        # used by `pr-quality-cross-platform` in `ci.yml`.
         run: |
+          set +e
           for attempt in 1 2; do
-            bun test packages/gateway packages/cli packages/sdk packages/client packages/mcp-connectors scripts --coverage --coverage-reporter=lcov --reporter=junit --reporter-outfile=junit-reports/junit-unit.xml && break
-            echo "Attempt $attempt failed, retrying in 5 s..." && sleep 5
+            bun test packages/gateway packages/cli packages/sdk packages/client packages/mcp-connectors scripts --coverage --coverage-reporter=lcov --reporter=junit --reporter-outfile=junit-reports/junit-unit.xml
+            code=$?
+            if [ "$code" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "Both attempts failed with exit code $code"
+              exit "$code"
+            fi
+            echo "Attempt $attempt failed (exit $code), retrying in 5 s..."
+            sleep 5
           done
         env:
           CI: "true"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     # Needed when using the default GITHUB_TOKEN (no RELEASE_PLEASE_PAT). Optional PAT keeps
     # the same scopes off the automatic token if you add secret RELEASE_PLEASE_PAT later.


### PR DESCRIPTION
## Summary

Two CI hardening fixes discovered during a CI/CD audit:

### 1. `release-please.yml` runner pin
`release-please.yml:14` was running on `ubuntu-latest` while every other workflow in the repo pinned `ubuntu-24.04`. When GitHub flips the `ubuntu-latest` alias, release-please would jump runner image alone — the rest of the matrix wouldn't. Pin to `ubuntu-24.04` for consistency.

### 2. `_test-suite.yml` macOS/Windows retry exit-code propagation
The retry block at L117-126 used `&& break` on success and a bare `echo` on failure, then fell out of the loop with **no explicit exit**. Two consecutive genuine failures therefore ended the script with `rc 0`, hiding flake on the very platforms where unit-test signal is weakest.

Adopt the exit-code-propagating shape already used by `pr-quality-cross-platform` in `ci.yml:147-169` (where the original author specifically noted "Unlike the `_test-suite.yml` retry, this version PROPAGATES the failed exit code from attempt 2"). The `ci.yml` site already had it right; this just brings `_test-suite.yml` in line.

## Out of scope

The third item from the audit — npm Trusted Publisher migration for `@nimbus-dev/client` and `@nimbus-dev/sdk` — needs the publishers to be configured on npm.org first. Will land as a follow-up PR once that side is set up.

## Test plan
- [ ] `release-please` job still runs successfully on the next merge to main
- [ ] No regression in `_test-suite.yml` unit-test step (the success path is unchanged; only the two-failure path differs)
- [ ] If a future macOS/Windows test genuinely fails twice, the job now exits non-zero (was previously 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)