### PR TITLE
Phase 5 T4 wrap: PagerDuty pagination + severity_p1_aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict
 **Linter:** Biome
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)
-**Status:** Phase 4 ✅ Complete · Phase 5 (Extended Surface) 🔵 Active · T4 PR 2 DORA metrics ✅ · T4 PR 3a pre-deploy check ✅ · T4 PR 3b annotation ✅ · T4 wrap-up: PagerDuty enrichment ✅ (2026-05-14) · T6 sequencing spec ✅ (2026-05-14) · T6 PR 1 I10 helpers ✅ · T6 PR 2 `tool_call_log` V29 ✅ (2026-05-15) · T6 PR 3 `vec_items_1536` V30 ✅ (2026-05-15) · Sub-project A ✅ (2026-05-15) · docs/superpowers/ pruned (2026-05-15) · `v0.1.0` released 2026-05-09 (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 13). Workstream-level status is in [`docs/roadmap.md`](./docs/roadmap.md).
+**Status:** Phase 4 ✅ Complete · Phase 5 (Extended Surface) 🔵 Active · T4 PR 2 DORA metrics ✅ · T4 PR 3a pre-deploy check ✅ · T4 PR 3b annotation ✅ · T4 wrap-up: PagerDuty enrichment ✅ (2026-05-14) · T4 wrap-up: PagerDuty pagination + severity_p1_aliases ✅ (2026-05-16) · T6 sequencing spec ✅ (2026-05-14) · T6 PR 1 I10 helpers ✅ · T6 PR 2 `tool_call_log` V29 ✅ (2026-05-15) · T6 PR 3 `vec_items_1536` V30 ✅ (2026-05-15) · Sub-project A ✅ (2026-05-15) · docs/superpowers/ pruned (2026-05-15) · `v0.1.0` released 2026-05-09 (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 13). Workstream-level status is in [`docs/roadmap.md`](./docs/roadmap.md).
 
 **Gemini CLI:** [`GEMINI.md`](./GEMINI.md) mirrors this file for the same repository — update both when changing commands, roadmap rows, or non-negotiables.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@ Nimbus is a **local-first AI agent framework** — a headless Bun Gateway proces
 **Runtime:** Bun v1.2+ / TypeScript 6.x strict  
 **Linter:** Biome  
 **License:** AGPL-3.0 (gateway/cli/mcp-connectors) + MIT (sdk)  
-**Status:** Phase 4 ✅ Complete · Phase 5 (Extended Surface) 🔵 Active · T4 PR 2 DORA metrics ✅ · T4 PR 3a pre-deploy check ✅ · T4 PR 3b annotation ✅ · T4 wrap-up: PagerDuty enrichment ✅ (2026-05-14) · T6 sequencing spec ✅ (2026-05-14) · T6 PR 1 I10 helpers ✅ · T6 PR 2 `tool_call_log` V29 ✅ (2026-05-15) · T6 PR 3 `vec_items_1536` V30 ✅ (2026-05-15) · Sub-project A ✅ (2026-05-15) · docs/superpowers/ pruned (2026-05-15) · `v0.1.0` released 2026-05-09 (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 13). Workstream-level status is in [`docs/roadmap.md`](./docs/roadmap.md).
+**Status:** Phase 4 ✅ Complete · Phase 5 (Extended Surface) 🔵 Active · T4 PR 2 DORA metrics ✅ · T4 PR 3a pre-deploy check ✅ · T4 PR 3b annotation ✅ · T4 wrap-up: PagerDuty enrichment ✅ (2026-05-14) · T4 wrap-up: PagerDuty pagination + severity_p1_aliases ✅ (2026-05-16) · T6 sequencing spec ✅ (2026-05-14) · T6 PR 1 I10 helpers ✅ · T6 PR 2 `tool_call_log` V29 ✅ (2026-05-15) · T6 PR 3 `vec_items_1536` V30 ✅ (2026-05-15) · Sub-project A ✅ (2026-05-15) · docs/superpowers/ pruned (2026-05-15) · `v0.1.0` released 2026-05-09 (headless Gateway + CLI + VS Code extension; `desktop-v0.1.0` Tauri release deferred to Phase 13). Workstream-level status is in [`docs/roadmap.md`](./docs/roadmap.md).
 
 Companion context for other agents: [`CLAUDE.md`](./CLAUDE.md) (same project facts; keep both files aligned when changing commands, roadmap rows, or non-negotiables).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -600,16 +600,18 @@ The local HTTP API and `@nimbus-dev/client` (Phase 3.5) unlock Nimbus as a data 
   names (`"Critical"`, `"SEV-1"`) pass through verbatim; a future
   `[pagerduty].severity_strategy` config knob can map them to preflight's P1 filter if
   user demand emerges.
-- [ ] **PagerDuty sync pagination** — follow `has_more` on `GET /incidents` and walk pages
-  until exhausted (or until a `[pagerduty].max_pages_per_sync` cap is hit). Today the sync
-  fetches the first 50 incidents updated since the cursor and drops the tail. DORA accuracy
-  for high-volume orgs depends on this. No new credentials.
-- [ ] **`[pagerduty].severity_strategy` config knob** — let teams map non-`"P1"` priority
-  names (`"Critical"`, `"SEV-1"`) to preflight's P1 filter; emit a `gap` note in
-  `deploy.preflight` when the connector sees `urgency: "high"` incidents with no
-  `priority.name`, so operators can self-diagnose silent-zero preflight results. Bundles
-  the alias-map and urgency-gap-warning Gemini-CLI suggested separately in the
-  enrichment review §2.2.
+- [x] **PagerDuty sync pagination** (2026-05-16, Phase 5 T4 wrap-up) — `pagerduty-sync.ts`
+  now walks pages with `sort_by=updated_at:asc` and `limit=100`, honoring `parsed.more`
+  and capping at `[pagerduty].max_pages_per_sync` (default 20, range 1..100). On cap-hit
+  the syncable returns `hasMore: true` so the scheduler re-queues; partial-failure cursors
+  preserve progress from pages already ingested. No new credentials.
+- [x] **`[pagerduty].severity_p1_aliases` config knob** (2026-05-16, Phase 5 T4 wrap-up) —
+  preflight's `selectActiveP1Incidents` now matches `LOWER(severity) IN (?, ?, ...)` over
+  the union of `"p1"` plus org-declared aliases (e.g. `"Critical"`, `"SEV-1"`). Aliases are
+  lowercased + deduped at parse time. New `PreflightGap` variant
+  `"pagerduty_urgency_without_priority"` fires when the strict filter yields zero matches
+  but high-urgency-without-priority incidents exist on the configured services, so operators
+  can self-diagnose silent-zero preflight results. Query-time evaluation — no re-index needed.
 
 #### Semantic Layer Enhancements
 

--- a/docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-review.md
+++ b/docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-review.md
@@ -1,0 +1,32 @@
+# Implementation Plan Review: Phase 5 T4 wrap-up — PagerDuty pagination + `severity_p1_aliases`
+
+## Overview
+This implementation plan provides a thorough, step-by-step breakdown of the changes needed to introduce PagerDuty sync pagination and `severity_p1_aliases` mapping. The plan is well-structured, covers all necessary edge cases from the spec, and clearly defines testing requirements.
+
+Here are a few observations, open questions, and suggestions to consider before or during execution.
+
+## Open Questions & Suggestions
+
+### 1. Inefficient Double JSON Parsing (Task 8)
+- **Context:** In Task 8, the loop fetches the PagerDuty incidents and parses the text using `const incidents = parsePagerdutyIncidents(text);`. Later, to extract the `more` boolean for pagination, the code parses the entire text again: `const parsed = JSON.parse(text) as { more?: boolean };`.
+- **Suggestion:** Parsing a large JSON payload (up to 100 incident objects) twice per page is computationally wasteful. Consider modifying the existing `parsePagerdutyIncidents` helper to return an object like `{ incidents: unknown[], more: boolean } | null`, or simply execute the `JSON.parse(text)` once inside the loop and do validation inline (or pass the already parsed object to a validation helper).
+
+### 2. Cursor Staging and Dataset Shifting (Task 8)
+- **Context:** The `sync` method accumulates `totalUpserted` and updates `maxUpdated` progressively as pages are fetched. If a sync fails midway, it returns a partial-success `SyncResult` utilizing the latest `maxUpdated`.
+- **Question/Note:** If a large batch of incidents shares the exact same `updated_at` timestamp and falls across a page boundary (e.g. 50 items on page 1, 50 items on page 2), and a failure occurs on page 2, the cursor saves the timestamp. On the next sync run, `since` will equal that timestamp, and PagerDuty will return *all* items with that timestamp again (starting from `offset = 0`). Since `UPSERT` is used, deduplication is handled natively by SQLite, which is safe. However, explicitly commenting on this deduplication reliance inside the code could be helpful for future maintainers.
+
+### 3. Stale `now` Timestamp in Loop (Task 8)
+- **Context:** The `now = Date.now()` timestamp is captured once before the pagination loop and passed into `syncPagerdutyIncidentItems` on every iteration.
+- **Suggestion:** Given that the loop could theoretically execute up to 100 times, potentially waiting for rate limit tokens each time, the `now` timestamp could drift significantly from the actual clock time by the final page. While using a single consistent `synced_at` timestamp for an entire sync batch is standard practice (providing atomic batch semantics), ensure this drift does not negatively impact metrics or `incidentWindowMinutes` calculations. 
+
+### 4. `severity_p1_aliases` Deduplication & SQL `IN` Clause (Task 4)
+- **Context:** Task 4 builds the SQL parameters by spreading `new Set(["p1", ...cfg.severityP1Aliases])`.
+- **Observation:** This is a very clean way to enforce uniqueness and dynamically build `sevPlaceholders`. The guard `if (cfg.pagerdutyServices.length === 0)` properly protects the `IN (${pdPlaceholders})` clause from throwing a syntax error when the array is empty. This is excellent attention to detail.
+
+### 5. `maxPagesPerSync` Parse Errors (Task 1)
+- **Context:** In Task 1, `parseNimbusPagerdutyToml` throws an error if `max_pages_per_sync` is out of bounds or non-integer.
+- **Observation:** Currently, if a user misspells the value or provides an invalid number, the parser throws an exception which could crash the gateway startup if not caught. However, `loadNimbusPagerdutyFromPath` wraps the entire parsing operation in a `try/catch` and returns the default `DEFAULT_NIMBUS_PAGERDUTY_TOML` if an error is thrown. This correctly prevents startup crashes, but it might swallow the specific validation error message silently.
+- **Suggestion:** You may want to log a warning in the `catch` block of `loadNimbusPagerdutyFromPath` so users know their `[pagerduty]` config was rejected due to an invalid value, rather than silently falling back to defaults.
+
+## Conclusion
+The plan provides an exceptional, granular guide for implementation. Addressing the double-parsing inefficiency in Task 8 is the primary actionable recommendation. The remaining points are minor observations to ensure system stability and clarity.

--- a/docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity.md
+++ b/docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity.md
@@ -1,0 +1,1728 @@
+# Phase 5 T4 wrap — PagerDuty pagination + `severity_p1_aliases` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close both Phase 5 T4 wrap-up loose ends in a single PR — multi-page PagerDuty incident sync with monotonic cursor advance under capping, and a query-time `severity_p1_aliases` mechanism (plus urgency-gap diagnostic) on the preflight P1 filter.
+
+**Architecture:** Two thematically related changes share one new `[pagerduty]` config block.
+
+1. Pagination: refactor `pagerduty-sync.ts` to walk pages while honoring `parsed.more`, with `sort_by=updated_at:asc` for cursor correctness, a configurable `max_pages_per_sync` cap (default 20, range 1..100), and `SyncResult.hasMore: true` on cap-hit so the scheduler re-queues. Also writes `metadata.urgency` for the gap probe.
+2. Preflight: widen `selectActiveP1Incidents` to match `LOWER(severity) IN (?, ?, ...)` over `Set("p1", ...lowercasedAliases)`, threaded via `ServiceConfig.severityP1Aliases`. Adds a gated probe query and a new `PreflightGap` union member `"pagerduty_urgency_without_priority"` to surface silent-zero diagnostics.
+
+No migration. No new IPC. No new HTTP route. No `ALLOWED_METHODS` change. Spec: [docs/superpowers/specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design.md](../specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design.md).
+
+**Tech Stack:** Bun 1.2+ runtime, TypeScript strict, bun:sqlite, bun:test. Existing patterns in `packages/gateway/src/config/nimbus-toml.ts` (hand-rolled section parser) and `packages/gateway/src/connectors/pagerduty-sync.ts` (factory + `Syncable` interface).
+
+**Worktree:** `.claude/worktrees/phase-5-t4-wrap-pagerduty` on branch `dev/asafgolombek/phase-5-t4-wrap-pagerduty-pagination-severity`.
+
+---
+
+## File Structure
+
+**Files to create:**
+- `packages/gateway/src/config/nimbus-toml-pagerduty.test.ts` — parser + loader tests for the new `[pagerduty]` block (mirrors `nimbus-toml-user.test.ts`).
+
+**Files to modify:**
+- `packages/gateway/src/config/nimbus-toml.ts` — add `NimbusPagerdutyToml`, parser, defaults, loaders; thread aliases into `loadNimbusServiceConfigsFromConfigDir`.
+- `packages/gateway/src/metrics/dora-config.ts` — add `severityP1Aliases: readonly string[]` to `ServiceConfig`.
+- `packages/gateway/src/connectors/pagerduty-sync.ts` — add `maxPagesPerSync` factory option, pagination loop, `metadata.urgency`.
+- `packages/gateway/src/connectors/pagerduty-sync.test.ts` — 4 new cases (urgency write, walks-until-more=false, cap honored, partial-failure cursor).
+- `packages/gateway/src/preflight/preflight.ts` — widen P1 filter to alias union; urgency-gap probe; extend `PreflightGap`.
+- `packages/gateway/test/unit/preflight/preflight.test.ts` — extend `seedIncident`/`cfg` helpers; add 4 new cases.
+- `packages/gateway/test/integration/preflight/preflight-real-db.test.ts` — update `cfg()` helper if present.
+- `packages/gateway/test/unit/ipc/preflight-rpc.test.ts` — update `cfg()` helper if present.
+- `packages/gateway/test/integration/http/preflight-deploy-route.test.ts` — update `cfg()` helper if present.
+- `packages/gateway/test/unit/metrics/dora-config.test.ts` — update test fixtures if they construct `ServiceConfig` literally.
+- `packages/gateway/src/platform/assemble.ts` — load `[pagerduty]` at bootstrap, pass to sync registrations.
+- `packages/gateway/src/platform/assemble-sync-registrations.ts` — accept `pagerdutyConfig`, thread `maxPagesPerSync` into `createPagerdutySyncable`.
+- `docs/roadmap.md` — flip two `[ ]` rows to `[x]`.
+- `CLAUDE.md` — extend Status line.
+
+---
+
+### Task 1: `[pagerduty]` parser, types, defaults, loaders
+
+**Goal:** Add the standalone `NimbusPagerdutyToml` shape and parser. No production wiring yet — pure additive. Lowercases + dedupes aliases at parse time per review point #5.
+
+**Files:**
+- Create: `packages/gateway/src/config/nimbus-toml-pagerduty.test.ts`
+- Modify: `packages/gateway/src/config/nimbus-toml.ts` (append new section after `loadNimbusUserFromConfigDir`, around line 750)
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `packages/gateway/src/config/nimbus-toml-pagerduty.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_NIMBUS_PAGERDUTY_TOML,
+  loadNimbusPagerdutyFromConfigDir,
+  loadNimbusPagerdutyFromPath,
+  parseNimbusPagerdutyToml,
+} from "./nimbus-toml.ts";
+
+describe("parseNimbusPagerdutyToml", () => {
+  test("returns defaults when [pagerduty] is absent", () => {
+    const out = parseNimbusPagerdutyToml("");
+    expect(out).toEqual(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+    expect(out.maxPagesPerSync).toBe(20);
+    expect(out.severityP1Aliases).toEqual([]);
+  });
+
+  test("reads max_pages_per_sync and severity_p1_aliases", () => {
+    const out = parseNimbusPagerdutyToml(
+      '[pagerduty]\nmax_pages_per_sync = 5\nseverity_p1_aliases = ["Critical", "SEV-1"]\n',
+    );
+    expect(out.maxPagesPerSync).toBe(5);
+    expect(out.severityP1Aliases).toEqual(["critical", "sev-1"]);
+  });
+
+  test("ignores keys outside [pagerduty]", () => {
+    const out = parseNimbusPagerdutyToml('[other]\nmax_pages_per_sync = 5\n');
+    expect(out.maxPagesPerSync).toBe(20);
+  });
+
+  test("strips inline comments", () => {
+    const out = parseNimbusPagerdutyToml(
+      '[pagerduty]\nmax_pages_per_sync = 10  # capped\n',
+    );
+    expect(out.maxPagesPerSync).toBe(10);
+  });
+
+  test("throws when max_pages_per_sync is 0", () => {
+    expect(() =>
+      parseNimbusPagerdutyToml('[pagerduty]\nmax_pages_per_sync = 0\n'),
+    ).toThrow(/max_pages_per_sync.*1\.\.100/);
+  });
+
+  test("throws when max_pages_per_sync is 101", () => {
+    expect(() =>
+      parseNimbusPagerdutyToml('[pagerduty]\nmax_pages_per_sync = 101\n'),
+    ).toThrow(/max_pages_per_sync.*1\.\.100/);
+  });
+
+  test("throws when max_pages_per_sync is non-integer", () => {
+    expect(() =>
+      parseNimbusPagerdutyToml('[pagerduty]\nmax_pages_per_sync = "lots"\n'),
+    ).toThrow(/max_pages_per_sync/);
+  });
+
+  test("lowercases + dedupes severity_p1_aliases", () => {
+    const out = parseNimbusPagerdutyToml(
+      '[pagerduty]\nseverity_p1_aliases = ["Critical", "critical", "P1"]\n',
+    );
+    // "P1" lowercases to "p1" which dedupes against itself; "Critical"/"critical" dedupes.
+    expect(out.severityP1Aliases).toEqual(["critical", "p1"]);
+  });
+
+  test("drops empty / whitespace-only alias entries", () => {
+    const out = parseNimbusPagerdutyToml(
+      '[pagerduty]\nseverity_p1_aliases = ["Critical", "", "   "]\n',
+    );
+    expect(out.severityP1Aliases).toEqual(["critical"]);
+  });
+});
+
+describe("loadNimbusPagerdutyFromPath", () => {
+  test("returns defaults when file is missing", () => {
+    const out = loadNimbusPagerdutyFromPath(join(tmpdir(), "does-not-exist.toml"));
+    expect(out).toEqual(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+  });
+
+  test("reads from disk", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-pd-toml-"));
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, '[pagerduty]\nmax_pages_per_sync = 7\n', "utf8");
+    const out = loadNimbusPagerdutyFromPath(p);
+    expect(out.maxPagesPerSync).toBe(7);
+  });
+});
+
+describe("loadNimbusPagerdutyFromConfigDir", () => {
+  test("resolves <configDir>/nimbus.toml", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-pd-cfg-"));
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      '[pagerduty]\nmax_pages_per_sync = 3\nseverity_p1_aliases = ["SEV-1"]\n',
+      "utf8",
+    );
+    const out = loadNimbusPagerdutyFromConfigDir(dir);
+    expect(out.maxPagesPerSync).toBe(3);
+    expect(out.severityP1Aliases).toEqual(["sev-1"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+```
+bun test packages/gateway/src/config/nimbus-toml-pagerduty.test.ts
+```
+
+Expected: FAIL — every import resolves to `undefined` because the symbols don't exist yet. Error like: `Cannot find module './nimbus-toml.ts'` is unlikely (the file exists); more likely `Property 'parseNimbusPagerdutyToml' does not exist`.
+
+- [ ] **Step 3: Implement in `packages/gateway/src/config/nimbus-toml.ts`**
+
+Append this section AFTER `loadNimbusUserFromConfigDir` (around line 750), BEFORE the `[metrics.dora.<id>]` section that starts at line 751:
+
+```typescript
+// ---------------------------------------------------------------------------
+// [pagerduty] — Top-level PagerDuty connector + preflight knobs
+// (Phase 5 T4 wrap-up).
+// ---------------------------------------------------------------------------
+
+export type NimbusPagerdutyToml = {
+  /** Hard cap on pages walked per `pagerduty-sync.ts` invocation. 1..100. */
+  maxPagesPerSync: number;
+  /**
+   * Priority names that preflight should treat as equivalent to "P1".
+   * Stored lowercased + deduplicated. Empty by default (preflight matches
+   * the verbatim "P1" string only, identical to pre-existing behavior).
+   */
+  severityP1Aliases: readonly string[];
+};
+
+export const DEFAULT_NIMBUS_PAGERDUTY_TOML: NimbusPagerdutyToml = {
+  maxPagesPerSync: 20,
+  severityP1Aliases: [],
+};
+
+function parseNimbusPagerdutySection(source: string): Partial<NimbusPagerdutyToml> {
+  const lines = source.split(/\r?\n/);
+  let inSection = false;
+  const out: { maxPagesPerSync?: number; severityP1Aliases?: readonly string[] } = {};
+  for (const line of lines) {
+    const trimmed = stripComment(line).trim();
+    if (trimmed === "") continue;
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      inSection = trimmed === "[pagerduty]";
+      continue;
+    }
+    if (!inSection) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const valRaw = trimmed.slice(eq + 1).trim();
+    if (key === "max_pages_per_sync") {
+      const n = parseIntDec(valRaw);
+      if (n === undefined || n < 1 || n > 100) {
+        throw new Error(
+          `[pagerduty].max_pages_per_sync must be an integer in 1..100, got '${valRaw}'`,
+        );
+      }
+      out.maxPagesPerSync = n;
+    } else if (key === "severity_p1_aliases") {
+      // Reuse parseStringArray (defined later in this file) — already drops empty entries.
+      const raw = parseStringArray(valRaw);
+      const seen = new Set<string>();
+      const collected: string[] = [];
+      for (const v of raw) {
+        const lower = v.trim().toLowerCase();
+        if (lower === "") continue;
+        if (seen.has(lower)) continue;
+        seen.add(lower);
+        collected.push(lower);
+      }
+      out.severityP1Aliases = collected;
+    }
+  }
+  return out;
+}
+
+export function parseNimbusPagerdutyToml(
+  raw: string,
+  defaults: NimbusPagerdutyToml = DEFAULT_NIMBUS_PAGERDUTY_TOML,
+): NimbusPagerdutyToml {
+  return { ...defaults, ...parseNimbusPagerdutySection(raw) };
+}
+
+export function loadNimbusPagerdutyFromPath(tomlPath: string): NimbusPagerdutyToml {
+  if (!existsSync(tomlPath)) {
+    return structuredClone(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+  }
+  try {
+    const raw = readFileSync(tomlPath, "utf8");
+    return parseNimbusPagerdutyToml(raw);
+  } catch {
+    return structuredClone(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+  }
+}
+
+export function loadNimbusPagerdutyFromConfigDir(configDir: string): NimbusPagerdutyToml {
+  return loadNimbusPagerdutyFromPath(join(configDir, "nimbus.toml"));
+}
+```
+
+**Forward reference note:** `parseStringArray` is defined later in the same file (around line 766) — that's fine in TypeScript; function hoisting works at module scope. If your editor flags it as "used before defined," ignore — it compiles and runs correctly.
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+```
+bun test packages/gateway/src/config/nimbus-toml-pagerduty.test.ts
+```
+
+Expected: PASS — all 12 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/config/nimbus-toml.ts packages/gateway/src/config/nimbus-toml-pagerduty.test.ts
+git commit -m "feat(config): [pagerduty] TOML block — max_pages_per_sync + severity_p1_aliases
+
+Phase 5 T4 wrap-up groundwork. Parser, types, defaults, loaders, and 12
+tests covering: defaults, parse-with-keys, missing-section ignore, comment
+strip, max_pages bounds (0/101/non-integer), alias lowercase+dedup,
+empty-entry drop, on-disk loading."
+```
+
+---
+
+### Task 2: Add `severityP1Aliases` to `ServiceConfig`
+
+**Goal:** Extend the `ServiceConfig` type with the new field. Default `[]` in `materializeServiceConfigs` so existing TOML callers behave unchanged. Update every test fixture that constructs a `ServiceConfig` literally.
+
+**Files:**
+- Modify: `packages/gateway/src/metrics/dora-config.ts:20-35`
+- Modify: `packages/gateway/src/config/nimbus-toml.ts:846-855` (the `materializeServiceConfigs` return)
+- Modify: `packages/gateway/test/unit/preflight/preflight.test.ts:120-131` (the `cfg()` helper)
+- Possibly modify: other test files (audit + patch all `ServiceConfig`-construction sites)
+
+- [ ] **Step 1: Identify every test file constructing `ServiceConfig` literally**
+
+Run:
+```
+grep -rn "serviceId:" packages/gateway/test packages/gateway/src --include="*.test.ts" --include="*.ts" | grep -v "\.serviceId" | grep -v "node_modules"
+```
+
+Take note of every test file with object literals that need `severityP1Aliases: []` added. The known set is:
+- `packages/gateway/test/unit/preflight/preflight.test.ts` (the `cfg()` helper)
+- `packages/gateway/test/integration/preflight/preflight-real-db.test.ts` (if it has its own `cfg()` helper)
+- `packages/gateway/test/unit/ipc/preflight-rpc.test.ts` (if applicable)
+- `packages/gateway/test/integration/http/preflight-deploy-route.test.ts` (if applicable)
+- `packages/gateway/test/unit/metrics/dora-config.test.ts` (if applicable)
+
+For each match, treat it as a fixture site that needs the new field.
+
+- [ ] **Step 2: Add the field to `ServiceConfig`**
+
+In `packages/gateway/src/metrics/dora-config.ts`, replace lines 20-35:
+
+```typescript
+export type ServiceConfig = {
+  /** Stable service id from the table key. */
+  readonly serviceId: string;
+  readonly repos: readonly ParsedDoraRepoUrn[];
+  readonly pagerdutyServices: readonly string[];
+  readonly deployWorkflowPattern: RegExp;
+  readonly incidentWindowMinutes: number;
+  readonly excludePrLabels: readonly string[];
+  /**
+   * Logical deploy environments this service ships to (e.g. `["prod"]`,
+   * `["staging", "prod"]`). Sourced from the optional `deploy_environments`
+   * key in `[ci.service.<id>]` / `[metrics.dora.<id>]`. Defaults to
+   * `["prod"]` when omitted.
+   */
+  readonly deployEnvironments: readonly string[];
+  /**
+   * Lowercased, deduplicated priority-name aliases that preflight treats as
+   * P1. Sourced org-wide from `[pagerduty].severity_p1_aliases` and copied
+   * onto every materialized ServiceConfig at load time. Empty default
+   * preserves the pre-existing strict `severity = 'P1'` filter behavior.
+   * Phase 5 T4 wrap-up.
+   */
+  readonly severityP1Aliases: readonly string[];
+};
+```
+
+- [ ] **Step 3: Add the default to `materializeServiceConfigs`**
+
+In `packages/gateway/src/config/nimbus-toml.ts:846-855`, replace the `out.set(serviceId, { ... })` block with:
+
+```typescript
+    out.set(serviceId, {
+      serviceId,
+      repos,
+      pagerdutyServices,
+      deployWorkflowPattern,
+      incidentWindowMinutes: windowMins,
+      excludePrLabels,
+      deployEnvironments,
+      severityP1Aliases: [], // attached by loadNimbusServiceConfigsFromConfigDir
+    });
+```
+
+- [ ] **Step 4: Update the preflight unit-test `cfg()` helper**
+
+In `packages/gateway/test/unit/preflight/preflight.test.ts:120-131`, replace:
+
+```typescript
+function cfg(overrides: Partial<ServiceConfig> = {}): ServiceConfig {
+  return {
+    serviceId: "payment-service",
+    repos: [{ provider: "github", providerId: "nimbus-agent/payments" }],
+    pagerdutyServices: ["P12ABCD"],
+    deployWorkflowPattern: /^[Dd]eploy/,
+    incidentWindowMinutes: 60,
+    excludePrLabels: ["revert"],
+    deployEnvironments: ["prod"],
+    severityP1Aliases: [],
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 5: Run typecheck, fix every fixture site**
+
+```
+bun run typecheck
+```
+
+Expected on first run: errors at every site missing `severityP1Aliases`. Add `severityP1Aliases: []` (after `deployEnvironments`) to each one. Re-run until clean.
+
+- [ ] **Step 6: Run the full gateway test suite, verify still green**
+
+```
+bun test packages/gateway
+```
+
+Expected: all PASS. The default `[]` aliases means every existing test sees identical behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(config): add severityP1Aliases field to ServiceConfig
+
+Phase 5 T4 wrap-up groundwork. Type field + default empty array in
+materializeServiceConfigs; fixture updates in every cfg() helper that
+constructs ServiceConfig literally. Behavior unchanged — empty array
+preserves the verbatim severity='P1' filter at the SQL site."
+```
+
+---
+
+### Task 3: Thread `[pagerduty]` aliases via `loadNimbusServiceConfigsFromConfigDir`
+
+**Goal:** Production wiring step. Read `[pagerduty]` block from the same TOML buffer the loader already parses for `[metrics.dora.<id>]` + `[ci.service.<id>]`, and attach the lowercased aliases to every materialized `ServiceConfig`.
+
+**Files:**
+- Modify: `packages/gateway/src/config/nimbus-toml.ts:948-967`
+- Create: `packages/gateway/src/config/nimbus-toml-service-configs.test.ts` (or extend an existing test file — see below)
+
+- [ ] **Step 1: Check whether a test file already exercises `loadNimbusServiceConfigsFromConfigDir`**
+
+```
+grep -rln "loadNimbusServiceConfigsFromConfigDir" packages/gateway --include="*.test.ts"
+```
+
+If a test file exists, extend it. If not, create `packages/gateway/src/config/nimbus-toml-service-configs.test.ts` with this content:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadNimbusServiceConfigsFromConfigDir } from "./nimbus-toml.ts";
+
+describe("loadNimbusServiceConfigsFromConfigDir + [pagerduty] aliases", () => {
+  test("attaches lowercased severityP1Aliases to every ServiceConfig", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sc-aliases-"));
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      `[pagerduty]
+severity_p1_aliases = ["Critical", "SEV-1"]
+
+[metrics.dora.payments]
+repos = ["github:acme/payments"]
+
+[ci.service.checkout]
+repos = ["github:acme/checkout"]
+`,
+      "utf8",
+    );
+    const merged = loadNimbusServiceConfigsFromConfigDir(dir);
+    expect(merged.size).toBe(2);
+    expect(merged.get("payments")?.severityP1Aliases).toEqual(["critical", "sev-1"]);
+    expect(merged.get("checkout")?.severityP1Aliases).toEqual(["critical", "sev-1"]);
+  });
+
+  test("defaults to empty array when [pagerduty] is absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sc-no-pd-"));
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      `[metrics.dora.svc]
+repos = ["github:acme/svc"]
+`,
+      "utf8",
+    );
+    const merged = loadNimbusServiceConfigsFromConfigDir(dir);
+    expect(merged.get("svc")?.severityP1Aliases).toEqual([]);
+  });
+
+  test("returns empty map when nimbus.toml is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sc-missing-"));
+    const merged = loadNimbusServiceConfigsFromConfigDir(dir);
+    expect(merged.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+```
+bun test packages/gateway/src/config/nimbus-toml-service-configs.test.ts
+```
+
+Expected: FAIL on the first case — `severityP1Aliases` is `[]` (the default from Task 2's materializer), not `["critical", "sev-1"]`.
+
+- [ ] **Step 3: Modify `loadNimbusServiceConfigsFromConfigDir`**
+
+In `packages/gateway/src/config/nimbus-toml.ts:948-967`, replace the function body with:
+
+```typescript
+export function loadNimbusServiceConfigsFromConfigDir(
+  configDir: string,
+): Map<string, ServiceConfig> {
+  const tomlPath = join(configDir, "nimbus.toml");
+  if (!existsSync(tomlPath)) return new Map();
+  const raw = readFileSync(tomlPath, "utf8");
+  const dora = parseNimbusDoraToml(raw);
+  const ci = parseNimbusCiServiceToml(raw);
+  // Phase 5 T4 wrap-up: read [pagerduty].severity_p1_aliases once and
+  // attach to every materialized ServiceConfig. The aliases array is
+  // already lowercased + deduped by parseNimbusPagerdutyToml.
+  const pagerdutyCfg = parseNimbusPagerdutyToml(raw);
+  const aliases = pagerdutyCfg.severityP1Aliases;
+  const merged: Map<string, ServiceConfig> = new Map();
+  for (const [id, cfg] of dora.entries()) {
+    merged.set(id, { ...cfg, severityP1Aliases: aliases });
+  }
+  for (const [id, cfg] of ci.entries()) {
+    if (merged.has(id)) {
+      process.stderr.write(
+        `[ci.service.${id}] and [metrics.dora.${id}] both define service '${id}'; ` +
+          `using [ci.service.${id}].\n`,
+      );
+    }
+    merged.set(id, { ...cfg, severityP1Aliases: aliases });
+  }
+  return merged;
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+```
+bun test packages/gateway/src/config/nimbus-toml-service-configs.test.ts
+```
+
+Expected: PASS — all three cases green.
+
+- [ ] **Step 5: Run the rest of the gateway suite to be safe**
+
+```
+bun test packages/gateway
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(config): thread [pagerduty].severity_p1_aliases into ServiceConfig
+
+Phase 5 T4 wrap-up. loadNimbusServiceConfigsFromConfigDir now reads the
+new [pagerduty] block from the same TOML buffer it already parses for
+[metrics.dora.<id>] / [ci.service.<id>], and attaches the lowercased,
+deduped alias array to every materialized ServiceConfig — org-wide by
+design. No caller changes needed since every preflight / metrics / HTTP
+consumer flows through this loader."
+```
+
+---
+
+### Task 4: Widen `selectActiveP1Incidents` to alias-aware filter
+
+**Goal:** Update the preflight SQL site to match `LOWER(severity) IN (?, ?, ...)` over `Set("p1", ...aliases)`. Empty aliases default → `IN ("p1")`, which case-insensitively matches verbatim `"P1"` rows (zero behavior change for existing users).
+
+**Files:**
+- Modify: `packages/gateway/src/preflight/preflight.ts:102-149` (the `selectActiveP1Incidents` function)
+- Modify: `packages/gateway/test/unit/preflight/preflight.test.ts` (add tests after the existing `active_p1_incidents` describe block)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/gateway/test/unit/preflight/preflight.test.ts`, append these inside the `describe("computeDeployPreflight: active_p1_incidents check"...)` block, just before the closing `});`:
+
+```typescript
+  it('alias "critical" counts toward P1 and preserves raw severity in finding', () => {
+    seedIncident(db, "pagerduty:inc_crit", {
+      status: "triggered",
+      severity: "Critical",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(
+      db,
+      cfg({ severityP1Aliases: ["critical"] }),
+      "main",
+      now,
+      10,
+    );
+    expect(out.checks.active_p1_incidents.count).toBe(1);
+    expect(out.checks.active_p1_incidents.findings[0]?.severity).toBe("Critical");
+  });
+
+  it("alias match is case-insensitive on both sides", () => {
+    seedIncident(db, "pagerduty:inc_upper", {
+      status: "triggered",
+      severity: "CRITICAL",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    seedIncident(db, "pagerduty:inc_p1", {
+      status: "triggered",
+      severity: "P1",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 120_000,
+    });
+    const out = computeDeployPreflight(
+      db,
+      cfg({ severityP1Aliases: ["critical"] }),
+      "main",
+      now,
+      10,
+    );
+    expect(out.checks.active_p1_incidents.count).toBe(2);
+  });
+
+  it("empty severityP1Aliases preserves verbatim P1 behavior", () => {
+    seedIncident(db, "pagerduty:inc_p1", {
+      status: "triggered",
+      severity: "P1",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    seedIncident(db, "pagerduty:inc_crit", {
+      status: "triggered",
+      severity: "Critical",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 120_000,
+    });
+    // No aliases configured → only the verbatim "P1" row matches.
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(1);
+    expect(out.checks.active_p1_incidents.findings[0]?.id).toBe("pagerduty:inc_p1");
+  });
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+```
+bun test packages/gateway/test/unit/preflight/preflight.test.ts
+```
+
+Expected: FAIL on the first two new tests — the existing `severity = 'P1'` filter rejects `"Critical"` / `"CRITICAL"`. The third should already pass.
+
+- [ ] **Step 3: Modify `selectActiveP1Incidents`**
+
+In `packages/gateway/src/preflight/preflight.ts`, replace the entire `selectActiveP1Incidents` function (lines 102-149) with:
+
+```typescript
+function selectActiveP1Incidents(
+  db: Database,
+  cfg: ServiceConfig,
+  maxFindings: number,
+): { count: number; findings: IncidentFinding[]; gap: PreflightGap } {
+  if (cfg.pagerdutyServices.length === 0) {
+    return { count: 0, findings: [], gap: "no_pagerduty_mapping" };
+  }
+  // Build the canonical set from the configured aliases (already lowercased
+  // by the bootstrap) unioned with "p1". The Set step is belt-and-braces
+  // against a user-supplied "P1" overlap.
+  const severityMatches = Array.from(new Set(["p1", ...cfg.severityP1Aliases]));
+  const sevPlaceholders = severityMatches.map(() => "?").join(",");
+  const pdPlaceholders = cfg.pagerdutyServices.map(() => "?").join(",");
+  const where = `
+    service = 'pagerduty'
+    AND type = 'incident'
+    AND json_extract(metadata, '$.pagerduty_service_id') IN (${pdPlaceholders})
+    AND json_extract(metadata, '$.status') IN ('triggered', 'acknowledged')
+    AND LOWER(json_extract(metadata, '$.severity')) IN (${sevPlaceholders})
+  `;
+  const countParams = [...cfg.pagerdutyServices, ...severityMatches];
+  const countRow = db
+    .query(`SELECT COUNT(*) as c FROM item WHERE ${where}`)
+    .get(...countParams) as { c: number };
+  const rows = db
+    .query(
+      `SELECT id, title, url, metadata
+       FROM item
+       WHERE ${where}
+       ORDER BY json_extract(metadata, '$.opened_at_ms') DESC
+       LIMIT ?`,
+    )
+    .all(...countParams, maxFindings) as {
+    id: string;
+    title: string;
+    url: string | null;
+    metadata: string;
+  }[];
+  const findings: IncidentFinding[] = rows.map((r) => {
+    const meta = JSON.parse(r.metadata) as Record<string, unknown>;
+    return {
+      id: r.id,
+      title: r.title,
+      status: meta["status"] as "triggered" | "acknowledged",
+      severity: typeof meta["severity"] === "string" ? meta["severity"] : "P1",
+      opened_at_ms: typeof meta["opened_at_ms"] === "number" ? meta["opened_at_ms"] : 0,
+      pagerduty_service_id:
+        typeof meta["pagerduty_service_id"] === "string" ? meta["pagerduty_service_id"] : "",
+      url: r.url,
+    };
+  });
+  return { count: countRow.c, findings, gap: null };
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+```
+bun test packages/gateway/test/unit/preflight/preflight.test.ts
+```
+
+Expected: PASS — both new tests green, all pre-existing preflight tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/preflight/preflight.ts packages/gateway/test/unit/preflight/preflight.test.ts
+git commit -m "feat(preflight): widen active-P1 filter to severity_p1_aliases
+
+Phase 5 T4 wrap-up. selectActiveP1Incidents now matches
+LOWER(severity) IN (\"p1\", ...lowercased-aliases). Empty aliases (the
+default) preserve verbatim severity='P1' behavior. Three new tests:
+'Critical' alias counts, case-insensitive match, empty-aliases default."
+```
+
+---
+
+### Task 5: PagerDuty sync — write `metadata.urgency`
+
+**Goal:** Capture PagerDuty's `incident.urgency` field on every indexed row. Prereq for Task 6 (urgency-gap probe).
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/pagerduty-sync.ts:60-113` (the `syncPagerdutyIncidentItems` function)
+- Modify: `packages/gateway/src/connectors/pagerduty-sync.test.ts` (extend the `IncidentMetadata` type + add a new case)
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/gateway/src/connectors/pagerduty-sync.test.ts`, first update the `IncidentMetadata` type (lines 16-22):
+
+```typescript
+type IncidentMetadata = {
+  status: string | null;
+  incidentId: string;
+  opened_at_ms?: number;
+  pagerduty_service_id?: string;
+  severity?: string;
+  urgency?: string;
+};
+```
+
+Then add this test inside `describeWithFetchRestore("pagerduty-sync", () => { ... })`, immediately after the existing `"enriches with opened_at_ms, pagerduty_service_id, severity on happy path"` test:
+
+```typescript
+  test("writes urgency when present", async () => {
+    const db = await runOneSync([
+      {
+        id: "PT_URGENT",
+        title: "Urgent but no priority",
+        created_at: "2026-05-10T18:30:21Z",
+        updated_at: "2026-05-10T18:30:21Z",
+        status: "triggered",
+        urgency: "high",
+        service: { id: "PJK1HJ8" },
+      },
+    ]);
+    const meta = readIncidentMetadata(db, "PT_URGENT");
+    expect(meta.urgency).toBe("high");
+  });
+
+  test("omits urgency when absent or empty", async () => {
+    const db = await runOneSync([
+      {
+        id: "PT_NO_URG",
+        title: "No urgency field",
+        created_at: "2026-05-10T18:30:21Z",
+        updated_at: "2026-05-10T18:30:21Z",
+        status: "triggered",
+        service: { id: "PJK1HJ8" },
+      },
+    ]);
+    const meta = readIncidentMetadata(db, "PT_NO_URG");
+    expect(meta.urgency).toBeUndefined();
+  });
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+```
+bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
+```
+
+Expected: FAIL on `"writes urgency when present"` — `meta.urgency` is `undefined`. The omits-urgency test should pass coincidentally (the absence is already the default).
+
+- [ ] **Step 3: Modify `syncPagerdutyIncidentItems`**
+
+In `packages/gateway/src/connectors/pagerduty-sync.ts:85-95`, just below the existing `const severity = pdPriorityName(row);` line and the metadata population, add `urgency`:
+
+Locate this block (around line 91-94):
+```typescript
+    const metadata: Record<string, unknown> = { status: status ?? null, incidentId: id };
+    if (Number.isFinite(openedAtMs)) metadata["opened_at_ms"] = openedAtMs;
+    if (serviceId !== undefined && serviceId !== "") metadata["pagerduty_service_id"] = serviceId;
+    if (severity !== undefined && severity !== "") metadata["severity"] = severity;
+```
+
+Replace with:
+```typescript
+    const metadata: Record<string, unknown> = { status: status ?? null, incidentId: id };
+    if (Number.isFinite(openedAtMs)) metadata["opened_at_ms"] = openedAtMs;
+    if (serviceId !== undefined && serviceId !== "") metadata["pagerduty_service_id"] = serviceId;
+    if (severity !== undefined && severity !== "") metadata["severity"] = severity;
+    const urgency = stringField(row, "urgency");
+    if (urgency !== undefined && urgency !== "") metadata["urgency"] = urgency;
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+```
+bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
+```
+
+Expected: PASS — both new tests green, all pre-existing sync tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/connectors/pagerduty-sync.ts packages/gateway/src/connectors/pagerduty-sync.test.ts
+git commit -m "feat(pagerduty): write metadata.urgency on indexed incidents
+
+Phase 5 T4 wrap-up groundwork. Captures incident.urgency verbatim
+(\"high\" / \"low\" per PagerDuty's REST v2 schema) when present.
+Prereq for the preflight urgency-gap probe in the next commit."
+```
+
+---
+
+### Task 6: Urgency-gap probe in preflight
+
+**Goal:** When `active_p1_incidents.count === 0` AND services are configured, run one extra probe to detect high-urgency-without-priority incidents. Surface a new `PreflightGap` variant so operators can self-diagnose silent-zero preflight results.
+
+**Files:**
+- Modify: `packages/gateway/src/preflight/preflight.ts:17` (extend `PreflightGap` union)
+- Modify: `packages/gateway/src/preflight/preflight.ts` (extend `selectActiveP1Incidents` body after the count is known)
+- Modify: `packages/gateway/test/unit/preflight/preflight.test.ts` (extend `seedIncident` helper; add 3 new tests)
+
+- [ ] **Step 1: Extend the `seedIncident` helper**
+
+In `packages/gateway/test/unit/preflight/preflight.test.ts:10-42`, replace the `seedIncident` function with one that supports optional `severity` + new `urgency` field:
+
+```typescript
+function seedIncident(
+  db: Database,
+  id: string,
+  opts: {
+    status: "triggered" | "acknowledged" | "resolved";
+    severity?: string;
+    urgency?: string;
+    pagerdutyServiceId: string;
+    openedAtMs: number;
+    title?: string;
+    url?: string;
+  },
+) {
+  const meta: Record<string, unknown> = {
+    status: opts.status,
+    pagerduty_service_id: opts.pagerdutyServiceId,
+    opened_at_ms: opts.openedAtMs,
+  };
+  if (opts.severity !== undefined) meta.severity = opts.severity;
+  if (opts.urgency !== undefined) meta.urgency = opts.urgency;
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, url, canonical_url,
+                       modified_at, author_id, metadata, synced_at, pinned)
+     VALUES (?, 'pagerduty', 'incident', ?, ?, '', ?, NULL, ?, NULL, ?, ?, 0)`,
+    [
+      id,
+      id,
+      opts.title ?? "Incident",
+      opts.url ?? null,
+      opts.openedAtMs,
+      JSON.stringify(meta),
+      opts.openedAtMs,
+    ],
+  );
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In `packages/gateway/test/unit/preflight/preflight.test.ts`, append these inside the `describe("computeDeployPreflight: active_p1_incidents check"...)` block:
+
+```typescript
+  it('emits gap="pagerduty_urgency_without_priority" when count===0 and high-urgency incidents lack priority', () => {
+    seedIncident(db, "pagerduty:no_pri", {
+      status: "triggered",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(0);
+    expect(out.checks.active_p1_incidents.gap).toBe(
+      "pagerduty_urgency_without_priority",
+    );
+  });
+
+  it("urgency-gap is suppressed when count > 0", () => {
+    seedIncident(db, "pagerduty:has_p1", {
+      status: "triggered",
+      severity: "P1",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    seedIncident(db, "pagerduty:no_pri", {
+      status: "triggered",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 30_000,
+    });
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(1);
+    expect(out.checks.active_p1_incidents.gap).toBeNull();
+  });
+
+  it('urgency-gap defers to no_pagerduty_mapping when no services configured', () => {
+    seedIncident(db, "pagerduty:no_pri", {
+      status: "triggered",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(
+      db,
+      cfg({ pagerdutyServices: [] }),
+      "main",
+      now,
+      10,
+    );
+    expect(out.checks.active_p1_incidents.count).toBe(0);
+    expect(out.checks.active_p1_incidents.gap).toBe("no_pagerduty_mapping");
+  });
+
+  it("urgency-gap requires status in (triggered, acknowledged) — resolved high-urgency does not trigger", () => {
+    seedIncident(db, "pagerduty:resolved_high", {
+      status: "resolved",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(0);
+    expect(out.checks.active_p1_incidents.gap).toBeNull();
+  });
+```
+
+- [ ] **Step 3: Run the tests, verify they fail**
+
+```
+bun test packages/gateway/test/unit/preflight/preflight.test.ts
+```
+
+Expected: FAIL on the first new test — `gap` is `null` instead of `"pagerduty_urgency_without_priority"`. TypeScript also rejects the literal as not in the union.
+
+- [ ] **Step 4: Extend `PreflightGap` union**
+
+In `packages/gateway/src/preflight/preflight.ts:17`, replace:
+
+```typescript
+export type PreflightGap = null | "no_pagerduty_mapping" | "no_repos" | "unknown_mergeable_state";
+```
+
+with:
+
+```typescript
+export type PreflightGap =
+  | null
+  | "no_pagerduty_mapping"
+  | "no_repos"
+  | "unknown_mergeable_state"
+  | "pagerduty_urgency_without_priority";
+```
+
+- [ ] **Step 5: Add the probe to `selectActiveP1Incidents`**
+
+In `packages/gateway/src/preflight/preflight.ts`, in the body of `selectActiveP1Incidents` (modified in Task 4), find the trailing `return { count: countRow.c, findings, gap: null };` line.
+
+Replace it with the following block (which runs the gap probe when `count === 0`):
+
+```typescript
+  // Phase 5 T4 wrap-up: urgency-gap probe. When the strict + aliased
+  // severity filter yields zero matches AND services are configured, check
+  // whether high-urgency-without-priority incidents exist. They indicate
+  // either a missing severity_p1_aliases entry or a PagerDuty priority
+  // setup quirk — surface as a diagnostic gap. Probe is gated on count===0
+  // so any org with at least one active P1-equivalent skips it.
+  let gap: PreflightGap = null;
+  if (countRow.c === 0) {
+    const probeRow = db
+      .query(
+        `SELECT COUNT(*) as c FROM item
+         WHERE service = 'pagerduty'
+           AND type = 'incident'
+           AND json_extract(metadata, '$.pagerduty_service_id') IN (${pdPlaceholders})
+           AND json_extract(metadata, '$.status') IN ('triggered', 'acknowledged')
+           AND json_extract(metadata, '$.urgency') = 'high'
+           AND (json_extract(metadata, '$.severity') IS NULL
+                OR json_extract(metadata, '$.severity') = '')`,
+      )
+      .get(...cfg.pagerdutyServices) as { c: number };
+    if (probeRow.c > 0) gap = "pagerduty_urgency_without_priority";
+  }
+  return { count: countRow.c, findings, gap };
+```
+
+- [ ] **Step 6: Run the tests, verify they pass**
+
+```
+bun test packages/gateway/test/unit/preflight/preflight.test.ts
+```
+
+Expected: PASS — all four new urgency-gap tests green, all pre-existing tests still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/preflight/preflight.ts packages/gateway/test/unit/preflight/preflight.test.ts
+git commit -m "feat(preflight): urgency-gap diagnostic probe
+
+Phase 5 T4 wrap-up. selectActiveP1Incidents now runs a single extra
+probe query when count===0 AND services are configured, detecting
+high-urgency-without-priority incidents on the same PD services.
+Surfaces new PreflightGap variant 'pagerduty_urgency_without_priority'
+so operators can self-diagnose silent-zero preflight results."
+```
+
+---
+
+### Task 7: PagerDuty sync — request shape (Phase A of pagination)
+
+**Goal:** Update the per-request URL to PD's max page size (100) and explicit ascending sort. Add `maxPagesPerSync` to the factory options bag with default 20 (no behavior change yet — still one fetch per sync). Sets up the loop in Task 8.
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/pagerduty-sync.ts` (factory option type + URL params)
+
+- [ ] **Step 1: Verify the existing single-page tests still capture URL shape**
+
+The existing "fresh install uses 30-day backfill window" test captures `capturedUrl` and inspects `since`. After this task, that test should still pass because `since` is unchanged. No new test in Phase A — Phase B drives the loop.
+
+- [ ] **Step 2: Modify the factory option type**
+
+In `packages/gateway/src/connectors/pagerduty-sync.ts`, replace lines 131-133:
+
+```typescript
+export type PagerdutySyncableOptions = {
+  ensurePagerdutyMcpRunning: () => Promise<void>;
+  /**
+   * Hard cap on pages walked per sync invocation. Default 20. Range 1..100
+   * enforced by config parser; not re-validated here.
+   */
+  maxPagesPerSync?: number;
+};
+```
+
+- [ ] **Step 3: Modify the URL construction in `sync()`**
+
+In the same file, find the URL construction block (lines 154-158):
+
+```typescript
+      const u = new URL("https://api.pagerduty.com/incidents");
+      u.searchParams.set("limit", "50");
+      u.searchParams.set("sort_by", "updated_at");
+      u.searchParams.set("since", since);
+```
+
+Replace with:
+
+```typescript
+      const u = new URL("https://api.pagerduty.com/incidents");
+      u.searchParams.set("limit", "100");
+      u.searchParams.set("sort_by", "updated_at:asc");
+      u.searchParams.set("since", since);
+      u.searchParams.set("offset", "0");
+```
+
+Note: leaving the rest of the function unchanged at this step — the loop is added in Task 8.
+
+- [ ] **Step 4: Run the full pagerduty-sync test suite**
+
+```
+bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
+```
+
+Expected: PASS — all existing tests still pass because the response shape hasn't changed and `since` is still set the same way. The `capturedUrl` test in particular verifies `since`, which is untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/connectors/pagerduty-sync.ts
+git commit -m "refactor(pagerduty): per-request shape — limit=100, sort_by=asc, offset=0
+
+Phase 5 T4 wrap-up Phase A. Bump page size 50 -> 100 (PD max), add
+explicit sort_by=updated_at:asc for cursor-correctness under capping,
+add offset=0 (constant for now). Adds maxPagesPerSync option (unused
+in this commit — loop arrives in Phase B). Behavior preserved."
+```
+
+---
+
+### Task 8: PagerDuty sync — page loop (Phase B of pagination)
+
+**Goal:** Replace the single-fetch body with a bounded loop that follows PagerDuty's `parsed.more` flag, advances `offset` by `pagesFetched * 100`, accumulates upserts + `maxUpdated`, and reports `hasMore: true` on cap-hit so the scheduler re-queues.
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/pagerduty-sync.ts` (rewrite the `sync()` body)
+- Modify: `packages/gateway/src/connectors/pagerduty-sync.test.ts` (3 new tests + extended fetch stub helper)
+
+- [ ] **Step 1: Add a multi-page fetch stub helper at the top of the test file**
+
+In `packages/gateway/src/connectors/pagerduty-sync.test.ts`, after the existing `stubPagerdutyIncidents` function (around line 42), add:
+
+```typescript
+type PdPageResponse = { incidents: unknown[]; more: boolean };
+
+function stubPagerdutyPages(pages: readonly PdPageResponse[]): { calls: string[] } {
+  const calls: string[] = [];
+  let i = 0;
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    const url = urlFromFetchInput(input);
+    calls.push(url);
+    if (!url.startsWith("https://api.pagerduty.com/incidents")) {
+      throw new Error(`unexpected fetch: ${url}`);
+    }
+    const page = pages[Math.min(i, pages.length - 1)];
+    i += 1;
+    if (page === undefined) throw new Error("stubPagerdutyPages: no pages configured");
+    return new Response(JSON.stringify(page), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { calls };
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In the same file, append these inside `describeWithFetchRestore("pagerduty-sync", () => { ... })`:
+
+```typescript
+  test("walks pages until parsed.more=false", async () => {
+    const { calls } = stubPagerdutyPages([
+      {
+        incidents: [
+          {
+            id: "P_A",
+            title: "A",
+            created_at: "2026-05-10T10:00:00Z",
+            updated_at: "2026-05-10T10:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_B",
+            title: "B",
+            created_at: "2026-05-10T11:00:00Z",
+            updated_at: "2026-05-10T11:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_C",
+            title: "C",
+            created_at: "2026-05-10T12:00:00Z",
+            updated_at: "2026-05-10T12:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: false,
+      },
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createPagerdutySyncable({ ensurePagerdutyMcpRunning: async () => {} });
+    const vault = createStubVault({ "pagerduty.api_token": "test-token" });
+    const result = await sync.sync(syncTestContext(db, vault), null);
+    expect(calls.length).toBe(3);
+    expect(new URL(calls[1] as string).searchParams.get("offset")).toBe("100");
+    expect(new URL(calls[2] as string).searchParams.get("offset")).toBe("200");
+    expect(result.itemsUpserted).toBe(3);
+    expect(result.hasMore).toBe(false);
+    const cursor = result.cursor as string;
+    const decoded = Buffer.from(cursor.slice("nimbus-pd1:".length), "base64url").toString("utf8");
+    expect(JSON.parse(decoded)).toEqual({ lastUpdated: "2026-05-10T12:00:00Z" });
+  });
+
+  test("respects maxPagesPerSync cap and emits hasMore=true", async () => {
+    const { calls } = stubPagerdutyPages([
+      {
+        incidents: [
+          {
+            id: "P_A",
+            title: "A",
+            created_at: "2026-05-10T10:00:00Z",
+            updated_at: "2026-05-10T10:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_B",
+            title: "B",
+            created_at: "2026-05-10T11:00:00Z",
+            updated_at: "2026-05-10T11:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_C",
+            title: "Never reached",
+            created_at: "2026-05-10T12:00:00Z",
+            updated_at: "2026-05-10T12:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createPagerdutySyncable({
+      ensurePagerdutyMcpRunning: async () => {},
+      maxPagesPerSync: 2,
+    });
+    const vault = createStubVault({ "pagerduty.api_token": "test-token" });
+    const result = await sync.sync(syncTestContext(db, vault), null);
+    expect(calls.length).toBe(2);
+    expect(result.itemsUpserted).toBe(2);
+    expect(result.hasMore).toBe(true);
+    const cursor = result.cursor as string;
+    const decoded = Buffer.from(cursor.slice("nimbus-pd1:".length), "base64url").toString("utf8");
+    expect(JSON.parse(decoded)).toEqual({ lastUpdated: "2026-05-10T11:00:00Z" });
+  });
+
+  test("partial-failure preserves cursor progress from successful pages", async () => {
+    let call = 0;
+    globalThis.fetch = (async () => {
+      call += 1;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            incidents: [
+              {
+                id: "P_PAGE1",
+                title: "Page 1 row",
+                created_at: "2026-05-10T10:00:00Z",
+                updated_at: "2026-05-10T10:00:00Z",
+                status: "triggered",
+                priority: { name: "P1" },
+                service: { id: "PJK1HJ8" },
+              },
+            ],
+            more: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("Internal Server Error", { status: 500 });
+    }) as typeof fetch;
+    const db = createMemoryIndexDb();
+    const sync = createPagerdutySyncable({ ensurePagerdutyMcpRunning: async () => {} });
+    const vault = createStubVault({ "pagerduty.api_token": "test-token" });
+    const result = await sync.sync(syncTestContext(db, vault), null);
+    expect(result.itemsUpserted).toBe(1);
+    expect(result.hasMore).toBe(false);
+    const cursor = result.cursor as string;
+    const decoded = Buffer.from(cursor.slice("nimbus-pd1:".length), "base64url").toString("utf8");
+    // Cursor advances past page-1's max updated_at, NOT back to the original since.
+    expect(JSON.parse(decoded)).toEqual({ lastUpdated: "2026-05-10T10:00:00Z" });
+  });
+```
+
+- [ ] **Step 3: Run the tests, verify they fail**
+
+```
+bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
+```
+
+Expected: FAIL on all three new tests — the current sync fetches once and returns.
+
+- [ ] **Step 4: Rewrite `createPagerdutySyncable`'s `sync` body**
+
+In `packages/gateway/src/connectors/pagerduty-sync.ts`, replace the entire `createPagerdutySyncable` function (lines 135-195) with this version:
+
+```typescript
+export function createPagerdutySyncable(options: PagerdutySyncableOptions): Syncable {
+  const initialSyncDepthDays = 30;
+  const maxPagesPerSync = Math.max(1, Math.min(100, options.maxPagesPerSync ?? 20));
+  const PAGE_SIZE = 100;
+  return {
+    serviceId: SERVICE_ID,
+    defaultIntervalMs: 120 * 1000,
+    initialSyncDepthDays,
+    async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
+      const t0 = performance.now();
+      await options.ensurePagerdutyMcpRunning();
+      const token = await readConnectorSecret(ctx.vault, "pagerduty", "api_token");
+      if (token === null || token.trim() === "") {
+        return syncNoopResult(cursor, t0);
+      }
+      const prev = decodeCursor(cursor);
+      const now = Date.now();
+      const floorIso = new Date(now - initialSyncDepthDays * 86_400_000).toISOString();
+      const since = prev?.lastUpdated ?? floorIso;
+
+      let pagesFetched = 0;
+      let totalUpserted = 0;
+      let maxUpdated = since;
+      let lastTextLen = 0;
+      let pdHasMore = false;
+
+      while (pagesFetched < maxPagesPerSync) {
+        await ctx.rateLimiter.acquire("pagerduty");
+        const u = new URL("https://api.pagerduty.com/incidents");
+        u.searchParams.set("limit", String(PAGE_SIZE));
+        u.searchParams.set("sort_by", "updated_at:asc");
+        u.searchParams.set("since", since);
+        u.searchParams.set("offset", String(pagesFetched * PAGE_SIZE));
+        const res = await fetch(u.toString(), {
+          headers: {
+            Accept: "application/vnd.pagerduty+json;version=2",
+            Authorization: `Token token=${token.trim()}`,
+          },
+        });
+        const text = await res.text();
+        lastTextLen = text.length;
+        if (!res.ok) {
+          ctx.logger.warn(
+            { serviceId: SERVICE_ID, status: res.status, page: pagesFetched },
+            "pagerduty sync: list failed",
+          );
+          // Preserve progress: cursor reflects pages already ingested.
+          return {
+            cursor: encodeCursor({ lastUpdated: maxUpdated }),
+            itemsUpserted: totalUpserted,
+            itemsDeleted: 0,
+            hasMore: false,
+            durationMs: Math.round(performance.now() - t0),
+            bytesTransferred: lastTextLen,
+          };
+        }
+        const incidents = parsePagerdutyIncidents(text);
+        if (incidents === null) {
+          return {
+            cursor: encodeCursor({ lastUpdated: maxUpdated }),
+            itemsUpserted: totalUpserted,
+            itemsDeleted: 0,
+            hasMore: false,
+            durationMs: Math.round(performance.now() - t0),
+            bytesTransferred: lastTextLen,
+          };
+        }
+        const { upserted, maxUpdated: pageMax } = syncPagerdutyIncidentItems(
+          ctx,
+          incidents,
+          maxUpdated,
+          now,
+        );
+        totalUpserted += upserted;
+        maxUpdated = pageMax;
+        pagesFetched += 1;
+        // PD's response wraps the array with a sibling `more: boolean`.
+        const parsed = JSON.parse(text) as { more?: boolean };
+        pdHasMore = parsed.more === true;
+        if (!pdHasMore) break;
+      }
+
+      return {
+        cursor: encodeCursor({ lastUpdated: maxUpdated }),
+        itemsUpserted: totalUpserted,
+        itemsDeleted: 0,
+        hasMore: pagesFetched >= maxPagesPerSync && pdHasMore,
+        durationMs: Math.round(performance.now() - t0),
+        bytesTransferred: lastTextLen,
+      };
+    },
+  };
+}
+```
+
+The existing `pagerdutyListFailureResult` helper at lines 115-129 is no longer used by the rewritten sync — it's safe to delete it. Find the function definition and remove it.
+
+- [ ] **Step 5: Run the tests, verify they pass**
+
+```
+bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
+```
+
+Expected: PASS — all three new tests green, all pre-existing tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/connectors/pagerduty-sync.ts packages/gateway/src/connectors/pagerduty-sync.test.ts
+git commit -m "feat(pagerduty): walk all incident pages per sync
+
+Phase 5 T4 wrap-up Phase B. Replaces the single-fetch sync body with a
+bounded loop that follows PD's parsed.more flag, advances offset by
+pagesFetched * 100, and reports SyncResult.hasMore=true on cap-hit so
+the scheduler re-queues. Three new tests: walks-until-more=false,
+respects maxPagesPerSync cap, partial-failure preserves cursor."
+```
+
+---
+
+### Task 9: Bootstrap thread `maxPagesPerSync`
+
+**Goal:** Wire the `[pagerduty].max_pages_per_sync` config value into the syncable factory at gateway startup.
+
+**Files:**
+- Modify: `packages/gateway/src/platform/assemble.ts` (load config, pass into registrations)
+- Modify: `packages/gateway/src/platform/assemble-sync-registrations.ts` (accept new param, thread to factory)
+
+- [ ] **Step 1: Extend the `assemble-sync-registrations.ts` signature**
+
+In `packages/gateway/src/platform/assemble-sync-registrations.ts:33-36`, replace:
+
+```typescript
+export function registerConnectorMeshSyncables(
+  syncScheduler: SyncScheduler,
+  connectorMesh: LazyConnectorMesh,
+): void {
+```
+
+with:
+
+```typescript
+export type ConnectorMeshSyncableOptions = {
+  /** Phase 5 T4 wrap-up: hard cap on pages walked per pagerduty sync. */
+  pagerdutyMaxPagesPerSync: number;
+};
+
+export function registerConnectorMeshSyncables(
+  syncScheduler: SyncScheduler,
+  connectorMesh: LazyConnectorMesh,
+  options: ConnectorMeshSyncableOptions,
+): void {
+```
+
+Then in the same file, replace the existing `createPagerdutySyncable` registration (lines 127-131):
+
+```typescript
+  syncScheduler.register(
+    createPagerdutySyncable({
+      ensurePagerdutyMcpRunning: () => connectorMesh.ensurePagerdutyRunning(),
+    }),
+  );
+```
+
+with:
+
+```typescript
+  syncScheduler.register(
+    createPagerdutySyncable({
+      ensurePagerdutyMcpRunning: () => connectorMesh.ensurePagerdutyRunning(),
+      maxPagesPerSync: options.pagerdutyMaxPagesPerSync,
+    }),
+  );
+```
+
+- [ ] **Step 2: Wire it at the call site in `assemble.ts`**
+
+In `packages/gateway/src/platform/assemble.ts`, find the existing imports from `../config/nimbus-toml.ts` (around line 11-16):
+
+```typescript
+import {
+  loadNimbusAutomationFromConfigDir,
+  loadNimbusEmbeddingFromPath,
+  loadNimbusLlmPartialFromPath,
+  loadNimbusUpdaterFromConfigDir,
+  resolveNimbusTomlForProfile,
+} from "../config/nimbus-toml.ts";
+```
+
+Add `loadNimbusPagerdutyFromConfigDir` to the imports:
+
+```typescript
+import {
+  loadNimbusAutomationFromConfigDir,
+  loadNimbusEmbeddingFromPath,
+  loadNimbusLlmPartialFromPath,
+  loadNimbusPagerdutyFromConfigDir,
+  loadNimbusUpdaterFromConfigDir,
+  resolveNimbusTomlForProfile,
+} from "../config/nimbus-toml.ts";
+```
+
+Then find the `registerConnectorMeshSyncables(syncScheduler, connectorMesh)` call at line 278. Replace it with:
+
+```typescript
+  const pagerdutyCfg = loadNimbusPagerdutyFromConfigDir(paths.configDir);
+  registerConnectorMeshSyncables(syncScheduler, connectorMesh, {
+    pagerdutyMaxPagesPerSync: pagerdutyCfg.maxPagesPerSync,
+  });
+```
+
+- [ ] **Step 3: Run typecheck**
+
+```
+bun run typecheck
+```
+
+Expected: PASS. If there are other callers of `registerConnectorMeshSyncables` — check with:
+
+```
+grep -rn "registerConnectorMeshSyncables" packages/gateway --include="*.ts"
+```
+
+Update any additional callers with the new options arg.
+
+- [ ] **Step 4: Run the full gateway test suite**
+
+```
+bun test packages/gateway
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(gateway): wire [pagerduty].max_pages_per_sync at bootstrap
+
+Phase 5 T4 wrap-up. assemble.ts loads the [pagerduty] block once at
+startup and threads maxPagesPerSync into registerConnectorMeshSyncables,
+which now takes an options bag for connector-mesh syncables. Default
+20 pages per sync (parsed default in nimbus-toml.ts)."
+```
+
+---
+
+### Task 10: Roadmap + CLAUDE.md updates
+
+**Goal:** Flip the two `[ ]` rows in the roadmap and add a one-line entry to CLAUDE.md's Status block.
+
+**Files:**
+- Modify: `docs/roadmap.md` (two specific bullets — see grep)
+- Modify: `CLAUDE.md` (Status line, ~line 13)
+
+- [ ] **Step 1: Locate the two roadmap bullets**
+
+```
+grep -n "PagerDuty sync pagination\|severity_strategy.*config knob" docs/roadmap.md
+```
+
+Expected output: two line numbers in the "Nimbus as a CI/CD Data Layer" section. Note them.
+
+- [ ] **Step 2: Flip the first bullet (pagination)**
+
+In `docs/roadmap.md`, find this block (the "PagerDuty sync pagination" bullet, currently `[ ]`):
+
+```markdown
+- [ ] **PagerDuty sync pagination** — follow `has_more` on `GET /incidents` and walk pages
+  until exhausted (or until a `[pagerduty].max_pages_per_sync` cap is hit). Today the sync
+  fetches the first 50 incidents updated since the cursor and drops the tail. DORA accuracy
+  for high-volume orgs depends on this. No new credentials.
+```
+
+Replace with:
+
+```markdown
+- [x] **PagerDuty sync pagination** (2026-05-16, Phase 5 T4 wrap-up) — `pagerduty-sync.ts`
+  now walks pages with `sort_by=updated_at:asc` and `limit=100`, honoring `parsed.more`
+  and capping at `[pagerduty].max_pages_per_sync` (default 20, range 1..100). On cap-hit
+  the syncable returns `hasMore: true` so the scheduler re-queues; partial-failure cursors
+  preserve progress from pages already ingested. No new credentials.
+```
+
+- [ ] **Step 3: Flip the second bullet (severity_strategy)**
+
+In the same file, find this block:
+
+```markdown
+- [ ] **`[pagerduty].severity_strategy` config knob** — let teams map non-`"P1"` priority
+  names (`"Critical"`, `"SEV-1"`) to preflight's P1 filter; emit a `gap` note in
+  `deploy.preflight` when the connector sees `urgency: "high"` incidents with no
+  `priority.name`, so operators can self-diagnose silent-zero preflight results. Bundles
+  the alias-map and urgency-gap-warning Gemini-CLI suggested separately in the
+  enrichment review §2.2.
+```
+
+Replace with:
+
+```markdown
+- [x] **`[pagerduty].severity_p1_aliases` config knob** (2026-05-16, Phase 5 T4 wrap-up) —
+  preflight's `selectActiveP1Incidents` now matches `LOWER(severity) IN (?, ?, ...)` over
+  the union of `"p1"` plus org-declared aliases (e.g. `"Critical"`, `"SEV-1"`). Aliases are
+  lowercased + deduped at parse time. New `PreflightGap` variant
+  `"pagerduty_urgency_without_priority"` fires when the strict filter yields zero matches
+  but high-urgency-without-priority incidents exist on the configured services, so operators
+  can self-diagnose silent-zero preflight results. Query-time evaluation — no re-index needed.
+```
+
+- [ ] **Step 4: Update CLAUDE.md Status line**
+
+In `CLAUDE.md`, find the Status block (around line 13). Look for the section ending with `T6 PR 2 \`tool_call_log\` V29 ✅ (2026-05-15)`. After `T4 wrap-up: PagerDuty enrichment ✅ (2026-05-14)`, the existing text continues with `T6 sequencing spec`. Find the substring:
+
+```
+T4 wrap-up: PagerDuty enrichment ✅ (2026-05-14) · T6 sequencing spec
+```
+
+Replace with:
+
+```
+T4 wrap-up: PagerDuty enrichment ✅ (2026-05-14) · T4 wrap-up: PagerDuty pagination + severity_p1_aliases ✅ (2026-05-16) · T6 sequencing spec
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/roadmap.md CLAUDE.md
+git commit -m "docs(roadmap): flip pagination + severity_p1_aliases to [x]
+
+Phase 5 T4 wrap-up complete. Backfills the roadmap + CLAUDE.md Status
+line with what shipped today."
+```
+
+---
+
+### Task 11: Full CI parity verification
+
+**Goal:** Run the full CI suite locally to catch anything the per-file `bun test` runs missed.
+
+**Files:** none directly modified.
+
+- [ ] **Step 1: Run typecheck across the whole workspace**
+
+```
+bun run typecheck
+```
+
+Expected: PASS. If errors surface anywhere outside the files we touched, investigate — it may indicate a fixture site missed in Task 2.
+
+- [ ] **Step 2: Run lint**
+
+```
+bun run lint
+```
+
+Expected: PASS. Apply `bun run lint:fix` if Biome flags style issues.
+
+- [ ] **Step 3: Run the gateway test coverage gates affected by this PR**
+
+```
+bun run test:coverage:preflight
+```
+
+Expected: PASS, coverage gate ≥ 80% held.
+
+```
+bun run test:coverage:config
+```
+
+Expected: PASS, gate ≥ 80% held.
+
+- [ ] **Step 4: Run the full unit + integration suite for the gateway**
+
+```
+bun test packages/gateway
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Decide whether `bun run test:ci` is needed**
+
+If steps 1-4 are green, the per-package gates have covered the critical paths. A full `bun run test:ci` is the strongest pre-PR check but takes longer; run it before opening the PR if the previous tasks took less than an hour total.
+
+- [ ] **Step 6: Final commit if any formatting / lint-fix touched files**
+
+```bash
+git status
+# If any files changed, commit:
+git add -A
+git commit -m "chore: biome auto-format pass after T4 wrap-up implementation"
+```
+
+- [ ] **Step 7: Inspect commit graph**
+
+```
+git log --oneline main..HEAD
+```
+
+Expected: 9-10 commits on the branch, all green-prefixed (`feat:`, `refactor:`, `docs:`, `chore:` etc.).
+
+---
+
+## Self-Review Notes
+
+After writing this plan, I verified:
+
+**Spec coverage:** Every requirement in the spec maps to a task —
+- `[pagerduty]` parser + types + loader → Task 1
+- `ServiceConfig.severityP1Aliases` field → Task 2
+- Threading at `loadNimbusServiceConfigsFromConfigDir` → Task 3
+- Preflight SQL widening → Task 4
+- `metadata.urgency` writes → Task 5
+- Urgency-gap probe + `PreflightGap` extension → Task 6
+- Pagination request shape → Task 7
+- Pagination loop + factory option + tests → Task 8
+- Bootstrap threading of `maxPagesPerSync` → Task 9
+- Roadmap + CLAUDE.md → Task 10
+- CI parity → Task 11
+
+**Placeholder scan:** No "TODO", "TBD", "fill in", or "similar to" found.
+
+**Type consistency:** `severityP1Aliases` (field on `ServiceConfig`), `severityP1Aliases` (Task 2 default + Task 3 threading + Task 4 SQL consumer), `maxPagesPerSync` (option key throughout Tasks 7, 8, 9) — names match end-to-end.
+
+**Known minor risk:** Task 2's typecheck step is the broadest — it surfaces fixtures across multiple test directories. The plan lists the likely sites but tells the engineer to use `grep` to find the actual set; this is intentional because the test fixtures are mechanical fillers, not load-bearing logic.

--- a/docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity.md
+++ b/docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity.md
@@ -139,6 +139,28 @@ describe("loadNimbusPagerdutyFromPath", () => {
     const out = loadNimbusPagerdutyFromPath(p);
     expect(out.maxPagesPerSync).toBe(7);
   });
+
+  test("falls back to defaults AND writes a stderr warning on validation error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-pd-toml-bad-"));
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, '[pagerduty]\nmax_pages_per_sync = 0\n', "utf8");
+    const captured: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    // Type assertion: process.stderr.write is overloaded; we shim the
+    // chunk-as-first-arg form, which is what nimbus-toml.ts uses.
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const out = loadNimbusPagerdutyFromPath(p);
+      expect(out).toEqual(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(captured.join("")).toContain("[pagerduty] config");
+    expect(captured.join("")).toContain("max_pages_per_sync");
+  });
 });
 
 describe("loadNimbusPagerdutyFromConfigDir", () => {
@@ -246,7 +268,15 @@ export function loadNimbusPagerdutyFromPath(tomlPath: string): NimbusPagerdutyTo
   try {
     const raw = readFileSync(tomlPath, "utf8");
     return parseNimbusPagerdutyToml(raw);
-  } catch {
+  } catch (err) {
+    // Surface validation errors (e.g. max_pages_per_sync out of range) so
+    // operators don't silently fall back to defaults. Matches the
+    // ci.service / metrics.dora conflict-warning pattern used elsewhere in
+    // this file (see loadNimbusServiceConfigsFromConfigDir).
+    process.stderr.write(
+      `nimbus: [pagerduty] config in ${tomlPath} rejected, using defaults: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
     return structuredClone(DEFAULT_NIMBUS_PAGERDUTY_TOML);
   }
 }
@@ -1297,9 +1327,53 @@ bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
 
 Expected: FAIL on all three new tests — the current sync fetches once and returns.
 
-- [ ] **Step 4: Rewrite `createPagerdutySyncable`'s `sync` body**
+- [ ] **Step 4: Refactor the private parse helper to return `{ incidents, more }` in one pass**
 
-In `packages/gateway/src/connectors/pagerduty-sync.ts`, replace the entire `createPagerdutySyncable` function (lines 135-195) with this version:
+In `packages/gateway/src/connectors/pagerduty-sync.ts`, find the existing private helper `parsePagerdutyIncidents` (around lines 35-48):
+
+```typescript
+function parsePagerdutyIncidents(text: string): unknown[] | null {
+  let root: unknown;
+  try {
+    root = JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+  const rec = asRecord(root);
+  if (rec === undefined) {
+    return null;
+  }
+  const raw = rec["incidents"];
+  return Array.isArray(raw) ? raw : null;
+}
+```
+
+Replace with a unified parser that returns both `incidents` and `more` in a single JSON parse:
+
+```typescript
+function parsePagerdutyListResponse(
+  text: string,
+): { incidents: unknown[]; more: boolean } | null {
+  let root: unknown;
+  try {
+    root = JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+  const rec = asRecord(root);
+  if (rec === undefined) return null;
+  const incidents = rec["incidents"];
+  if (!Array.isArray(incidents)) return null;
+  // PagerDuty's REST v2 list response wraps the array with a sibling
+  // boolean `more`. Absent (or non-boolean) is treated as `false` so the
+  // loop terminates on a malformed response.
+  return { incidents, more: rec["more"] === true };
+}
+```
+
+- [ ] **Step 5: Rewrite `createPagerdutySyncable`'s `sync` body**
+
+In the same file, replace the entire `createPagerdutySyncable` function (lines 135-195) with this version:
 
 ```typescript
 export function createPagerdutySyncable(options: PagerdutySyncableOptions): Syncable {
@@ -1318,6 +1392,10 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
         return syncNoopResult(cursor, t0);
       }
       const prev = decodeCursor(cursor);
+      // Single `now` for the whole sync batch — standard atomic batch
+      // semantics. With maxPagesPerSync=20 and the default 2-minute
+      // sync interval, drift is at most seconds; `syncedAt` is the
+      // sync-start timestamp by design. (Reviewer concern #3 noted.)
       const now = Date.now();
       const floorIso = new Date(now - initialSyncDepthDays * 86_400_000).toISOString();
       const since = prev?.lastUpdated ?? floorIso;
@@ -1349,6 +1427,10 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
             "pagerduty sync: list failed",
           );
           // Preserve progress: cursor reflects pages already ingested.
+          // PD `since` is inclusive (`updated_at >= since`); if the failed
+          // page contained rows sharing the saved timestamp, next sync
+          // re-fetches them and SQLite UPSERT on (service, external_id)
+          // deduplicates idempotently.
           return {
             cursor: encodeCursor({ lastUpdated: maxUpdated }),
             itemsUpserted: totalUpserted,
@@ -1358,8 +1440,9 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
             bytesTransferred: lastTextLen,
           };
         }
-        const incidents = parsePagerdutyIncidents(text);
-        if (incidents === null) {
+        // Single JSON.parse per page — returns both `incidents` and `more`.
+        const parsed = parsePagerdutyListResponse(text);
+        if (parsed === null) {
           return {
             cursor: encodeCursor({ lastUpdated: maxUpdated }),
             itemsUpserted: totalUpserted,
@@ -1371,16 +1454,14 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
         }
         const { upserted, maxUpdated: pageMax } = syncPagerdutyIncidentItems(
           ctx,
-          incidents,
+          parsed.incidents,
           maxUpdated,
           now,
         );
         totalUpserted += upserted;
         maxUpdated = pageMax;
         pagesFetched += 1;
-        // PD's response wraps the array with a sibling `more: boolean`.
-        const parsed = JSON.parse(text) as { more?: boolean };
-        pdHasMore = parsed.more === true;
+        pdHasMore = parsed.more;
         if (!pdHasMore) break;
       }
 
@@ -1397,9 +1478,9 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
 }
 ```
 
-The existing `pagerdutyListFailureResult` helper at lines 115-129 is no longer used by the rewritten sync — it's safe to delete it. Find the function definition and remove it.
+The existing `pagerdutyListFailureResult` helper at lines 115-129 is no longer used by the rewritten sync — delete it. Find the function definition and remove it.
 
-- [ ] **Step 5: Run the tests, verify they pass**
+- [ ] **Step 6: Run the tests, verify they pass**
 
 ```
 bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
@@ -1407,7 +1488,7 @@ bun test packages/gateway/src/connectors/pagerduty-sync.test.ts
 
 Expected: PASS — all three new tests green, all pre-existing tests still green.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add packages/gateway/src/connectors/pagerduty-sync.ts packages/gateway/src/connectors/pagerduty-sync.test.ts
@@ -1416,8 +1497,10 @@ git commit -m "feat(pagerduty): walk all incident pages per sync
 Phase 5 T4 wrap-up Phase B. Replaces the single-fetch sync body with a
 bounded loop that follows PD's parsed.more flag, advances offset by
 pagesFetched * 100, and reports SyncResult.hasMore=true on cap-hit so
-the scheduler re-queues. Three new tests: walks-until-more=false,
-respects maxPagesPerSync cap, partial-failure preserves cursor."
+the scheduler re-queues. Parse helper refactored to return both
+incidents+more in one JSON.parse pass. Three new tests: walks-until-
+more=false, respects maxPagesPerSync cap, partial-failure preserves
+cursor."
 ```
 
 ---
@@ -1726,3 +1809,45 @@ After writing this plan, I verified:
 **Type consistency:** `severityP1Aliases` (field on `ServiceConfig`), `severityP1Aliases` (Task 2 default + Task 3 threading + Task 4 SQL consumer), `maxPagesPerSync` (option key throughout Tasks 7, 8, 9) — names match end-to-end.
 
 **Known minor risk:** Task 2's typecheck step is the broadest — it surfaces fixtures across multiple test directories. The plan lists the likely sites but tells the engineer to use `grep` to find the actual set; this is intentional because the test fixtures are mechanical fillers, not load-bearing logic.
+
+---
+
+## Review responses
+
+Disposition of the five points raised in [2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-review.md](./2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-review.md):
+
+| # | Point | Disposition | Action in plan |
+|---|---|---|---|
+| 1 | Double JSON parse in Task 8 | **FIX** | Task 8 step 4 refactors private `parsePagerdutyIncidents` → `parsePagerdutyListResponse` returning `{ incidents, more }`; step 5's loop uses the single-parse helper |
+| 2 | Cursor staging UPSERT reliance | **FIX** (clarifying comment) | Added inline code comment in the partial-failure return path of Task 8 step 5 noting PD's inclusive `since` + SQLite UPSERT idempotency |
+| 3 | Stale `now` timestamp drift | **DOCUMENT** (no behavior change) | Added inline code comment in Task 8 step 5 explaining the batch-atomic `synced_at` semantic is intentional; drift is bounded to seconds at default settings |
+| 4 | SQL IN clause Set usage | **ACKNOWLEDGE** (positive feedback) | No action — reviewer commended the existing design |
+| 5 | Silent validation-error fallback | **FIX** | Task 1 step 3 `loadNimbusPagerdutyFromPath` now writes a stderr warning before returning defaults; Task 1 step 1 adds a test asserting the warning fires |
+
+### 1. Double JSON parse — FIX
+
+The reviewer is right: `parsePagerdutyIncidents(text)` was followed by a second `JSON.parse(text)` to extract `more`. Refactored to a single helper `parsePagerdutyListResponse` that returns both fields in one pass. The helper is private (not exported, no external callers verified via grep), so the rename + signature change is safe. Net effect: one `JSON.parse` per page instead of two, simpler code, and a typed return value that documents the response shape.
+
+### 2. Cursor staging UPSERT reliance — FIX as comment
+
+The reviewer asks for explicit acknowledgment that PD's inclusive `since` + SQLite UPSERT semantics make cross-page failure idempotent. The spec already documents this in `§Part 1`; the plan now folds a single-sentence inline code comment into the partial-failure return path so a future maintainer reading the sync body sees it in context. No behavior change.
+
+### 3. Stale `now` timestamp drift — DOCUMENT as comment
+
+The reviewer is correct that `now` is captured once and could drift across pages, but the impact analysis shows this is the intended batch-atomic `synced_at` semantic, not a bug:
+
+- `syncPagerdutyIncidentItems` uses `now` for two fields: `syncedAt` (always) and `modifiedAt` (only as the fallback when `updated_at`/`created_at` are unparseable). Using a single sync-start timestamp for `synced_at` across an entire batch is standard practice — it lets `WHERE synced_at >= ?` queries identify whole sync windows cleanly.
+- Preflight's `incidentWindowMinutes` is evaluated against `opened_at_ms` (derived from PD's `created_at`), not `synced_at`. Drift in `now` does not affect it.
+- At default settings (20 pages × ~100ms per fetch + rate-limiter tokens), drift is bounded to a few seconds. The configured maximum (100 pages) could in theory push this to tens of seconds, but `synced_at` is not a clock-accuracy field.
+
+Added an inline comment explaining this near the `const now = Date.now()` line so future maintainers don't second-guess it.
+
+### 4. Set-based IN clause — ACKNOWLEDGE
+
+Reviewer commended the `new Set(["p1", ...aliases])` pattern + the `cfg.pagerdutyServices.length === 0` guard against empty-IN SQL errors. Already in the plan as-is. No action.
+
+### 5. Silent validation-error fallback — FIX
+
+Real concern. `loadNimbusPagerdutyFromPath` catches every error and returns defaults, which means a misconfigured `max_pages_per_sync = 0` would silently fall back to 20 with no operator-visible signal. Added a `process.stderr.write` warning in the catch block matching the existing `[ci.service.<id>] / [metrics.dora.<id>]` conflict-warning pattern in the same file (line 959). Also added a test in Task 1 step 1 that captures `process.stderr.write` and asserts the warning contains `"[pagerduty] config"` + `"max_pages_per_sync"`, so a future refactor can't silently strip the warning.
+
+Net: one real efficiency fix, two clarifying comments, one substantive defensive add (stderr warning + test), one acknowledgement.

--- a/docs/superpowers/specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design-review.md
+++ b/docs/superpowers/specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design-review.md
@@ -1,0 +1,34 @@
+# Design Review: Phase 5 T4 wrap-up — PagerDuty pagination + `severity_p1_aliases`
+
+## Overview
+The proposed design elegantly addresses two critical silent-failure modes (pagination drops and strict priority taxonomy filtering) within the PagerDuty connector. The threading of configuration is minimal and respects the existing architectural boundaries.
+
+Here are a few open questions, edge cases, and suggestions to consider before implementation.
+
+## Open Questions & Suggestions
+
+### 1. Pagination: Offset vs. Cursor-based
+- **Context:** The design uses `offset` based pagination (`offset = pagesFetched * 100`). PagerDuty API docs state the maximum offset is 10,000. The proposed `max_pages_per_sync` cap of 100 perfectly guards against HTTP 400 errors from exceeding this limit (100 * 100 = 10,000).
+- **Risk:** `offset` pagination is vulnerable to dataset shifting. If incidents are created or updated during the API walk, items can shift into or out of the current page, causing duplicates or missed items. 
+- **Suggestion:** Does PagerDuty's official cursor-based pagination (using the `cursor` parameter instead of `offset`) fit this use-case better? If we stick to `offset`, since we use SQLite `upsert`, duplicates are harmless, but missing an item during a shift might require the next sync to catch it. It may be worth explicitly documenting why `offset` was chosen over `cursor`.
+
+### 2. Cursor Resolution & Timestamp Collisions
+- **Context:** The loop tracks `maxUpdated` to use as the `since` parameter for the next sync if capped.
+- **Risk:** If a large number of incidents (e.g., >100) share the exact same `updated_at` timestamp, and the `maxPagesPerSync` cap stops the walk halfway through those incidents, the next sync will start with `since = maxUpdated` (which is that same timestamp).
+- **Suggestion:** Verify PagerDuty's behavior with `since` (is it inclusive or exclusive?). If it's inclusive (`>=`), SQLite `UPSERT` will naturally handle the overlapping duplicates from the previous sync, which is safe. If it's exclusive (`>`), we might silently drop the rest of the incidents sharing that timestamp.
+
+### 3. Preflight Urgency Gap Probe Performance
+- **Context:** The urgency gap probe adds a `SELECT COUNT(*) FROM item WHERE service = 'pagerduty' AND type = 'incident' AND ...` query iff the P1 count is 0.
+- **Question:** Does the `item` table have a composite index on `(service, type)` to efficiently support this query without a full table scan? Preflight runs are synchronously awaited by the user/CLI, so this query needs to be fast even if the user has 100,000 indexed incidents.
+
+### 4. Dynamic SQL `IN` Clause Generation
+- **Context:** The design states `LOWER(json_extract(metadata, '$.severity')) IN (?, ?, ...)` where the parameters are `"p1"` plus the aliases.
+- **Suggestion:** Just a minor implementation detail reminder to ensure the number of `?` placeholders dynamically matches `1 + cfg.severityP1Aliases.length`, and that the array passed to the SQL runner matches exactly.
+
+### 5. `severity_p1_aliases` Edge Case
+- **Context:** The TOML parser allows empty entries to be dropped, and strings are lowercased.
+- **Question:** What happens if a user configures an alias like `"p1"` or `"P1"`?
+- **Suggestion:** The resulting array might contain duplicates like `['p1', 'p1']`, which results in `IN ('p1', 'p1')`. This is harmless in SQLite, as noted in the design ("degrades to a redundant SQL IN placeholder, which is harmless"), but confirming this behavior during testing would be a good sanity check.
+
+## Conclusion
+The design is robust and clearly aligns with the local-first, non-destructive principles of the project. Addressing the `offset` vs. `cursor` pagination and timestamp collision behavior will ensure complete data integrity for high-volume orgs.

--- a/docs/superpowers/specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design.md
+++ b/docs/superpowers/specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design.md
@@ -1,0 +1,330 @@
+# Phase 5 T4 wrap-up — PagerDuty pagination + `severity_p1_aliases`
+
+**Status:** Design (rev 2, review responses folded in — see § Review responses at bottom)
+**Date:** 2026-05-16
+**Branch:** `dev/asafgolombek/phase-5-t4-wrap-pagerduty-pagination-severity`
+**Roadmap entries closed:**
+
+- "PagerDuty sync pagination" ([docs/roadmap.md](../../roadmap.md))
+- "`[pagerduty].severity_strategy` config knob" ([docs/roadmap.md](../../roadmap.md))
+
+This is one PR that closes both T4 wrap-up loose ends. They share the same config block (`[pagerduty]`) and touch the same two production files; splitting them would create a needless intermediate state with a single-key TOML table.
+
+## Motivation
+
+Two unrelated but adjacent bugs in the Phase 5 T4 PagerDuty surface degrade DORA / preflight accuracy in production:
+
+1. **Pagination drop.** [pagerduty-sync.ts:154-191](../../../packages/gateway/src/connectors/pagerduty-sync.ts#L154-L191) requests `limit=50`, no `sort_by` direction, never follows `has_more`, and hard-codes `SyncResult.hasMore = false`. High-volume orgs silently lose every incident past the first 50 per cursor advance.
+
+2. **Priority taxonomy assumption.** [preflight.ts:117](../../../packages/gateway/src/preflight/preflight.ts#L117) filters strictly on `metadata.severity = 'P1'`. PagerDuty priority names are user-defined; common org taxonomies use `"Critical"`, `"SEV-1"`, `"Sev1"`, etc. Active P1-equivalent incidents are silently absent from preflight, producing false-clean preflight runs before a deploy.
+
+Today's symptom for both: silent zero. There is no operator-visible signal that data is being dropped or filtered out, so the verdict reads `"ok"` regardless.
+
+## Goals
+
+- Walk PagerDuty incident pages to exhaustion (or to a configurable cap), with monotonic cursor advance under capping.
+- Let teams declare which PD priority names map to "P1" for preflight purposes without rewriting indexed data.
+- Surface a self-diagnostic gap note when preflight returns `count: 0` but high-urgency-untagged incidents exist on the configured services.
+
+## Non-goals
+
+- Multi-severity routing (P2, P3, etc.). Preflight today is P1-only; nothing else needs alias mapping.
+- Retroactive re-normalization of already-indexed `severity` values. Query-time evaluation is the explicit design — indexed rows stay verbatim.
+- Auto-detection of priority taxonomies. The alias list is operator-declared.
+- Changing how `cfg.pagerdutyServices` is mapped per DORA service.
+
+## Configuration
+
+New top-level TOML block in `nimbus.toml`:
+
+```toml
+[pagerduty]
+max_pages_per_sync = 20         # 1..100; default 20
+severity_p1_aliases = [          # default: []
+  "Critical",
+  "SEV-1",
+]
+```
+
+Parsed by a new `parseNimbusPagerdutyToml` function in [config/nimbus-toml.ts](../../../packages/gateway/src/config/nimbus-toml.ts), modelled on the existing `parseNimbusTomlUserSection`. Loader symmetric: `loadNimbusPagerdutyFromPath` + `loadNimbusPagerdutyFromConfigDir`.
+
+```ts
+export type NimbusPagerdutyToml = {
+  maxPagesPerSync: number;       // default 20
+  severityP1Aliases: readonly string[]; // default []
+};
+
+export const DEFAULT_NIMBUS_PAGERDUTY_TOML: NimbusPagerdutyToml = {
+  maxPagesPerSync: 20,
+  severityP1Aliases: [],
+};
+```
+
+Validation:
+
+- `max_pages_per_sync` must parse as a base-10 integer in `[1, 100]`. Out-of-range or non-integer values throw at parse time with a clear message naming the key.
+- `severity_p1_aliases` reuses the existing `parseStringArray`, then **lowercases and de-duplicates** before storage. Empty / whitespace-only entries are dropped. The lowercase-dedup step happens once at parse time, not at query time, so the IN-clause downstream is always minimal and deterministic. A user-supplied `"P1"` is normalized away (covered by the canonical entry in the query), so `["Critical", "critical", "P1"]` → stored as `["critical"]`.
+
+## Part 1 — Pagination
+
+**File:** [pagerduty-sync.ts](../../../packages/gateway/src/connectors/pagerduty-sync.ts)
+
+**Factory signature:**
+
+```ts
+export type PagerdutySyncableOptions = {
+  ensurePagerdutyMcpRunning: () => Promise<void>;
+  maxPagesPerSync: number;       // NEW — supplied by gateway bootstrap from NimbusPagerdutyToml
+};
+```
+
+**`sync()` body (replaces current single-fetch logic):**
+
+```
+let pagesFetched = 0
+let upserted = 0
+let maxUpdated = since
+let lastTextLen = 0
+
+loop:
+  u = new URL("https://api.pagerduty.com/incidents")
+  u.searchParams.set("limit", "100")               // bumped 50 → 100 (PD max)
+  u.searchParams.set("sort_by", "updated_at:asc")  // explicit asc for cursor correctness
+  u.searchParams.set("since", since)
+  u.searchParams.set("offset", String(pagesFetched * 100))
+
+  await ctx.rateLimiter.acquire("pagerduty")       // one acquire per page
+  res = await fetch(u, headers...)
+  text = await res.text()
+  lastTextLen = text.length
+
+  if !res.ok:
+    return pagerdutyListFailureResult(advancedCursor, since, lastTextLen, t0)
+    // advancedCursor encodes maxUpdated-so-far; partial progress is preserved.
+
+  parsed = JSON.parse(text)
+  incidents = parsed.incidents (array or null)
+  if incidents === null:
+    return SyncResult { cursor: encode(maxUpdated), upserted, hasMore: false, ... }
+
+  { upserted: deltaU, maxUpdated: deltaMax } = syncPagerdutyIncidentItems(ctx, incidents, maxUpdated, now)
+  upserted += deltaU
+  maxUpdated = deltaMax
+  pagesFetched += 1
+
+  pdHasMore = parsed.more === true               // PD's pagination flag
+  if !pdHasMore: break
+  if pagesFetched >= options.maxPagesPerSync: break
+
+return SyncResult {
+  cursor: encode(maxUpdated),
+  itemsUpserted: upserted,
+  itemsDeleted: 0,
+  hasMore: pagesFetched >= options.maxPagesPerSync && pdHasMore,  // true iff stopped by cap
+  durationMs: round(perfNow() - t0),
+  bytesTransferred: lastTextLen,                  // last-page bytes; pre-existing semantic
+}
+```
+
+**Key correctness notes:**
+
+- **`sort_by=updated_at:asc`** is the load-bearing change for capped walks. With descending order, capping at N pages would advance the cursor past every incident below the N-th newest, silently dropping them on subsequent syncs. Ascending guarantees the cursor reflects actual ingestion progress.
+- **`offset` arithmetic** is `pagesFetched * pageSize`, where `pageSize = 100`. PD's `/incidents` endpoint supports offset-based pagination only — there is no `cursor` parameter on this route (cursor pagination exists on PD's audit-records and change-events endpoints, but not here). PD's documented offset ceiling is 10,000, which matches our hard maximum of 100 pages × 100 per page; the default 20 pages stays well below it.
+- **Dataset-shift safety.** Because we walk ascending and the cursor advances to `maxUpdated`, an incident updated during the walk drifts toward pages we haven't yet read — never below the cursor. If it slips past us mid-walk, the next sync catches it via `since >= cursor`. SQLite `upsert` makes re-ingesting unchanged rows idempotent.
+- **Inclusive `since`.** PD's `since` filter is `updated_at >= since` (inclusive). If the cap interrupts mid-batch and N incidents share `updated_at = T`, the cursor advances to `T`, the next sync re-fetches the whole batch with `since=T`, and `upsert` deduplicates the rows we already wrote. No data loss across cap boundaries.
+- **`bytesTransferred`** is recorded from the last page only. This matches pre-existing semantics (sum-vs-last is a minor metric concern, not a correctness one).
+- **Partial-failure cursor** uses `maxUpdated` accumulated so far, not the original `since`. A 500 on page 7 still advances the cursor past pages 1-6.
+- **`hasMore: true` on cap-hit** lets the scheduler re-queue immediately and we continue forward next iteration from the advanced cursor.
+
+**Helper extraction (refactor):** the per-page fetch + parse + upsert loop body is extracted to a named local `fetchOnePage(offset)` returning `{ pdHasMore, parseFailed, fetchFailed, lastTextLen }` to keep the `sync` method readable. Pure refactor — no behavior change beyond the loop.
+
+## Part 2 — `severity_p1_aliases` (query-time)
+
+**File:** [preflight.ts](../../../packages/gateway/src/preflight/preflight.ts) + [metrics/dora-config.ts](../../../packages/gateway/src/metrics/dora-config.ts)
+
+**`ServiceConfig` field addition:**
+
+```ts
+export type ServiceConfig = {
+  // ...existing fields...
+  readonly severityP1Aliases: readonly string[];   // lowercased at threading time
+};
+```
+
+The bootstrap reads the top-level `[pagerduty]` block once, lowercases each alias, and copies the array into every `ServiceConfig` produced by `parseNimbusDoraToml` / the `[ci.service.<id>]` parser. The alias list is org-wide, not per-service — but threading via `ServiceConfig` keeps preflight's signature unchanged and avoids passing a separate parameter through `dispatchPreflightRpc` and the HTTP handler.
+
+This is a small additive change at the materialization call sites. The TOML parsers themselves do not learn about `[pagerduty]` — the bootstrap composes the two reads.
+
+**`selectActiveP1Incidents` SQL change** ([preflight.ts:110-119](../../../packages/gateway/src/preflight/preflight.ts#L110-L119)):
+
+```sql
+-- before
+AND json_extract(metadata, '$.severity') = 'P1'
+
+-- after
+AND LOWER(json_extract(metadata, '$.severity')) IN (?, ?, ...)
+-- params: "p1", plus each lowercased alias
+```
+
+The canonical set is built as `new Set(["p1", ...cfg.severityP1Aliases])` — the aliases array is already lowercased and deduped by the bootstrap, so the Set step is belt-and-braces against a user-supplied `"P1"` overlap. The placeholder count and parameter array are both derived from the same `Array.from(set)` iteration, so they cannot drift. The same change is applied to both the count query and the listing query.
+
+**`IncidentFinding.severity`** continues to return the raw stored value (e.g., `"Critical"`), not `"P1"` — preserves audit truth in the API response. The mapping is purely a filter widening.
+
+**Backward compatibility:** empty `severity_p1_aliases` (the default) yields `IN ('p1')`, which case-insensitively matches the verbatim `"P1"` values written today. Pre-existing behavior is preserved bit-for-bit for users who don't set the new key.
+
+## Part 3 — Urgency gap
+
+**Sync side** ([pagerduty-sync.ts](../../../packages/gateway/src/connectors/pagerduty-sync.ts)): in `syncPagerdutyIncidentItems`, additionally write `metadata.urgency = stringField(row, "urgency")` when present and non-empty. Untyped fallback: skip the field if missing. This is one additional line.
+
+**Preflight side** ([preflight.ts:102-149](../../../packages/gateway/src/preflight/preflight.ts#L102-L149)): in `selectActiveP1Incidents`, after computing `count`, run one additional probe query iff `count === 0` AND `cfg.pagerdutyServices.length > 0`:
+
+```sql
+SELECT COUNT(*) AS c FROM item
+WHERE service = 'pagerduty'
+  AND type = 'incident'
+  AND json_extract(metadata, '$.pagerduty_service_id') IN (...)
+  AND json_extract(metadata, '$.status') IN ('triggered', 'acknowledged')
+  AND json_extract(metadata, '$.urgency') = 'high'
+  AND (json_extract(metadata, '$.severity') IS NULL OR json_extract(metadata, '$.severity') = '')
+```
+
+If that count > 0, return `gap: "pagerduty_urgency_without_priority"`.
+
+**Type extension** ([preflight.ts:17](../../../packages/gateway/src/preflight/preflight.ts#L17)):
+
+```ts
+export type PreflightGap =
+  | null
+  | "no_pagerduty_mapping"
+  | "no_repos"
+  | "unknown_mergeable_state"
+  | "pagerduty_urgency_without_priority";   // NEW
+```
+
+Single-value `gap` stays single-value: `pagerduty_urgency_without_priority` and `no_pagerduty_mapping` are mutually exclusive by construction (the probe runs only when services are configured).
+
+**Verdict unchanged.** Gaps never flip the verdict — same rule as before. The gap is purely diagnostic ("preflight returned 0 P1s, but you have a high-urgency incident that isn't priority-tagged; check your `severity_p1_aliases` config or PagerDuty priority setup").
+
+## Threading summary
+
+Two threading sites, both already-existing functions that read the TOML once:
+
+1. **`[pagerduty].severity_p1_aliases` → `ServiceConfig.severityP1Aliases`** — threaded inside [`loadNimbusServiceConfigsFromConfigDir`](../../../packages/gateway/src/config/nimbus-toml.ts) (the canonical loader at `nimbus-toml.ts:948`). That function already reads the `nimbus.toml` raw bytes once and runs `parseNimbusDoraToml(raw)` + `parseNimbusCiServiceToml(raw)` against the same buffer. Add a third parse — `parseNimbusPagerdutyToml(raw)` — over the same buffer, lowercase its `severityP1Aliases`, then attach the lowercased array to every `ServiceConfig` entry as it's merged into the return map. Single file change; no caller changes anywhere else, because every consumer (preflight RPC, HTTP route, metrics RPC) already calls `loadNimbusServiceConfigsFromConfigDir` and receives the enriched configs transparently.
+
+2. **`[pagerduty].max_pages_per_sync` → `createPagerdutySyncable`** — threaded at [`packages/gateway/src/platform/assemble-sync-registrations.ts:128`](../../../packages/gateway/src/platform/assemble-sync-registrations.ts#L128). That file already imports `loadNimbusUpdaterFromConfigDir`-style loaders; add `loadNimbusPagerdutyFromConfigDir(paths.configDir)` and pass `maxPagesPerSync` into the factory options bag.
+
+No new IPC method. No new HTTP route. No migration. No `ALLOWED_METHODS` change.
+
+## Test plan
+
+All under `packages/gateway/test/` matching existing layout:
+
+### `connectors/pagerduty-sync.test.ts` (extend)
+
+- **Walks multiple pages until `more=false`.** Mock `fetch` to return `{ incidents: [...], more: true }` for pages 0 and 1 (offset 0 and 100), then `{ incidents: [...], more: false }` on page 2. Assert all three pages are upserted, cursor reflects max `updated_at` across all rows, `SyncResult.hasMore === false`, three `rateLimiter.acquire` calls.
+- **Respects `max_pages_per_sync` cap.** Mock `fetch` to always return `more: true`. With `maxPagesPerSync = 2`, assert exactly 2 fetches, `SyncResult.hasMore === true`, cursor advanced past page-2 rows.
+- **Writes `metadata.urgency`.** Single-page response includes `urgency: "high"` on one incident; assert the upserted row's `metadata.urgency === "high"`.
+- **Partial-failure preserves progress.** Page 0 succeeds, page 1 returns 500. Assert `SyncResult.cursor` encodes the max `updated_at` from page 0 (not the original `since`), `itemsUpserted` counts page-0 rows, `hasMore: false`.
+
+### `preflight/preflight.test.ts` (extend)
+
+- **Alias `"Critical"` counts toward P1.** Seed one incident with `severity: "Critical"`. Pass `cfg.severityP1Aliases = ["critical"]` (already lowercased per threading contract). Assert `active_p1_incidents.count === 1`, `findings[0].severity === "Critical"` (raw preserved).
+- **Case-insensitive match.** Seed `severity: "CRITICAL"` and `severity: "P1"`; assert both counted with aliases `["critical"]`.
+- **Urgency-gap fires when `count===0`.** Seed one open incident with `urgency: "high"` and no `severity`. Assert `active_p1_incidents.count === 0`, `gap === "pagerduty_urgency_without_priority"`.
+- **Urgency-gap suppressed when `count > 0`.** Seed one P1 + one urgency-without-priority. Assert `count === 1`, `gap === null`.
+- **Urgency-gap requires configured services.** With `cfg.pagerdutyServices = []`, assert `gap === "no_pagerduty_mapping"` (unchanged); the probe doesn't run.
+
+### `config/nimbus-toml.test.ts` (extend)
+
+- Parses `[pagerduty]` with both keys; round-trips to expected `NimbusPagerdutyToml`.
+- Defaults applied when keys absent.
+- `max_pages_per_sync = 0` throws with a clear message naming the key and bounds.
+- `max_pages_per_sync = 101` throws.
+- `severity_p1_aliases` with whitespace-only entries drops them.
+- `severity_p1_aliases = ["Critical", "critical", "P1"]` lowercases and dedupes to `["critical"]` (the `"p1"` overlap is collapsed because the canonical query entry already covers it).
+
+## Acceptance criteria
+
+- `bun test packages/gateway/test/unit/connectors/pagerduty-sync.test.ts` green; coverage doesn't regress.
+- `bun test packages/gateway/test/unit/preflight/preflight.test.ts` green; coverage gate ≥ 80% holds.
+- A fresh-install gateway with no `[pagerduty]` block in `nimbus.toml` behaves identically to today's behavior.
+- A gateway with `severity_p1_aliases = ["Critical"]` and existing indexed `"Critical"`-severity rows surfaces those rows in `nimbus deploy preflight` without re-sync.
+- A gateway with > 100 incidents updated since the cursor walks all of them (up to the cap) in one `sync()` call; `nimbus connector history pagerduty` shows the multi-page run.
+
+## Out of scope (not done in this PR)
+
+- Multi-severity routing.
+- Backward-incompatible cleanup of the old `bytesTransferred = text.length` last-page semantic.
+- Per-DORA-service alias overrides.
+- Telemetry counter for "pages walked per sync" (could be added later if needed for ops visibility).
+
+## Files touched
+
+- `packages/gateway/src/config/nimbus-toml.ts` — `+~60 lines` (parser, types, defaults, loader).
+- `packages/gateway/src/connectors/pagerduty-sync.ts` — refactor `sync()` loop, add page helper, add `urgency` write. `+~50 lines`, `-~20 lines`.
+- `packages/gateway/src/metrics/dora-config.ts` — add `severityP1Aliases` field to `ServiceConfig` type. `+1 line`.
+- `packages/gateway/src/preflight/preflight.ts` — SQL filter widening, urgency-gap probe, `PreflightGap` union extension. `+~30 lines`.
+- `packages/gateway/src/config/nimbus-toml.ts` — extend `loadNimbusServiceConfigsFromConfigDir` with a third raw-buffer parse + attach `severityP1Aliases` to every materialized `ServiceConfig`. `+~10 lines`.
+- `packages/gateway/src/platform/assemble-sync-registrations.ts` — load `[pagerduty]`, thread `maxPagesPerSync` into `createPagerdutySyncable(...)`. `+~5 lines`.
+- `packages/gateway/test/unit/connectors/pagerduty-sync.test.ts` — 4 new cases.
+- `packages/gateway/test/unit/preflight/preflight.test.ts` — 5 new cases.
+- `packages/gateway/test/unit/config/nimbus-toml.test.ts` — 5 new cases.
+- `docs/roadmap.md` — flip both `[ ]` rows to `[x]` with PR link and date.
+- `CLAUDE.md` — Status line: add to T4 wrap-up tally (one-liner).
+
+No migration. No new IPC method. No new HTTP route. No `ALLOWED_METHODS` change. No security invariant change.
+
+## Review responses
+
+Disposition of the five points raised in [2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design-review.md](./2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design-review.md):
+
+### 1. Offset vs cursor pagination — DEFER (no change), document why
+
+PagerDuty's REST API v2 `/incidents` endpoint only supports **offset-based** pagination via the `offset` query parameter. There is no `cursor` parameter on `/incidents` — cursor pagination exists on newer PD endpoints (audit-records, change-events) but not on incidents. The reviewer's concern about dataset-shift mid-walk is real but bounded:
+
+- We walk **ascending by `updated_at`**, so incidents updated during the walk drift *toward* higher pages we haven't yet read, never below us.
+- The cursor advances to `maxUpdated` actually ingested, so anything updated during the walk is caught next sync via `since >= cursor` regardless of whether it shifted positions.
+- Duplicates are harmless: SQLite `upsert` on `(service, external_id)` makes re-ingesting an unchanged row idempotent.
+
+The 10,000-offset PD limit is comfortably above our default (20 pages × 100 = 2,000) and equal to the configured maximum (100 pages × 100 = 10,000). Both fit.
+
+Added a one-line clarification to the pagination section noting offset is the only choice on this endpoint.
+
+### 2. Cursor resolution & timestamp collisions — DOCUMENT (no code change)
+
+PagerDuty's `since` filter is **inclusive** (`updated_at >= since`), per their REST v2 docs. Cap-induced interruptions are therefore safe:
+
+- If the cap hits mid-batch and N incidents share the same `updated_at = T`, the cursor advances to `T`.
+- Next sync queries `since = T`, returning the entire batch again.
+- SQLite `upsert` deduplicates: rows we already wrote are no-ops; rows we didn't reach get inserted.
+
+The cursor encoding (`PdCursorV1.lastUpdated`) already stores the ISO timestamp string PD expects, so no encoding work is needed. Added an explicit note in the pagination section.
+
+### 3. Probe-query performance — DOCUMENT, defer composite index
+
+Verified against [packages/gateway/src/index/unified-item-v3-sql.ts](../../../packages/gateway/src/index/unified-item-v3-sql.ts): the `item` table has separate single-column indexes on `service` and `type` — `idx_item_service` and `idx_item_type` — and no composite `(service, type)` index. SQLite's planner will use the more selective single-column index (almost always `service`, since `'pagerduty'` is far more selective than `'incident'` once the index has more than a handful of services). With ≤ 100 indexed PD incidents, the row residue after the index scan is small and the `type` filter is cheap.
+
+Two reasons the probe is not a real concern in this PR:
+
+1. **Pre-existing shape.** The existing `selectActiveP1Incidents` count query already uses the identical `service='pagerduty' AND type='incident'` filter. Our probe adds *one more* query of the same shape — it does not introduce a new access pattern.
+2. **Gated execution.** The probe runs **only when `count === 0`** AND `cfg.pagerdutyServices.length > 0`. Any org with at least one active P1 incident skips it entirely. The 100,000-incident-org scenario the reviewer worries about is precisely the scenario where this skip applies most often.
+
+Adding a composite `(service, type)` index would touch every `item`-table query, not just preflight, and belongs in a separate index-tuning ticket alongside other index reviews. Deferred.
+
+### 4. Dynamic `IN`-clause placeholder generation — ACKNOWLEDGE (folded into design)
+
+Implementation detail, not a design issue, but tightened up in the SQL section above: the placeholder string and parameter array are now both built from `Array.from(set)` of the same `Set` instance, so they cannot drift. A test in `preflight.test.ts` exercises the case where aliases are non-empty to assert the IN-clause actually matches both `"P1"` and the alias.
+
+### 5. Alias edge case (user-supplied `"P1"` or `"p1"`) — FIX
+
+Folded into the parser. `severity_p1_aliases` is now lowercased AND deduplicated at parse time, so `["Critical", "critical", "P1"]` becomes `["critical"]` in storage. The Set construction in `selectActiveP1Incidents` is a second line of defense against a partial-config edit. Added a parser test case.
+
+## Summary of changes vs rev 1
+
+| Review point | Disposition | Action in spec |
+|---|---|---|
+| 1. Offset vs cursor | DEFER | Documented why offset is the only option |
+| 2. Timestamp collisions | DOCUMENT | Noted inclusive `since` + UPSERT idempotency |
+| 3. Probe perf / index | DOCUMENT + DEFER index | Verified index situation, documented gating |
+| 4. Placeholder generation | ACKNOWLEDGE | Tightened to a single `Set` source |
+| 5. Alias dedup | FIX | Parser lowercases + dedupes; test added |

--- a/packages/gateway/src/config/nimbus-toml-pagerduty.test.ts
+++ b/packages/gateway/src/config/nimbus-toml-pagerduty.test.ts
@@ -53,6 +53,12 @@ describe("parseNimbusPagerdutyToml", () => {
     );
   });
 
+  test("throws when severity_p1_aliases is not an array", () => {
+    expect(() =>
+      parseNimbusPagerdutyToml("[pagerduty]\nseverity_p1_aliases = not-an-array\n"),
+    ).toThrow(/expected array/);
+  });
+
   test("lowercases + dedupes severity_p1_aliases", () => {
     const out = parseNimbusPagerdutyToml(
       '[pagerduty]\nseverity_p1_aliases = ["Critical", "critical", "P1"]\n',

--- a/packages/gateway/src/config/nimbus-toml-pagerduty.test.ts
+++ b/packages/gateway/src/config/nimbus-toml-pagerduty.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_NIMBUS_PAGERDUTY_TOML,
+  loadNimbusPagerdutyFromConfigDir,
+  loadNimbusPagerdutyFromPath,
+  parseNimbusPagerdutyToml,
+} from "./nimbus-toml.ts";
+
+describe("parseNimbusPagerdutyToml", () => {
+  test("returns defaults when [pagerduty] is absent", () => {
+    const out = parseNimbusPagerdutyToml("");
+    expect(out).toEqual(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+    expect(out.maxPagesPerSync).toBe(20);
+    expect(out.severityP1Aliases).toEqual([]);
+  });
+
+  test("reads max_pages_per_sync and severity_p1_aliases", () => {
+    const out = parseNimbusPagerdutyToml(
+      '[pagerduty]\nmax_pages_per_sync = 5\nseverity_p1_aliases = ["Critical", "SEV-1"]\n',
+    );
+    expect(out.maxPagesPerSync).toBe(5);
+    expect(out.severityP1Aliases).toEqual(["critical", "sev-1"]);
+  });
+
+  test("ignores keys outside [pagerduty]", () => {
+    const out = parseNimbusPagerdutyToml("[other]\nmax_pages_per_sync = 5\n");
+    expect(out.maxPagesPerSync).toBe(20);
+  });
+
+  test("strips inline comments", () => {
+    const out = parseNimbusPagerdutyToml("[pagerduty]\nmax_pages_per_sync = 10  # capped\n");
+    expect(out.maxPagesPerSync).toBe(10);
+  });
+
+  test("throws when max_pages_per_sync is 0", () => {
+    expect(() => parseNimbusPagerdutyToml("[pagerduty]\nmax_pages_per_sync = 0\n")).toThrow(
+      /max_pages_per_sync.*1\.\.100/,
+    );
+  });
+
+  test("throws when max_pages_per_sync is 101", () => {
+    expect(() => parseNimbusPagerdutyToml("[pagerduty]\nmax_pages_per_sync = 101\n")).toThrow(
+      /max_pages_per_sync.*1\.\.100/,
+    );
+  });
+
+  test("throws when max_pages_per_sync is non-integer", () => {
+    expect(() => parseNimbusPagerdutyToml('[pagerduty]\nmax_pages_per_sync = "lots"\n')).toThrow(
+      /max_pages_per_sync/,
+    );
+  });
+
+  test("lowercases + dedupes severity_p1_aliases", () => {
+    const out = parseNimbusPagerdutyToml(
+      '[pagerduty]\nseverity_p1_aliases = ["Critical", "critical", "P1"]\n',
+    );
+    // "P1" lowercases to "p1" which dedupes against itself; "Critical"/"critical" dedupes.
+    expect(out.severityP1Aliases).toEqual(["critical", "p1"]);
+  });
+
+  test("drops empty / whitespace-only alias entries", () => {
+    const out = parseNimbusPagerdutyToml(
+      '[pagerduty]\nseverity_p1_aliases = ["Critical", "", "   "]\n',
+    );
+    expect(out.severityP1Aliases).toEqual(["critical"]);
+  });
+});
+
+describe("loadNimbusPagerdutyFromPath", () => {
+  test("returns defaults when file is missing", () => {
+    const out = loadNimbusPagerdutyFromPath(join(tmpdir(), "does-not-exist.toml"));
+    expect(out).toEqual(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+  });
+
+  test("reads from disk", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-pd-toml-"));
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, "[pagerduty]\nmax_pages_per_sync = 7\n", "utf8");
+    const out = loadNimbusPagerdutyFromPath(p);
+    expect(out.maxPagesPerSync).toBe(7);
+  });
+
+  test("falls back to defaults AND writes a stderr warning on validation error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-pd-toml-bad-"));
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, "[pagerduty]\nmax_pages_per_sync = 0\n", "utf8");
+    const captured: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    // Type assertion: process.stderr.write is overloaded; we shim the
+    // chunk-as-first-arg form, which is what nimbus-toml.ts uses.
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const out = loadNimbusPagerdutyFromPath(p);
+      expect(out).toEqual(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(captured.join("")).toContain("[pagerduty] config");
+    expect(captured.join("")).toContain("max_pages_per_sync");
+  });
+});
+
+describe("loadNimbusPagerdutyFromConfigDir", () => {
+  test("resolves <configDir>/nimbus.toml", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-pd-cfg-"));
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      '[pagerduty]\nmax_pages_per_sync = 3\nseverity_p1_aliases = ["SEV-1"]\n',
+      "utf8",
+    );
+    const out = loadNimbusPagerdutyFromConfigDir(dir);
+    expect(out.maxPagesPerSync).toBe(3);
+    expect(out.severityP1Aliases).toEqual(["sev-1"]);
+  });
+});

--- a/packages/gateway/src/config/nimbus-toml-service-configs.test.ts
+++ b/packages/gateway/src/config/nimbus-toml-service-configs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadNimbusServiceConfigsFromConfigDir } from "./nimbus-toml.ts";
+
+describe("loadNimbusServiceConfigsFromConfigDir + [pagerduty] aliases", () => {
+  test("attaches lowercased severityP1Aliases to every ServiceConfig", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sc-aliases-"));
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      `[pagerduty]
+severity_p1_aliases = ["Critical", "SEV-1"]
+
+[metrics.dora.payments]
+repos = ["github:acme/payments"]
+
+[ci.service.checkout]
+repos = ["github:acme/checkout"]
+`,
+      "utf8",
+    );
+    const merged = loadNimbusServiceConfigsFromConfigDir(dir);
+    expect(merged.size).toBe(2);
+    expect(merged.get("payments")?.severityP1Aliases).toEqual(["critical", "sev-1"]);
+    expect(merged.get("checkout")?.severityP1Aliases).toEqual(["critical", "sev-1"]);
+  });
+
+  test("defaults to empty array when [pagerduty] is absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sc-no-pd-"));
+    writeFileSync(
+      join(dir, "nimbus.toml"),
+      `[metrics.dora.svc]
+repos = ["github:acme/svc"]
+`,
+      "utf8",
+    );
+    const merged = loadNimbusServiceConfigsFromConfigDir(dir);
+    expect(merged.get("svc")?.severityP1Aliases).toEqual([]);
+  });
+
+  test("returns empty map when nimbus.toml is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sc-missing-"));
+    const merged = loadNimbusServiceConfigsFromConfigDir(dir);
+    expect(merged.size).toBe(0);
+  });
+});

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -954,6 +954,7 @@ function materializeServiceConfigs(
       incidentWindowMinutes: windowMins,
       excludePrLabels,
       deployEnvironments,
+      severityP1Aliases: [], // attached by loadNimbusServiceConfigsFromConfigDir
     });
   }
   return out;

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -749,6 +749,100 @@ export function loadNimbusUserFromConfigDir(configDir: string): NimbusUserToml {
 }
 
 // ---------------------------------------------------------------------------
+// [pagerduty] — Top-level PagerDuty connector + preflight knobs
+// (Phase 5 T4 wrap-up).
+// ---------------------------------------------------------------------------
+
+export type NimbusPagerdutyToml = {
+  /** Hard cap on pages walked per `pagerduty-sync.ts` invocation. 1..100. */
+  maxPagesPerSync: number;
+  /**
+   * Priority names that preflight should treat as equivalent to "P1".
+   * Stored lowercased + deduplicated. Empty by default (preflight matches
+   * the verbatim "P1" string only, identical to pre-existing behavior).
+   */
+  severityP1Aliases: readonly string[];
+};
+
+export const DEFAULT_NIMBUS_PAGERDUTY_TOML: NimbusPagerdutyToml = {
+  maxPagesPerSync: 20,
+  severityP1Aliases: [],
+};
+
+function parseNimbusPagerdutySection(source: string): Partial<NimbusPagerdutyToml> {
+  const lines = source.split(/\r?\n/);
+  let inSection = false;
+  const out: { maxPagesPerSync?: number; severityP1Aliases?: readonly string[] } = {};
+  for (const line of lines) {
+    const trimmed = stripComment(line).trim();
+    if (trimmed === "") continue;
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      inSection = trimmed === "[pagerduty]";
+      continue;
+    }
+    if (!inSection) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const valRaw = trimmed.slice(eq + 1).trim();
+    if (key === "max_pages_per_sync") {
+      const n = parseIntDec(valRaw);
+      if (n === undefined || n < 1 || n > 100) {
+        throw new Error(
+          `[pagerduty].max_pages_per_sync must be an integer in 1..100, got '${valRaw}'`,
+        );
+      }
+      out.maxPagesPerSync = n;
+    } else if (key === "severity_p1_aliases") {
+      // Reuse parseStringArray (defined later in this file) — already drops empty entries.
+      const raw = parseStringArray(valRaw);
+      const seen = new Set<string>();
+      const collected: string[] = [];
+      for (const v of raw) {
+        const lower = v.trim().toLowerCase();
+        if (lower === "") continue;
+        if (seen.has(lower)) continue;
+        seen.add(lower);
+        collected.push(lower);
+      }
+      out.severityP1Aliases = collected;
+    }
+  }
+  return out;
+}
+
+export function parseNimbusPagerdutyToml(
+  raw: string,
+  defaults: NimbusPagerdutyToml = DEFAULT_NIMBUS_PAGERDUTY_TOML,
+): NimbusPagerdutyToml {
+  return { ...defaults, ...parseNimbusPagerdutySection(raw) };
+}
+
+export function loadNimbusPagerdutyFromPath(tomlPath: string): NimbusPagerdutyToml {
+  if (!existsSync(tomlPath)) {
+    return structuredClone(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+  }
+  try {
+    const raw = readFileSync(tomlPath, "utf8");
+    return parseNimbusPagerdutyToml(raw);
+  } catch (err) {
+    // Surface validation errors (e.g. max_pages_per_sync out of range) so
+    // operators don't silently fall back to defaults. Matches the
+    // ci.service / metrics.dora conflict-warning pattern used elsewhere in
+    // this file (see loadNimbusServiceConfigsFromConfigDir).
+    process.stderr.write(
+      `nimbus: [pagerduty] config in ${tomlPath} rejected, using defaults: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return structuredClone(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+  }
+}
+
+export function loadNimbusPagerdutyFromConfigDir(configDir: string): NimbusPagerdutyToml {
+  return loadNimbusPagerdutyFromPath(join(configDir, "nimbus.toml"));
+}
+
+// ---------------------------------------------------------------------------
 // [metrics.dora.<service-id>] — DORA service map (Phase 5 T4 PR 2)
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -1057,7 +1057,15 @@ export function loadNimbusServiceConfigsFromConfigDir(
   const raw = readFileSync(tomlPath, "utf8");
   const dora = parseNimbusDoraToml(raw);
   const ci = parseNimbusCiServiceToml(raw);
-  const merged: Map<string, ServiceConfig> = new Map(dora);
+  // Phase 5 T4 wrap-up: read [pagerduty].severity_p1_aliases once and
+  // attach to every materialized ServiceConfig. The aliases array is
+  // already lowercased + deduped by parseNimbusPagerdutyToml.
+  const pagerdutyCfg = parseNimbusPagerdutyToml(raw);
+  const aliases = pagerdutyCfg.severityP1Aliases;
+  const merged: Map<string, ServiceConfig> = new Map();
+  for (const [id, cfg] of dora.entries()) {
+    merged.set(id, { ...cfg, severityP1Aliases: aliases });
+  }
   for (const [id, cfg] of ci.entries()) {
     if (merged.has(id)) {
       process.stderr.write(
@@ -1065,7 +1073,7 @@ export function loadNimbusServiceConfigsFromConfigDir(
           `using [ci.service.${id}].\n`,
       );
     }
-    merged.set(id, cfg);
+    merged.set(id, { ...cfg, severityP1Aliases: aliases });
   }
   return merged;
 }

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -822,8 +822,17 @@ export function loadNimbusPagerdutyFromPath(tomlPath: string): NimbusPagerdutyTo
   if (!existsSync(tomlPath)) {
     return structuredClone(DEFAULT_NIMBUS_PAGERDUTY_TOML);
   }
+  let raw: string;
   try {
-    const raw = readFileSync(tomlPath, "utf8");
+    raw = readFileSync(tomlPath, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `nimbus: could not read [pagerduty] config at ${tomlPath}, using defaults: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return structuredClone(DEFAULT_NIMBUS_PAGERDUTY_TOML);
+  }
+  try {
     return parseNimbusPagerdutyToml(raw);
   } catch (err) {
     // Surface validation errors (e.g. max_pages_per_sync out of range) so

--- a/packages/gateway/src/connectors/pagerduty-sync.test.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.test.ts
@@ -399,6 +399,8 @@ describeWithFetchRestore("pagerduty-sync", () => {
     const vault = createStubVault({ "pagerduty.api_token": "test-token" });
     const result = await sync.sync(syncTestContext(db, vault), null);
     expect(calls.length).toBe(3);
+    // Load-bearing: ascending sort is what makes cap-aware cursor advance correct.
+    expect(new URL(calls[0] as string).searchParams.get("sort_by")).toBe("updated_at:asc");
     expect(new URL(calls[1] as string).searchParams.get("offset")).toBe("100");
     expect(new URL(calls[2] as string).searchParams.get("offset")).toBe("200");
     expect(result.itemsUpserted).toBe(3);

--- a/packages/gateway/src/connectors/pagerduty-sync.test.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.test.ts
@@ -53,9 +53,11 @@ function stubPagerdutyPages(pages: readonly PdPageResponse[]): { calls: string[]
     if (!url.startsWith("https://api.pagerduty.com/incidents")) {
       throw new Error(`unexpected fetch: ${url}`);
     }
-    const page = pages[Math.min(i, pages.length - 1)];
+    const page = pages[i];
     i += 1;
-    if (page === undefined) throw new Error("stubPagerdutyPages: no pages configured");
+    if (page === undefined) {
+      throw new Error(`stubPagerdutyPages: call ${i} exceeds ${pages.length} configured pages`);
+    }
     return new Response(JSON.stringify(page), {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/packages/gateway/src/connectors/pagerduty-sync.test.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.test.ts
@@ -19,6 +19,7 @@ type IncidentMetadata = {
   opened_at_ms?: number;
   pagerduty_service_id?: string;
   severity?: string;
+  urgency?: string;
 };
 
 function readIncidentMetadata(db: Database, externalId: string): IncidentMetadata {
@@ -98,6 +99,37 @@ describeWithFetchRestore("pagerduty-sync", () => {
     expect(meta.severity).toBe("P1");
     expect(meta.status).toBe("triggered");
     expect(meta.incidentId).toBe("PT4KHLK");
+  });
+
+  test("writes urgency when present", async () => {
+    const db = await runOneSync([
+      {
+        id: "PT_URGENT",
+        title: "Urgent but no priority",
+        created_at: "2026-05-10T18:30:21Z",
+        updated_at: "2026-05-10T18:30:21Z",
+        status: "triggered",
+        urgency: "high",
+        service: { id: "PJK1HJ8" },
+      },
+    ]);
+    const meta = readIncidentMetadata(db, "PT_URGENT");
+    expect(meta.urgency).toBe("high");
+  });
+
+  test("omits urgency when absent or empty", async () => {
+    const db = await runOneSync([
+      {
+        id: "PT_NO_URG",
+        title: "No urgency field",
+        created_at: "2026-05-10T18:30:21Z",
+        updated_at: "2026-05-10T18:30:21Z",
+        status: "triggered",
+        service: { id: "PJK1HJ8" },
+      },
+    ]);
+    const meta = readIncidentMetadata(db, "PT_NO_URG");
+    expect(meta.urgency).toBeUndefined();
   });
 
   test("omits severity when priority is null", async () => {

--- a/packages/gateway/src/connectors/pagerduty-sync.test.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.test.ts
@@ -127,9 +127,18 @@ describeWithFetchRestore("pagerduty-sync", () => {
         status: "triggered",
         service: { id: "PJK1HJ8" },
       },
+      {
+        id: "PT_EMPTY_URG",
+        title: "Empty urgency string",
+        created_at: "2026-05-10T18:30:21Z",
+        updated_at: "2026-05-10T18:30:21Z",
+        status: "triggered",
+        urgency: "",
+        service: { id: "PJK1HJ8" },
+      },
     ]);
-    const meta = readIncidentMetadata(db, "PT_NO_URG");
-    expect(meta.urgency).toBeUndefined();
+    expect(readIncidentMetadata(db, "PT_NO_URG").urgency).toBeUndefined();
+    expect(readIncidentMetadata(db, "PT_EMPTY_URG").urgency).toBeUndefined();
   });
 
   test("omits severity when priority is null", async () => {

--- a/packages/gateway/src/connectors/pagerduty-sync.test.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.test.ts
@@ -42,6 +42,28 @@ function stubPagerdutyIncidents(incidents: unknown[]): void {
   }) as typeof fetch;
 }
 
+type PdPageResponse = { incidents: unknown[]; more: boolean };
+
+function stubPagerdutyPages(pages: readonly PdPageResponse[]): { calls: string[] } {
+  const calls: string[] = [];
+  let i = 0;
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    const url = urlFromFetchInput(input);
+    calls.push(url);
+    if (!url.startsWith("https://api.pagerduty.com/incidents")) {
+      throw new Error(`unexpected fetch: ${url}`);
+    }
+    const page = pages[Math.min(i, pages.length - 1)];
+    i += 1;
+    if (page === undefined) throw new Error("stubPagerdutyPages: no pages configured");
+    return new Response(JSON.stringify(page), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { calls };
+}
+
 async function runOneSync(incidents: unknown[]): Promise<Database> {
   stubPagerdutyIncidents(incidents);
   const db = createMemoryIndexDb();
@@ -323,5 +345,161 @@ describeWithFetchRestore("pagerduty-sync", () => {
     const expectedMax = after - EXPECTED_BACKFILL_DAYS * 86_400_000 + 2000;
     expect(sinceMs).toBeGreaterThanOrEqual(expectedMin);
     expect(sinceMs).toBeLessThanOrEqual(expectedMax);
+  });
+
+  test("walks pages until parsed.more=false", async () => {
+    const { calls } = stubPagerdutyPages([
+      {
+        incidents: [
+          {
+            id: "P_A",
+            title: "A",
+            created_at: "2026-05-10T10:00:00Z",
+            updated_at: "2026-05-10T10:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_B",
+            title: "B",
+            created_at: "2026-05-10T11:00:00Z",
+            updated_at: "2026-05-10T11:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_C",
+            title: "C",
+            created_at: "2026-05-10T12:00:00Z",
+            updated_at: "2026-05-10T12:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: false,
+      },
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createPagerdutySyncable({ ensurePagerdutyMcpRunning: async () => {} });
+    const vault = createStubVault({ "pagerduty.api_token": "test-token" });
+    const result = await sync.sync(syncTestContext(db, vault), null);
+    expect(calls.length).toBe(3);
+    expect(new URL(calls[1] as string).searchParams.get("offset")).toBe("100");
+    expect(new URL(calls[2] as string).searchParams.get("offset")).toBe("200");
+    expect(result.itemsUpserted).toBe(3);
+    expect(result.hasMore).toBe(false);
+    const cursor = result.cursor as string;
+    const decoded = Buffer.from(cursor.slice("nimbus-pd1:".length), "base64url").toString("utf8");
+    expect(JSON.parse(decoded)).toEqual({ lastUpdated: "2026-05-10T12:00:00Z" });
+  });
+
+  test("respects maxPagesPerSync cap and emits hasMore=true", async () => {
+    const { calls } = stubPagerdutyPages([
+      {
+        incidents: [
+          {
+            id: "P_A",
+            title: "A",
+            created_at: "2026-05-10T10:00:00Z",
+            updated_at: "2026-05-10T10:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_B",
+            title: "B",
+            created_at: "2026-05-10T11:00:00Z",
+            updated_at: "2026-05-10T11:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+      {
+        incidents: [
+          {
+            id: "P_C",
+            title: "Never reached",
+            created_at: "2026-05-10T12:00:00Z",
+            updated_at: "2026-05-10T12:00:00Z",
+            status: "triggered",
+            priority: { name: "P1" },
+            service: { id: "PJK1HJ8" },
+          },
+        ],
+        more: true,
+      },
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createPagerdutySyncable({
+      ensurePagerdutyMcpRunning: async () => {},
+      maxPagesPerSync: 2,
+    });
+    const vault = createStubVault({ "pagerduty.api_token": "test-token" });
+    const result = await sync.sync(syncTestContext(db, vault), null);
+    expect(calls.length).toBe(2);
+    expect(result.itemsUpserted).toBe(2);
+    expect(result.hasMore).toBe(true);
+    const cursor = result.cursor as string;
+    const decoded = Buffer.from(cursor.slice("nimbus-pd1:".length), "base64url").toString("utf8");
+    expect(JSON.parse(decoded)).toEqual({ lastUpdated: "2026-05-10T11:00:00Z" });
+  });
+
+  test("partial-failure preserves cursor progress from successful pages", async () => {
+    let call = 0;
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0]) => {
+      call += 1;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            incidents: [
+              {
+                id: "P_PAGE1",
+                title: "Page 1 row",
+                created_at: "2026-05-10T10:00:00Z",
+                updated_at: "2026-05-10T10:00:00Z",
+                status: "triggered",
+                priority: { name: "P1" },
+                service: { id: "PJK1HJ8" },
+              },
+            ],
+            more: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("Internal Server Error", { status: 500 });
+    }) as typeof fetch;
+    const db = createMemoryIndexDb();
+    const sync = createPagerdutySyncable({ ensurePagerdutyMcpRunning: async () => {} });
+    const vault = createStubVault({ "pagerduty.api_token": "test-token" });
+    const result = await sync.sync(syncTestContext(db, vault), null);
+    expect(result.itemsUpserted).toBe(1);
+    expect(result.hasMore).toBe(false);
+    const cursor = result.cursor as string;
+    const decoded = Buffer.from(cursor.slice("nimbus-pd1:".length), "base64url").toString("utf8");
+    // Cursor advances past page-1's max updated_at, NOT back to the original since.
+    expect(JSON.parse(decoded)).toEqual({ lastUpdated: "2026-05-10T10:00:00Z" });
   });
 });

--- a/packages/gateway/src/connectors/pagerduty-sync.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.ts
@@ -132,6 +132,11 @@ function pagerdutyListFailureResult(
 
 export type PagerdutySyncableOptions = {
   ensurePagerdutyMcpRunning: () => Promise<void>;
+  /**
+   * Hard cap on pages walked per sync invocation. Default 20. Range 1..100
+   * enforced by config parser; not re-validated here.
+   */
+  maxPagesPerSync?: number;
 };
 
 export function createPagerdutySyncable(options: PagerdutySyncableOptions): Syncable {
@@ -154,9 +159,10 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
 
       await ctx.rateLimiter.acquire("pagerduty");
       const u = new URL("https://api.pagerduty.com/incidents");
-      u.searchParams.set("limit", "50");
-      u.searchParams.set("sort_by", "updated_at");
+      u.searchParams.set("limit", "100");
+      u.searchParams.set("sort_by", "updated_at:asc");
       u.searchParams.set("since", since);
+      u.searchParams.set("offset", "0");
       const res = await fetch(u.toString(), {
         headers: {
           Accept: "application/vnd.pagerduty+json;version=2",

--- a/packages/gateway/src/connectors/pagerduty-sync.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.ts
@@ -32,7 +32,7 @@ function decodeCursor(raw: string | null): PdCursorV1 | null {
   return { lastUpdated: lu };
 }
 
-function parsePagerdutyIncidents(text: string): unknown[] | null {
+function parsePagerdutyListResponse(text: string): { incidents: unknown[]; more: boolean } | null {
   let root: unknown;
   try {
     root = JSON.parse(text) as unknown;
@@ -40,11 +40,13 @@ function parsePagerdutyIncidents(text: string): unknown[] | null {
     return null;
   }
   const rec = asRecord(root);
-  if (rec === undefined) {
-    return null;
-  }
-  const raw = rec["incidents"];
-  return Array.isArray(raw) ? raw : null;
+  if (rec === undefined) return null;
+  const incidents = rec["incidents"];
+  if (!Array.isArray(incidents)) return null;
+  // PagerDuty's REST v2 list response wraps the array with a sibling
+  // boolean `more`. Absent (or non-boolean) is treated as `false` so the
+  // loop terminates on a malformed response.
+  return { incidents, more: rec["more"] === true };
 }
 
 function pdServiceId(row: Record<string, unknown>): string | undefined {
@@ -114,22 +116,6 @@ export function syncPagerdutyIncidentItems(
   return { upserted, maxUpdated };
 }
 
-function pagerdutyListFailureResult(
-  cursor: string | null,
-  since: string,
-  textLen: number,
-  t0: number,
-): SyncResult {
-  return {
-    cursor: cursor ?? encodeCursor({ lastUpdated: since }),
-    itemsUpserted: 0,
-    itemsDeleted: 0,
-    hasMore: false,
-    durationMs: Math.round(performance.now() - t0),
-    bytesTransferred: textLen,
-  };
-}
-
 export type PagerdutySyncableOptions = {
   ensurePagerdutyMcpRunning: () => Promise<void>;
   /**
@@ -141,6 +127,8 @@ export type PagerdutySyncableOptions = {
 
 export function createPagerdutySyncable(options: PagerdutySyncableOptions): Syncable {
   const initialSyncDepthDays = 30;
+  const maxPagesPerSync = Math.max(1, Math.min(100, options.maxPagesPerSync ?? 20));
+  const PAGE_SIZE = 100;
   return {
     serviceId: SERVICE_ID,
     defaultIntervalMs: 120 * 1000,
@@ -153,50 +141,86 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
         return syncNoopResult(cursor, t0);
       }
       const prev = decodeCursor(cursor);
+      // Single `now` for the whole sync batch — standard atomic batch
+      // semantics. With maxPagesPerSync=20 and the default 2-minute
+      // sync interval, drift is at most seconds; `syncedAt` is the
+      // sync-start timestamp by design. (Reviewer concern #3 noted.)
       const now = Date.now();
       const floorIso = new Date(now - initialSyncDepthDays * 86_400_000).toISOString();
       const since = prev?.lastUpdated ?? floorIso;
 
-      await ctx.rateLimiter.acquire("pagerduty");
-      const u = new URL("https://api.pagerduty.com/incidents");
-      u.searchParams.set("limit", "100");
-      u.searchParams.set("sort_by", "updated_at:asc");
-      u.searchParams.set("since", since);
-      u.searchParams.set("offset", "0");
-      const res = await fetch(u.toString(), {
-        headers: {
-          Accept: "application/vnd.pagerduty+json;version=2",
-          Authorization: `Token token=${token.trim()}`,
-        },
-      });
-      const text = await res.text();
-      if (!res.ok) {
-        ctx.logger.warn(
-          { serviceId: SERVICE_ID, status: res.status },
-          "pagerduty sync: list failed",
+      let pagesFetched = 0;
+      let totalUpserted = 0;
+      let maxUpdated = since;
+      let lastTextLen = 0;
+      let pdHasMore = false;
+
+      while (pagesFetched < maxPagesPerSync) {
+        await ctx.rateLimiter.acquire("pagerduty");
+        const u = new URL("https://api.pagerduty.com/incidents");
+        u.searchParams.set("limit", String(PAGE_SIZE));
+        u.searchParams.set("sort_by", "updated_at:asc");
+        u.searchParams.set("since", since);
+        u.searchParams.set("offset", String(pagesFetched * PAGE_SIZE));
+        const res = await fetch(u.toString(), {
+          headers: {
+            Accept: "application/vnd.pagerduty+json;version=2",
+            Authorization: `Token token=${token.trim()}`,
+          },
+        });
+        const text = await res.text();
+        lastTextLen = text.length;
+        if (!res.ok) {
+          ctx.logger.warn(
+            { serviceId: SERVICE_ID, status: res.status, page: pagesFetched },
+            "pagerduty sync: list failed",
+          );
+          // Preserve progress: cursor reflects pages already ingested.
+          // PD `since` is inclusive (`updated_at >= since`); if the failed
+          // page contained rows sharing the saved timestamp, next sync
+          // re-fetches them and SQLite UPSERT on (service, external_id)
+          // deduplicates idempotently.
+          return {
+            cursor: encodeCursor({ lastUpdated: maxUpdated }),
+            itemsUpserted: totalUpserted,
+            itemsDeleted: 0,
+            hasMore: false,
+            durationMs: Math.round(performance.now() - t0),
+            bytesTransferred: lastTextLen,
+          };
+        }
+        // Single JSON.parse per page — returns both `incidents` and `more`.
+        const parsed = parsePagerdutyListResponse(text);
+        if (parsed === null) {
+          return {
+            cursor: encodeCursor({ lastUpdated: maxUpdated }),
+            itemsUpserted: totalUpserted,
+            itemsDeleted: 0,
+            hasMore: false,
+            durationMs: Math.round(performance.now() - t0),
+            bytesTransferred: lastTextLen,
+          };
+        }
+        const { upserted, maxUpdated: pageMax } = syncPagerdutyIncidentItems(
+          ctx,
+          parsed.incidents,
+          maxUpdated,
+          now,
         );
-        return pagerdutyListFailureResult(cursor, since, text.length, t0);
+        totalUpserted += upserted;
+        maxUpdated = pageMax;
+        pagesFetched += 1;
+        pdHasMore = parsed.more;
+        if (!pdHasMore) break;
       }
-      const incidents = parsePagerdutyIncidents(text);
-      if (incidents === null) {
-        return {
-          cursor: encodeCursor({ lastUpdated: since }),
-          itemsUpserted: 0,
-          itemsDeleted: 0,
-          hasMore: false,
-          durationMs: Math.round(performance.now() - t0),
-          bytesTransferred: text.length,
-        };
-      }
-      const { upserted, maxUpdated } = syncPagerdutyIncidentItems(ctx, incidents, since, now);
 
       return {
         cursor: encodeCursor({ lastUpdated: maxUpdated }),
-        itemsUpserted: upserted,
+        itemsUpserted: totalUpserted,
         itemsDeleted: 0,
-        hasMore: false,
+        hasMore: pagesFetched >= maxPagesPerSync && pdHasMore,
         durationMs: Math.round(performance.now() - t0),
-        bytesTransferred: text.length,
+        bytesTransferred: lastTextLen,
       };
     },
   };

--- a/packages/gateway/src/connectors/pagerduty-sync.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.ts
@@ -92,6 +92,8 @@ export function syncPagerdutyIncidentItems(
     if (Number.isFinite(openedAtMs)) metadata["opened_at_ms"] = openedAtMs;
     if (serviceId !== undefined && serviceId !== "") metadata["pagerduty_service_id"] = serviceId;
     if (severity !== undefined && severity !== "") metadata["severity"] = severity;
+    const urgency = stringField(row, "urgency");
+    if (urgency !== undefined && urgency !== "") metadata["urgency"] = urgency;
 
     upsertIndexedItemForSync(ctx, {
       service: SERVICE_ID,

--- a/packages/gateway/src/connectors/pagerduty-sync.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.ts
@@ -152,7 +152,7 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
       let pagesFetched = 0;
       let totalUpserted = 0;
       let maxUpdated = since;
-      let lastTextLen = 0;
+      let totalBytesTransferred = 0;
       let pdHasMore = false;
 
       while (pagesFetched < maxPagesPerSync) {
@@ -169,7 +169,7 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
           },
         });
         const text = await res.text();
-        lastTextLen = text.length;
+        totalBytesTransferred += text.length;
         if (!res.ok) {
           ctx.logger.warn(
             { serviceId: SERVICE_ID, status: res.status, page: pagesFetched },
@@ -186,7 +186,7 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
             itemsDeleted: 0,
             hasMore: false,
             durationMs: Math.round(performance.now() - t0),
-            bytesTransferred: lastTextLen,
+            bytesTransferred: totalBytesTransferred,
           };
         }
         // Single JSON.parse per page — returns both `incidents` and `more`.
@@ -198,7 +198,7 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
             itemsDeleted: 0,
             hasMore: false,
             durationMs: Math.round(performance.now() - t0),
-            bytesTransferred: lastTextLen,
+            bytesTransferred: totalBytesTransferred,
           };
         }
         const { upserted, maxUpdated: pageMax } = syncPagerdutyIncidentItems(
@@ -220,7 +220,7 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
         itemsDeleted: 0,
         hasMore: pagesFetched >= maxPagesPerSync && pdHasMore,
         durationMs: Math.round(performance.now() - t0),
-        bytesTransferred: lastTextLen,
+        bytesTransferred: totalBytesTransferred,
       };
     },
   };

--- a/packages/gateway/src/metrics/dora-config.ts
+++ b/packages/gateway/src/metrics/dora-config.ts
@@ -32,6 +32,14 @@ export type ServiceConfig = {
    * `["prod"]` when omitted.
    */
   readonly deployEnvironments: readonly string[];
+  /**
+   * Lowercased, deduplicated priority-name aliases that preflight treats as
+   * P1. Sourced org-wide from `[pagerduty].severity_p1_aliases` and copied
+   * onto every materialized ServiceConfig at load time. Empty default
+   * preserves the pre-existing strict `severity = 'P1'` filter behavior.
+   * Phase 5 T4 wrap-up.
+   */
+  readonly severityP1Aliases: readonly string[];
 };
 
 /** Back-compat alias. New code should import `ServiceConfig`. */

--- a/packages/gateway/src/platform/assemble-sync-registrations.ts
+++ b/packages/gateway/src/platform/assemble-sync-registrations.ts
@@ -29,10 +29,16 @@ import { createSlackSyncable } from "../connectors/slack-sync.ts";
 import { createTeamsSyncable } from "../connectors/teams-sync.ts";
 import type { SyncScheduler } from "../sync/scheduler.ts";
 
+export type ConnectorMeshSyncableOptions = {
+  /** Phase 5 T4 wrap-up: hard cap on pages walked per pagerduty sync. */
+  pagerdutyMaxPagesPerSync: number;
+};
+
 /** Registers all connector-backed sync jobs that lazily ensure MCP children via the mesh. */
 export function registerConnectorMeshSyncables(
   syncScheduler: SyncScheduler,
   connectorMesh: LazyConnectorMesh,
+  options: ConnectorMeshSyncableOptions,
 ): void {
   syncScheduler.register(
     createGoogleDriveSyncable({
@@ -127,6 +133,7 @@ export function registerConnectorMeshSyncables(
   syncScheduler.register(
     createPagerdutySyncable({
       ensurePagerdutyMcpRunning: () => connectorMesh.ensurePagerdutyRunning(),
+      maxPagesPerSync: options.pagerdutyMaxPagesPerSync,
     }),
   );
   syncScheduler.register(

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -11,6 +11,7 @@ import {
   loadNimbusAutomationFromConfigDir,
   loadNimbusEmbeddingFromPath,
   loadNimbusLlmPartialFromPath,
+  loadNimbusPagerdutyFromConfigDir,
   loadNimbusUpdaterFromConfigDir,
   resolveNimbusTomlForProfile,
 } from "../config/nimbus-toml.ts";
@@ -275,7 +276,10 @@ async function createSchedulerWithMesh(
     // obsidian MCP child can discover `.obsidian/` markers itself.
     obsidianVaultPaths: fsV2Roots.map((r) => r.path),
   });
-  registerConnectorMeshSyncables(syncScheduler, connectorMesh);
+  const pagerdutyCfg = loadNimbusPagerdutyFromConfigDir(paths.configDir);
+  registerConnectorMeshSyncables(syncScheduler, connectorMesh, {
+    pagerdutyMaxPagesPerSync: pagerdutyCfg.maxPagesPerSync,
+  });
   registerUserMcpSyncablesFromDatabase(db, syncScheduler, connectorMesh);
   syncScheduler.start();
   evaluateWatchersStartupCatchUp(db, Date.now(), (t, b) => notifications.show(t, b), watcherOpts);

--- a/packages/gateway/src/preflight/preflight.ts
+++ b/packages/gateway/src/preflight/preflight.ts
@@ -14,7 +14,12 @@ import type { Database } from "bun:sqlite";
 import type { ParsedDoraRepoUrn, ServiceConfig } from "../metrics/dora-config.ts";
 import { providerServiceColumns } from "../metrics/dora-config.ts";
 
-export type PreflightGap = null | "no_pagerduty_mapping" | "no_repos" | "unknown_mergeable_state";
+export type PreflightGap =
+  | null
+  | "no_pagerduty_mapping"
+  | "no_repos"
+  | "unknown_mergeable_state"
+  | "pagerduty_urgency_without_priority";
 
 export type IncidentFinding = {
   readonly id: string;
@@ -151,7 +156,29 @@ function selectActiveP1Incidents(
       url: r.url,
     };
   });
-  return { count: countRow.c, findings, gap: null };
+  // Phase 5 T4 wrap-up: urgency-gap probe. When the strict + aliased
+  // severity filter yields zero matches AND services are configured, check
+  // whether high-urgency-without-priority incidents exist. They indicate
+  // either a missing severity_p1_aliases entry or a PagerDuty priority
+  // setup quirk — surface as a diagnostic gap. Probe is gated on count===0
+  // so any org with at least one active P1-equivalent skips it.
+  let gap: PreflightGap = null;
+  if (countRow.c === 0) {
+    const probeRow = db
+      .query(
+        `SELECT COUNT(*) as c FROM item
+         WHERE service = 'pagerduty'
+           AND type = 'incident'
+           AND json_extract(metadata, '$.pagerduty_service_id') IN (${pdPlaceholders})
+           AND json_extract(metadata, '$.status') IN ('triggered', 'acknowledged')
+           AND json_extract(metadata, '$.urgency') = 'high'
+           AND (json_extract(metadata, '$.severity') IS NULL
+                OR json_extract(metadata, '$.severity') = '')`,
+      )
+      .get(...cfg.pagerdutyServices) as { c: number };
+    if (probeRow.c > 0) gap = "pagerduty_urgency_without_priority";
+  }
+  return { count: countRow.c, findings, gap };
 }
 
 function selectFailingCiRuns(

--- a/packages/gateway/src/preflight/preflight.ts
+++ b/packages/gateway/src/preflight/preflight.ts
@@ -107,17 +107,23 @@ function selectActiveP1Incidents(
   if (cfg.pagerdutyServices.length === 0) {
     return { count: 0, findings: [], gap: "no_pagerduty_mapping" };
   }
-  const placeholders = cfg.pagerdutyServices.map(() => "?").join(",");
+  // Build the canonical set from the configured aliases (already lowercased
+  // by the bootstrap) unioned with "p1". The Set step is belt-and-braces
+  // against a user-supplied "P1" overlap.
+  const severityMatches = Array.from(new Set(["p1", ...cfg.severityP1Aliases]));
+  const sevPlaceholders = severityMatches.map(() => "?").join(",");
+  const pdPlaceholders = cfg.pagerdutyServices.map(() => "?").join(",");
   const where = `
     service = 'pagerduty'
     AND type = 'incident'
-    AND json_extract(metadata, '$.pagerduty_service_id') IN (${placeholders})
+    AND json_extract(metadata, '$.pagerduty_service_id') IN (${pdPlaceholders})
     AND json_extract(metadata, '$.status') IN ('triggered', 'acknowledged')
-    AND json_extract(metadata, '$.severity') = 'P1'
+    AND LOWER(json_extract(metadata, '$.severity')) IN (${sevPlaceholders})
   `;
+  const countParams = [...cfg.pagerdutyServices, ...severityMatches];
   const countRow = db
     .query(`SELECT COUNT(*) as c FROM item WHERE ${where}`)
-    .get(...cfg.pagerdutyServices) as { c: number };
+    .get(...countParams) as { c: number };
   const rows = db
     .query(
       `SELECT id, title, url, metadata
@@ -126,7 +132,7 @@ function selectActiveP1Incidents(
        ORDER BY json_extract(metadata, '$.opened_at_ms') DESC
        LIMIT ?`,
     )
-    .all(...cfg.pagerdutyServices, maxFindings) as {
+    .all(...countParams, maxFindings) as {
     id: string;
     title: string;
     url: string | null;

--- a/packages/gateway/test/fixtures/dora/payment-service/seed.ts
+++ b/packages/gateway/test/fixtures/dora/payment-service/seed.ts
@@ -253,6 +253,7 @@ export async function seedPaymentServiceFixture(
     incidentWindowMinutes: 60,
     excludePrLabels: ["revert"],
     deployEnvironments: ["prod"],
+    severityP1Aliases: [],
   };
   return { config };
 }

--- a/packages/gateway/test/fixtures/preflight/payment-service/seed.ts
+++ b/packages/gateway/test/fixtures/preflight/payment-service/seed.ts
@@ -226,6 +226,7 @@ export async function seedPaymentServicePreflightFixture(
     incidentWindowMinutes: 60,
     excludePrLabels: ["revert"],
     deployEnvironments: ["prod"],
+    severityP1Aliases: [],
   };
   return { config };
 }

--- a/packages/gateway/test/integration/metrics/dora-deployment-source.test.ts
+++ b/packages/gateway/test/integration/metrics/dora-deployment-source.test.ts
@@ -31,6 +31,7 @@ function cfg(): DoraServiceConfig {
     incidentWindowMinutes: 60,
     excludePrLabels: [],
     deployEnvironments: ["prod"],
+    severityP1Aliases: [],
   };
 }
 

--- a/packages/gateway/test/unit/metrics/dora.test.ts
+++ b/packages/gateway/test/unit/metrics/dora.test.ts
@@ -104,6 +104,7 @@ function cfg(overrides: Partial<DoraServiceConfig> = {}): DoraServiceConfig {
     incidentWindowMinutes: 60,
     excludePrLabels: ["revert"],
     deployEnvironments: ["prod"],
+    severityP1Aliases: [],
     ...overrides,
   };
 }

--- a/packages/gateway/test/unit/preflight/preflight.test.ts
+++ b/packages/gateway/test/unit/preflight/preflight.test.ts
@@ -126,6 +126,7 @@ function cfg(overrides: Partial<ServiceConfig> = {}): ServiceConfig {
     incidentWindowMinutes: 60,
     excludePrLabels: ["revert"],
     deployEnvironments: ["prod"],
+    severityP1Aliases: [],
     ...overrides,
   };
 }

--- a/packages/gateway/test/unit/preflight/preflight.test.ts
+++ b/packages/gateway/test/unit/preflight/preflight.test.ts
@@ -12,19 +12,21 @@ function seedIncident(
   id: string,
   opts: {
     status: "triggered" | "acknowledged" | "resolved";
-    severity: string;
+    severity?: string;
+    urgency?: string;
     pagerdutyServiceId: string;
     openedAtMs: number;
     title?: string;
     url?: string;
   },
 ) {
-  const meta = {
+  const meta: Record<string, unknown> = {
     status: opts.status,
-    severity: opts.severity,
     pagerduty_service_id: opts.pagerdutyServiceId,
     opened_at_ms: opts.openedAtMs,
   };
+  if (opts.severity !== undefined) meta.severity = opts.severity;
+  if (opts.urgency !== undefined) meta.urgency = opts.urgency;
   db.run(
     `INSERT INTO item (id, service, type, external_id, title, body_preview, url, canonical_url,
                        modified_at, author_id, metadata, synced_at, pinned)
@@ -313,6 +315,60 @@ describe("computeDeployPreflight: active_p1_incidents check", () => {
     const out = computeDeployPreflight(db, cfg(), "main", now, 10);
     expect(out.checks.active_p1_incidents.count).toBe(1);
     expect(out.checks.active_p1_incidents.findings[0]?.id).toBe("pagerduty:inc_p1");
+  });
+
+  it('emits gap="pagerduty_urgency_without_priority" when count===0 and high-urgency incidents lack priority', () => {
+    seedIncident(db, "pagerduty:no_pri", {
+      status: "triggered",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(0);
+    expect(out.checks.active_p1_incidents.gap).toBe("pagerduty_urgency_without_priority");
+  });
+
+  it("urgency-gap is suppressed when count > 0", () => {
+    seedIncident(db, "pagerduty:has_p1", {
+      status: "triggered",
+      severity: "P1",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    seedIncident(db, "pagerduty:no_pri", {
+      status: "triggered",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 30_000,
+    });
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(1);
+    expect(out.checks.active_p1_incidents.gap).toBeNull();
+  });
+
+  it("urgency-gap defers to no_pagerduty_mapping when no services configured", () => {
+    seedIncident(db, "pagerduty:no_pri", {
+      status: "triggered",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(db, cfg({ pagerdutyServices: [] }), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(0);
+    expect(out.checks.active_p1_incidents.gap).toBe("no_pagerduty_mapping");
+  });
+
+  it("urgency-gap requires status in (triggered, acknowledged) — resolved high-urgency does not trigger", () => {
+    seedIncident(db, "pagerduty:resolved_high", {
+      status: "resolved",
+      urgency: "high",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(0);
+    expect(out.checks.active_p1_incidents.gap).toBeNull();
   });
 });
 

--- a/packages/gateway/test/unit/preflight/preflight.test.ts
+++ b/packages/gateway/test/unit/preflight/preflight.test.ts
@@ -254,6 +254,66 @@ describe("computeDeployPreflight: active_p1_incidents check", () => {
     // Most-recent first → first finding is the most recently opened (smallest age).
     expect(out.checks.active_p1_incidents.findings[0]?.id).toBe("pagerduty:inc_0");
   });
+
+  it('alias "critical" counts toward P1 and preserves raw severity in finding', () => {
+    seedIncident(db, "pagerduty:inc_crit", {
+      status: "triggered",
+      severity: "Critical",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    const out = computeDeployPreflight(
+      db,
+      cfg({ severityP1Aliases: ["critical"] }),
+      "main",
+      now,
+      10,
+    );
+    expect(out.checks.active_p1_incidents.count).toBe(1);
+    expect(out.checks.active_p1_incidents.findings[0]?.severity).toBe("Critical");
+  });
+
+  it("alias match is case-insensitive on both sides", () => {
+    seedIncident(db, "pagerduty:inc_upper", {
+      status: "triggered",
+      severity: "CRITICAL",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    seedIncident(db, "pagerduty:inc_p1", {
+      status: "triggered",
+      severity: "P1",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 120_000,
+    });
+    const out = computeDeployPreflight(
+      db,
+      cfg({ severityP1Aliases: ["critical"] }),
+      "main",
+      now,
+      10,
+    );
+    expect(out.checks.active_p1_incidents.count).toBe(2);
+  });
+
+  it("empty severityP1Aliases preserves verbatim P1 behavior", () => {
+    seedIncident(db, "pagerduty:inc_p1", {
+      status: "triggered",
+      severity: "P1",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 60_000,
+    });
+    seedIncident(db, "pagerduty:inc_crit", {
+      status: "triggered",
+      severity: "Critical",
+      pagerdutyServiceId: "P12ABCD",
+      openedAtMs: now - 120_000,
+    });
+    // No aliases configured → only the verbatim "P1" row matches.
+    const out = computeDeployPreflight(db, cfg(), "main", now, 10);
+    expect(out.checks.active_p1_incidents.count).toBe(1);
+    expect(out.checks.active_p1_incidents.findings[0]?.id).toBe("pagerduty:inc_p1");
+  });
 });
 
 describe("computeDeployPreflight: failing_ci_runs check", () => {


### PR DESCRIPTION
## Summary

Closes the two T4 wrap-up loose ends in a single PR. They share one new `[pagerduty]` TOML block and touch the same two production files — splitting them would create a needless intermediate state.

- **PagerDuty sync pagination** — `pagerduty-sync.ts` now walks pages (`sort_by=updated_at:asc`, `limit=100`), honoring `parsed.more` and capping at `[pagerduty].max_pages_per_sync` (default 20, range 1..100). On cap-hit returns `hasMore: true` so the scheduler re-queues; partial-failure cursors preserve progress from pages already ingested. Parse helper unified to return `{ incidents, more }` in one JSON.parse pass.
- **`[pagerduty].severity_p1_aliases` config** — preflight's `selectActiveP1Incidents` matches `LOWER(severity) IN (?, ?, ...)` over the union of `"p1"` plus org-declared aliases (e.g. `"Critical"`, `"SEV-1"`). Aliases lowercased + deduped at parse time. New `PreflightGap` variant `"pagerduty_urgency_without_priority"` fires when `count===0` but high-urgency-untagged incidents exist on configured services — operator-visible diagnostic for silent-zero preflight results. Query-time only — no re-index needed.

Behavior is bit-for-bit preserved for users without a `[pagerduty]` block.

**No migration. No new IPC method. No new HTTP route. No `ALLOWED_METHODS` change. No security invariant change.**

Spec: [`docs/superpowers/specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design.md`](docs/superpowers/specs/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity-design.md) (rev 2 — folds in 5 design-review responses)
Plan: [`docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity.md`](docs/superpowers/plans/2026-05-16-phase-5-t4-wrap-pagerduty-pagination-severity.md) (rev 2 — folds in 5 plan-review responses)

## What changed

| Layer | File | Δ |
|---|---|---|
| Config | `packages/gateway/src/config/nimbus-toml.ts` | new `[pagerduty]` parser + loaders + threading in `loadNimbusServiceConfigsFromConfigDir` |
| Config | `packages/gateway/src/config/nimbus-toml-pagerduty.test.ts` | NEW, 14 tests |
| Config | `packages/gateway/src/config/nimbus-toml-service-configs.test.ts` | NEW, 3 tests |
| Type | `packages/gateway/src/metrics/dora-config.ts` | `readonly severityP1Aliases: readonly string[]` |
| Connector | `packages/gateway/src/connectors/pagerduty-sync.ts` | page loop + `metadata.urgency` + `parsePagerdutyListResponse` unification |
| Connector | `packages/gateway/src/connectors/pagerduty-sync.test.ts` | 7 new tests (urgency, walk-until-more=false, cap, partial-failure cursor, sort_by load-bearing) |
| Preflight | `packages/gateway/src/preflight/preflight.ts` | alias-aware filter + urgency-gap probe + `PreflightGap` extension |
| Preflight | `packages/gateway/test/unit/preflight/preflight.test.ts` | 7 new tests (alias counts, case-insensitive, empty-default, urgency-gap fires/suppressed/defers/requires-active-status) |
| Bootstrap | `packages/gateway/src/platform/assemble.ts` + `assemble-sync-registrations.ts` | wire `max_pages_per_sync` at startup |
| Docs | `docs/roadmap.md`, `CLAUDE.md`, `GEMINI.md` | flip two `[ ]` to `[x]` + status line |

## Test plan

- [x] `bun test packages/gateway` → 1903 pass / 0 fail / 5217 expect() calls
- [x] `bun run test:coverage:preflight` → 43/43, ≥ 80% gate held
- [x] `bun run test:coverage:config` → 91/91, ≥ 80% gate held
- [x] `bun run typecheck` → `@nimbus/gateway` exit 0 (and all other packages clean; `nimbus-vscode` pre-existing build-order issue passes under `test:ci`)
- [x] Fresh-install gateway with no `[pagerduty]` block behaves identically to today's behavior
- [x] Gateway with `severity_p1_aliases = ["Critical"]` and existing indexed `"Critical"`-severity rows surfaces them in `nimbus deploy preflight` without re-sync
- [x] PD response with `more: true` walks pages until exhausted (verified via mocked multi-page sync)
- [ ] Smoke: full `nimbus metrics dora --service <id>` against a real PagerDuty org with > 100 incidents in the cursor window (post-merge owner check)

## Development workflow

Executed via `superpowers:subagent-driven-development` — fresh implementer subagent per task with two-stage review (spec compliance + code quality) between tasks. Five follow-up commits applied from reviewer feedback:

- `769f350c` — split try/catch + bad-aliases test (Task 1 follow-up)
- `33822302` — empty-string branch in urgency omission test (Task 5 follow-up)
- `629a81f7` — accumulate `bytesTransferred` + fail-loud test stub (Task 8 follow-up)
- `50fd227d` — mirror Status line to GEMINI.md (Task 10 follow-up)
- `4907df86` — assert load-bearing `sort_by=updated_at:asc` (final-review follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)