### PR TITLE
ci: wire SONAR_TOKEN into the reusable test-suite workflow

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -13,6 +13,14 @@ on:
         description: Build headless bundle and Linux installers after tests (Ubuntu only)
         type: boolean
         default: false
+    secrets:
+      SONAR_TOKEN:
+        description: |
+          SonarQube Cloud token for the optional SonarQube analysis step
+          (Linux-only, gated on the token being non-empty). When omitted the
+          analysis step is silently skipped — useful for forks and contributor
+          PRs that legitimately have no token access.
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
     with:
       runner: ubuntu-24.04
       run-packaging: true
+    secrets:
+      # Optional; the reusable workflow silently skips the SonarQube step
+      # when this is unset (e.g. on fork PRs).
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     permissions:
       contents: read
       checks: write
@@ -222,6 +226,10 @@ jobs:
     with:
       runner: ${{ matrix.os }}
       run-packaging: ${{ matrix.os == 'ubuntu-24.04' }}
+    secrets:
+      # Optional; the reusable workflow silently skips the SonarQube step
+      # when this is unset.
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
     with:
       runner: ubuntu-24.04
       run-packaging: false
+    secrets:
+      # Optional; the reusable workflow silently skips the SonarQube step
+      # when this is unset.
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Fixes a long-standing CI configuration gap where the SonarQube Cloud analysis step in [`_test-suite.yml`](.github/workflows/_test-suite.yml) was silently skipping on every PR and every push to main.

**Root cause:** the reusable workflow gates the Sonar step on `env.SONAR_TOKEN != ''`, but:
- `_test-suite.yml`'s `workflow_call` block never declared `secrets:`.
- Its three callers (`ci.yml` pr-quality-ts, `ci.yml` ci-ts, `release.yml` test) invoked it via `uses:` without a `secrets:` block.

Result: `${{ secrets.SONAR_TOKEN }}` evaluated to empty inside the reusable workflow and the SonarQube step silently skipped — no failure, no signal.

**Fix (least-privilege):** declare `SONAR_TOKEN: { required: false }` in the reusable workflow and pass it explicitly from each caller. Only this one secret crosses the boundary — `secrets: inherit` was deliberately avoided. `required: false` preserves the silent-skip behavior for fork PRs and contributors who legitimately have no token access.

## What changed

| File | Δ |
|---|---|
| `.github/workflows/_test-suite.yml` | declare `secrets: SONAR_TOKEN: { required: false }` on `workflow_call:` |
| `.github/workflows/ci.yml` | add `secrets: SONAR_TOKEN: ...` to `pr-quality-ts` + `ci-ts` |
| `.github/workflows/release.yml` | add `secrets: SONAR_TOKEN: ...` to `test` |

No code change. CI-only.

## Test plan

- [x] YAML parses (committing without `--no-verify`)
- [ ] On merge to main, observe that the next `pr-quality-ts` job on a subsequent PR includes a "SonarQube Cloud analysis" step that actually runs (not skipped)
- [ ] Verify the run posts results to https://sonarcloud.io/project/overview?id=asafgolombek_Nimbus

## Notes

- The `SONAR_TOKEN` repo secret is already set (added 2026-05-16T10:58:14Z).
- Fork PRs continue to skip Sonar silently — that's the intended behavior of `required: false`.
- Unblocks PR #316 from getting a Sonar check on its next push (once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)