### PR TITLE
docs(skills): align I14 references, add T4 CLI ref + 3 Phase 5 skills

### DIFF
--- a/.claude/commands/nimbus-cicd-data-layer.md
+++ b/.claude/commands/nimbus-cicd-data-layer.md
@@ -1,0 +1,196 @@
+---
+name: nimbus-cicd-data-layer
+description: >
+  Reference for the Phase 5 T4 CI/CD data layer: the four DORA metric calculators
+  (deployment frequency, lead time for changes, change failure rate, MTTR), the
+  pre-deploy preflight check, the post-deploy annotation pipeline, the
+  `[metrics.dora.<service-id>]` + `[ci.service.<service-id>]` nimbus.toml schema,
+  the URN-based repo + PagerDuty service binding, the OpenAPI surface
+  (`/v1/metrics/dora`, `/v1/preflight/deploy`, `POST /v1/deployments`), and the
+  first-party GitHub Actions in `packages/github-actions/`. Use this skill whenever
+  you are adding a new DORA metric, a new preflight check, a new deployment provider,
+  changing the pure calculators, wiring a new CI integration that feeds the local
+  index, modifying the `ServiceConfig` schema, or asking why `nimbus metrics dora`
+  returns nulls. Also trigger for questions like "where do I add a fifth DORA metric?",
+  "how does preflight count P1 incidents?", "what's a `severity_p1_aliases`?", "why
+  doesn't my deploy show up in `deployment_frequency`?", or "should this calculation
+  be pure or have side effects?". Consult before any change under
+  `packages/gateway/src/metrics/`, `packages/gateway/src/preflight/`, or
+  `packages/gateway/src/deployment/`.
+---
+
+# Nimbus CI/CD Data Layer (Phase 5 T4)
+
+## Why This Skill Exists
+
+Phase 5 T4 introduced three connected systems: DORA metric calculators that read the local index, a pre-deploy check that returns three structured counts, and a post-deploy annotation pipeline that lets CI feed back into the index over a narrow HTTP write surface. Together they let a CI job answer "is it safe to deploy?" and then record what happened, all without an external SaaS metrics store.
+
+The pieces are deliberately separated:
+
+- **Calculators are pure functions.** They take inputs and return envelopes; they do not touch the database or the network.
+- **RPC handlers are thin wrappers.** They parse, hand off to a calculator, format the response.
+- **HTTP routes are dispatched via I13** — see the `nimbus-http-write-surface` skill for the write-side discipline.
+- **GitHub Actions are thin client wrappers.** They call the HTTP API; they contain no calculation logic.
+
+Adding a new metric or check means writing a pure calculator and wiring it; do not let business logic leak into the RPC handler or the GitHub Action.
+
+## Where It Lives
+
+| Area | File | Role |
+|---|---|---|
+| **DORA calculators** | [`packages/gateway/src/metrics/dora.ts`](../../packages/gateway/src/metrics/dora.ts) | Four pure functions: `deploymentFrequency`, `leadTimeForChanges`, `changeFailureRate`, `mttr`. Each returns a `{ value, unit, sample, gap }` envelope |
+| | [`packages/gateway/src/metrics/dora-config.ts`](../../packages/gateway/src/metrics/dora-config.ts) | `ServiceConfig` type (and `DoraServiceConfig` back-compat alias), URN parser, provider-prefix → `service` column map |
+| **Preflight** | [`packages/gateway/src/preflight/preflight.ts`](../../packages/gateway/src/preflight/preflight.ts) | Pure: counts active P1 incidents, failing CI on target ref, open PR conflicts. Returns `DeployPreflightResult` envelope |
+| **Deployment annotation** | [`packages/gateway/src/deployment/annotate.ts`](../../packages/gateway/src/deployment/annotate.ts) | Pure validator + index upsert (one `item` row + one `deployment_items` shadow row + one audit entry) |
+| | [`packages/gateway/src/deployment/external-id.ts`](../../packages/gateway/src/deployment/external-id.ts) | Stable `external_id` derivation: `<provider>:<sha>:<env>` |
+| | [`packages/gateway/src/deployment/types.ts`](../../packages/gateway/src/deployment/types.ts) | Shared `DeploymentAnnotateInput` / `DeploymentAnnotateResult` types |
+| **RPC** | [`packages/gateway/src/ipc/metrics-rpc.ts`](../../packages/gateway/src/ipc/metrics-rpc.ts) | `metrics.dora` handler |
+| | [`packages/gateway/src/ipc/preflight-rpc.ts`](../../packages/gateway/src/ipc/preflight-rpc.ts) | `deploy.preflight` handler |
+| | [`packages/gateway/src/ipc/deployment-rpc.ts`](../../packages/gateway/src/ipc/deployment-rpc.ts) | Internal `deployment.annotate` handler (NOT in renderer allowlist) |
+| **HTTP surface** | [`packages/gateway/openapi/v1.yaml`](../../packages/gateway/openapi/v1.yaml) | OpenAPI schema for `/v1/metrics/dora`, `/v1/preflight/deploy`, `POST /v1/deployments` |
+| **CLI** | [`packages/cli/src/commands/metrics.ts`](../../packages/cli/src/commands/metrics.ts) | `nimbus metrics dora` |
+| | [`packages/cli/src/commands/deploy.ts`](../../packages/cli/src/commands/deploy.ts) | `nimbus deploy preflight` |
+| | [`packages/cli/src/commands/deploy-annotate.ts`](../../packages/cli/src/commands/deploy-annotate.ts) | `nimbus deploy annotate` |
+| **First-party Actions** | [`packages/github-actions/preflight-query/`](../../packages/github-actions/preflight-query/) | Wraps `GET /v1/preflight/deploy` |
+| | [`packages/github-actions/annotate-action/`](../../packages/github-actions/annotate-action/) | Wraps `POST /v1/deployments` |
+
+## Service Configuration
+
+The `<service-id>` chosen by the user (e.g. `payment-service`) is the table key for both `[metrics.dora.<id>]` and `[ci.service.<id>]` blocks. The format is enforced separately at each surface:
+
+- **DORA / preflight CLI:** accept any non-empty string (TOML key validity is the only constraint).
+- **`deploy annotate` CLI + HTTP body:** 1..64 chars matching `/^[a-z0-9][a-z0-9._-]*$/`. No colons, no slashes — distinct from URN format.
+
+Repos and PagerDuty services bind to the service id via URNs in the config block:
+
+```toml
+[metrics.dora.payment-service]
+repos = ["github:acme/payment-service", "github:acme/payment-service-infra"]
+pagerduty_services = ["PSVC123", "PSVC456"]
+deploy_workflow_pattern = "^Deploy"
+incident_window_minutes = 60
+exclude_pr_labels = ["dependabot", "docs"]
+deploy_environments = ["production"]
+```
+
+The provider prefix (`github:`, `gitlab:`, `bitbucket:`, `jenkins:`, `circleci:`) maps to a `service` column value via `providerToServiceColumn` in `dora-config.ts`. Adding a new provider means adding both the type alias entry and the column-map entry.
+
+`severity_p1_aliases` (added in T4 wrap-up, 2026-05-16) is org-wide in `[pagerduty]`:
+
+```toml
+[pagerduty]
+severity_p1_aliases = ["sev1", "sev-1", "critical"]
+```
+
+The set is lowercased + deduplicated at load and copied onto every materialized `ServiceConfig`. An empty default preserves the pre-existing strict `severity = 'P1'` filter — adding aliases is opt-in.
+
+## DORA Calculators
+
+Each calculator is a pure function:
+
+```typescript
+function deploymentFrequency(input: {
+  readonly deployments: readonly Deployment[];
+  readonly windowMs: { since: number; until: number };
+  readonly deployEnvironments: readonly string[];
+}): DoraMetricEnvelope;
+```
+
+The envelope shape is uniform across all four metrics:
+
+| Field | Meaning |
+|---|---|
+| `value` | The metric value, or `null` if `sample` is too small to compute |
+| `unit` | Human-readable unit string (e.g. `"per_day"`, `"hours"`, `"percent"`) |
+| `sample` | Number of inputs the metric was computed from |
+| `gap` | Optional explanation when `value === null` (e.g. `"no deployments in window"`) |
+
+Adding a fifth metric: add a fifth pure function with the same envelope shape, extend the `DoraEnvelope.metrics` type, and update both `metrics-rpc.ts` and the CLI renderer.
+
+## Preflight
+
+```typescript
+function computePreflight(input: {
+  readonly activeP1Count: number;
+  readonly failingCiCount: number;
+  readonly openPrConflictCount: number;
+}): DeployPreflightResult;
+```
+
+The function itself is trivial; the heavy lifting is in the SQL the RPC handler runs to compute the three counts. Use the existing handler's queries as the template — they hit the unified `item` table with the provider→service-column map, filtered by the service's repo set and the optional `severity_p1_aliases`.
+
+Verdict is `ok` if all three counts are zero, `warn` otherwise. The CLI's `--mode block` flag flips a `warn` verdict into exit code 1; the calculator itself does not know about modes.
+
+## Deployment Annotation
+
+`annotateDeployment` validates the input, derives the `external_id` (`<provider>:<sha>:<env>`), and writes three rows in one transaction via `dbRun` (invariant I14):
+
+1. An `item` row with `type = 'deployment'`, `external_id` from the helper, `metadata` JSON containing `nimbus_service_id`, ref, status, durations, workflow URL.
+2. A `deployment_items` shadow row (V28) with structured columns for fast DORA queries.
+3. One audit entry — `actionType = 'deployment.annotated'`, `hitlStatus = 'not_required'`.
+
+The conflict resolution is `ON CONFLICT(service, external_id) DO UPDATE` so retries are idempotent. The `is_new` flag in the response tells the caller whether the row was created or updated.
+
+`dora_eligible` is `true` when `environment` is in the service's `deploy_environments` list — non-prod deploys are recorded but excluded from DORA metric inputs.
+
+## Adding a New Provider — Checklist
+
+When adding a new CI provider (e.g. `azure-pipelines`):
+
+- [ ] Add the literal to `DoraProvider` in `dora-config.ts` and to `DeploymentProvider` in `deployment/types.ts`.
+- [ ] Add the provider → `service` column entry in `providerToServiceColumn`.
+- [ ] Add the literal to `PROVIDER_VALUES` in `deploy-annotate.ts`.
+- [ ] Add a unit test in `dora.test.ts` that exercises a deployment from the new provider.
+- [ ] If the provider needs a connector, follow the `nimbus-connector-authoring` skill.
+- [ ] If the provider needs a first-party GitHub Action equivalent, add it under `packages/github-actions/<name>-action/`.
+
+## Adding a New DORA Metric — Checklist
+
+- [ ] Author a pure function in `metrics/dora.ts` returning the standard `{ value, unit, sample, gap }` envelope.
+- [ ] Add the new metric key to the `DoraEnvelope.metrics` type in `metrics-rpc.ts`.
+- [ ] Update the CLI pretty-print renderer in `metrics.ts` to show the new card.
+- [ ] Update [`packages/gateway/openapi/v1.yaml`](../../packages/gateway/openapi/v1.yaml) — the `DoraEnvelope` schema. **Failing to do this fails `bun run audit:openapi-drift`** (CI gate from T4 PR 1).
+- [ ] Update [`docs/cli-reference.md`](../../docs/cli-reference.md) §"CI/CD".
+- [ ] Add a unit test covering the new metric in `dora.test.ts`; coverage gate is `bun run test:coverage:metrics` (≥80%).
+
+## Adding a New Preflight Check — Checklist
+
+- [ ] Add the count to the `DeployPreflightResult.findings` shape.
+- [ ] Run the SQL in `preflight-rpc.ts` (the calculator stays pure).
+- [ ] Decide whether a non-zero count flips verdict from `ok` → `warn`. If yes, that's a single new clause in the verdict computation.
+- [ ] Update the CLI renderer in `deploy.ts` for both pretty and `--json` output.
+- [ ] Update OpenAPI schema (the gate will catch you if not).
+- [ ] Add coverage in `preflight.test.ts`; gate is `bun run test:coverage:preflight` (≥80%).
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's bad | What to do instead |
+|---|---|---|
+| Putting SQL or HTTP fetches in the pure calculator | Calculators are reused by tests, multiple RPC paths, and (someday) a Grafana scraper. Side effects in the calculator kill all three | Keep the calculator pure; the RPC handler is the I/O boundary |
+| Hardcoding `severity = 'P1'` in a new preflight or DORA query | The org-wide `severity_p1_aliases` list is the canonical source. New queries must read it from the materialized `ServiceConfig` | Pass the alias list through; default to the strict P1 filter when the set is empty |
+| Adding a new HTTP write route directly in `http-server.ts` for "deployment.cancel" | Bypasses I13 entirely | Follow the `nimbus-http-write-surface` skill: add to `WRITE_ROUTE_ALLOWLIST`, update the count assertion, route through `dispatchWriteRoute` |
+| Letting the GitHub Action contain calculation logic | The Action is a thin curl wrapper. Logic in the Action means you have two implementations to keep in sync, and shell logic is worse than TS | Put the logic in the gateway calculator; the Action just POSTs |
+| Building a new "deploy" calculator that calls `connector-sync` to refresh data first | Calculators are read-only and synchronous. Refreshing is a sync-scheduler concern; if the user wants fresher data they run `nimbus sync` first | Document the freshness expectation in the metric's `gap` field |
+| Returning `value: 0` when the sample is empty instead of `value: null` + `gap: "no data in window"` | Confuses "zero deploys" (legitimate signal) with "no data" (operational gap) | Always use `null` + `gap` for unknowable; reserve `0` for measured-as-zero |
+| Adding a per-route bearer-token vault key (e.g. `http_api.preflight_token`) | One token covers the entire HTTP write surface today by design. Per-route tokens would multiply the rotation burden | Use the existing `http_api.deployment_token`. If finer-grained auth is genuinely needed, that's a discrete design discussion, not an implementation detail |
+
+## Testing
+
+Coverage gates:
+
+| Subsystem | Bun script | Threshold |
+|---|---|---|
+| DORA calculators + IPC | `bun run test:coverage:metrics` | ≥80% |
+| Preflight calculator + IPC + HTTP + github-sync `mergeable` enrichment | `bun run test:coverage:preflight` | ≥80% |
+| Post-deploy annotation calculator + HTTP write surface | `bun run test:coverage:deployment` | ≥80% |
+
+All three are part of `bun run test:ci`. A new calculator without a corresponding unit test fails CI on the relevant gate before any feature is reviewed.
+
+## See Also
+
+- `nimbus-http-write-surface` skill — for the I13 discipline that the `POST /v1/deployments` route follows
+- `nimbus-ipc` skill — for the RPC handler conventions (`metrics.*`, `deploy.*`, `deployment.*`)
+- `nimbus-commands` skill — for the CLI invocation, vault key, and coverage-gate names
+- `nimbus-architecture` skill — for the unified `item` table model and the V28 `deployment_items` shadow
+- [`docs/cli-reference.md`](../../docs/cli-reference.md) §"CI/CD" — user-facing CLI documentation
+- [`docs/SECURITY.md`](../../docs/SECURITY.md) §"IPC Surface" — boundary description for the HTTP write surface

--- a/.claude/commands/nimbus-commands.md
+++ b/.claude/commands/nimbus-commands.md
@@ -213,13 +213,13 @@ nimbus impact <file-or-PR-url>    # IPC: agents.impact; emits agents.impact.brie
 ```bash
 nimbus metrics dora --service <id> [--since 30d] [--json]   # four DORA metrics from the local index
 nimbus deploy preflight --service <id> --target-ref <ref> [--mode warn|block|off] [--json]   # pre-deploy index check
-nimbus deploy annotate --service <id> --sha <sha> --target-ref <ref> --env <env> --status <success|failure|rolled_back> --started-at <ms> [--finished-at <ms>] [--provider <github|gitlab|...>] [--run-id <id>] [--json]   # POST a deployment event to the local HTTP write surface
+nimbus deploy annotate --service <id> --sha <sha> --target-ref <ref> --env <env> --status <success|failure|cancelled|in_progress> --started-at <ms> [--finished-at <ms>] [--provider <github-actions|gitlab|jenkins|circleci|bitbucket|other>] [--workflow-url <url>] [--run-id <id>] [--job-id <id>] [--json]   # POST a deployment event to the local HTTP write surface
 ```
 
 **Vault keys for the HTTP write surface:**
 
 ```
-http_api.deployment_token   # Bearer token required for POST /v1/deployments; set via `nimbus vault set http_api.deployment_token <token>` (CLI-only). Without it, the HTTP write surface refuses all POSTs with 401.
+http_api.deployment_token   # Bearer token required for POST /v1/deployments; set via `nimbus vault set http_api.deployment_token <token>` (CLI-only). Without it, the HTTP write surface refuses all POSTs with 503 (write_surface_disabled).
 ```
 
 ### Phase 5 T6 — Forensic + hybrid embedding

--- a/.claude/commands/nimbus-embedding-routing.md
+++ b/.claude/commands/nimbus-embedding-routing.md
@@ -1,0 +1,197 @@
+---
+name: nimbus-embedding-routing
+description: >
+  Reference for the hybrid 384-dim / 1536-dim embedding routing pipeline shipped in
+  Phase 5 T6 PR 3: `PROSE_HEAVY_TYPES`, `EMBEDDING_DIM_LOCAL` / `EMBEDDING_DIM_OPENAI`,
+  the `RoutingEmbeddingPipeline` wrapper, the dual-table search (`vec_items_384` +
+  `vec_items_1536` via `vectorSearchChunksDual`), the migration story (V30 added the
+  1536-dim table with dim-aware delete triggers), the `nimbus index reembed` CLI +
+  long-running IPC contract, and the hybrid-mode factory's MiniLM-only fallback when
+  `openai.api_key` is absent. Use this skill whenever you are adding a new connector
+  item type and need to decide its embedding routing, modifying `PROSE_HEAVY_TYPES`,
+  changing the embedding-table dimensions, authoring search code that should hit
+  both tables, debugging "why isn't my new item embedded into the right table?",
+  wiring a new long-running IPC notification (`index.reembedProgress` is the canonical
+  example), or asking what `nimbus index reembed` actually does. Also trigger for
+  questions like "MiniLM or OpenAI for this type?", "do I need a new V31 migration to
+  add a 3072-dim provider?", "why is my reembed run hitting the wrong table?", or
+  "is reembed cancellable?".
+---
+
+# Nimbus Embedding Routing (T6 PR 3)
+
+## Why This Skill Exists
+
+Phase 5 T6 PR 3 split the embedding store into two dim-specific virtual tables (`vec_items_384` for MiniLM, `vec_items_1536` for `text-embedding-3-small`) and introduced a routing layer that dispatches each item to the right pipeline based on its `(service, type)`. Adding a connector that emits, say, `obsidian:obsidian_note` requires deciding whether the type is prose-heavy (route to OpenAI) or sparse-structured (stay on local MiniLM). Getting that decision wrong silently degrades recall for that type for every user who runs in hybrid mode.
+
+This skill is the rule a contributor consults **before** touching `PROSE_HEAVY_TYPES`, the routing pipeline, the dual-search code, or the reembed flow.
+
+## Where It Lives
+
+| File | Role |
+|---|---|
+| [`packages/gateway/src/embedding/routing.ts`](../../packages/gateway/src/embedding/routing.ts) | `EMBEDDING_DIM_LOCAL` (384) + `EMBEDDING_DIM_OPENAI` (1536) + `SUPPORTED_EMBEDDING_DIMS` + `PROSE_HEAVY_TYPES` + `routingKey` + `isProseHeavy` |
+| [`packages/gateway/src/embedding/routing-pipeline.ts`](../../packages/gateway/src/embedding/routing-pipeline.ts) | `RoutingEmbeddingPipeline` — wraps two `SqliteEmbeddingPipeline` instances and dispatches by `isProseHeavy(service, type)` |
+| [`packages/gateway/src/embedding/create-routing-runtime.ts`](../../packages/gateway/src/embedding/create-routing-runtime.ts) | `tryCreateRoutingEmbeddingRuntime` — hybrid-mode factory; **falls back to MiniLM-only when `openai.api_key` is missing** so the gateway never refuses to start because of a missing optional secret |
+| [`packages/gateway/src/search/dual-search.ts`](../../packages/gateway/src/search/dual-search.ts) | `vectorSearchChunksDual` — KNN over both `vec_items_*` tables, merged by distance. This is the only correct way to do vector search after T6 PR 3 |
+| [`packages/gateway/src/index/vec-items-1536-v30-sql.ts`](../../packages/gateway/src/index/vec-items-1536-v30-sql.ts) | V30 migration SQL — `vec_items_1536` virtual table + dim-aware delete triggers |
+| [`packages/gateway/src/ipc/index-reembed-rpc.ts`](../../packages/gateway/src/ipc/index-reembed-rpc.ts) | `dispatchIndexReembedRpc` — `index.reembed` / `index.reembedCancel` long-running handler. **CLI-only**: NOT LAN-callable (`I5`), NOT in Tauri allowlist (`I7`) |
+| [`packages/cli/src/commands/index-cmd.ts`](../../packages/cli/src/commands/index-cmd.ts) | `nimbus index reembed` CLI; subscribes to `index.reembedProgress` / `index.reembedDone` / `index.reembedError` notifications |
+
+## The Routing Decision
+
+```typescript
+export const PROSE_HEAVY_TYPES: ReadonlySet<string> = new Set([
+  "slack:message",
+  "discord:message",
+  "teams:message",
+  "gmail:email",
+  "outlook:email",
+  "notion:page",
+  "confluence:page",
+  "obsidian:obsidian_note",
+  "pagerduty:incident",
+  "linear:issue",
+  "jira:issue",
+  "github:issue",
+  "gitlab:issue",
+  "bitbucket:issue",
+]);
+```
+
+The key shape is `"<service>:<type>"` — same shape every `IndexedItem.id` uses on its left side. When you add a new item type, decide:
+
+- **Prose-heavy** (paragraphs of natural language; semantic search benefits from a larger model): add to `PROSE_HEAVY_TYPES`. Routes to OpenAI `text-embedding-3-small` in hybrid mode. Examples: chat messages, email bodies, wiki pages, free-form ticket descriptions.
+- **Sparse / structured** (titles, file paths, identifiers, code snippets, short metadata): omit from the set. Stays on local MiniLM-L6-v2 (384-dim). Examples: PR titles, file names, API endpoint paths, deployment items, CI run names.
+
+**Default to omitting.** Adding a new entry sends every existing user's `(service, type)` corpus through OpenAI on the next embed pass — for free OSS users that means surprise API spend the first time the gateway encounters that type after upgrade. The default of "stay on local" is the safer floor.
+
+## The Routing Pipeline
+
+`RoutingEmbeddingPipeline` is a drop-in `EmbeddingPipeline` that takes two `SqliteEmbeddingPipeline` instances at construction:
+
+```typescript
+class RoutingEmbeddingPipeline implements EmbeddingPipeline {
+  constructor(
+    private readonly db: Database,
+    private readonly local: SqliteEmbeddingPipeline,    // MiniLM, 384
+    private readonly openai: SqliteEmbeddingPipeline,   // text-embedding-3-small, 1536
+  ) {}
+
+  async embedItem(item: IndexedItem): Promise<void> {
+    const target = isProseHeavy(item.service, item.type) ? this.openai : this.local;
+    await target.embedItem(item);
+  }
+
+  async deleteItemEmbeddings(itemId: string): Promise<void> {
+    // V30 dim-aware delete triggers on `embedding_chunk` fan out to
+    // both vec_items_* tables automatically — one DELETE is enough.
+    dbRun(this.db, `DELETE FROM embedding_chunk WHERE item_id = ?`, [itemId]);
+  }
+
+  async backfillAll(onProgress?): Promise<void> {
+    const proseKeys = Array.from(PROSE_HEAVY_TYPES);
+    await this.openai.backfillForRoutingKeys({ in: proseKeys }, onProgress);
+    await this.local.backfillForRoutingKeys({ notIn: proseKeys }, onProgress);
+  }
+}
+```
+
+Two non-obvious properties:
+
+1. **Deletes go through `embedding_chunk` only** — the V30 migration installed triggers that fan a single `DELETE FROM embedding_chunk WHERE item_id = ?` to whichever `vec_items_*` table holds the chunks. Do not try to delete from `vec_items_384` and `vec_items_1536` separately — that's a bug, not a defence-in-depth.
+2. **The write goes through `dbRun`** (invariant `I14`). Direct `db.run(...)` in routing code would fail the static-time audit.
+
+## Dual Search
+
+After T6 PR 3, vector search **must** consult both tables and merge by distance. The canonical helper is:
+
+```typescript
+import { vectorSearchChunksDual } from "../search/dual-search.ts";
+
+const hits = await vectorSearchChunksDual(db, {
+  queryVector384: localEmbedding,    // optional — undefined skips local KNN
+  queryVector1536: openaiEmbedding,  // optional — undefined skips OpenAI KNN
+  k: 50,
+});
+```
+
+The dispatcher computes the query embedding(s) using the same routing decision (the query type is `chat:user_query` by default; pass through both if you want hybrid recall). **Never `SELECT FROM vec_items_384`** in new search code — it silently misses every prose-heavy item.
+
+## Hybrid Runtime Factory + Fallback
+
+`tryCreateRoutingEmbeddingRuntime` is the gateway-startup factory. The important property:
+
+> If `openai.api_key` is missing from the vault but `embedding.provider = "hybrid"` is set in `nimbus.toml`, the factory **falls back to MiniLM-only** and logs one info-level line. The gateway never refuses to start because of the missing optional secret.
+
+This is the right default for OSS: hybrid is opt-in via vault key, not config. A user who configures `provider = "hybrid"` but never adds the key gets degraded recall, not a startup failure.
+
+## Reembed (long-running IPC pattern)
+
+`nimbus index reembed` is the canonical long-running IPC contract. Use it as a template when adding any future long-running gateway operation.
+
+**Surfaces:**
+
+| Layer | Surface |
+|---|---|
+| CLI | [`packages/cli/src/commands/index-cmd.ts`](../../packages/cli/src/commands/index-cmd.ts) — `nimbus index reembed --model <id> [--item-type <key>] [--service <name>] [--limit N] [--batch-size N] [--dry-run] [--yes] [--json]` |
+| IPC request | `index.reembed` → `{ jobId }` (returns immediately) |
+| IPC cancellation | `index.reembedCancel { jobId }` → `{ cancelled: boolean }` |
+| IPC notifications | `index.reembedProgress { jobId, done, total, skipped }` per batch · `index.reembedDone { jobId, succeeded, skipped, durationMs }` on completion · `index.reembedError { jobId, code, message }` on fatal abort |
+
+**Security posture (CLI-only):**
+
+- `index.reembed` and `index.reembedCancel` are in `FORBIDDEN_OVER_LAN` (invariant `I5`).
+- Neither is in the Tauri renderer allowlist (invariant `I7`).
+- They are not exposed over the HTTP API.
+
+Adding a new method that should follow the same posture: list it by full name in `FORBIDDEN_OVER_LAN`, omit it from `ALLOWED_METHODS` in `gateway_bridge.rs`, and do not register an HTTP route for it.
+
+**Idempotence:** items already embedded against the target model are skipped, so re-running after a transient OpenAI 5xx is safe. Exit code `0` covers "completed with any number of skips"; operator re-runs to retry. Exit code `1` is reserved for fatal aborts (vault key missing, unknown model id, auth failure, gateway down).
+
+**Dry-run:** `--dry-run` emits exactly one `index.reembedDone` notification with `{ dryRun: true, planned: N }` and writes nothing.
+
+## Adding a New Item Type — Checklist
+
+When a new connector emits a new `(service, type)` pair:
+
+- [ ] Decide prose-heavy vs sparse using the criteria above. Default to sparse.
+- [ ] If prose-heavy, add `"<service>:<type>"` to `PROSE_HEAVY_TYPES` in `routing.ts`. Keep alphabetical order within blocks if it helps readability.
+- [ ] Update the unit test for `isProseHeavy` to cover the new key.
+- [ ] If you also want existing users' historical data re-embedded on the next start, leave it for the user — `RoutingEmbeddingPipeline.backfillAll` will pick it up at the next pass; or document `nimbus index reembed --item-type <key> --model openai:text-embedding-3-small`.
+- [ ] Confirm new search code uses `vectorSearchChunksDual`. Never `vec_items_384`-only.
+
+## Adding a New Provider Track (e.g. 3072-dim)
+
+This is a larger change than adding a routing key — it's a new migration + new constants + new pipeline plumbing:
+
+- [ ] Add a new `EMBEDDING_DIM_<NAME>` constant in `routing.ts`. Add it to `SUPPORTED_EMBEDDING_DIMS`.
+- [ ] Add a V`<N>` migration mirroring V30: `vec_items_<dim>` virtual table + dim-aware delete trigger on `embedding_chunk`.
+- [ ] Extend `RoutingEmbeddingPipeline` to hold a third pipeline (or restructure into an `n`-pipeline router keyed by target dim).
+- [ ] Extend `vectorSearchChunksDual` (or replace with `vectorSearchChunksMulti`) so search queries can target the third table.
+- [ ] Extend `nimbus index reembed --model` validation to accept the new model id; vault-key requirement, if any, declared in the validator.
+- [ ] Update `nimbus-file-map.md` and `nimbus-commands.md` with the new model id and any new vault key.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's bad | What to do instead |
+|---|---|---|
+| Adding a new `(service, type)` to `PROSE_HEAVY_TYPES` because "OpenAI gives better results for everything" | Forces every hybrid-mode user to pay for OpenAI embedding of a corpus they didn't ask for. Sparse-structured types (titles, paths, IDs) embed fine on 384-dim MiniLM | Default to omitting. Add only when the content is genuinely prose-paragraph-shaped |
+| Calling `SELECT ... FROM vec_items_384 WHERE …` in new search code | Silently misses every prose-heavy item; recall regresses for the OpenAI-embedded portion of the corpus without any test failure | Always go through `vectorSearchChunksDual` |
+| Issuing parallel `DELETE FROM vec_items_384 WHERE item_id = ?` + `DELETE FROM vec_items_1536 WHERE item_id = ?` | Defeats the V30 trigger design; introduces a window where one table is half-deleted | Delete once from `embedding_chunk`; let the triggers fan out |
+| Direct `db.run(...)` inside the routing pipeline | Regresses `I14` (the static audit `D12` exits 1) | Use `dbRun` from `db/write.ts` |
+| Hard-failing gateway startup when `openai.api_key` is missing | The hybrid-mode fallback to MiniLM-only is intentional — OSS users have no obligation to provide an OpenAI key | Trust the factory's fallback; do not add a startup precondition |
+| Adding `index.reembed` to the Tauri allowlist for a "convenient UI button" | Long-running ops with API cost on every batch should not be one-click from the renderer | Keep it CLI-only. If the desktop UI needs status, expose a read-only `index.reembedStatus` instead |
+| Suppressing `index.reembedProgress` notifications because "they're noisy" | The CLI's progress streamer + the user's ability to know if a long run is making progress depend on these. Suppression means the user sees nothing for tens of minutes | Keep the per-batch cadence; throttle batch size instead |
+
+## Tests
+
+Coverage gate: `bun run test:coverage:embedding` (≥80%). Add a unit test for any new entry in `PROSE_HEAVY_TYPES` (round-trip through `isProseHeavy`); an integration test for any change to `RoutingEmbeddingPipeline.embedItem` (asserts the right inner pipeline is called); an e2e test for any change to the `nimbus index reembed` CLI surface.
+
+## See Also
+
+- [`packages/gateway/src/embedding/`](../../packages/gateway/src/embedding/) — pipeline implementations
+- [`docs/architecture.md`](../../docs/architecture.md) §"Local Database Schema" — `embedding_chunk` + `vec_items_*` schemas
+- `nimbus-db-migrations` skill — for V`<N>` migration authoring + FTS5/vec0 caveats
+- `nimbus-ipc` skill — for the long-running IPC notification pattern
+- `nimbus-commands` skill — for the `nimbus index reembed` CLI invocation and coverage gates

--- a/.claude/commands/nimbus-file-map.md
+++ b/.claude/commands/nimbus-file-map.md
@@ -233,7 +233,7 @@ This is the curated pointer index. Source-of-truth is the working tree — verif
 |---|---|
 | `docs/architecture.md` | Full subsystem design — read before modifying any subsystem |
 | `docs/roadmap.md` | Phases, acceptance criteria, delivered summary |
-| `docs/SECURITY-INVARIANTS.md` | I1–I12 rationale + anti-patterns + audit cross-references |
+| `docs/SECURITY-INVARIANTS.md` | I1–I14 rationale + anti-patterns + audit cross-references |
 | `docs/release/manual-smoke-headless.md` | Reusable manual smoke checklist for headless releases; per-platform results matrix |
 | `docs/cli/use-in-ci.md` | Worked CI integration examples (GitHub Actions self-hosted, GitLab CI, Jenkins) using `nimbus query --json` (Phase 5 T4 PR 1) |
 | `docs/templates/nimbus-pre-commit.sh` | Bash pre-commit hook template — fail-open `nimbus diag --json` reachability check + incident/CI gates (Phase 5 T4 PR 1) |

--- a/.claude/commands/nimbus-http-write-surface.md
+++ b/.claude/commands/nimbus-http-write-surface.md
@@ -1,0 +1,132 @@
+---
+name: nimbus-http-write-surface
+description: >
+  Reference for the local HTTP API write surface and the `WRITE_ROUTE_ALLOWLIST` /
+  bearer-auth / per-token rate-limit / audit-on-rejection pipeline that protects it
+  (security invariant `I13`). Use this skill whenever you are adding a new HTTP
+  `POST` / `PUT` / `DELETE` handler, modifying an existing one, debating whether a
+  route should live on the local socket or on the HTTP API, wiring a new CI integration
+  that needs to feed data into the local index, or touching `http-server.ts` /
+  `http-write-routes.ts` / `http-auth.ts` / `http-rate-limit.ts`. Also trigger for
+  questions like "can I POST to the HTTP API?", "where does this token check live?",
+  "why is my route returning 503 `write_surface_disabled`?", "should this be a new
+  HTTP route or an IPC method?", or "the WRITE_ROUTE_ALLOWLIST count assertion is
+  wrong". Consult before any code that lets an external process write into the
+  gateway over HTTP — the HTTP API was historically read-only, and the carve-out
+  for `POST /v1/deployments` is the **only** sanctioned write path.
+---
+
+# Nimbus HTTP Write Surface (I13)
+
+## Why This Skill Exists
+
+Before Phase 5 T4 PR 3b, the read-only HTTP API (`nimbus serve`) was structurally read-only: a single `SQLITE_OPEN_READONLY` handle backed every route. T4 PR 3b carved out a narrow write surface for post-deploy annotation (`POST /v1/deployments`) so CI can feed DORA metrics directly. That carve-out is **the only HTTP write path Nimbus accepts**, and the discipline that keeps it that way is invariant `I13`. Adding a second write route is a security boundary change, not a routine handler addition.
+
+This skill is the rule a contributor consults **before** adding any HTTP `POST` / `PUT` / `DELETE` handler.
+
+## Where It Lives
+
+| File | Role |
+|---|---|
+| [`packages/gateway/src/ipc/http-write-routes.ts`](../../packages/gateway/src/ipc/http-write-routes.ts) | `WRITE_ROUTE_ALLOWLIST` (frozen, compile-time) + `dispatchWriteRoute` — the single dispatcher every HTTP write goes through |
+| [`packages/gateway/src/ipc/http-server.ts`](../../packages/gateway/src/ipc/http-server.ts) | Where POST requests are routed to `dispatchWriteRoute`; opens **at most one** writable `Database` handle (the read handle stays `SQLITE_OPEN_READONLY`) |
+| [`packages/gateway/src/ipc/http-auth.ts`](../../packages/gateway/src/ipc/http-auth.ts) | `requireBearer` + `tokenFingerprint` — reads the expected token from the `http_api.deployment_token` vault key; constant-time compare via `constantTimeStringEqual` (invariant `I10`) |
+| [`packages/gateway/src/ipc/http-rate-limit.ts`](../../packages/gateway/src/ipc/http-rate-limit.ts) | Per-token sliding-window rate limiter (default 60 req/min); surfaces `X-RateLimit-*` headers |
+| [`packages/gateway/src/security-invariants.test.ts`](../../packages/gateway/src/security-invariants.test.ts) | Three I13 sub-assertions — see "Enforcement" below |
+| [`packages/gateway/openapi/v1.yaml`](../../packages/gateway/openapi/v1.yaml) | Hand-authored OpenAPI schema; **the schema must list every allowlisted write route** — see "OpenAPI drift" below |
+
+## The Allowlist
+
+Currently a single entry:
+
+```typescript
+export const WRITE_ROUTE_ALLOWLIST: readonly string[] = Object.freeze([
+  "POST /v1/deployments",
+]);
+```
+
+Entries are `"<METHOD> <PATH>"` strings — exact match, no path templating, no method aliasing. `dispatchWriteRoute` rejects anything not in this array; unknown paths return 404, known paths on the wrong method return 405 with `Allow` header.
+
+## Enforcement (the I13 test triple)
+
+[`security-invariants.test.ts`](../../packages/gateway/src/security-invariants.test.ts) carries three assertions:
+
+1. **`http-server.ts` imports `dispatchWriteRoute`** from `./http-write-routes.ts`. A second dispatcher cannot exist; the import is the proof.
+2. **`http-server.ts` opens at most one writable `Database` handle** — counted by source-grep. Any second writable handle is a structural regression because it bypasses the dispatcher.
+3. **`WRITE_ROUTE_ALLOWLIST.length === 1`** and contains exactly `"POST /v1/deployments"`. Adding an entry **requires updating this assertion in the same commit** — the count is the integrity check, not just decoration.
+
+## Request Flow
+
+Every accepted write goes through this pipeline in `dispatchWriteRoute`:
+
+1. **Allowlist lookup** — `"<METHOD> <PATH>"` must be in `WRITE_ROUTE_ALLOWLIST`. Unknown → 404; known path, wrong method → 405.
+2. **Bearer auth** — `requireBearer(req, { expectedToken })`. Three outcomes:
+   - `surfaceDisabled`: vault key `http_api.deployment_token` not set → 503 `write_surface_disabled` (no audit row — surface is structurally off).
+   - `!ok`: bad / missing token → 401 `unauthorized` + audit row.
+   - `ok`: continue with `auth.fingerprint` (SHA-256 prefix of the token, for forensic tagging).
+3. **Rate limit** — `ctx.rateLimiter.check(auth.fingerprint)`. On miss → 429 + `Retry-After` + audit row. On hit, the response always carries `X-RateLimit-{Limit,Remaining,Reset}`.
+4. **Body parse** — `Content-Length` is checked against `MAX_BODY_BYTES = 8 KiB` **before** the body is read; the streaming length cap then re-checks `bodyBytes.byteLength`. UTF-8 decode is `{ fatal: true }`. JSON parse failures → 400 `invalid_json` + audit row.
+5. **Service allowlist (per-route)** — for `POST /v1/deployments`, the body's `service` field must be in `ctx.knownServices()`. Unknown → 400 `unknown_service` + audit row (with `known_services` hint truncated to 25 entries).
+6. **Route handler** — currently `dispatchDeploymentRpc("deployment.annotate", parsed, …)`. The handler writes its own success audit (do **not** double-write).
+7. **Rejection audit** — any non-2xx path calls `recordRejection(ctx, { tokenFingerprint, resultCode, reason, … })`, which appends a `deployment.annotation_rejected` row via `appendAuditEntry` (BLAKE3-chained, tamper-evident). The audit write is best-effort — wrapped in `try { … } catch { /* silent */ }` so a corrupted chain or full disk **cannot** fingerprint the rejection path.
+
+## Forbidden Categories
+
+These can **never** become HTTP write surfaces, no matter the bearer auth quality:
+
+| Category | Reason |
+|---|---|
+| `vault.*` writes | Same posture as I7 — credentials never leave the local socket. |
+| `engine.ask` / agent surfaces | Inbound prompts via HTTP are a prompt-injection multiplier; the only LLM entry points are the local socket + Tauri allowlist. |
+| Anything that bypasses `ToolExecutor` for a destructive action | Would regress I2 (HITL frozen set) silently. |
+| Anything that opens its own `Database` handle | Regresses the "at most one writable handle in `http-server.ts`" sub-assertion. |
+
+## Adding a New HTTP Write Route — Checklist
+
+When a new POST/PUT/DELETE genuinely needs to live on the HTTP API (not the IPC socket):
+
+- [ ] Confirm the action is **not** in the forbidden categories above. If destructive, it must go through `ToolExecutor` first and only become an HTTP surface for already-approved automation flows (CI annotation patterns).
+- [ ] Add `"<METHOD> <PATH>"` to `WRITE_ROUTE_ALLOWLIST` in `http-write-routes.ts`.
+- [ ] **Bump the `length` assertion** in `security-invariants.test.ts` (`expect(WRITE_ROUTE_ALLOWLIST.length).toBe(N)`). The count *is* the integrity check.
+- [ ] Add an `if (key === "<METHOD> <PATH>")` branch in `dispatchWriteRoute` that calls the route's handler. Route handlers throw typed errors (e.g. `DeploymentRpcError`) so the dispatcher can map them to `400 invalid_<field>` audit rows.
+- [ ] Decide whether the handler writes its own success audit (current pattern for `dispatchDeploymentRpc`). If yes, **do not double-write** in the dispatcher.
+- [ ] Add the route to [`packages/gateway/openapi/v1.yaml`](../../packages/gateway/openapi/v1.yaml). If you forget, `bun run audit:openapi-drift` (CI gate from Phase 5 T4 PR 1) will fail — the OpenAPI schema is the single source of truth for the published API surface.
+- [ ] The route must use the existing `ctx.writeDb` — never call `new Database(path, { readonly: false })` from a route handler.
+- [ ] If the route accepts a body, enforce a tight `MAX_BODY_BYTES` (8 KiB is the current default; raise only with documented justification).
+- [ ] Verify the bearer-auth + rate-limit + audit-on-rejection pattern still wraps the new route — `dispatchWriteRoute` does this by construction, but a handler that throws after auth must still surface a `recordRejection` call.
+- [ ] Update [`docs/cli-reference.md`](../../docs/cli-reference.md) §"CI/CD" (or a new section) and [`docs/SECURITY.md`](../../docs/SECURITY.md) §"IPC Surface" if the boundary description changes.
+- [ ] Update the `WRITE_ROUTE_ALLOWLIST` entry list in this skill and in [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) §I13.
+
+## Removing or Renaming a Route
+
+- [ ] Delete the allowlist entry, the dispatcher branch, and the OpenAPI path. **Decrement** the count assertion.
+- [ ] If the removal was security-driven (route turned out to be a vector), add a comment near the count assertion locking in the absence — same pattern Tauri allowlist uses for `extension.install`.
+- [ ] Audit the BLAKE3 chain (`nimbus audit verify`) — confirm the route never produced rows that downstream code depends on parsing.
+
+## OpenAPI Drift
+
+[`scripts/structure-audit/check-openapi-drift.ts`](../../scripts/structure-audit/check-openapi-drift.ts) compares `v1.yaml`'s declared paths against `READ_ONLY_HTTP_ROUTES` (and, by transitivity, against the live handler set). It's wired as `bun run audit:openapi-drift` and runs in the structure-audit CI gate. The write surface is small enough that drift here means *someone added a route and forgot the schema* — easy to fix, but the gate catches it before merge.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's bad | What to do instead |
+|---|---|---|
+| Adding a POST handler directly in `http-server.ts` and skipping `dispatchWriteRoute` | Bypasses the allowlist, bearer auth, rate limiting, and audit-on-rejection in one shot. This is the exact failure I13 prevents | Route every write through `dispatchWriteRoute`; add the allowlist entry first |
+| Opening a second writable `Database` handle "for performance" | Defeats sub-assertion 2 of the invariant test and reintroduces silent-write paths that bypass `dbRun` (I14) | Use `ctx.writeDb`. If write throughput is genuinely the bottleneck, that's a `db/write.ts` change, not a new handle |
+| Adding a route to `WRITE_ROUTE_ALLOWLIST` without updating the count assertion | Test fails immediately, but if `--no-verify` ships the commit, the integrity gate is gone | Always update both in the same diff. The count is the audit trail |
+| Loosening the 8 KiB body cap to support "richer" payloads | DoS surface — the cap exists so an unauthenticated probe can't fill the audit chain or exhaust memory before bearer auth runs | Keep payloads small. If the route genuinely needs more, raise the cap with justification in the PR and add a corresponding rate-limit tightening |
+| Suppressing the rejection audit because "rate-limit rejections are noisy" | The audit chain is the only forensic trail; suppression makes brute-force probes invisible | Tune the rate limit threshold instead; the audit row is the structural protection |
+| Logging the bearer token (or even the full fingerprint) to stderr | Bearer token must never appear in logs (`*.token` redact pattern). The 8-hex `tokenFingerprint` is the only safe identifier | Use `auth.fingerprint`; the redact rules cover the rest |
+
+## Reading the Audit
+
+`deployment.annotation_rejected` rows carry `{ token_fingerprint, source_ip, result_code, reason, service?, external_id? }`. Brute-force probes show up as runs of 401s with the same (or rotating) fingerprints; pattern-match `reason` to distinguish unauthorized / rate_limited / invalid_json / unknown_service / invalid_<field> / payload_too_large / internal_error. Success rows live in the `deployment.annotated` action type with the matching `external_id`.
+
+## See Also
+
+- [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) §I13 — canonical invariant statement
+- [`docs/SECURITY.md`](../../docs/SECURITY.md) §"IPC Surface" — boundary description
+- [`docs/architecture.md`](../../docs/architecture.md) §"Security Model" — threat-to-mitigation table
+- `nimbus-tauri-allowlist` skill — parallel pattern for the renderer-callable surface (I7)
+- `nimbus-security-invariants` skill — the triple rule (production wiring + docs + test) that all fourteen invariants follow
+- `nimbus-cicd-data-layer` skill — pair with this skill when authoring new DORA / preflight / deploy-annotation surfaces

--- a/.claude/commands/nimbus-tauri-allowlist.md
+++ b/.claude/commands/nimbus-tauri-allowlist.md
@@ -129,4 +129,4 @@ When the desktop UI needs a new IPC method:
 - [`docs/SECURITY.md`](../../docs/SECURITY.md) §"IPC Surface" — Gateway IPC trust model
 - [`packages/ui/src-tauri/src/gateway_bridge.rs`](../../packages/ui/src-tauri/src/gateway_bridge.rs) — production source of truth
 - `nimbus-ipc` skill — Gateway-side IPC method conventions; pair with this skill when adding a method that is *both* CLI-callable and renderer-callable
-- `nimbus-security-invariants` skill — the invariant triple rule (wiring + docs + test) that all twelve invariants follow
+- `nimbus-security-invariants` skill — the invariant triple rule (wiring + docs + test) that all fourteen invariants follow

--- a/.claude/commands/nimbus-tool-output-envelope.md
+++ b/.claude/commands/nimbus-tool-output-envelope.md
@@ -104,4 +104,4 @@ When registering a new agent tool or extending a sub-agent worker:
 - [`docs/SECURITY-INVARIANTS.md`](../../docs/SECURITY-INVARIANTS.md) — full I-numbered list with anti-patterns
 - [`docs/SECURITY.md`](../../docs/SECURITY.md) §"Prompt Injection" — the hard structural barrier (HITL gate) vs the soft barrier (envelope) split
 - [`docs/architecture.md`](../../docs/architecture.md) §"Security Model" — threat-to-mitigation table
-- `nimbus-security-invariants` skill — the invariant triple rule (production wiring + docs entry + enforcement test) that all twelve invariants follow
+- `nimbus-security-invariants` skill — the invariant triple rule (production wiring + docs entry + enforcement test) that all fourteen invariants follow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,10 +122,13 @@ When implementing, focus on the current phase. Do not add Phase N+1 features in 
 
 @.claude/commands/nimbus-agent-patterns.md
 @.claude/commands/nimbus-architecture.md
+@.claude/commands/nimbus-cicd-data-layer.md
 @.claude/commands/nimbus-commands.md
 @.claude/commands/nimbus-connector-authoring.md
 @.claude/commands/nimbus-db-migrations.md
+@.claude/commands/nimbus-embedding-routing.md
 @.claude/commands/nimbus-file-map.md
+@.claude/commands/nimbus-http-write-surface.md
 @.claude/commands/nimbus-ipc.md
 @.claude/commands/nimbus-security-invariants.md
 @.claude/commands/nimbus-tauri-allowlist.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -46,10 +46,11 @@ Each invariant has a production wiring site and an enforcement test in `packages
 | I11 | LLM-facing tool results wrapped via `wrapToolOutput` | `engine/agent.ts`, `engine/tool-output-envelope.ts` | New agent surface that feeds raw tool results to the LLM |
 | I12 | DPAPI calls pass `pOptionalEntropy` from `<configDir>/vault/.entropy` | `vault/win32.ts` | Dropping the entropy parameter "for compatibility" |
 | I13 | HTTP write routes go through `WRITE_ROUTE_ALLOWLIST` + bearer auth | `ipc/http-server.ts`, `ipc/http-write-routes.ts` | New POST/PUT/DELETE handler that bypasses `dispatchWriteRoute` or opens a second writable DB outside the server context |
+| I14 | All SQLite write paths route through `dbRun` / `dbExec` / `dbStmtRun` | `db/write.ts` (`dbRun`, `dbExec`, `dbStmtRun`); enforced statically by `D12` in `check-nimbus-invariants.ts` | Direct `db.run(` or `db.exec(` outside `DB_RUN_EXEC_ALLOW_LIST` — swallows `SQLITE_FULL` |
 
 When changing a wiring site, update both the test and `SECURITY-INVARIANTS.md` in the same commit. When retiring an invariant, delete the row — never leave it as documentation drift.
 
-**Static-time complement:** `scripts/structure-audit/check-nimbus-invariants.ts` enforces I1 (`spawn` under `connectors/` must use `extensionProcessEnv()`) and the vault-key allow-list at static time. Runtime tests remain authoritative; the static checks fail before the test suite runs.
+**Static-time complement:** `scripts/structure-audit/check-nimbus-invariants.ts` enforces I1 (`spawn` under `connectors/` must use `extensionProcessEnv()`), the vault-key allow-list, and I14 (`DB_RUN_EXEC_ALLOW_LIST` — direct `db.run`/`db.exec` outside `db/write.ts` exits 1) at static time. Runtime tests remain authoritative; the static checks fail before the test suite runs.
 
 ---
 
@@ -110,6 +111,6 @@ When implementing, focus on the current phase. Do not add Phase N+1 features in 
 
 - [`docs/architecture.md`](./docs/architecture.md) — full subsystem design, IPC method catalogue, schema reference. Read before modifying any subsystem.
 - [`docs/roadmap.md`](./docs/roadmap.md) — phases, acceptance criteria, delivered summaries.
-- [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md) — I1–I12 rationale + anti-patterns.
+- [`docs/SECURITY-INVARIANTS.md`](./docs/SECURITY-INVARIANTS.md) — I1–I14 rationale + anti-patterns.
 - [`docs/cli-reference.md`](./docs/cli-reference.md) — full CLI subcommand reference.
-- `.claude/commands/nimbus-*.md` — domain skills (architecture, IPC, file-map, commands, testing, agents, connectors, migrations, security invariants, Tauri allowlist, tool-output envelope, Phase 4 reference). The Gemini CLI activates these on demand via `activate_skill`.
+- `.claude/commands/nimbus-*.md` — domain skills (architecture, IPC, file-map, commands, testing, agents, connectors, migrations, security invariants, Tauri allowlist, tool-output envelope, HTTP write surface (I13), embedding routing (T6 PR 3), CI/CD data layer (T4), Phase 4 reference). The Gemini CLI activates these on demand via `activate_skill`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -164,6 +164,8 @@ The Gateway listens only on a local domain socket (Unix) or named pipe (Windows)
 
 The optional LAN server (`nimbus lan enable`) and auto-updater (`nimbus update`) are guarded by the structural defenses listed in [`SECURITY-INVARIANTS.md`](./SECURITY-INVARIANTS.md) — the LAN method allowlist (`I5`), loopback bind default (`I6`), and updater signature/version checks. The B1 audit closed the High and Medium findings on these subsystems; remaining Low items are tracked in the [Phase 4 / Phase 10 roadmap entries](./roadmap.md). Production wiring of both features lands once GA prerequisites (signing certs, manifest server, LAN forward-secrecy redesign) are signed off.
 
+The opt-in read-only HTTP API (`nimbus serve`) gained a narrow write surface in Phase 5 T4 for post-deploy annotation (`POST /v1/deployments`). The surface is protected by a compile-time allowlist (`WRITE_ROUTE_ALLOWLIST` — invariant `I13`), bearer-token auth keyed on the `http_api.deployment_token` vault entry, and per-token rate limiting; every rejected request emits a `deployment.annotation_rejected` audit row so brute-force probes are tamper-evident on the BLAKE3 chain. The read-only `Database` handle still runs in `SQLITE_OPEN_READONLY` mode — writes go through a second, dedicated handle bound only to the allowlisted route. All SQLite writes anywhere in the gateway also pass through the `dbRun` / `dbExec` / `dbStmtRun` wrappers (invariant `I14`), which translate `SQLITE_FULL` into a typed `DiskFullError` so a full-disk event surfaces as a typed exception rather than a silently swallowed write.
+
 #### LAN remote access — trust model
 
 When `nimbus lan enable` is on, the LAN server accepts length-framed TCP connections protected by NaCl box (X25519 ECDH + XSalsa20-Poly1305). The trust establishment model is **explicit pairing**, not transparent discovery:
@@ -217,9 +219,9 @@ Migration V18 (`packages/gateway/src/index/audit-chain-v18-sql.ts`) added `row_h
 
 ---
 
-### Standing Approvals (Phase 5 — Security Model Pre-Design)
+### Standing Approvals (design for a future phase)
 
-Phase 5 will introduce standing approvals: pre-authorized patterns that allow recurring write actions to execute without an interactive HITL prompt. Because standing approvals are functionally a scoped HITL bypass, the security boundaries are defined here before implementation begins.
+A future phase will introduce standing approvals: pre-authorized patterns that allow recurring write actions to execute without an interactive HITL prompt. The feature is not yet on the Phase 5 delivery list, but because standing approvals are functionally a scoped HITL bypass, the security boundaries are recorded here so the design constraints are settled before any implementation begins.
 
 **Threat model:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1465,7 +1465,7 @@ A new structural defense lands as a *triple*: the production wiring, an entry in
 
 ### Active invariants summary
 
-The current `I1`–`I13` set, mirrored from [`SECURITY-INVARIANTS.md`](./SECURITY-INVARIANTS.md). When changing a wiring site listed below, update the invariants file *and* the enforcement test in the same commit.
+The current `I1`–`I14` set, mirrored from [`SECURITY-INVARIANTS.md`](./SECURITY-INVARIANTS.md). When changing a wiring site listed below, update the invariants file *and* the enforcement test in the same commit.
 
 | # | Invariant | Wired at | Anti-pattern that regresses it |
 |---|---|---|---|
@@ -1482,8 +1482,9 @@ The current `I1`–`I13` set, mirrored from [`SECURITY-INVARIANTS.md`](./SECURIT
 | I11 | LLM-facing tool results wrapped via `wrapToolOutput` | `engine/agent.ts`, `engine/tool-output-envelope.ts` | New agent surface that feeds raw tool results to the LLM |
 | I12 | DPAPI calls pass `pOptionalEntropy` from `<configDir>/vault/.entropy` | `vault/win32.ts` | Dropping the entropy parameter "for compatibility" |
 | I13 | HTTP write routes go through `WRITE_ROUTE_ALLOWLIST` + bearer auth | `ipc/http-server.ts`, `ipc/http-write-routes.ts` | New POST/PUT/DELETE handler that bypasses `dispatchWriteRoute` or opens a second writable DB outside the server context |
+| I14 | All SQLite write paths route through `dbRun` / `dbExec` / `dbStmtRun` | `db/write.ts` (`dbRun`, `dbExec`, `dbStmtRun`); enforced statically by `D12` in `check-nimbus-invariants.ts` | Direct `db.run(` or `db.exec(` outside `DB_RUN_EXEC_ALLOW_LIST` — swallows `SQLITE_FULL` |
 
-A static-time complement (`scripts/structure-audit/check-nimbus-invariants.ts`) catches I1 (`spawn` under `connectors/` must use `extensionProcessEnv()`) and the vault-key allow-list at audit time. The runtime tests in `packages/gateway/src/security-invariants.test.ts` remain authoritative for invariant wiring; the static checks just catch regressions before the tests run.
+A static-time complement (`scripts/structure-audit/check-nimbus-invariants.ts`) catches I1 (`spawn` under `connectors/` must use `extensionProcessEnv()`), the vault-key allow-list, and I14 (`DB_RUN_EXEC_ALLOW_LIST` — direct `db.run`/`db.exec` outside `db/write.ts` exits 1) at audit time. The runtime tests in `packages/gateway/src/security-invariants.test.ts` remain authoritative for invariant wiring; the static checks just catch regressions before the tests run.
 
 ### Threat-to-mitigation table
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -220,6 +220,103 @@ nimbus expert --json src/billing/retry.ts
 
 ---
 
+## CI/CD
+
+DORA metrics, pre-deploy checks, and post-deploy annotation — answered from the local index without an external API call. All three commands target a stable `<service-id>` you choose (e.g. `payment-service`); the underlying repo URNs (`<provider>:<owner>/<repo>`) and PagerDuty service ids are configured per-service in `[metrics.dora.<service-id>]` / `[ci.service.<service-id>]` blocks in `nimbus.toml`.
+
+### `nimbus metrics dora`
+
+Compute the four DORA metrics — deployment frequency, lead time for changes, change failure rate, MTTR — for a service over a chosen window. Answered entirely from indexed deployments, PRs, and incidents.
+
+```bash
+nimbus metrics dora --service payment-service
+nimbus metrics dora --service payment-service --since 30d --json
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--service <id>` | Service id (the table key in `[metrics.dora.<id>]`) (required) |
+| `--since <duration>` | Window — `<n>d` or `<n>h`, e.g. `30d`, `24h` (default: `30d`) |
+| `--json` | Machine-readable JSON output |
+
+Read-only; no HITL.
+
+---
+
+### `nimbus deploy preflight`
+
+Pre-deploy index check: counts active P1 incidents, failing CI on the target ref, and open PR conflicts. Useful as a deploy-gate step in CI.
+
+```bash
+nimbus deploy preflight --service payment-service --target-ref main
+nimbus deploy preflight --service payment-service --target-ref release/v2.14 --mode block --json
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--service <id>` | Service id (required) |
+| `--target-ref <ref>` | Git ref being deployed (required) |
+| `--mode <warn\|block\|off>` | `warn` (default) — print findings, exit 0. `block` — exit 1 when any finding triggers the gate. `off` — skip checks |
+| `--json` | Machine-readable JSON output |
+
+**Exit codes:** `0` = ok (or `warn` mode with findings); `1` = `block` mode triggered or usage error; `2` = infrastructure failure (gateway not running, IPC error, malformed envelope).
+
+A first-party GitHub Action wraps `GET /v1/preflight/deploy` for use directly in workflows — see [`packages/github-actions/preflight-query/`](../packages/github-actions/preflight-query/).
+
+Read-only; no HITL.
+
+---
+
+### `nimbus deploy annotate`
+
+Record a deployment event in the local index after a deploy completes. The Gateway upserts a `deployment` item and writes one audit entry. Used by CI to feed DORA metrics.
+
+```bash
+nimbus deploy annotate \
+  --service payment-service \
+  --sha 4a3f9c2 \
+  --target-ref main \
+  --env production \
+  --status success \
+  --started-at 1715812800000 \
+  --finished-at 1715813100000 \
+  --provider github-actions \
+  --run-id 12345
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--service <id>` | Service id — 1..64 chars matching `[a-z0-9][a-z0-9._-]*` (required) |
+| `--sha <sha>` | Deployed commit SHA — 7..64 lowercase hex chars (required) |
+| `--target-ref <ref>` | Git ref deployed (required) |
+| `--env <env>` | Environment (`production`, `staging`, …) — 1..32 chars matching `[a-z0-9][a-z0-9._-]*` (required) |
+| `--status <s>` | One of `success`, `failure`, `cancelled`, `in_progress` (required) |
+| `--started-at <ms>` | Deploy start time, unix milliseconds (required) |
+| `--finished-at <ms>` | Deploy end time, unix milliseconds (optional) |
+| `--provider <name>` | One of `github-actions`, `gitlab`, `jenkins`, `circleci`, `bitbucket`, `other` (default: `other`) |
+| `--workflow-url <url>` | Optional pointer to the CI run URL |
+| `--run-id <id>` | CI run identifier |
+| `--job-id <id>` | CI job identifier within the run |
+| `--json` | Machine-readable JSON output |
+
+**HTTP write surface:** internally this routes through `POST /v1/deployments` on the local HTTP API, which is the **only** write route the HTTP server accepts (invariant `I13`). Bearer auth, an 8 KiB body cap, and per-token rate limiting all apply; every rejection is recorded as a `deployment.annotation_rejected` audit row.
+
+**Required vault key:**
+
+| Key | Purpose |
+|---|---|
+| `http_api.deployment_token` | Bearer token sent with every `POST /v1/deployments`. Set with `nimbus vault set http_api.deployment_token <token>`. Without it the HTTP write surface returns 503 (`write_surface_disabled`). |
+
+A first-party GitHub Action wraps the endpoint for use directly in workflows — see [`packages/github-actions/annotate-action/`](../packages/github-actions/annotate-action/).
+
+---
+
 ## Interactive Sessions
 
 ### `nimbus tui`


### PR DESCRIPTION
## Summary

Re-apply the docs/skill alignment originally committed directly to `main` as `d3eba61d` (reverted in `dc0588cc` so it could go through PR review).

- **Invariant-count drift fixed in 5 files** — GEMINI.md, docs/architecture.md, and three skill files were still saying "twelve invariants" or "I1–I12" after I13/I14 landed.
- **CI/CD CLI commands documented for the first time** — docs/cli-reference.md gains a CI/CD section for `nimbus metrics dora`, `nimbus deploy preflight`, `nimbus deploy annotate`, plus the `http_api.deployment_token` vault key.
- **Three new Phase 5 skills**:
  - `nimbus-http-write-surface` (I13): `WRITE_ROUTE_ALLOWLIST`, bearer auth, rate limiting, audit-on-rejection.
  - `nimbus-embedding-routing` (T6 PR 3): `PROSE_HEAVY_TYPES`, `RoutingEmbeddingPipeline`, dual-table search, reembed IPC.
  - `nimbus-cicd-data-layer` (T4): pure DORA calculators, preflight, post-deploy annotation, `ServiceConfig` schema.
- **Smaller fixes**: nimbus-commands.md had wrong `--status` / `--provider` enums and 401-vs-503 vault behaviour for `deploy annotate`; docs/SECURITY.md's "Standing Approvals (Phase 5 — Security Model Pre-Design)" heading was stale.

12 files changed, +641 / −12. No source code changed.

## Test plan
- [ ] Visual diff review of the three new skills against the production sources they cite (`http-write-routes.ts`, `routing.ts`, `dora.ts`, `annotate.ts`)
- [ ] Confirm doc-ref drift gate (`bun scripts/structure-audit/check-doc-references.ts --check`) passes — every backtick path in the new content resolves
- [ ] Confirm GEMINI.md and CLAUDE.md invariant tables match each other row-for-row
- [ ] CI need only run the doc/markdown gates; no test suite changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)