### PR TITLE
fix(sandbox-helper): guard _GNU_SOURCE redefine to unblock -Werror build

### DIFF
--- a/packages/gateway/src-native/sandbox-helper/main.c
+++ b/packages/gateway/src-native/sandbox-helper/main.c
@@ -28,7 +28,9 @@
  *
  * Build: `make` in this directory; requires libcap-dev. C99 + -Werror clean.
  */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netdb.h>


### PR DESCRIPTION
## Summary
- One-line fix to unblock `bun run build:sandbox-helper` on every CI run since T2 PR 2 (#343) merged on 2026-05-18.
- T2 PR 2 introduced `#define _GNU_SOURCE` at `main.c:31` AND `-D_GNU_SOURCE` in the Makefile compile flags. With `-Werror` on, gcc 11+ rejects the redefinition (`error: "_GNU_SOURCE" redefined`).
- Wraps the in-source define in `#ifndef` so the Makefile flag wins when present and the source still self-defines for manual `gcc main.c` builds. Canonical glibc-style feature-test guard.

## Diff

```c
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
```

## Why this slipped through

T2 PR 2's CI run for the merge commit failed for this exact reason. The PR was merged before the fix landed. Two subsequent main CI runs (including the Phase 2B merge commit `c8772b24`) are still red on this step.

## Test plan
- [ ] CI `Build sandbox helper` step turns green
- [ ] No other change to sandbox-helper behavior — `#define _GNU_SOURCE` is set unconditionally either way, just no longer redefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)
