### PR TITLE
ci(gitleaks): path-based allowlist to survive squash-merge SHA churn

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,31 @@
+# Gitleaks repo config.
+#
+# Inherits the default ruleset and adds a path-based allowlist for the two
+# locations that legitimately carry secret-shaped fixtures by design:
+#
+#   1. packages/gateway/src/security/secret-patterns.test.ts
+#      — unit-test fixtures that intentionally assert SECRET_PATTERNS regexes
+#        fire on canonical prefix strings (PEM headers, `xoxb-…`, `sk-…`, etc).
+#        Required for the Phase 5 `nimbus security scan` test suite.
+#
+#   2. docs/superpowers/plans/**/*.md
+#      — implementation plan docs frequently quote test source verbatim,
+#        so any plan covering security-adjacent work reproduces the same
+#        fixture strings. Plans never carry real credentials.
+#
+# Why path-based instead of fingerprint pins in `.gitleaksignore`:
+# fingerprints are `<commit-sha>:<path>:<rule>:<line>`. Squash-merges rewrite
+# the SHA, rebases shift line numbers, and the pin then misses the (now
+# rewritten) commit — which is exactly how PR #391 broke `main` CI: the
+# branch-SHA pins (5f889abd, 317c6f12) carried over but the squash-merge to
+# 77fefdb4 was unpinned, failing every downstream PR's gitleaks job.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Synthetic fixtures for the secret-pattern unit tests and committed planning docs"
+paths = [
+  '''packages/gateway/src/security/secret-patterns\.test\.ts''',
+  '''docs/superpowers/plans/.*\.md''',
+]


### PR DESCRIPTION
## Summary

Adds a repo-level `.gitleaks.toml` with a path-based allowlist for the two locations that legitimately carry secret-shaped fixtures by design. Unblocks `gitleaks` CI on every downstream PR (PR #395 is the first to hit it).

## Root cause

`gitleaks detect --source .` scans full git history. The repo already has a `.gitleaksignore`, but its entries are pinned to commit SHAs. When PR #391 squash-merged to `main` as `77fefdb4`, the branch-SHA pins (`5f889abd…`, `317c6f12…`) were left targeting commits that no longer exist on `main`, so the four findings (PEM headers + Slack `xoxb-…` shape regex assertions) became unpinned and started failing every PR's gitleaks job.

## Fix

Path-based `.gitleaks.toml` allowlist for:

1. `packages/gateway/src/security/secret-patterns.test.ts` — the v1 secret-pattern unit-test fixtures that intentionally assert the regexes fire on canonical prefix strings.
2. `docs/superpowers/plans/**/*.md` — implementation plans frequently quote test source verbatim.

Path-based is resilient to squash-merges (paths don't change) and line drift (no line numbers in the pin). Existing `.gitleaksignore` entries stay in place as belt-and-suspenders for the other historical fingerprints they cover (`gateway-log-redact.test.ts`, `create-routing-runtime.test.ts`, `auth.test.ts`).

## Test plan

- [x] `python -c "import tomllib; tomllib.loads(open('.gitleaks.toml').read())"` — parses
- [ ] PR's own gitleaks job — should pass (this PR adds no secret-shaped content of its own)
- [ ] After merge, re-run gitleaks on PR #395 — expected to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)