### PR TITLE
ci: fix push-side workflow validation + Windows cross-platform typecheck

### DIFF
--- a/.github/actions/setup-nimbus-ci/action.yml
+++ b/.github/actions/setup-nimbus-ci/action.yml
@@ -37,7 +37,18 @@ runs:
     # restores would leave a stale tree that frozen-install can't repair).
     # Per-package node_modules are included because Bun's monorepo layout
     # puts non-hoistable deps under each workspace package.
+    #
+    # SKIPPED ON WINDOWS: Bun's monorepo layout under
+    # `node_modules/.bun/<pkg>@<version>+<hash>/node_modules/<pkg>/` relies on
+    # NT junctions, which `actions/cache@v5`'s tar pack/restore does not preserve
+    # correctly. A restored tree on Windows produces EPERM reads on `.bun/...`
+    # paths and yields stripped-down ambient `@types/bun` / `@types/node`
+    # declarations (e.g. `Response.text/ok/status` go missing), failing
+    # `bun run typecheck`. `bun install --frozen-lockfile` skips re-linking
+    # a tree it considers installed, so the safety net does not repair it.
+    # macOS (POSIX symlinks) and Linux are unaffected.
     - name: Cache node_modules
+      if: runner.os != 'Windows'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,7 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     permissions:
       contents: read
+      checks: write
       id-token: write
 
   # Rust/Tauri checks — all 3 OSes, runs in parallel with ci-ts


### PR DESCRIPTION
## Summary

Two related CI fixes; both surfaced today after #451 + the `_test-suite.yml` split.

### 1. Push-side workflow validation (the original report)

`_test-suite.yml`'s `integration`, `e2e-gateway`, and `e2e-cli` jobs request `checks: write` (to publish JUnit). The PR-side `pr-quality-ts` caller in `ci.yml` already granted it; the push-side `ci-ts` caller did not — so every push to a feature branch failed validation with *"nested job requesting 'checks: write' but is only allowed 'checks: none'"*. Granted it on `ci-ts`.

### 2. Windows cross-platform typecheck (root-caused)

`Cross-platform (gateway, windows-2025)` has been failing on every PR since #451 with hundreds of `Property 'text'/'ok'/'status'/'json'/'body' does not exist on type 'Response'/'Request'/'Headers'` errors and an EPERM read on `node_modules\.bun\astro@…\node_modules\yargs-parser`.

**Cause:** PR #451 added a `node_modules` cache to `setup-nimbus-ci`. Bun's monorepo layout under `node_modules/.bun/<pkg>@<ver>+<hash>/node_modules/<pkg>/` relies on NT junctions, which `actions/cache@v5`'s tar pack/restore does not preserve on Windows. The restored tree has broken `.bun` paths → broken `@types/bun` / `@types/node` resolution → stripped ambient `Response` / `Request` / `Headers` types → typecheck failure. `bun install --frozen-lockfile` does not repair the tree; it considers it installed and early-exits. macOS (POSIX symlinks) and Linux are unaffected — that's why `Cross-platform (cli, macos-15)` passes.

**Fix:** gate the cache step on `runner.os != 'Windows'`. Windows reverts to the pre-#451 behaviour (fresh `bun install --frozen-lockfile`, which already worked). Bun's download cache (`~/.bun/install/cache`) stays cached on all OSes, so install is still fast.

## Test plan

- [ ] `Cross-platform (gateway, windows-2025)` passes — typecheck succeeds, no EPERM, no `Response.text` errors.
- [ ] `Cross-platform (cli, windows-2025)` passes — tests succeed.
- [ ] `Cross-platform (gateway, macos-15)` / `(cli, macos-15)` still pass — cache step unchanged on macOS.
- [ ] Push-side `ci-ts` matrix actually starts (no more `startup_failure`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)