### PR TITLE
refactor: reduce cognitive complexity (typescript:S3776)

### DIFF
--- a/packages/gateway/src/extensions/verify-extensions.ts
+++ b/packages/gateway/src/extensions/verify-extensions.ts
@@ -272,6 +272,46 @@ function backfillDependencyRowsBestEffort(
   }
 }
 
+type DependencyRow = { extension_id: string; depends_on_id: string; range: string };
+
+/*
+ * Classify one extension_dependency row: returns the registry mark to record —
+ * dependency_missing when the dependency is unusable, dependency_unsatisfied
+ * when the installed version is out of range — or null when satisfied. The
+ * caller owns the registry mutation and the fixpoint loop.
+ */
+function evaluateDependencyRow(
+  r: DependencyRow,
+  installed: ReadonlyMap<string, string>,
+  isUsable: (id: string) => boolean,
+): Parameters<typeof missingDependencyRegistry.mark>[0] | null {
+  if (!isUsable(r.depends_on_id)) {
+    return {
+      extensionId: r.extension_id,
+      reason: "dependency_missing",
+      missingDepId: r.depends_on_id,
+      requiredRange: r.range,
+    };
+  }
+  const depVersion = installed.get(r.depends_on_id);
+  let satisfies = false;
+  try {
+    satisfies = depVersion !== undefined && semver.satisfies(depVersion, r.range);
+  } catch {
+    satisfies = false;
+  }
+  if (!satisfies) {
+    return {
+      extensionId: r.extension_id,
+      reason: "dependency_unsatisfied",
+      missingDepId: r.depends_on_id,
+      requiredRange: r.range,
+      ...(depVersion !== undefined ? { observedVersion: depVersion } : {}),
+    };
+  }
+  return null;
+}
+
 function completenessGuard(
   db: Database,
   installed: ReadonlyMap<string, string>,
@@ -296,31 +336,9 @@ function completenessGuard(
     changed = false;
     for (const r of rows) {
       if (missingDependencyRegistry.has(r.extension_id)) continue;
-      if (!isUsable(r.depends_on_id)) {
-        missingDependencyRegistry.mark({
-          extensionId: r.extension_id,
-          reason: "dependency_missing",
-          missingDepId: r.depends_on_id,
-          requiredRange: r.range,
-        });
-        changed = true;
-        continue;
-      }
-      const depVersion = installed.get(r.depends_on_id);
-      let satisfies = false;
-      try {
-        satisfies = depVersion !== undefined && semver.satisfies(depVersion, r.range);
-      } catch {
-        satisfies = false;
-      }
-      if (!satisfies) {
-        missingDependencyRegistry.mark({
-          extensionId: r.extension_id,
-          reason: "dependency_unsatisfied",
-          missingDepId: r.depends_on_id,
-          requiredRange: r.range,
-          ...(depVersion !== undefined ? { observedVersion: depVersion } : {}),
-        });
+      const mark = evaluateDependencyRow(r, installed, isUsable);
+      if (mark !== null) {
+        missingDependencyRegistry.mark(mark);
         changed = true;
       }
     }

--- a/packages/gateway/src/ipc/index-reembed-rpc.ts
+++ b/packages/gateway/src/ipc/index-reembed-rpc.ts
@@ -170,6 +170,46 @@ async function embedSlice(
   }
 }
 
+type EmbedErrorDecision =
+  | { kind: "retry"; retryAfterMs: number }
+  | { kind: "fatal-auth"; status: number }
+  | { kind: "rethrow" };
+
+function classifyEmbedError(err: unknown): EmbedErrorDecision {
+  const status = (err as { status?: number } | undefined)?.status;
+  if (isRetryableStatus(status)) {
+    const retryAfterMs = (err as { retryAfterMs?: number }).retryAfterMs ?? FALLBACK_RETRY_AFTER_MS;
+    return { kind: "retry", retryAfterMs };
+  }
+  if (status === 401 || status === 403) {
+    return { kind: "fatal-auth", status };
+  }
+  return { kind: "rethrow" };
+}
+
+async function retryEmbedSliceOrSkip(
+  pipeline: ReembedSink,
+  ctx: IndexReembedRpcContext,
+  slice: readonly IndexedItem[],
+  batchStart: number,
+  counters: BatchCounters,
+): Promise<void> {
+  try {
+    await embedSlice(pipeline, slice, counters);
+  } catch (retryErr) {
+    ctx.logger.warn(
+      {
+        errName: retryErr instanceof Error ? retryErr.name : "Error",
+        errMessage: retryErr instanceof Error ? retryErr.message : String(retryErr),
+        batchStart,
+        batchSize: slice.length,
+      },
+      "reembed batch failed after retry; skipping",
+    );
+    counters.skipped += slice.length;
+  }
+}
+
 export async function embedBatchWithRetry(
   pipeline: ReembedSink,
   ctx: IndexReembedRpcContext,
@@ -179,34 +219,20 @@ export async function embedBatchWithRetry(
 ): Promise<void> {
   try {
     await embedSlice(pipeline, slice, counters);
+    return;
   } catch (err) {
-    const status = (err as { status?: number } | undefined)?.status;
-    if (isRetryableStatus(status)) {
-      const retryAfterMs =
-        (err as { retryAfterMs?: number }).retryAfterMs ?? FALLBACK_RETRY_AFTER_MS;
-      await new Promise((r) => setTimeout(r, retryAfterMs));
-      try {
-        await embedSlice(pipeline, slice, counters);
-      } catch (retryErr) {
-        ctx.logger.warn(
-          {
-            errName: retryErr instanceof Error ? retryErr.name : "Error",
-            errMessage: retryErr instanceof Error ? retryErr.message : String(retryErr),
-            batchStart,
-            batchSize: slice.length,
-          },
-          "reembed batch failed after retry; skipping",
-        );
-        counters.skipped += slice.length;
-      }
-    } else if (status === 401 || status === 403) {
+    const decision = classifyEmbedError(err);
+    if (decision.kind === "fatal-auth") {
       throw new IndexReembedRpcError(
         -32603,
-        `Fatal: OpenAI returned ${String(status)}. Check openai.api_key validity.`,
+        `Fatal: OpenAI returned ${String(decision.status)}. Check openai.api_key validity.`,
       );
-    } else {
+    }
+    if (decision.kind === "rethrow") {
       throw err;
     }
+    await new Promise((r) => setTimeout(r, decision.retryAfterMs));
+    await retryEmbedSliceOrSkip(pipeline, ctx, slice, batchStart, counters);
   }
 }
 


### PR DESCRIPTION
Behavior-preserving cognitive-complexity reductions from the post-merge SonarCloud analysis. **Stacked on #463**; review only this branch's 2 commits.

## What
- **`ipc/index-reembed-rpc.ts`** `embedBatchWithRetry` cc 16 → <15: extracted `classifyEmbedError` + `retryEmbedSliceOrSkip` out of the nested try/catch. The file's existing branch tests (success, retry-then-success, retry-persists-skip, 401/403 fatal, non-retryable rethrow) stay green.
- **`extensions/verify-extensions.ts`** `completenessGuard` cc 21 → <15: extracted per-row classification into `evaluateDependencyRow` (returns the registry mark or null); the dependency fixpoint loop just applies it.

## Verification
Changed files are typecheck + lint clean (the only local `tsc` errors are pre-existing `nimbus-mcp-*` missing-dep noise, unrelated); extensions + reembed tests green; the **I16 security-invariants test stays green**.

## Remaining S3776 (follow-up)
`config/nimbus-toml.ts` `accumulateServiceTables` (cc 25) and `extensions/install-from-local.ts` (cc 18) — deferred to a later session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)