### PR TITLE
Cleanup Pass 3b (1/5) — SonarCloud smell sweep

### DIFF
--- a/packages/cli/src/commands/extension.ts
+++ b/packages/cli/src/commands/extension.ts
@@ -488,7 +488,7 @@ export async function runExtensionSyncWithCaller(opts: RunExtensionSyncOpts): Pr
 export async function runExtensionSync(client: IPCClient, args: string[]): Promise<number> {
   return runExtensionSyncWithCaller({
     args,
-    caller: async (params) => (await client.call("extension.sync", params)) as SyncResult,
+    caller: async (params) => await client.call("extension.sync", params),
     writeStdout: (s) => process.stdout.write(s),
     writeStderr: (s) => process.stderr.write(s),
   });

--- a/packages/cli/src/commands/metrics.ts
+++ b/packages/cli/src/commands/metrics.ts
@@ -120,8 +120,8 @@ export interface MetricRowInput {
 export function renderMetricRow(metric: MetricRowInput, options: RenderOptions): string {
   const useColor = options.tty && !options.noColor;
   const valueStr = metric.value === null ? "—" : metric.value.toFixed(3);
-  const gapStr =
-    metric.gap === null ? "" : useColor ? `\x1b[33m[${metric.gap}]\x1b[0m` : `[${metric.gap}]`;
+  const gapText = metric.gap === null ? "" : `[${metric.gap}]`;
+  const gapStr = gapText !== "" && useColor ? `\x1b[33m${gapText}\x1b[0m` : gapText;
   const prefix = metric.gap === "mixed_source" && useColor ? "\x1b[33m⚠\x1b[0m " : "";
   return `  ${prefix}${metric.label.padEnd(20)} ${valueStr.padStart(10)} ${metric.unit.padEnd(20)} n=${String(metric.sample)}  ${gapStr}`;
 }

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -135,7 +135,7 @@ function isItemLikeRow(row: Record<string, unknown>): boolean {
 
 function printItemCard(row: Record<string, unknown>, idx: number): void {
   const num = `${String(idx + 1)}.`;
-  const title = String(row["title"] ?? "(untitled)");
+  const title = typeof row["title"] === "string" ? row["title"] : "(untitled)";
   const meta: string[] = [];
   if (typeof row["service"] === "string") meta.push(row["service"]);
   if (typeof row["type"] === "string") meta.push(row["type"]);

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -899,6 +899,36 @@ function materializeServiceConfigs(
   return out;
 }
 
+function resolveServiceTableId(
+  trimmed: string,
+  tablePrefix: string,
+  blockLabel: string,
+  accum: Map<string, Record<string, string>>,
+): string | undefined {
+  if (!trimmed.startsWith(tablePrefix)) return undefined;
+  const id = trimmed.slice(tablePrefix.length, -1);
+  if (id.length === 0) throw new Error(`empty service id in [${blockLabel}.<id>]`);
+  if (!accum.has(id)) accum.set(id, {});
+  return id;
+}
+
+function applyServiceConfigLine(
+  trimmed: string,
+  currentId: string,
+  blockLabel: string,
+  accum: Map<string, Record<string, string>>,
+): void {
+  const kv = splitKeyValue(trimmed);
+  if (kv === undefined) return;
+  if (!SERVICE_CONFIG_KNOWN_KEYS.has(kv.key)) {
+    throw new Error(`unknown key '${kv.key}' in [${blockLabel}.${currentId}]`);
+  }
+  const bucket = accum.get(currentId);
+  if (bucket !== undefined) {
+    bucket[kv.key] = kv.valRaw;
+  }
+}
+
 function accumulateServiceTables(
   raw: string,
   tablePrefix: string,
@@ -910,25 +940,11 @@ function accumulateServiceTables(
     const trimmed = stripComment(line).trim();
     if (trimmed === "") continue;
     if (isTableHeader(trimmed)) {
-      if (trimmed.startsWith(tablePrefix)) {
-        const id = trimmed.slice(tablePrefix.length, -1);
-        if (id.length === 0) throw new Error(`empty service id in [${blockLabel}.<id>]`);
-        currentId = id;
-        if (!accum.has(id)) accum.set(id, {});
-      } else {
-        currentId = undefined;
-      }
+      currentId = resolveServiceTableId(trimmed, tablePrefix, blockLabel, accum);
       continue;
     }
-    if (currentId === undefined) continue;
-    const kv = splitKeyValue(trimmed);
-    if (kv === undefined) continue;
-    if (!SERVICE_CONFIG_KNOWN_KEYS.has(kv.key)) {
-      throw new Error(`unknown key '${kv.key}' in [${blockLabel}.${currentId}]`);
-    }
-    const bucket = accum.get(currentId);
-    if (bucket !== undefined) {
-      bucket[kv.key] = kv.valRaw;
+    if (currentId !== undefined) {
+      applyServiceConfigLine(trimmed, currentId, blockLabel, accum);
     }
   }
   return accum;

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -617,7 +617,9 @@ export const DEFAULT_NIMBUS_EXTENSIONS_TOML: NimbusExtensionsToml = {
 function parseUpdateCheckIntervalHours(valRaw: string): number {
   const n = Number(valRaw);
   if (!Number.isFinite(n) || !Number.isInteger(n)) {
-    throw new Error(`[extensions].update_check_interval_hours must be an integer (got: ${valRaw})`);
+    throw new TypeError(
+      `[extensions].update_check_interval_hours must be an integer (got: ${valRaw})`,
+    );
   }
   if (n < 1 || n > 168) {
     throw new Error(`[extensions].update_check_interval_hours must be in [1, 168] (got: ${n})`);

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -113,7 +113,7 @@ function listPackageJsonFiles(
     }
     let entries: Dirent[];
     try {
-      entries = readdirSync(dir, { withFileTypes: true }) as Dirent[];
+      entries = readdirSync(dir, { withFileTypes: true });
     } catch {
       return;
     }
@@ -315,7 +315,7 @@ const CODE_EXT = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
 
 function readDirectoryDirentsOrUndefined(dir: string): Dirent[] | undefined {
   try {
-    return readdirSync(dir, { withFileTypes: true }) as Dirent[];
+    return readdirSync(dir, { withFileTypes: true });
   } catch {
     return undefined;
   }

--- a/packages/gateway/src/connectors/readwise-highlight-mapping.ts
+++ b/packages/gateway/src/connectors/readwise-highlight-mapping.ts
@@ -69,12 +69,14 @@ export function mapReadwiseHighlightToItem(
   const updatedAt = parseIsoMs(row["updated"]);
 
   const trimmedText = text === null ? "" : text.trim();
-  const title =
-    trimmedText === ""
-      ? `Highlight ${id}`
-      : trimmedText.length > TITLE_MAX
-        ? `${trimmedText.slice(0, TITLE_MAX)}…`
-        : trimmedText;
+  let title: string;
+  if (trimmedText === "") {
+    title = `Highlight ${id}`;
+  } else if (trimmedText.length > TITLE_MAX) {
+    title = `${trimmedText.slice(0, TITLE_MAX)}…`;
+  } else {
+    title = trimmedText;
+  }
 
   const bodyPreview = note !== null && note !== "" ? note : (text ?? "");
 

--- a/packages/gateway/src/deployment/annotate.ts
+++ b/packages/gateway/src/deployment/annotate.ts
@@ -245,7 +245,7 @@ export function annotateDeployment(
       timestamp: nowMs,
     });
     return isNewInner;
-  })() as boolean;
+  })();
 
   return {
     external_id: externalId,

--- a/packages/gateway/src/engine/run-conversational-agent.ts
+++ b/packages/gateway/src/engine/run-conversational-agent.ts
@@ -70,11 +70,11 @@ export async function runConversationalAgent(
 
   try {
     if (!p.stream) {
-      const out = await p.agent.generate(promptArg as never, { maxSteps });
+      const out = await p.agent.generate(promptArg, { maxSteps });
       return { reply: out.text };
     }
 
-    const streamOut = await p.agent.stream(promptArg as never, { maxSteps });
+    const streamOut = await p.agent.stream(promptArg, { maxSteps });
     for await (const chunk of streamOut.fullStream) {
       if (isTextDeltaChunk(chunk) && chunk.payload.text.length > 0) {
         p.sendChunk(chunk.payload.text);

--- a/packages/gateway/src/extensions/dependency-graph.ts
+++ b/packages/gateway/src/extensions/dependency-graph.ts
@@ -38,16 +38,15 @@ export async function resolveClosure(
   const resolved: Map<string, ResolvedNode> = new Map();
   const initialInstalled = new Map(opts.installed);
 
-  await visit(
-    root,
-    initialPinned,
-    initialRanges,
+  await visit(root, {
+    pinned: initialPinned,
+    ranges: initialRanges,
     ancestors,
     fetcher,
     manifestCache,
     resolved,
     initialInstalled,
-  );
+  });
 
   return { nodes: topoSort(resolved) };
 }
@@ -108,18 +107,19 @@ async function loadDepManifest(
   return depManifest;
 }
 
-async function visit(
-  current: ExtensionManifestForSolver,
-  pinned: Pinned,
-  ranges: Ranges,
-  ancestors: Set<string>,
-  fetcher: RegistryFetcher,
-  manifestCache: ManifestCache,
-  resolved: Map<string, ResolvedNode>,
-  initialInstalled: ReadonlyMap<string, string>,
-): Promise<void> {
-  ancestors.add(current.id);
-  pinned.set(current.id, current.version);
+type SolveContext = {
+  pinned: Pinned;
+  ranges: Ranges;
+  ancestors: Set<string>;
+  fetcher: RegistryFetcher;
+  manifestCache: ManifestCache;
+  resolved: Map<string, ResolvedNode>;
+  initialInstalled: ReadonlyMap<string, string>;
+};
+
+async function visit(current: ExtensionManifestForSolver, ctx: SolveContext): Promise<void> {
+  ctx.ancestors.add(current.id);
+  ctx.pinned.set(current.id, current.version);
 
   try {
     const deps: ResolvedDep[] = [];
@@ -134,56 +134,47 @@ async function visit(
         });
       }
 
-      if (ancestors.has(depId)) {
-        const chain = [...ancestors, depId];
+      if (ctx.ancestors.has(depId)) {
+        const chain = [...ctx.ancestors, depId];
         throw new DependencyConflictError({ kind: "cycle", id: depId, chain });
       }
 
-      const constraintList = ranges.get(depId) ?? [];
+      const constraintList = ctx.ranges.get(depId) ?? [];
       constraintList.push({ from: current.id, range });
-      ranges.set(depId, constraintList);
+      ctx.ranges.set(depId, constraintList);
 
       const candidate = await resolveDepCandidate(
         depId,
         current.id,
-        pinned,
+        ctx.pinned,
         constraintList,
-        fetcher,
+        ctx.fetcher,
       );
 
       const depManifest = await loadDepManifest(
         depId,
         current.id,
         candidate,
-        fetcher,
-        manifestCache,
+        ctx.fetcher,
+        ctx.manifestCache,
       );
 
       deps.push({ id: depId, range, resolvedVersion: candidate });
 
-      if (!resolved.has(depId)) {
-        await visit(
-          depManifest,
-          pinned,
-          ranges,
-          ancestors,
-          fetcher,
-          manifestCache,
-          resolved,
-          initialInstalled,
-        );
+      if (!ctx.resolved.has(depId)) {
+        await visit(depManifest, ctx);
       }
     }
 
-    const installedVersion = initialInstalled.get(current.id);
-    resolved.set(current.id, {
+    const installedVersion = ctx.initialInstalled.get(current.id);
+    ctx.resolved.set(current.id, {
       id: current.id,
       version: current.version,
       newlyInstalled: installedVersion !== current.version,
       deps,
     });
   } finally {
-    ancestors.delete(current.id);
+    ctx.ancestors.delete(current.id);
   }
 }
 

--- a/packages/gateway/src/extensions/install-from-local.ts
+++ b/packages/gateway/src/extensions/install-from-local.ts
@@ -113,14 +113,7 @@ async function verifyAndRecordSignature(
       fetcher: options.fetcher,
       enforceAirGap: options.enforceAirGap ?? false,
     });
-    await verifyManifestSignature(
-      rawManifestObj as {
-        publisher?: { id: string; key: string };
-        signature?: string;
-        [k: string]: unknown;
-      },
-      resolvedPubkey,
-    );
+    await verifyManifestSignature(rawManifestObj, resolvedPubkey);
     await writePublisherKey(vault, publisherId, resolvedPubkey);
     appendAuditEntry(options.db, {
       actionType: "extension.signature_verified",

--- a/packages/gateway/src/extensions/install-from-local.ts
+++ b/packages/gateway/src/extensions/install-from-local.ts
@@ -611,16 +611,52 @@ async function installRootNode(
   });
 }
 
+type InstallPlanNodesOptions = {
+  db: Database;
+  extensionsDir: string;
+  vault?: NimbusVault;
+  fetcher?: PublisherKeyFetcher;
+  enforceAirGap?: boolean;
+  publisherKeyPath?: string;
+  registryClient?: RegistryClient;
+};
+
+async function installDependencyNode(
+  node: ResolvedNode,
+  options: InstallPlanNodesOptions,
+  signal: AbortSignal,
+): Promise<string> {
+  if (options.registryClient === undefined) {
+    throw new Error(
+      `cannot install dependency ${node.id}@${node.version}: no registryClient provided`,
+    );
+  }
+  const { dest } = await installDepFromRegistry({
+    db: options.db,
+    extensionsDir: options.extensionsDir,
+    registryClient: options.registryClient,
+    depId: node.id,
+    depVersion: node.version,
+    abortSignal: signal,
+    ...(options.vault !== undefined && { vault: options.vault }),
+    ...(options.fetcher !== undefined && { pubkeyFetcher: options.fetcher }),
+    ...(options.enforceAirGap !== undefined && { enforceAirGap: options.enforceAirGap }),
+  });
+  return dest;
+}
+
+function rollbackCreatedDirs(createdDirs: readonly string[]): void {
+  for (let i = createdDirs.length - 1; i >= 0; i--) {
+    try {
+      rmSync(createdDirs[i] as string, { recursive: true, force: true });
+    } catch {
+      /* best-effort rollback */
+    }
+  }
+}
+
 async function installPlanNodes(
-  options: {
-    db: Database;
-    extensionsDir: string;
-    vault?: NimbusVault;
-    fetcher?: PublisherKeyFetcher;
-    enforceAirGap?: boolean;
-    publisherKeyPath?: string;
-    registryClient?: RegistryClient;
-  },
+  options: InstallPlanNodesOptions,
   plan: { nodes: readonly ResolvedNode[] },
   sourceResolved: string,
   manifest: ExtensionManifest,
@@ -635,33 +671,11 @@ async function installPlanNodes(
       if (node.id === manifest.id) {
         await installRootNode(options, sourceResolved, manifest, (dir) => createdDirs.push(dir));
       } else {
-        if (options.registryClient === undefined) {
-          throw new Error(
-            `cannot install dependency ${node.id}@${node.version}: no registryClient provided`,
-          );
-        }
-        const { dest } = await installDepFromRegistry({
-          db: options.db,
-          extensionsDir: options.extensionsDir,
-          registryClient: options.registryClient,
-          depId: node.id,
-          depVersion: node.version,
-          abortSignal: signal,
-          ...(options.vault !== undefined && { vault: options.vault }),
-          ...(options.fetcher !== undefined && { pubkeyFetcher: options.fetcher }),
-          ...(options.enforceAirGap !== undefined && { enforceAirGap: options.enforceAirGap }),
-        });
-        createdDirs.push(dest);
+        createdDirs.push(await installDependencyNode(node, options, signal));
       }
     }
   } catch (e) {
-    for (let i = createdDirs.length - 1; i >= 0; i--) {
-      try {
-        rmSync(createdDirs[i] as string, { recursive: true, force: true });
-      } catch {
-        /* best-effort rollback */
-      }
-    }
+    rollbackCreatedDirs(createdDirs);
     throw e;
   }
 }

--- a/packages/gateway/src/extensions/sync.ts
+++ b/packages/gateway/src/extensions/sync.ts
@@ -71,7 +71,7 @@ function gatherPublisherManifests(db: Database): {
     }
     const m = parsed.manifest;
     if (m.publisher === undefined) continue;
-    manifestByExtId.set(row.id, m as unknown as Record<string, unknown>);
+    manifestByExtId.set(row.id, m);
     const arr = publisherIdToExtensions.get(m.publisher.id) ?? [];
     arr.push(row.id);
     publisherIdToExtensions.set(m.publisher.id, arr);
@@ -90,10 +90,7 @@ async function reverifyPublisherExtensions(
     const m = manifestByExtId.get(extId);
     if (m === undefined) continue;
     try {
-      await verifyManifestSignature(
-        m as { publisher?: { id: string; key: string }; signature?: string },
-        pubkey,
-      );
+      await verifyManifestSignature(m, pubkey);
     } catch {
       failed.push(extId);
       allOk = false;

--- a/packages/gateway/src/extensions/verify-extensions.ts
+++ b/packages/gateway/src/extensions/verify-extensions.ts
@@ -420,14 +420,7 @@ async function computeRowSignatureReason(
     return "publisher_key_missing";
   }
   try {
-    await verifyManifestSignature(
-      rawManifestObj as {
-        publisher?: { id: string; key: string };
-        signature?: string;
-        [k: string]: unknown;
-      },
-      pubkey,
-    );
+    await verifyManifestSignature(rawManifestObj, pubkey);
   } catch (err) {
     return errorToHardDisableReason(err);
   }

--- a/packages/gateway/src/ipc/automation-rpc.ts
+++ b/packages/gateway/src/ipc/automation-rpc.ts
@@ -390,7 +390,7 @@ async function handleAutoUpdateRpc(
   if (ctx.autoUpdate === undefined) {
     throw new AutomationRpcError(-32603, "Gateway is not configured with auto-update support");
   }
-  const value = (await dispatchAutoUpdateRpc(method, rec ?? {}, ctx.autoUpdate)) as unknown;
+  const value = await dispatchAutoUpdateRpc(method, rec ?? {}, ctx.autoUpdate);
   return { kind: "hit", value };
 }
 

--- a/packages/gateway/src/perf/gateway-spawn-bench.ts
+++ b/packages/gateway/src/perf/gateway-spawn-bench.ts
@@ -32,7 +32,7 @@ function spawnChild<W, S>(opts: SpawnGatewayForBenchOptions<W, S>): ProcSubset {
     stdout: "pipe",
     stderr: "pipe",
     ...(opts.env !== undefined && { env: { ...process.env, ...opts.env } }),
-  }) as unknown as ProcSubset;
+  });
 }
 
 const STDERR_BUFFER_LINES = 20;

--- a/packages/gateway/src/perf/rss-sampler.ts
+++ b/packages/gateway/src/perf/rss-sampler.ts
@@ -19,7 +19,7 @@ let cachedPidusage: ((pid: number) => Promise<{ memory: number }>) | undefined;
 async function realPidusage(pid: number): Promise<{ memory: number }> {
   if (cachedPidusage === undefined) {
     const mod = await import("pidusage");
-    cachedPidusage = mod.default as (pid: number) => Promise<{ memory: number }>;
+    cachedPidusage = mod.default;
   }
   return cachedPidusage(pid);
 }

--- a/packages/gateway/src/perf/slo-thresholds.ts
+++ b/packages/gateway/src/perf/slo-thresholds.ts
@@ -192,7 +192,7 @@ function buildS8Cells(): readonly SloThreshold[] {
   for (const length of S8_LENGTHS) {
     for (const batch of S8_BATCHES) {
       out.push({
-        surfaceId: `S8-l${length}-b${batch}` as BenchSurfaceId,
+        surfaceId: `S8-l${length}-b${batch}`,
         metric: "throughput_per_sec",
         ghaMax: "tbd-c2",
         gated: false,

--- a/packages/gateway/src/perf/surfaces/sqlite-worker-audit.ts
+++ b/packages/gateway/src/perf/surfaces/sqlite-worker-audit.ts
@@ -5,7 +5,7 @@ import { Database } from "bun:sqlite";
 import { computeAuditRowHash, GENESIS_HASH } from "../../db/audit-chain.ts";
 import { dbRun } from "../../db/write.ts";
 import { LocalIndex } from "../../index/local-index.ts";
-import { runWorkerEntry, type WorkerSelf } from "./sqlite-worker-shared.ts";
+import { runWorkerEntry } from "./sqlite-worker-shared.ts";
 
 declare const self: Worker;
 
@@ -13,7 +13,7 @@ const AUDIT_INSERT_SQL = `INSERT INTO audit_log (
   action_type, hitl_status, action_json, timestamp, row_hash, prev_hash
 ) VALUES (?, ?, ?, ?, ?, ?)`;
 
-runWorkerEntry<Record<string, unknown>>(self as unknown as WorkerSelf, {
+runWorkerEntry<Record<string, unknown>>(self, {
   init: (_config, dbPath) => {
     const db = new Database(dbPath);
     LocalIndex.ensureSchema(db);

--- a/packages/gateway/src/perf/surfaces/sqlite-worker-sync.ts
+++ b/packages/gateway/src/perf/surfaces/sqlite-worker-sync.ts
@@ -4,7 +4,7 @@ import { Database } from "bun:sqlite";
 
 import { dbRun } from "../../db/write.ts";
 import { LocalIndex } from "../../index/local-index.ts";
-import { runWorkerEntry, type WorkerSelf } from "./sqlite-worker-shared.ts";
+import { runWorkerEntry } from "./sqlite-worker-shared.ts";
 
 declare const self: Worker;
 
@@ -31,7 +31,7 @@ ON CONFLICT(id) DO UPDATE SET
   synced_at = excluded.synced_at,
   pinned = excluded.pinned`;
 
-runWorkerEntry<SyncConfig>(self as unknown as WorkerSelf, {
+runWorkerEntry<SyncConfig>(self, {
   init: (config, dbPath) => {
     const db = new Database(dbPath);
     LocalIndex.ensureSchema(db);

--- a/packages/gateway/src/perf/surfaces/sqlite-worker-watcher.ts
+++ b/packages/gateway/src/perf/surfaces/sqlite-worker-watcher.ts
@@ -4,7 +4,7 @@ import { Database } from "bun:sqlite";
 
 import { dbRun } from "../../db/write.ts";
 import { LocalIndex } from "../../index/local-index.ts";
-import { runWorkerEntry, type WorkerSelf } from "./sqlite-worker-shared.ts";
+import { runWorkerEntry } from "./sqlite-worker-shared.ts";
 
 declare const self: Worker;
 
@@ -18,7 +18,7 @@ const WATCHER_EVENT_INSERT_SQL = `INSERT INTO watcher_event (
   watcher_id, fired_at, condition_snapshot, action_result
 ) VALUES (?, ?, ?, ?)`;
 
-runWorkerEntry<Record<string, unknown>>(self as unknown as WorkerSelf, {
+runWorkerEntry<Record<string, unknown>>(self, {
   init: (_config, dbPath) => {
     const db = new Database(dbPath);
     LocalIndex.ensureSchema(db);

--- a/packages/mcp-connectors/zoom/src/server.ts
+++ b/packages/mcp-connectors/zoom/src/server.ts
@@ -59,12 +59,9 @@ await runReadOnlyMcpConnector("nimbus-zoom", (reg) => {
     async (p) => {
       const root = await zoomGet("/v2/users/me/meetings?type=scheduled&page_size=100");
       const meetings = (root as { meetings?: unknown[] } | null)?.meetings;
-      const matches = Array.isArray(meetings)
-        ? filterZoomMeetings(
-            meetings,
-            p.limit === undefined ? { query: p.query } : { query: p.query, limit: p.limit },
-          )
-        : [];
+      const filterOptions =
+        p.limit === undefined ? { query: p.query } : { query: p.query, limit: p.limit };
+      const matches = Array.isArray(meetings) ? filterZoomMeetings(meetings, filterOptions) : [];
       return jsonResult({ matches });
     },
   );

--- a/packages/sdk/src/testing/sandbox-probe.ts
+++ b/packages/sdk/src/testing/sandbox-probe.ts
@@ -78,4 +78,6 @@ async function main(): Promise<void> {
   process.exit(2);
 }
 
-main();
+export {};
+
+await main();


### PR DESCRIPTION
@
SonarCloud quality pass, scope item 1 of 5 (drive TS smells toward 0). Behaviour-preserving throughout — every type-assertion removal is runtime-erased and gated by `tsc --noEmit`.

## Findings cleared (~26)
- **typescript:S4325** ×16 — redundant type assertions (gateway + cli). 3 Bun-lib-strictness false-positives (`bytes as unknown as ArrayBuffer`, `Subprocess as ProcSubset`) left in place because `tsc` proved the cast load-bearing.
- **typescript:S3358** ×3 — flatten nested ternaries (cli metrics `gapStr`, readwise `title`, zoom filter options).
- **typescript:S7786** — `TypeError` for the integer type-check in `parseUpdateCheckIntervalHours`.
- **typescript:S3776** ×2 — `accumulateServiceTables` (cc 25→~4) and `installPlanNodes` (cc 18→~5) via helper extraction.
- **typescript:S107** — `visit()` 8 params → `(current, ctx)` via a `SolveContext` of the recursion-invariant instances.
- **typescript:S6551** — `printItemCard` title now uses a `typeof` guard instead of `String(... ?? ...)`.
- **typescript:S7785** — top-level `await main()` in `sandbox-probe` (+ `export {}`; spawned by path, never imported).

## Verification
- `bun run preflight:fast` — **PASSED** (all 16 static gates: typecheck, biome, markdownlint, every `audit:*` incl. `audit:invariants` + `audit:any`, cross-platform, duplication).
- Per-package `tsc --noEmit` clean (gateway / cli / sdk / mcp / vscode after `client` build).
- 277+ affected unit tests pass; `security-invariants` (I16: `verify-extensions` / `install-from-local` / `sync` edits) green.

## Deferred (documented, follow-up)
`S7735`×2, `S3735`×3, `S5914`×8, `S6564` (intentional back-compat alias + test), `S7763` (mixed re-export), `S6606` (github-actions dist-drift zone), `S5843` (security-reviewed VTT regex — preserve matching), `S2301`, and vscode×3 + ui×1 (platform-excluded). Scope items 2–5 (connector dedup, long-file splits, coverage raises, Pass-5 SOLID) follow as separate PRs.

> Note: SonarCloud last analysed `87b4f6b3` (#460), not #462 — its line numbers are stale, so findings were located in current code via a TS-compiler-API detector rather than by Sonar `file:LINE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@