### PR TITLE
Cleanup Pass 3b (2/5) — connector dedup (search-filter factory + MappedRow)

### DIFF
--- a/packages/gateway/src/connectors/greenhouse-job-mapping.ts
+++ b/packages/gateway/src/connectors/greenhouse-job-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface GreenhouseMappingContext {
   readonly syncedAt: number;
 }
 
-export interface GreenhouseMappedRow {
-  readonly service: "greenhouse";
-  readonly type: "job";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type GreenhouseMappedRow = MappedRow<"greenhouse", "job">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/intercom-conversation-mapping.ts
+++ b/packages/gateway/src/connectors/intercom-conversation-mapping.ts
@@ -1,3 +1,4 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { secondsToMs } from "./stripe-invoice-mapping.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
@@ -5,18 +6,7 @@ export interface IntercomMappingContext {
   readonly syncedAt: number;
 }
 
-export interface IntercomMappedRow {
-  readonly service: "intercom";
-  readonly type: "conversation";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type IntercomMappedRow = MappedRow<"intercom", "conversation">;
 
 export function stripHtml(raw: unknown): string {
   if (typeof raw !== "string") {

--- a/packages/gateway/src/connectors/lever-posting-mapping.ts
+++ b/packages/gateway/src/connectors/lever-posting-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface LeverMappingContext {
   readonly syncedAt: number;
 }
 
-export interface LeverMappedRow {
-  readonly service: "lever";
-  readonly type: "posting";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type LeverMappedRow = MappedRow<"lever", "posting">;
 
 function epochMs(row: Record<string, unknown>, key: string): number | null {
   const v = numberField(row, key);

--- a/packages/gateway/src/connectors/mapped-row.ts
+++ b/packages/gateway/src/connectors/mapped-row.ts
@@ -1,0 +1,17 @@
+/**
+ * Common shape every connector item-mapper returns. The `service` and `type`
+ * string-literal types are supplied per connector; the remaining ten fields
+ * are uniform across all mappers.
+ */
+export interface MappedRow<S extends string, T extends string> {
+  readonly service: S;
+  readonly type: T;
+  readonly externalId: string;
+  readonly title: string;
+  readonly bodyPreview: string;
+  readonly url: string | null;
+  readonly canonicalUrl: string | null;
+  readonly modifiedAt: number;
+  readonly metadata: Record<string, unknown>;
+  readonly syncedAt: number;
+}

--- a/packages/gateway/src/connectors/mercury-account-mapping.ts
+++ b/packages/gateway/src/connectors/mercury-account-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface MercuryMappingContext {
   readonly syncedAt: number;
 }
 
-export interface MercuryMappedRow {
-  readonly service: "mercury";
-  readonly type: "account";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type MercuryMappedRow = MappedRow<"mercury", "account">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/netlify-site-mapping.ts
+++ b/packages/gateway/src/connectors/netlify-site-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
 
 export interface NetlifyMappingContext {
   readonly syncedAt: number;
 }
 
-export interface NetlifyMappedRow {
-  readonly service: "netlify";
-  readonly type: "site";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type NetlifyMappedRow = MappedRow<"netlify", "site">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/pipedrive-deal-mapping.ts
+++ b/packages/gateway/src/connectors/pipedrive-deal-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface PipedriveMappingContext {
   readonly syncedAt: number;
 }
 
-export interface PipedriveMappedRow {
-  readonly service: "pipedrive";
-  readonly type: "deal";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type PipedriveMappedRow = MappedRow<"pipedrive", "deal">;
 
 export function pipedriveTimeMs(v: unknown): number | null {
   if (typeof v !== "string" || v.trim() === "") {

--- a/packages/gateway/src/connectors/raindrop-bookmark-mapping.ts
+++ b/packages/gateway/src/connectors/raindrop-bookmark-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface RaindropMappingContext {
   readonly syncedAt: number;
 }
 
-export interface RaindropMappedRow {
-  readonly service: "raindrop";
-  readonly type: "bookmark";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type RaindropMappedRow = MappedRow<"raindrop", "bookmark">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/readwise-highlight-mapping.ts
+++ b/packages/gateway/src/connectors/readwise-highlight-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface ReadwiseMappingContext {
   readonly syncedAt: number;
 }
 
-export interface ReadwiseMappedRow {
-  readonly service: "readwise";
-  readonly type: "highlight";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type ReadwiseMappedRow = MappedRow<"readwise", "highlight">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/stackoverflow-question-mapping.ts
+++ b/packages/gateway/src/connectors/stackoverflow-question-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface StackOverflowMappingContext {
   readonly syncedAt: number;
 }
 
-export interface StackOverflowMappedRow {
-  readonly service: "stackoverflow";
-  readonly type: "question";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type StackOverflowMappedRow = MappedRow<"stackoverflow", "question">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/stripe-invoice-mapping.ts
+++ b/packages/gateway/src/connectors/stripe-invoice-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface StripeMappingContext {
   readonly syncedAt: number;
 }
 
-export interface StripeMappedRow {
-  readonly service: "stripe";
-  readonly type: "invoice";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type StripeMappedRow = MappedRow<"stripe", "invoice">;
 
 export function secondsToMs(n: number | undefined): number | null {
   if (n === undefined || !Number.isFinite(n) || n === 0) {

--- a/packages/gateway/src/connectors/vercel-deployment-mapping.ts
+++ b/packages/gateway/src/connectors/vercel-deployment-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface VercelMappingContext {
   readonly syncedAt: number;
 }
 
-export interface VercelMappedRow {
-  readonly service: "vercel";
-  readonly type: "deployment";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type VercelMappedRow = MappedRow<"vercel", "deployment">;
 
 export function deploymentUrl(
   inspectorUrl: string | null,

--- a/packages/gateway/src/connectors/zendesk-ticket-mapping.ts
+++ b/packages/gateway/src/connectors/zendesk-ticket-mapping.ts
@@ -1,3 +1,4 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface ZendeskMappingContext {
@@ -5,18 +6,7 @@ export interface ZendeskMappingContext {
   readonly syncedAt: number;
 }
 
-export interface ZendeskMappedRow {
-  readonly service: "zendesk";
-  readonly type: "ticket";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type ZendeskMappedRow = MappedRow<"zendesk", "ticket">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/zoom-meeting-mapping.ts
+++ b/packages/gateway/src/connectors/zoom-meeting-mapping.ts
@@ -1,21 +1,11 @@
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 export interface ZoomMeetingMappingContext {
   readonly syncedAt: number;
 }
 
-export interface ZoomMeetingMappedRow {
-  readonly service: "zoom";
-  readonly type: "meeting";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type ZoomMeetingMappedRow = MappedRow<"zoom", "meeting">;
 
 function parseIsoMs(v: unknown): number | null {
   return typeof v === "string" && Number.isFinite(Date.parse(v)) ? Date.parse(v) : null;

--- a/packages/gateway/src/connectors/zoom-transcript-mapping.ts
+++ b/packages/gateway/src/connectors/zoom-transcript-mapping.ts
@@ -18,6 +18,7 @@
  * Receiving already-fetched `plainText` keeps the mapper pure.
  */
 
+import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
 
 const TRANSCRIPT_PREVIEW_MAX_CHARS = 280;
@@ -32,18 +33,7 @@ export interface ZoomTranscriptMappingInput {
   readonly syncedAt: number;
 }
 
-export interface ZoomTranscriptMappedRow {
-  readonly service: "zoom";
-  readonly type: "transcript";
-  readonly externalId: string;
-  readonly title: string;
-  readonly bodyPreview: string;
-  readonly url: string | null;
-  readonly canonicalUrl: string | null;
-  readonly modifiedAt: number;
-  readonly metadata: Record<string, unknown>;
-  readonly syncedAt: number;
-}
+export type ZoomTranscriptMappedRow = MappedRow<"zoom", "transcript">;
 
 /** ISO-8601 string → epoch ms, or null for non-strings / unparseable input. */
 function parseIsoMs(v: unknown): number | null {

--- a/packages/mcp-connectors/argocd/src/search-filter.ts
+++ b/packages/mcp-connectors/argocd/src/search-filter.ts
@@ -1,4 +1,4 @@
-import { asRecord, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import { asRecord, makeQueryFilter, type SearchMatchOptions } from "../../shared/search-filter.ts";
 
 export type ArgocdSearchMatchOptions = SearchMatchOptions;
 
@@ -28,9 +28,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterArgocdApplications(
-  apps: readonly unknown[],
-  options: ArgocdSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(apps, { ...options, fields: fieldsOf });
-}
+export const filterArgocdApplications = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/bitrise/src/search-filter.ts
+++ b/packages/mcp-connectors/bitrise/src/search-filter.ts
@@ -1,28 +1,11 @@
-import { asObjectish, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import {
+  fieldsFromKeys,
+  makeQueryFilter,
+  type SearchMatchOptions,
+} from "../../shared/search-filter.ts";
 
 export type BitriseSearchMatchOptions = SearchMatchOptions;
 
-function pickString(r: Record<string, unknown>, key: string): string {
-  const v = r[key];
-  return typeof v === "string" ? v : "";
-}
-
-function fieldsOf(item: unknown): readonly string[] | null {
-  const row = asObjectish(item);
-  if (row === undefined) {
-    return null;
-  }
-  return [
-    pickString(row, "branch"),
-    pickString(row, "commit_message"),
-    pickString(row, "triggered_workflow"),
-    pickString(row, "status_text"),
-  ];
-}
-
-export function filterBitriseBuilds(
-  builds: readonly unknown[],
-  options: BitriseSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(builds, { ...options, fields: fieldsOf });
-}
+export const filterBitriseBuilds = makeQueryFilter(
+  fieldsFromKeys(["branch", "commit_message", "triggered_workflow", "status_text"]),
+);

--- a/packages/mcp-connectors/databricks/src/search-filter.ts
+++ b/packages/mcp-connectors/databricks/src/search-filter.ts
@@ -1,4 +1,4 @@
-import { asRecord, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import { asRecord, makeQueryFilter, type SearchMatchOptions } from "../../shared/search-filter.ts";
 
 export type DatabricksSearchMatchOptions = SearchMatchOptions;
 
@@ -21,9 +21,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [stringAt(settings, "name"), stringAt(row, "creator_user_name"), numberAt(row, "job_id")];
 }
 
-export function filterDatabricksJobs(
-  jobs: readonly unknown[],
-  options: DatabricksSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(jobs, { ...options, fields: fieldsOf });
-}
+export const filterDatabricksJobs = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/dbt/src/search-filter.ts
+++ b/packages/mcp-connectors/dbt/src/search-filter.ts
@@ -1,4 +1,8 @@
-import { asObjectish, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import {
+  asObjectish,
+  makeQueryFilter,
+  type SearchMatchOptions,
+} from "../../shared/search-filter.ts";
 
 export type DbtSearchMatchOptions = SearchMatchOptions;
 
@@ -21,6 +25,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [field(row, "name"), field(row, "dbt_version"), field(row, "id")];
 }
 
-export function filterDbtJobs(jobs: readonly unknown[], options: DbtSearchMatchOptions): unknown[] {
-  return filterByQuery(jobs, { ...options, fields: fieldsOf });
-}
+export const filterDbtJobs = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/flagsmith/src/search-filter.ts
+++ b/packages/mcp-connectors/flagsmith/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -26,9 +26,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [stringField(row, "name"), stringField(row, "description"), tagsString(row)];
 }
 
-export function filterFlagsmithFeatures(
-  features: readonly unknown[],
-  options: FlagsmithSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(features, { ...options, fields: fieldsOf });
-}
+export const filterFlagsmithFeatures = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/flux/src/search-filter.ts
+++ b/packages/mcp-connectors/flux/src/search-filter.ts
@@ -1,4 +1,4 @@
-import { asRecord, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import { asRecord, makeQueryFilter, type SearchMatchOptions } from "../../shared/search-filter.ts";
 
 export type FluxSearchMatchOptions = SearchMatchOptions;
 
@@ -46,9 +46,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterFluxResources(
-  items: readonly unknown[],
-  options: FluxSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(items, { ...options, fields: fieldsOf });
-}
+export const filterFluxResources = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/greenhouse/src/search-filter.ts
+++ b/packages/mcp-connectors/greenhouse/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -62,9 +62,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterGreenhouseJobs(
-  jobs: readonly unknown[],
-  options: GreenhouseSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(jobs, { ...options, fields: fieldsOf });
-}
+export const filterGreenhouseJobs = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/intercom/src/search-filter.ts
+++ b/packages/mcp-connectors/intercom/src/search-filter.ts
@@ -1,7 +1,7 @@
 import {
   asObjectish,
   asRecord,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -43,9 +43,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [subject, body, state, authorName, authorEmail, tagText(row)];
 }
 
-export function filterIntercomConversations(
-  conversations: readonly unknown[],
-  options: IntercomSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(conversations, { ...options, fields: fieldsOf });
-}
+export const filterIntercomConversations = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/launchdarkly/src/search-filter.ts
+++ b/packages/mcp-connectors/launchdarkly/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -28,9 +28,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterLaunchDarklyFlags(
-  flags: readonly unknown[],
-  options: LaunchDarklySearchMatchOptions,
-): unknown[] {
-  return filterByQuery(flags, { ...options, fields: fieldsOf });
-}
+export const filterLaunchDarklyFlags = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/lever/src/search-filter.ts
+++ b/packages/mcp-connectors/lever/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
   tagText,
@@ -32,9 +32,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterLeverPostings(
-  postings: readonly unknown[],
-  options: LeverSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(postings, { ...options, fields: fieldsOf });
-}
+export const filterLeverPostings = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/mercury/src/search-filter.ts
+++ b/packages/mcp-connectors/mercury/src/search-filter.ts
@@ -1,30 +1,11 @@
 import {
-  asObjectish,
-  filterByQuery,
+  fieldsFromKeys,
+  makeQueryFilter,
   type SearchMatchOptions,
-  stringField,
 } from "../../shared/search-filter.ts";
 
 export type MercurySearchMatchOptions = SearchMatchOptions;
 
-function fieldsOf(item: unknown): readonly string[] | null {
-  const row = asObjectish(item);
-  if (row === undefined) {
-    return null;
-  }
-  return [
-    stringField(row, "id"),
-    stringField(row, "name"),
-    stringField(row, "status"),
-    stringField(row, "type"),
-    stringField(row, "kind"),
-    stringField(row, "legalBusinessName"),
-  ];
-}
-
-export function filterMercuryAccounts(
-  accounts: readonly unknown[],
-  options: MercurySearchMatchOptions,
-): unknown[] {
-  return filterByQuery(accounts, { ...options, fields: fieldsOf });
-}
+export const filterMercuryAccounts = makeQueryFilter(
+  fieldsFromKeys(["id", "name", "status", "type", "kind", "legalBusinessName"]),
+);

--- a/packages/mcp-connectors/metabase/src/search-filter.ts
+++ b/packages/mcp-connectors/metabase/src/search-filter.ts
@@ -1,4 +1,4 @@
-import { asRecord, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import { asRecord, makeQueryFilter, type SearchMatchOptions } from "../../shared/search-filter.ts";
 
 export type MetabaseSearchMatchOptions = SearchMatchOptions;
 
@@ -15,9 +15,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [stringAt(row, "name"), stringAt(row, "description")];
 }
 
-export function filterMetabaseDashboards(
-  dashboards: readonly unknown[],
-  options: MetabaseSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(dashboards, { ...options, fields: fieldsOf });
-}
+export const filterMetabaseDashboards = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/mlflow/src/search-filter.ts
+++ b/packages/mcp-connectors/mlflow/src/search-filter.ts
@@ -1,4 +1,4 @@
-import { asRecord, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import { asRecord, makeQueryFilter, type SearchMatchOptions } from "../../shared/search-filter.ts";
 
 export type MlflowSearchMatchOptions = SearchMatchOptions;
 
@@ -31,9 +31,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [stringAt(row, "name"), stringAt(row, "description"), tagsHaystack(row)];
 }
 
-export function filterMlflowModels(
-  models: readonly unknown[],
-  options: MlflowSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(models, { ...options, fields: fieldsOf });
-}
+export const filterMlflowModels = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/netlify/src/search-filter.ts
+++ b/packages/mcp-connectors/netlify/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -34,9 +34,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterNetlifySites(
-  sites: readonly unknown[],
-  options: NetlifySearchMatchOptions,
-): unknown[] {
-  return filterByQuery(sites, { ...options, fields: fieldsOf });
-}
+export const filterNetlifySites = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/pipedrive/src/search-filter.ts
+++ b/packages/mcp-connectors/pipedrive/src/search-filter.ts
@@ -1,30 +1,11 @@
 import {
-  asObjectish,
-  filterByQuery,
+  fieldsFromKeys,
+  makeQueryFilter,
   type SearchMatchOptions,
-  stringField,
 } from "../../shared/search-filter.ts";
 
 export type PipedriveSearchMatchOptions = SearchMatchOptions;
 
-function fieldsOf(item: unknown): readonly string[] | null {
-  const row = asObjectish(item);
-  if (row === undefined) {
-    return null;
-  }
-  return [
-    stringField(row, "title"),
-    stringField(row, "status"),
-    stringField(row, "org_name"),
-    stringField(row, "person_name"),
-    stringField(row, "owner_name"),
-    stringField(row, "label"),
-  ];
-}
-
-export function filterPipedriveDeals(
-  deals: readonly unknown[],
-  options: PipedriveSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(deals, { ...options, fields: fieldsOf });
-}
+export const filterPipedriveDeals = makeQueryFilter(
+  fieldsFromKeys(["title", "status", "org_name", "person_name", "owner_name", "label"]),
+);

--- a/packages/mcp-connectors/raindrop/src/search-filter.ts
+++ b/packages/mcp-connectors/raindrop/src/search-filter.ts
@@ -1,32 +1,11 @@
 import {
-  asObjectish,
-  filterByQuery,
+  fieldsFromKeys,
+  makeQueryFilter,
   type SearchMatchOptions,
-  stringField,
-  tagText,
 } from "../../shared/search-filter.ts";
 
 export type RaindropSearchMatchOptions = SearchMatchOptions;
 
-function fieldsOf(item: unknown): readonly string[] | null {
-  const row = asObjectish(item);
-  if (row === undefined) {
-    return null;
-  }
-  return [
-    stringField(row, "title"),
-    stringField(row, "excerpt"),
-    stringField(row, "note"),
-    stringField(row, "domain"),
-    stringField(row, "link"),
-    stringField(row, "type"),
-    tagText(row),
-  ];
-}
-
-export function filterRaindropBookmarks(
-  bookmarks: readonly unknown[],
-  options: RaindropSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(bookmarks, { ...options, fields: fieldsOf });
-}
+export const filterRaindropBookmarks = makeQueryFilter(
+  fieldsFromKeys(["title", "excerpt", "note", "domain", "link", "type"], { tags: true }),
+);

--- a/packages/mcp-connectors/readwise/src/search-filter.ts
+++ b/packages/mcp-connectors/readwise/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -38,9 +38,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterReadwiseHighlights(
-  highlights: readonly unknown[],
-  options: ReadwiseSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(highlights, { ...options, fields: fieldsOf });
-}
+export const filterReadwiseHighlights = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/semgrep/src/search-filter.ts
+++ b/packages/mcp-connectors/semgrep/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -28,9 +28,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterSemgrepFindings(
-  findings: readonly unknown[],
-  options: SemgrepSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(findings, { ...options, fields: fieldsOf });
-}
+export const filterSemgrepFindings = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/shared/search-filter.ts
+++ b/packages/mcp-connectors/shared/search-filter.ts
@@ -62,3 +62,38 @@ export function filterByQuery<T>(items: readonly T[], options: FilterByQueryOpti
   }
   return out;
 }
+
+export type FieldExtractor = (item: unknown) => readonly (string | null | undefined)[] | null;
+
+/**
+ * Build a {@link FieldExtractor} that reads a fixed list of string keys off each
+ * objectish row, optionally appending the standard `tags` text. Collapses the
+ * boilerplate `fieldsOf` body shared by the simpler connectors.
+ */
+export function fieldsFromKeys(
+  keys: readonly string[],
+  opts?: { readonly tags?: boolean },
+): FieldExtractor {
+  return (item: unknown) => {
+    const row = asObjectish(item);
+    if (row === undefined) {
+      return null;
+    }
+    const parts = keys.map((key) => stringField(row, key));
+    if (opts?.tags === true) {
+      parts.push(tagText(row));
+    }
+    return parts;
+  };
+}
+
+/**
+ * Build a `filter<Thing>(items, options)` search function from a field
+ * extractor. Connectors with bespoke extraction pass their own `fieldsOf`;
+ * simple ones pair this with {@link fieldsFromKeys}.
+ */
+export function makeQueryFilter(
+  fields: FieldExtractor,
+): (items: readonly unknown[], options: SearchMatchOptions) => unknown[] {
+  return (items, options) => filterByQuery(items, { ...options, fields });
+}

--- a/packages/mcp-connectors/snyk/src/search-filter.ts
+++ b/packages/mcp-connectors/snyk/src/search-filter.ts
@@ -1,4 +1,8 @@
-import { asObjectish, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import {
+  asObjectish,
+  makeQueryFilter,
+  type SearchMatchOptions,
+} from "../../shared/search-filter.ts";
 
 export type SnykSearchMatchOptions = SearchMatchOptions;
 
@@ -21,9 +25,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [title, cves.join(" "), pkg];
 }
 
-export function filterSnykAggregatedIssues(
-  issues: readonly unknown[],
-  options: SnykSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(issues, { ...options, fields: fieldsOf });
-}
+export const filterSnykAggregatedIssues = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/sonarqube/src/search-filter.ts
+++ b/packages/mcp-connectors/sonarqube/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -25,9 +25,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterSonarIssues(
-  issues: readonly unknown[],
-  options: SonarSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(issues, { ...options, fields: fieldsOf });
-}
+export const filterSonarIssues = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/stackoverflow/src/search-filter.ts
+++ b/packages/mcp-connectors/stackoverflow/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -49,9 +49,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterStackOverflowQuestions(
-  questions: readonly unknown[],
-  options: StackOverflowSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(questions, { ...options, fields: fieldsOf });
-}
+export const filterStackOverflowQuestions = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/stripe/src/search-filter.ts
+++ b/packages/mcp-connectors/stripe/src/search-filter.ts
@@ -1,31 +1,19 @@
 import {
-  asObjectish,
-  filterByQuery,
+  fieldsFromKeys,
+  makeQueryFilter,
   type SearchMatchOptions,
-  stringField,
 } from "../../shared/search-filter.ts";
 
 export type StripeSearchMatchOptions = SearchMatchOptions;
 
-function fieldsOf(item: unknown): readonly string[] | null {
-  const row = asObjectish(item);
-  if (row === undefined) {
-    return null;
-  }
-  return [
-    stringField(row, "id"),
-    stringField(row, "number"),
-    stringField(row, "status"),
-    stringField(row, "customer"),
-    stringField(row, "customer_name"),
-    stringField(row, "customer_email"),
-    stringField(row, "description"),
-  ];
-}
-
-export function filterStripeInvoices(
-  invoices: readonly unknown[],
-  options: StripeSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(invoices, { ...options, fields: fieldsOf });
-}
+export const filterStripeInvoices = makeQueryFilter(
+  fieldsFromKeys([
+    "id",
+    "number",
+    "status",
+    "customer",
+    "customer_name",
+    "customer_email",
+    "description",
+  ]),
+);

--- a/packages/mcp-connectors/superset/src/search-filter.ts
+++ b/packages/mcp-connectors/superset/src/search-filter.ts
@@ -1,4 +1,4 @@
-import { asRecord, filterByQuery, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import { asRecord, makeQueryFilter, type SearchMatchOptions } from "../../shared/search-filter.ts";
 
 export type SupersetSearchMatchOptions = SearchMatchOptions;
 
@@ -15,9 +15,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   return [stringAt(row, "dashboard_title"), stringAt(row, "slug")];
 }
 
-export function filterSupersetDashboards(
-  dashboards: readonly unknown[],
-  options: SupersetSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(dashboards, { ...options, fields: fieldsOf });
-}
+export const filterSupersetDashboards = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/vercel/src/search-filter.ts
+++ b/packages/mcp-connectors/vercel/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -31,9 +31,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterVercelDeployments(
-  deployments: readonly unknown[],
-  options: VercelSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(deployments, { ...options, fields: fieldsOf });
-}
+export const filterVercelDeployments = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/wiz/src/search-filter.ts
+++ b/packages/mcp-connectors/wiz/src/search-filter.ts
@@ -1,6 +1,6 @@
 import {
   asObjectish,
-  filterByQuery,
+  makeQueryFilter,
   type SearchMatchOptions,
   stringField,
 } from "../../shared/search-filter.ts";
@@ -47,9 +47,4 @@ function fieldsOf(item: unknown): readonly string[] | null {
   ];
 }
 
-export function filterWizIssues(
-  issues: readonly unknown[],
-  options: WizSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(issues, { ...options, fields: fieldsOf });
-}
+export const filterWizIssues = makeQueryFilter(fieldsOf);

--- a/packages/mcp-connectors/zendesk/src/search-filter.ts
+++ b/packages/mcp-connectors/zendesk/src/search-filter.ts
@@ -1,31 +1,11 @@
 import {
-  asObjectish,
-  filterByQuery,
+  fieldsFromKeys,
+  makeQueryFilter,
   type SearchMatchOptions,
-  stringField,
-  tagText,
 } from "../../shared/search-filter.ts";
 
 export type ZendeskSearchMatchOptions = SearchMatchOptions;
 
-function fieldsOf(item: unknown): readonly string[] | null {
-  const row = asObjectish(item);
-  if (row === undefined) {
-    return null;
-  }
-  return [
-    stringField(row, "subject"),
-    stringField(row, "description"),
-    stringField(row, "status"),
-    stringField(row, "priority"),
-    stringField(row, "type"),
-    tagText(row),
-  ];
-}
-
-export function filterZendeskTickets(
-  tickets: readonly unknown[],
-  options: ZendeskSearchMatchOptions,
-): unknown[] {
-  return filterByQuery(tickets, { ...options, fields: fieldsOf });
-}
+export const filterZendeskTickets = makeQueryFilter(
+  fieldsFromKeys(["subject", "description", "status", "priority", "type"], { tags: true }),
+);

--- a/scripts/coverage-floor/exclusions.ts
+++ b/scripts/coverage-floor/exclusions.ts
@@ -23,6 +23,7 @@ export const EXCLUSIONS: readonly ExclusionPattern[] = Object.freeze([
   { kind: "exact", path: "packages/gateway/src/vault/factory.ts" },
   { kind: "exact", path: "packages/gateway/src/platform/sandbox/index.ts" },
   { kind: "exact", path: "packages/gateway/src/connectors/index.ts" },
+  { kind: "exact", path: "packages/gateway/src/connectors/mapped-row.ts" },
   { kind: "exact", path: "packages/client/src/index.ts" },
   { kind: "exact", path: "packages/client/src/stream-events.ts" },
   { kind: "exact", path: "packages/sdk/src/ipc/index.ts" },


### PR DESCRIPTION
@
Scope item 2 of 5: collapse duplicated connector boilerplate. Behaviour-preserving throughout (the second commit is type-only).

## 1. Search-filter factory (`mcp-connectors`)
Added `fieldsFromKeys(keys, {tags})` + `makeQueryFilter(fields)` to `shared/search-filter.ts` and migrated 26 of 27 connector `search-filter.ts`:
- **6 fully-simple** (raindrop, stripe, mercury, pipedrive, zendesk, bitrise) → compact `makeQueryFilter(fieldsFromKeys([...]))`.
- **20 bespoke** keep their custom `fieldsOf` (number-coercion, nested extraction, object-`name` tags, …) and drop only the identical `filterByQuery` wrapper via `makeQueryFilter(fieldsOf)`.
- **zoom** left unchanged (hand-rolled loop with distinct empty-query semantics).

## 2. Shared `MappedRow<S, T>` item-envelope (`gateway/connectors`)
Every mapper returns the same 10-field envelope. Added a generic `MappedRow<S, T>` in `connectors/mapped-row.ts` and replaced the duplicated per-connector interface with a type alias in the **14 mappers whose shape matches exactly**. The other 14 declare `canonicalUrl` as non-nullable `string` (a stricter subtype) and were left unchanged to avoid widening downstream consumers. `MappingContext` interfaces are connector-specific and untouched.

**Net: −162 lines (search-filter) + ~14 deduped interfaces.**

## Verification
- `bun run preflight:fast` — **PASSED** (all 16 static gates incl. `duplication (jscpd)`, `audit:invariants`, `audit:any`).
- Per-package `tsc` clean (mcp + gateway). `bun test packages/mcp-connectors` → 267 pass / 0 fail; `bun test packages/gateway/src/connectors` → 543 pass / 0 fail. Biome clean.
- All exported names + `XSearchMatchOptions` / `XMappedRow` type-alias names preserved (no `server.ts` / sync-handler import changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@