### PR TITLE
Cleanup Pass 3b (3/5) — split nimbus-toml.ts (SRP + loader dedup)

### DIFF
--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -1,16 +1,33 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import {
-  DEFAULT_DEPLOY_ENVIRONMENTS,
-  DEFAULT_DEPLOY_WORKFLOW_PATTERN,
-  DEFAULT_EXCLUDE_PR_LABELS,
-  DEFAULT_INCIDENT_WINDOW_MINUTES,
-  isValidDeployEnvironmentName,
-  parseDoraRepoUrn,
-  type ServiceConfig,
-} from "../metrics/dora-config.ts";
+import type { ServiceConfig } from "../metrics/dora-config.ts";
 import { processEnvGet } from "../platform/env-access.ts";
+import { parseNimbusCiServiceToml, parseNimbusDoraToml } from "./service-config-toml.ts";
+import {
+  isTableHeader,
+  parseIntDec,
+  parseString,
+  parseStringArray,
+  splitKeyValue,
+  stripComment,
+} from "./toml-primitives.ts";
+
+// Re-export the DORA / CI service-config surface so external importers
+// (http-server.ts, ipc/server/dispatchers.ts, config + metrics tests) keep
+// working through `./nimbus-toml.ts` unchanged.
+export * from "./service-config-toml.ts";
+
+function loadTomlSection<T>(tomlPath: string, fallback: T, parse: (raw: string) => T): T {
+  if (!existsSync(tomlPath)) {
+    return structuredClone(fallback);
+  }
+  try {
+    return parse(readFileSync(tomlPath, "utf8"));
+  } catch {
+    return structuredClone(fallback);
+  }
+}
 
 export type NimbusEmbeddingToml = {
   enabled: boolean;
@@ -32,14 +49,6 @@ export const DEFAULT_NIMBUS_EMBEDDING_TOML: NimbusEmbeddingToml = {
   pauseOnBattery: true,
 };
 
-function stripComment(line: string): string {
-  const hash = line.indexOf("#");
-  if (hash < 0) {
-    return line;
-  }
-  return line.slice(0, hash);
-}
-
 function parseBool(raw: string): boolean | undefined {
   const s = raw.trim().toLowerCase();
   if (s === "true") {
@@ -49,31 +58,6 @@ function parseBool(raw: string): boolean | undefined {
     return false;
   }
   return undefined;
-}
-
-function parseString(raw: string): string {
-  const t = raw.trim();
-  if (t.startsWith('"') && t.endsWith('"') && t.length >= 2) {
-    return t.slice(1, -1).replaceAll(String.raw`\\"`, '"');
-  }
-  return t;
-}
-
-function parseIntDec(raw: string): number | undefined {
-  const n = Number.parseInt(raw.trim(), 10);
-  return Number.isFinite(n) ? n : undefined;
-}
-
-function isTableHeader(trimmed: string): boolean {
-  return trimmed.startsWith("[") && trimmed.endsWith("]");
-}
-
-function splitKeyValue(trimmed: string): { key: string; valRaw: string } | undefined {
-  const eq = trimmed.indexOf("=");
-  if (eq <= 0) {
-    return undefined;
-  }
-  return { key: trimmed.slice(0, eq).trim(), valRaw: trimmed.slice(eq + 1).trim() };
 }
 
 function forEachSectionEntry(
@@ -190,18 +174,12 @@ export function resolveNimbusTomlForProfile(configDir: string): string {
 }
 
 export function loadNimbusEmbeddingFromPath(tomlPath: string): NimbusEmbeddingToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_EMBEDDING_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return structuredClone({
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_EMBEDDING_TOML, (raw) =>
+    structuredClone({
       ...DEFAULT_NIMBUS_EMBEDDING_TOML,
       ...parseNimbusTomlEmbeddingSection(raw),
-    });
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_EMBEDDING_TOML);
-  }
+    }),
+  );
 }
 
 export function loadNimbusEmbeddingFromConfigDir(configDir: string): NimbusEmbeddingToml {
@@ -285,30 +263,16 @@ export function parseNimbusTomlLlmSection(source: string): Partial<NimbusLlmToml
 }
 
 export function loadNimbusLlmFromPath(tomlPath: string): NimbusLlmToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_LLM_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return structuredClone({
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_LLM_TOML, (raw) =>
+    structuredClone({
       ...DEFAULT_NIMBUS_LLM_TOML,
       ...parseNimbusTomlLlmSection(raw),
-    });
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_LLM_TOML);
-  }
+    }),
+  );
 }
 
 export function loadNimbusLlmPartialFromPath(tomlPath: string): Partial<NimbusLlmToml> {
-  if (!existsSync(tomlPath)) {
-    return {};
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return parseNimbusTomlLlmSection(raw);
-  } catch {
-    return {};
-  }
+  return loadTomlSection<Partial<NimbusLlmToml>>(tomlPath, {}, parseNimbusTomlLlmSection);
 }
 
 export function loadNimbusLlmFromConfigDir(configDir: string): NimbusLlmToml {
@@ -374,18 +338,12 @@ export function parseNimbusTomlVoiceSection(source: string): Partial<NimbusVoice
 }
 
 export function loadNimbusVoiceFromPath(tomlPath: string): NimbusVoiceToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_VOICE_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return structuredClone({
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_VOICE_TOML, (raw) =>
+    structuredClone({
       ...DEFAULT_NIMBUS_VOICE_TOML,
       ...parseNimbusTomlVoiceSection(raw),
-    });
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_VOICE_TOML);
-  }
+    }),
+  );
 }
 
 export function loadNimbusVoiceFromConfigDir(configDir: string): NimbusVoiceToml {
@@ -457,15 +415,7 @@ export function parseNimbusUpdaterToml(
 }
 
 export function loadNimbusUpdaterFromPath(tomlPath: string): NimbusUpdaterToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_UPDATER_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return parseNimbusUpdaterToml(raw);
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_UPDATER_TOML);
-  }
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_UPDATER_TOML, parseNimbusUpdaterToml);
 }
 
 export function loadNimbusUpdaterFromConfigDir(configDir: string): NimbusUpdaterToml {
@@ -549,15 +499,7 @@ export function parseNimbusLanToml(
 }
 
 export function loadNimbusLanFromPath(tomlPath: string): NimbusLanToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_LAN_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return parseNimbusLanToml(raw);
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_LAN_TOML);
-  }
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_LAN_TOML, parseNimbusLanToml);
 }
 
 export function loadNimbusLanFromConfigDir(configDir: string): NimbusLanToml {
@@ -591,15 +533,7 @@ export function parseNimbusAutomationToml(
 }
 
 export function loadNimbusAutomationFromPath(tomlPath: string): NimbusAutomationToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_AUTOMATION_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return parseNimbusAutomationToml(raw);
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_AUTOMATION_TOML);
-  }
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_AUTOMATION_TOML, parseNimbusAutomationToml);
 }
 
 export function loadNimbusAutomationFromConfigDir(configDir: string): NimbusAutomationToml {
@@ -645,15 +579,7 @@ export function parseNimbusExtensionsToml(
 }
 
 export function loadNimbusExtensionsFromPath(tomlPath: string): NimbusExtensionsToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_EXTENSIONS_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return parseNimbusExtensionsToml(raw);
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_EXTENSIONS_TOML);
-  }
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_EXTENSIONS_TOML, parseNimbusExtensionsToml);
 }
 
 export function loadNimbusExtensionsFromConfigDir(configDir: string): NimbusExtensionsToml {
@@ -685,15 +611,7 @@ export function parseNimbusUserToml(
 }
 
 export function loadNimbusUserFromPath(tomlPath: string): NimbusUserToml {
-  if (!existsSync(tomlPath)) {
-    return structuredClone(DEFAULT_NIMBUS_USER_TOML);
-  }
-  try {
-    const raw = readFileSync(tomlPath, "utf8");
-    return parseNimbusUserToml(raw);
-  } catch {
-    return structuredClone(DEFAULT_NIMBUS_USER_TOML);
-  }
+  return loadTomlSection(tomlPath, DEFAULT_NIMBUS_USER_TOML, parseNimbusUserToml);
 }
 
 export function loadNimbusUserFromConfigDir(configDir: string): NimbusUserToml {
@@ -778,204 +696,12 @@ export function loadNimbusPagerdutyFromConfigDir(configDir: string): NimbusPager
   return loadNimbusPagerdutyFromPath(join(configDir, "nimbus.toml"));
 }
 
-const DORA_TABLE_PREFIX = "[metrics.dora.";
-const SERVICE_CONFIG_KNOWN_KEYS: ReadonlySet<string> = new Set([
-  "repos",
-  "pagerduty_services",
-  "deploy_workflow_pattern",
-  "incident_window_minutes",
-  "exclude_pr_labels",
-  "deploy_environments",
-]);
-
-function parseStringArray(raw: string): string[] {
-  const t = raw.trim();
-  if (!t.startsWith("[") || !t.endsWith("]")) {
-    throw new TypeError(`expected array, got: ${raw}`);
-  }
-  const inner = t.slice(1, -1).trim();
-  if (inner.length === 0) return [];
-  const out: string[] = [];
-  for (const part of inner.split(",")) {
-    const v = parseString(part);
-    if (v.length > 0) out.push(v);
-  }
-  return out;
-}
-
-function materializeDeployWorkflowPattern(
-  kv: Record<string, string>,
-  blockLabel: string,
-  serviceId: string,
-): RegExp {
-  const patternSrc =
-    kv["deploy_workflow_pattern"] === undefined
-      ? DEFAULT_DEPLOY_WORKFLOW_PATTERN
-      : parseString(kv["deploy_workflow_pattern"]);
-  try {
-    return new RegExp(patternSrc);
-  } catch (e) {
-    throw new Error(
-      `[${blockLabel}.${serviceId}].deploy_workflow_pattern is not a valid regex: ${
-        e instanceof Error ? e.message : String(e)
-      }`,
-    );
-  }
-}
-
-function materializeIncidentWindowMinutes(
-  kv: Record<string, string>,
-  blockLabel: string,
-  serviceId: string,
-): number {
-  const windowRaw = kv["incident_window_minutes"];
-  const windowMins =
-    windowRaw === undefined ? DEFAULT_INCIDENT_WINDOW_MINUTES : parseIntDec(windowRaw);
-  if (windowMins === undefined || windowMins < 1 || windowMins > 1440) {
-    throw new Error(
-      `[${blockLabel}.${serviceId}].incident_window_minutes must be 1..1440, got '${windowRaw}'`,
-    );
-  }
-  return windowMins;
-}
-
-function materializeDeployEnvironments(
-  kv: Record<string, string>,
-  blockLabel: string,
-  serviceId: string,
-): string[] {
-  const raw = kv["deploy_environments"];
-  const deployEnvironments =
-    raw === undefined ? Array.from(DEFAULT_DEPLOY_ENVIRONMENTS) : parseStringArray(raw);
-  if (deployEnvironments.length === 0) {
-    throw new Error(
-      `[${blockLabel}.${serviceId}].deploy_environments must be a non-empty array of names`,
-    );
-  }
-  for (const env of deployEnvironments) {
-    if (!isValidDeployEnvironmentName(env)) {
-      throw new Error(
-        `[${blockLabel}.${serviceId}].deploy_environments entry '${env}' is invalid: ` +
-          `must match /^[a-z0-9][a-z0-9._-]*$/`,
-      );
-    }
-  }
-  return deployEnvironments;
-}
-
-function materializeOneServiceConfig(
-  serviceId: string,
-  kv: Record<string, string>,
-  blockLabel: string,
-): ServiceConfig {
-  const reposRaw = kv["repos"];
-  if (reposRaw === undefined) {
-    throw new Error(`[${blockLabel}.${serviceId}] missing required 'repos'`);
-  }
-  return {
-    serviceId,
-    repos: parseStringArray(reposRaw).map(parseDoraRepoUrn),
-    pagerdutyServices:
-      kv["pagerduty_services"] === undefined ? [] : parseStringArray(kv["pagerduty_services"]),
-    deployWorkflowPattern: materializeDeployWorkflowPattern(kv, blockLabel, serviceId),
-    incidentWindowMinutes: materializeIncidentWindowMinutes(kv, blockLabel, serviceId),
-    excludePrLabels:
-      kv["exclude_pr_labels"] === undefined
-        ? Array.from(DEFAULT_EXCLUDE_PR_LABELS)
-        : parseStringArray(kv["exclude_pr_labels"]),
-    deployEnvironments: materializeDeployEnvironments(kv, blockLabel, serviceId),
-    severityP1Aliases: [], // attached by loadNimbusServiceConfigsFromConfigDir
-  };
-}
-
-function materializeServiceConfigs(
-  accum: Map<string, Record<string, string>>,
-  blockLabel: string,
-): Map<string, ServiceConfig> {
-  const out: Map<string, ServiceConfig> = new Map();
-  for (const [serviceId, kv] of accum.entries()) {
-    out.set(serviceId, materializeOneServiceConfig(serviceId, kv, blockLabel));
-  }
-  return out;
-}
-
-function resolveServiceTableId(
-  trimmed: string,
-  tablePrefix: string,
-  blockLabel: string,
-  accum: Map<string, Record<string, string>>,
-): string | undefined {
-  if (!trimmed.startsWith(tablePrefix)) return undefined;
-  const id = trimmed.slice(tablePrefix.length, -1);
-  if (id.length === 0) throw new Error(`empty service id in [${blockLabel}.<id>]`);
-  if (!accum.has(id)) accum.set(id, {});
-  return id;
-}
-
-function applyServiceConfigLine(
-  trimmed: string,
-  currentId: string,
-  blockLabel: string,
-  accum: Map<string, Record<string, string>>,
-): void {
-  const kv = splitKeyValue(trimmed);
-  if (kv === undefined) return;
-  if (!SERVICE_CONFIG_KNOWN_KEYS.has(kv.key)) {
-    throw new Error(`unknown key '${kv.key}' in [${blockLabel}.${currentId}]`);
-  }
-  const bucket = accum.get(currentId);
-  if (bucket !== undefined) {
-    bucket[kv.key] = kv.valRaw;
-  }
-}
-
-function accumulateServiceTables(
-  raw: string,
-  tablePrefix: string,
-  blockLabel: string,
-): Map<string, Record<string, string>> {
-  const accum: Map<string, Record<string, string>> = new Map();
-  let currentId: string | undefined;
-  for (const line of raw.split(/\r?\n/)) {
-    const trimmed = stripComment(line).trim();
-    if (trimmed === "") continue;
-    if (isTableHeader(trimmed)) {
-      currentId = resolveServiceTableId(trimmed, tablePrefix, blockLabel, accum);
-      continue;
-    }
-    if (currentId !== undefined) {
-      applyServiceConfigLine(trimmed, currentId, blockLabel, accum);
-    }
-  }
-  return accum;
-}
-
-export function parseNimbusDoraToml(raw: string): Map<string, ServiceConfig> {
-  return materializeServiceConfigs(
-    accumulateServiceTables(raw, DORA_TABLE_PREFIX, "metrics.dora"),
-    "metrics.dora",
-  );
-}
-
-export function loadNimbusDoraFromPath(tomlPath: string): Map<string, ServiceConfig> {
-  if (!existsSync(tomlPath)) return new Map();
-  const raw = readFileSync(tomlPath, "utf8");
-  return parseNimbusDoraToml(raw);
-}
-
-export function loadNimbusDoraFromConfigDir(configDir: string): Map<string, ServiceConfig> {
-  return loadNimbusDoraFromPath(join(configDir, "nimbus.toml"));
-}
-
-const CI_SERVICE_TABLE_PREFIX = "[ci.service.";
-
-export function parseNimbusCiServiceToml(raw: string): Map<string, ServiceConfig> {
-  return materializeServiceConfigs(
-    accumulateServiceTables(raw, CI_SERVICE_TABLE_PREFIX, "ci.service"),
-    "ci.service",
-  );
-}
-
+// The DORA / CI service-config machinery (parsing + materialization) lives in
+// `./service-config-toml.ts` and is re-exported from this module via the
+// `export *` barrel near the top. `loadNimbusServiceConfigsFromConfigDir`
+// stays here because it bridges that machinery with the `[pagerduty]` section
+// parser (`parseNimbusPagerdutyToml`) defined above — keeping it here avoids a
+// `service-config-toml.ts` → `nimbus-toml.ts` circular import.
 export function loadNimbusServiceConfigsFromConfigDir(
   configDir: string,
 ): Map<string, ServiceConfig> {

--- a/packages/gateway/src/config/service-config-toml.ts
+++ b/packages/gateway/src/config/service-config-toml.ts
@@ -1,0 +1,203 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  DEFAULT_DEPLOY_ENVIRONMENTS,
+  DEFAULT_DEPLOY_WORKFLOW_PATTERN,
+  DEFAULT_EXCLUDE_PR_LABELS,
+  DEFAULT_INCIDENT_WINDOW_MINUTES,
+  isValidDeployEnvironmentName,
+  parseDoraRepoUrn,
+  type ServiceConfig,
+} from "../metrics/dora-config.ts";
+import {
+  isTableHeader,
+  parseIntDec,
+  parseString,
+  parseStringArray,
+  splitKeyValue,
+  stripComment,
+} from "./toml-primitives.ts";
+
+const DORA_TABLE_PREFIX = "[metrics.dora.";
+const SERVICE_CONFIG_KNOWN_KEYS: ReadonlySet<string> = new Set([
+  "repos",
+  "pagerduty_services",
+  "deploy_workflow_pattern",
+  "incident_window_minutes",
+  "exclude_pr_labels",
+  "deploy_environments",
+]);
+
+function materializeDeployWorkflowPattern(
+  kv: Record<string, string>,
+  blockLabel: string,
+  serviceId: string,
+): RegExp {
+  const patternSrc =
+    kv["deploy_workflow_pattern"] === undefined
+      ? DEFAULT_DEPLOY_WORKFLOW_PATTERN
+      : parseString(kv["deploy_workflow_pattern"]);
+  try {
+    return new RegExp(patternSrc);
+  } catch (e) {
+    throw new Error(
+      `[${blockLabel}.${serviceId}].deploy_workflow_pattern is not a valid regex: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  }
+}
+
+function materializeIncidentWindowMinutes(
+  kv: Record<string, string>,
+  blockLabel: string,
+  serviceId: string,
+): number {
+  const windowRaw = kv["incident_window_minutes"];
+  const windowMins =
+    windowRaw === undefined ? DEFAULT_INCIDENT_WINDOW_MINUTES : parseIntDec(windowRaw);
+  if (windowMins === undefined || windowMins < 1 || windowMins > 1440) {
+    throw new Error(
+      `[${blockLabel}.${serviceId}].incident_window_minutes must be 1..1440, got '${windowRaw}'`,
+    );
+  }
+  return windowMins;
+}
+
+function materializeDeployEnvironments(
+  kv: Record<string, string>,
+  blockLabel: string,
+  serviceId: string,
+): string[] {
+  const raw = kv["deploy_environments"];
+  const deployEnvironments =
+    raw === undefined ? Array.from(DEFAULT_DEPLOY_ENVIRONMENTS) : parseStringArray(raw);
+  if (deployEnvironments.length === 0) {
+    throw new Error(
+      `[${blockLabel}.${serviceId}].deploy_environments must be a non-empty array of names`,
+    );
+  }
+  for (const env of deployEnvironments) {
+    if (!isValidDeployEnvironmentName(env)) {
+      throw new Error(
+        `[${blockLabel}.${serviceId}].deploy_environments entry '${env}' is invalid: ` +
+          `must match /^[a-z0-9][a-z0-9._-]*$/`,
+      );
+    }
+  }
+  return deployEnvironments;
+}
+
+function materializeOneServiceConfig(
+  serviceId: string,
+  kv: Record<string, string>,
+  blockLabel: string,
+): ServiceConfig {
+  const reposRaw = kv["repos"];
+  if (reposRaw === undefined) {
+    throw new Error(`[${blockLabel}.${serviceId}] missing required 'repos'`);
+  }
+  return {
+    serviceId,
+    repos: parseStringArray(reposRaw).map(parseDoraRepoUrn),
+    pagerdutyServices:
+      kv["pagerduty_services"] === undefined ? [] : parseStringArray(kv["pagerduty_services"]),
+    deployWorkflowPattern: materializeDeployWorkflowPattern(kv, blockLabel, serviceId),
+    incidentWindowMinutes: materializeIncidentWindowMinutes(kv, blockLabel, serviceId),
+    excludePrLabels:
+      kv["exclude_pr_labels"] === undefined
+        ? Array.from(DEFAULT_EXCLUDE_PR_LABELS)
+        : parseStringArray(kv["exclude_pr_labels"]),
+    deployEnvironments: materializeDeployEnvironments(kv, blockLabel, serviceId),
+    severityP1Aliases: [], // attached by loadNimbusServiceConfigsFromConfigDir
+  };
+}
+
+function materializeServiceConfigs(
+  accum: Map<string, Record<string, string>>,
+  blockLabel: string,
+): Map<string, ServiceConfig> {
+  const out: Map<string, ServiceConfig> = new Map();
+  for (const [serviceId, kv] of accum.entries()) {
+    out.set(serviceId, materializeOneServiceConfig(serviceId, kv, blockLabel));
+  }
+  return out;
+}
+
+function resolveServiceTableId(
+  trimmed: string,
+  tablePrefix: string,
+  blockLabel: string,
+  accum: Map<string, Record<string, string>>,
+): string | undefined {
+  if (!trimmed.startsWith(tablePrefix)) return undefined;
+  const id = trimmed.slice(tablePrefix.length, -1);
+  if (id.length === 0) throw new Error(`empty service id in [${blockLabel}.<id>]`);
+  if (!accum.has(id)) accum.set(id, {});
+  return id;
+}
+
+function applyServiceConfigLine(
+  trimmed: string,
+  currentId: string,
+  blockLabel: string,
+  accum: Map<string, Record<string, string>>,
+): void {
+  const kv = splitKeyValue(trimmed);
+  if (kv === undefined) return;
+  if (!SERVICE_CONFIG_KNOWN_KEYS.has(kv.key)) {
+    throw new Error(`unknown key '${kv.key}' in [${blockLabel}.${currentId}]`);
+  }
+  const bucket = accum.get(currentId);
+  if (bucket !== undefined) {
+    bucket[kv.key] = kv.valRaw;
+  }
+}
+
+function accumulateServiceTables(
+  raw: string,
+  tablePrefix: string,
+  blockLabel: string,
+): Map<string, Record<string, string>> {
+  const accum: Map<string, Record<string, string>> = new Map();
+  let currentId: string | undefined;
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = stripComment(line).trim();
+    if (trimmed === "") continue;
+    if (isTableHeader(trimmed)) {
+      currentId = resolveServiceTableId(trimmed, tablePrefix, blockLabel, accum);
+      continue;
+    }
+    if (currentId !== undefined) {
+      applyServiceConfigLine(trimmed, currentId, blockLabel, accum);
+    }
+  }
+  return accum;
+}
+
+export function parseNimbusDoraToml(raw: string): Map<string, ServiceConfig> {
+  return materializeServiceConfigs(
+    accumulateServiceTables(raw, DORA_TABLE_PREFIX, "metrics.dora"),
+    "metrics.dora",
+  );
+}
+
+export function loadNimbusDoraFromPath(tomlPath: string): Map<string, ServiceConfig> {
+  if (!existsSync(tomlPath)) return new Map();
+  const raw = readFileSync(tomlPath, "utf8");
+  return parseNimbusDoraToml(raw);
+}
+
+export function loadNimbusDoraFromConfigDir(configDir: string): Map<string, ServiceConfig> {
+  return loadNimbusDoraFromPath(join(configDir, "nimbus.toml"));
+}
+
+const CI_SERVICE_TABLE_PREFIX = "[ci.service.";
+
+export function parseNimbusCiServiceToml(raw: string): Map<string, ServiceConfig> {
+  return materializeServiceConfigs(
+    accumulateServiceTables(raw, CI_SERVICE_TABLE_PREFIX, "ci.service"),
+    "ci.service",
+  );
+}

--- a/packages/gateway/src/config/toml-primitives.ts
+++ b/packages/gateway/src/config/toml-primitives.ts
@@ -1,0 +1,52 @@
+// Shared low-level TOML line/value primitives used by both the per-section
+// config parsers in `nimbus-toml.ts` and the DORA/CI service-config parsers in
+// `service-config-toml.ts`. Keeping them in a dependency-free module avoids a
+// circular import between those two files.
+
+export function stripComment(line: string): string {
+  const hash = line.indexOf("#");
+  if (hash < 0) {
+    return line;
+  }
+  return line.slice(0, hash);
+}
+
+export function parseString(raw: string): string {
+  const t = raw.trim();
+  if (t.startsWith('"') && t.endsWith('"') && t.length >= 2) {
+    return t.slice(1, -1).replaceAll(String.raw`\\"`, '"');
+  }
+  return t;
+}
+
+export function parseIntDec(raw: string): number | undefined {
+  const n = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function isTableHeader(trimmed: string): boolean {
+  return trimmed.startsWith("[") && trimmed.endsWith("]");
+}
+
+export function splitKeyValue(trimmed: string): { key: string; valRaw: string } | undefined {
+  const eq = trimmed.indexOf("=");
+  if (eq <= 0) {
+    return undefined;
+  }
+  return { key: trimmed.slice(0, eq).trim(), valRaw: trimmed.slice(eq + 1).trim() };
+}
+
+export function parseStringArray(raw: string): string[] {
+  const t = raw.trim();
+  if (!t.startsWith("[") || !t.endsWith("]")) {
+    throw new TypeError(`expected array, got: ${raw}`);
+  }
+  const inner = t.slice(1, -1).trim();
+  if (inner.length === 0) return [];
+  const out: string[] = [];
+  for (const part of inner.split(",")) {
+    const v = parseString(part);
+    if (v.length > 0) out.push(v);
+  }
+  return out;
+}


### PR DESCRIPTION
Scope item 3 of 5 (long-file splits / SRP). This PR does the flagship split — `config/nimbus-toml.ts`, the largest config file and the one the plan flagged for its "~14 near-identical section loaders". Behaviour-preserving.

## What changed
`nimbus-toml.ts` was a 1003-line monolith mixing per-section config loaders with the DORA/CI service-config machinery. Split into three cohesive files:

| File | Lines | Responsibility |
|---|---|---|
| `config/toml-primitives.ts` (new) | 52 | shared scalar/line parsers (`stripComment`, `isTableHeader`, `splitKeyValue`, `parseString`, `parseIntDec`, `parseStringArray`) |
| `config/service-config-toml.ts` (new) | 203 | DORA + `[ci.service.*]` `ServiceConfig` parse/materialize |
| `config/nimbus-toml.ts` | 1003 → **729** | per-section types/defaults/parsers/loaders; barrel-re-exports service-config for back-compat |

Plus the **loader dedup**: the ~14 near-identical `load<X>FromPath` bodies now go through one generic `loadTomlSection<T>(path, fallback, parse)`, preserving each loader's exact variant (merge-partial vs full-parse). `loadNimbusPagerdutyFromPath` is kept verbatim — it emits distinct stderr diagnostics the generic would swallow.

Imports are **strictly acyclic** (primitives ← both; service-config ← nimbus-toml only). External importers (`http-server.ts`, `ipc/server/dispatchers.ts`, config + metrics tests) are unchanged — service-config symbols reach them via the `export *` barrel.

## Verification
- `bun run preflight:fast` — **PASSED** (all 16 gates incl. `audit:invariants` — **I6 LAN bind default 127.0.0.1 intact**, `audit:any`, `duplication`).
- gateway `tsc --noEmit` clean; 180 config + metrics tests pass / 0 fail; biome clean.
- **Coverage-floor pre-checked on lcov** (the gate that bit PR #468): all three files clear 80% — `nimbus-toml.ts` 82.1%, `service-config-toml.ts` 97.5%, `toml-primitives.ts` 94.4% (lower bound from the config/metrics subset; the full run only adds).

## Remaining splits (deferred to follow-up PRs)
The other 6 candidates — `cli/commands/connector.ts` (1234), `index/local-index.ts` (938), `lazy-mesh/phase3-config.ts` (873), `lazy-mesh/connector-spawns.ts` (784), `cli/commands/extension.ts` (758), `ipc/server/dispatchers.ts` (738) — are each a substantial independent split; bundling them would make this PR unreviewable and compound regression risk on load-bearing modules. Each will get its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
