### PR TITLE
Cleanup Pass 3b (4/5) — coverage raises (shared utils + teams-sync ratchet)

### DIFF
--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -7,9 +7,6 @@
     },
     "packages/gateway/src/connectors/gmail-sync.ts": {
       "min_coverage_pct": 78.91
-    },
-    "packages/gateway/src/connectors/teams-sync.ts": {
-      "min_coverage_pct": 74.48
     }
   }
 }

--- a/packages/gateway/src/connectors/teams-sync.test.ts
+++ b/packages/gateway/src/connectors/teams-sync.test.ts
@@ -115,4 +115,214 @@ describe("createTeamsSyncable", () => {
     expect(row?.type).toBe("message");
     expect(row?.author_id).not.toBeNull();
   });
+
+  test("teams phase paginates via @odata.nextLink (lines 55-67)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createTeamsSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("/joinedTeams")) {
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "team-1", displayName: "T1" }],
+            "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/joinedTeams?$skiptoken=abc",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r1 = await syncable.sync(ctx, null);
+    expect(r1.hasMore).toBe(true);
+    expect(r1.itemsUpserted).toBe(0);
+    // Cursor must still be in the teams phase with teamsNext set so the next
+    // pass resumes pagination rather than advancing to channels.
+    expect(typeof r1.cursor).toBe("string");
+    const decoded = decodeTeamsSyncCursor(r1.cursor as string);
+    expect(decoded?.phase).toBe("teams");
+    expect(decoded?.teamsNext).not.toBeNull();
+    expect(decoded?.teams).toEqual([{ id: "team-1" }]);
+  });
+
+  test("channels phase paginates via @odata.nextLink (lines 124-136)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createTeamsSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("/teams/team-1/channels") && !url.includes("/messages")) {
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "chan-1", membershipType: "standard" }],
+            "@odata.nextLink":
+              "https://graph.microsoft.com/v1.0/teams/team-1/channels?$skiptoken=z",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    // Drive directly into the channels phase with one team to discover.
+    const channelsCursor = encodeTeamsSyncCursor({
+      v: 1,
+      phase: "channels",
+      teams: [{ id: "team-1" }],
+      teamsNext: null,
+      channelTeamIdx: 0,
+      channelsByTeam: {},
+      chanNext: null,
+      pairs: [],
+      pairIdx: 0,
+      deltaByKey: {},
+    });
+
+    const r = await syncable.sync(ctx, channelsCursor);
+    expect(r.hasMore).toBe(true);
+    expect(r.itemsUpserted).toBe(0);
+    expect(typeof r.cursor).toBe("string");
+    const decoded = decodeTeamsSyncCursor(r.cursor as string);
+    // Still in channels phase, same team index, but chanNext now set for the
+    // next pass to continue paginating this team's channels.
+    expect(decoded?.phase).toBe("channels");
+    expect(decoded?.channelTeamIdx).toBe(0);
+    expect(decoded?.chanNext).not.toBeNull();
+    expect(decoded?.channelsByTeam["team-1"]).toEqual(["chan-1"]);
+  });
+
+  test("messages phase with empty pairs returns immediately (lines 156-164)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createTeamsSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    // No fetch should ever happen on this path.
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      throw new Error(`unexpected fetch: ${requestUrlString(input)}`);
+    }) as unknown as typeof fetch;
+
+    const emptyPairsCursor = encodeTeamsSyncCursor({
+      v: 1,
+      phase: "messages",
+      teams: [{ id: "team-1" }],
+      teamsNext: null,
+      channelTeamIdx: 1,
+      channelsByTeam: { "team-1": [] },
+      chanNext: null,
+      pairs: [],
+      pairIdx: 0,
+      deltaByKey: {},
+    });
+
+    const r = await syncable.sync(ctx, emptyPairsCursor);
+    expect(r.hasMore).toBe(false);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.itemsDeleted).toBe(0);
+    expect(typeof r.cursor).toBe("string");
+    const decoded = decodeTeamsSyncCursor(r.cursor as string);
+    expect(decoded?.phase).toBe("messages");
+    expect(decoded?.pairs).toEqual([]);
+  });
+
+  test("messages phase past last pair returns immediately (lines 166-175)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createTeamsSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      throw new Error(`unexpected fetch: ${requestUrlString(input)}`);
+    }) as unknown as typeof fetch;
+
+    // pairIdx points past the only pair → pair === undefined branch.
+    const exhaustedCursor = encodeTeamsSyncCursor({
+      v: 1,
+      phase: "messages",
+      teams: [{ id: "team-1" }],
+      teamsNext: null,
+      channelTeamIdx: 1,
+      channelsByTeam: { "team-1": ["chan-1"] },
+      chanNext: null,
+      pairs: [{ teamId: "team-1", channelId: "chan-1" }],
+      pairIdx: 1,
+      deltaByKey: {},
+    });
+
+    const r = await syncable.sync(ctx, exhaustedCursor);
+    expect(r.hasMore).toBe(false);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.itemsDeleted).toBe(0);
+  });
+
+  test("messages phase deletes @removed messages (lines 200-206)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createTeamsSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    // Pass 1: index a normal message so there is a row to delete later.
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [
+              {
+                id: "msg-del",
+                createdDateTime: "2024-05-01T10:00:00Z",
+                body: { contentType: "text", content: "soon to be removed" },
+                from: { user: { id: "ms-user-1", displayName: "Pat" } },
+              },
+            ],
+            "@odata.deltaLink":
+              "https://graph.microsoft.com/v1.0/teams/team-1/channels/chan-1/messages/delta?token=d1",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const messagesCursor = encodeTeamsSyncCursor({
+      v: 1,
+      phase: "messages",
+      teams: [{ id: "team-1" }],
+      teamsNext: null,
+      channelTeamIdx: 1,
+      channelsByTeam: { "team-1": ["chan-1"] },
+      chanNext: null,
+      pairs: [{ teamId: "team-1", channelId: "chan-1" }],
+      pairIdx: 0,
+      deltaByKey: {},
+    });
+
+    const r1 = await syncable.sync(ctx, messagesCursor);
+    expect(r1.itemsUpserted).toBe(1);
+
+    const beforeRow = db
+      .query("SELECT id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "team-1:chan-1:msg-del"));
+    expect(beforeRow).toBeTruthy();
+
+    // Pass 2: the delta now reports the message as removed → deletion branch.
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "msg-del", "@removed": { reason: "deleted" } }],
+            "@odata.deltaLink":
+              "https://graph.microsoft.com/v1.0/teams/team-1/channels/chan-1/messages/delta?token=d2",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r2 = await syncable.sync(ctx, r1.cursor);
+    expect(r2.itemsDeleted).toBe(1);
+    expect(r2.itemsUpserted).toBe(0);
+
+    const afterRow = db
+      .query("SELECT id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "team-1:chan-1:msg-del"));
+    expect(afterRow).toBeFalsy();
+  });
 });

--- a/packages/mcp-connectors/shared/mcp-tool-kit.test.ts
+++ b/packages/mcp-connectors/shared/mcp-tool-kit.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createRegisterSimpleTool,
+  createZodToolRegistrar,
+  encodeBasicAuthHeader,
+  type HttpJsonBodyResponse,
+  type HttpTextResponse,
+  mcpJsonResult,
+  mcpJsonResultFromTextIfOk,
+  mcpJsonResultIfOk,
+  parseJsonTextIfOk,
+  putOptionalBoolean,
+  putOptionalNonEmptyString,
+  type RegisterSimpleToolFn,
+  registerZodTool,
+  requireProcessEnv,
+  type ZodObjectSchema,
+} from "./mcp-tool-kit.ts";
+
+function parseText(result: { content: Array<{ type: "text"; text: string }> }): unknown {
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+describe("mcpJsonResult", () => {
+  it("wraps data as pretty-printed JSON text content", () => {
+    const r = mcpJsonResult({ a: 1, b: ["x"] });
+    expect(r.content[0]?.type).toBe("text");
+    expect(parseText(r)).toEqual({ a: 1, b: ["x"] });
+    expect(r.content[0]?.text).toContain("\n"); // pretty-printed (indent)
+  });
+});
+
+function okSchema<T>(data: T): ZodObjectSchema<T> {
+  return { shape: { q: {} }, safeParse: () => ({ success: true, data }) };
+}
+function failSchema(message: string): ZodObjectSchema<never> {
+  return { shape: {}, safeParse: () => ({ success: false, error: { message } }) };
+}
+
+describe("registerZodTool / createZodToolRegistrar", () => {
+  it("registers a tool that safeParses then calls the handler on success", async () => {
+    const calls: Array<{ name: string; shape: unknown }> = [];
+    let captured: unknown;
+    const register: RegisterSimpleToolFn = (name, _desc, shape, handler) => {
+      calls.push({ name, shape });
+      captured = handler;
+      return undefined;
+    };
+    registerZodTool(register, "t1", "desc", okSchema({ v: 5 }), async (args) =>
+      mcpJsonResult(args),
+    );
+    expect(calls[0]?.name).toBe("t1");
+    const run = captured as (a: unknown) => Promise<ReturnType<typeof mcpJsonResult>>;
+    expect(parseText(await run({}))).toEqual({ v: 5 });
+  });
+
+  it("throws the zod error message when safeParse fails", async () => {
+    let captured: unknown;
+    const register: RegisterSimpleToolFn = (_n, _d, _s, handler) => {
+      captured = handler;
+      return undefined;
+    };
+    registerZodTool(register, "t2", "d", failSchema("bad input"), async () => mcpJsonResult({}));
+    const run = captured as (a: unknown) => Promise<unknown>;
+    await expect(run({})).rejects.toThrow("bad input");
+  });
+
+  it("createZodToolRegistrar produces an equivalent registrar", async () => {
+    let captured: unknown;
+    const register: RegisterSimpleToolFn = (_n, _d, _s, handler) => {
+      captured = handler;
+      return undefined;
+    };
+    const registrar = createZodToolRegistrar(register);
+    registrar("t3", "d", okSchema({ ok: true }), async (a) => mcpJsonResult(a));
+    const run = captured as (a: unknown) => Promise<ReturnType<typeof mcpJsonResult>>;
+    expect(parseText(await run({}))).toEqual({ ok: true });
+  });
+});
+
+describe("mcpJsonResultIfOk", () => {
+  it("wraps json when ok", () => {
+    const res: HttpJsonBodyResponse = { ok: true, status: 200, json: { a: 1 }, text: "" };
+    expect(parseText(mcpJsonResultIfOk("svc", res))).toEqual({ a: 1 });
+  });
+  it("throws with status + truncated snippet when not ok", () => {
+    const res: HttpJsonBodyResponse = { ok: false, status: 503, json: null, text: "x".repeat(500) };
+    expect(() => mcpJsonResultIfOk("svc", res, 10)).toThrow("svc 503: xxxxxxxxxx");
+  });
+});
+
+describe("mcpJsonResultFromTextIfOk", () => {
+  it("parses and wraps JSON text when ok", () => {
+    const res: HttpTextResponse = { ok: true, status: 200, text: '{"k":2}' };
+    expect(parseText(mcpJsonResultFromTextIfOk("svc", res))).toEqual({ k: 2 });
+  });
+  it("throws status + snippet when not ok", () => {
+    const res: HttpTextResponse = { ok: false, status: 404, text: "missing" };
+    expect(() => mcpJsonResultFromTextIfOk("svc", res)).toThrow("svc 404: missing");
+  });
+  it("throws the default invalid-JSON message on parse failure", () => {
+    const res: HttpTextResponse = { ok: true, status: 200, text: "not json" };
+    expect(() => mcpJsonResultFromTextIfOk("svc", res)).toThrow("svc: invalid JSON response");
+  });
+  it("throws the custom jsonParseErrorMessage when provided", () => {
+    const res: HttpTextResponse = { ok: true, status: 200, text: "not json" };
+    expect(() =>
+      mcpJsonResultFromTextIfOk("svc", res, { jsonParseErrorMessage: "Jira parse failed" }),
+    ).toThrow("Jira parse failed");
+  });
+});
+
+describe("parseJsonTextIfOk", () => {
+  it("returns parsed JSON when ok", () => {
+    expect(parseJsonTextIfOk("svc", { ok: true, status: 200, text: "[1,2]" })).toEqual([1, 2]);
+  });
+  it("throws when not ok", () => {
+    expect(() => parseJsonTextIfOk("svc", { ok: false, status: 500, text: "err" })).toThrow(
+      "svc 500: err",
+    );
+  });
+});
+
+describe("putOptionalNonEmptyString / putOptionalBoolean", () => {
+  it("sets a non-empty string and skips undefined/empty", () => {
+    const body: Record<string, unknown> = {};
+    putOptionalNonEmptyString(body, "a", "x");
+    putOptionalNonEmptyString(body, "b", "");
+    putOptionalNonEmptyString(body, "c", undefined);
+    expect(body).toEqual({ a: "x" });
+  });
+  it("sets booleans (including false) and skips undefined", () => {
+    const body: Record<string, unknown> = {};
+    putOptionalBoolean(body, "t", true);
+    putOptionalBoolean(body, "f", false);
+    putOptionalBoolean(body, "u", undefined);
+    expect(body).toEqual({ t: true, f: false });
+  });
+});
+
+describe("createRegisterSimpleTool", () => {
+  it("binds server.tool when present", () => {
+    const seen: unknown[] = [];
+    const server = {
+      tool(this: unknown, ...args: unknown[]) {
+        seen.push(args);
+        return "registered";
+      },
+    };
+    const fn = createRegisterSimpleTool(server);
+    const out = fn("n", "d", {}, async () => mcpJsonResult({}));
+    expect(out).toBe("registered");
+    expect(seen).toHaveLength(1);
+  });
+  it("throws when the server has no .tool function", () => {
+    expect(() => createRegisterSimpleTool(null)).toThrow("expected MCP server with .tool");
+    expect(() => createRegisterSimpleTool({})).toThrow("expected MCP server with .tool");
+    expect(() => createRegisterSimpleTool({ tool: 1 })).toThrow("expected MCP server with .tool");
+  });
+});
+
+describe("requireProcessEnv", () => {
+  const KEY = "NIMBUS_MCP_TOOL_KIT_TEST_VAR";
+  it("returns the value when set", () => {
+    process.env[KEY] = "present";
+    try {
+      expect(requireProcessEnv(KEY)).toBe("present");
+    } finally {
+      delete process.env[KEY];
+    }
+  });
+  it("throws when unset or empty", () => {
+    delete process.env[KEY];
+    expect(() => requireProcessEnv(KEY)).toThrow(`${KEY} is not set`);
+    process.env[KEY] = "";
+    try {
+      expect(() => requireProcessEnv(KEY)).toThrow(`${KEY} is not set`);
+    } finally {
+      delete process.env[KEY];
+    }
+  });
+});
+
+describe("encodeBasicAuthHeader", () => {
+  it("produces a Basic header from email:token", () => {
+    const header = encodeBasicAuthHeader("a@b.com", "tok");
+    expect(header).toBe(`Basic ${Buffer.from("a@b.com:tok", "utf8").toString("base64")}`);
+    expect(header.startsWith("Basic ")).toBe(true);
+  });
+});

--- a/packages/mcp-connectors/shared/run-cli-json.test.ts
+++ b/packages/mcp-connectors/shared/run-cli-json.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+
+import { runCliJson, runCliOk, runCliOkThrowing } from "./run-cli-json.ts";
+
+// Spawn the current Bun binary with `-e <js>` — present on every platform, no shell.
+const BUN = process.execPath;
+const evalCmd = (js: string): readonly string[] => [BUN, "-e", js];
+
+describe("runCliJson", () => {
+  it("rejects an empty command", async () => {
+    expect(await runCliJson([], {})).toEqual({ ok: false, message: "empty command" });
+  });
+
+  it("parses JSON written to stdout", async () => {
+    const r = await runCliJson(evalCmd("process.stdout.write(JSON.stringify({x:1,y:['a']}))"), {});
+    expect(r).toEqual({ ok: true, data: { x: 1, y: ["a"] } });
+  });
+
+  it("returns data:null when stdout is empty", async () => {
+    const r = await runCliJson(evalCmd("process.exit(0)"), {});
+    expect(r).toEqual({ ok: true, data: null });
+  });
+
+  it("reports a non-zero exit with the stderr snippet", async () => {
+    const r = await runCliJson(evalCmd("process.stderr.write('boom'); process.exit(3)"), {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain("exited 3");
+      expect(r.message).toContain("boom");
+    }
+  });
+
+  it("reports invalid JSON from a successful command", async () => {
+    const r = await runCliJson(evalCmd("process.stdout.write('not json')"), {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain("invalid JSON from CLI");
+    }
+  });
+
+  it("passes env through to the child", async () => {
+    const r = await runCliJson(
+      evalCmd("process.stdout.write(JSON.stringify(process.env.NIMBUS_RCJ_TEST ?? null))"),
+      { NIMBUS_RCJ_TEST: "hello" },
+    );
+    expect(r).toEqual({ ok: true, data: "hello" });
+  });
+});
+
+describe("runCliOk", () => {
+  it("rejects an empty command", async () => {
+    expect(await runCliOk([], {})).toEqual({ ok: false, message: "empty command" });
+  });
+
+  it("returns ok on a zero exit", async () => {
+    expect(await runCliOk(evalCmd("process.exit(0)"), {})).toEqual({ ok: true });
+  });
+
+  it("returns the failure message on a non-zero exit", async () => {
+    const r = await runCliOk(evalCmd("process.stderr.write('nope'); process.exit(2)"), {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain("exited 2");
+      expect(r.message).toContain("nope");
+    }
+  });
+});
+
+describe("runCliOkThrowing", () => {
+  it("resolves on success", async () => {
+    await expect(runCliOkThrowing(evalCmd("process.exit(0)"), {})).resolves.toBeUndefined();
+  });
+
+  it("throws on a non-zero exit", async () => {
+    await expect(runCliOkThrowing(evalCmd("process.exit(1)"), {})).rejects.toThrow("exited 1");
+  });
+});


### PR DESCRIPTION
Scope item 4 of 5 (coverage raises). Tests only — zero production-code change.

## What changed
- **`mcp-tool-kit.ts` → ~100%** and **`run-cli-json.ts` → ~98%**: two shared MCP-connector utilities that were only incidentally covered now have dedicated unit tests (`mcpJsonResult`, `registerZodTool` + the `*IfOk` result helpers incl. parse-failure branches, `putOptional*`, `createRegisterSimpleTool` guard, `requireProcessEnv`, `encodeBasicAuthHeader`; and `runCliJson`/`runCliOk`/`runCliOkThrowing` exercised by spawning the current Bun binary with `-e` — empty-command, empty-output, non-zero-exit + stderr snippet, invalid-JSON, env passthrough). Cross-platform (spawns `process.execPath`, no shell). Lifts the `mcp` coverage-gate margin.
- **`teams-sync.ts` 74.5% → 100%** + **baseline ratchet**: 5 focused tests cover the previously-uncovered branches (teams- and channels-phase `@odata.nextLink` pagination, the two messages-phase early returns, the `@removed` message-deletion path). Since the file crosses the 80% floor, its grandfathered entry is removed from `docs/structure-audit/coverage-baseline.json` (the floor's must-remove rule requires it in the same change). The two remaining baselined files (gmail `history.ts`, `gmail-sync.ts`) are untouched.

## Verification
- `bun run preflight:fast` — **PASSED** (all 16 static gates).
- Per-file coverage measured on lcov: `mcp-tool-kit.ts` 100%, `run-cli-json.ts` 98.3%, `teams-sync.ts` 100% (192/192).
- All new/changed tests pass; gateway tsc clean; biome clean.

## Note on the other named targets
The plan also listed `client/ask-stream.ts` (72%) and `client/ipc-transport.ts` (78%). On current `main` those files are **not** baselined and **not** exempt, yet the coverage-floor is green — so their real CI coverage is already ≥80% (the old 72/78% figures were narrow/stale measurements). No ratchet is available there, so this PR focuses on the genuine wins: the two incidentally-covered shared utilities and the one actually-baselined file (`teams-sync.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
