### PR TITLE
Cleanup Pass 3b — SonarCloud stragglers (c:S5350, S7735, S3358)

### DIFF
--- a/packages/gateway/src-native/sandbox-helper/main.c
+++ b/packages/gateway/src-native/sandbox-helper/main.c
@@ -357,7 +357,7 @@ static int add_host_accept_rules(struct addrinfo *ai) {
         char ipstr[INET6_ADDRSTRLEN];
         char cmd[128];
         if (ai->ai_family == AF_INET) {
-            void *addr_ptr = &((struct sockaddr_in *)ai->ai_addr)->sin_addr;
+            const void *addr_ptr = &((struct sockaddr_in *)ai->ai_addr)->sin_addr;
             if (inet_ntop(AF_INET, addr_ptr, ipstr, sizeof(ipstr)) == NULL) {
                 fprintf(stderr, "inet_ntop(AF_INET) failed: %s\n", strerror(errno));
                 return 5;
@@ -372,7 +372,7 @@ static int add_host_accept_rules(struct addrinfo *ai) {
                 return 5;
             }
         } else if (ai->ai_family == AF_INET6) {
-            void *addr_ptr = &((struct sockaddr_in6 *)ai->ai_addr)->sin6_addr;
+            const void *addr_ptr = &((struct sockaddr_in6 *)ai->ai_addr)->sin6_addr;
             if (inet_ntop(AF_INET6, addr_ptr, ipstr, sizeof(ipstr)) == NULL) {
                 fprintf(stderr, "inet_ntop(AF_INET6) failed: %s\n", strerror(errno));
                 return 5;

--- a/packages/gateway/src/extensions/auto-update.ts
+++ b/packages/gateway/src/extensions/auto-update.ts
@@ -293,9 +293,9 @@ export class ExtensionAutoUpdater {
       signatureB64: newManifest.signature,
       entryHash: manifestResult.entryHash,
       tarballUrl: manifestResult.tarballUrl,
-      ...(manifestResult.tarballSizeBytes !== undefined
-        ? { tarballSizeBytes: manifestResult.tarballSizeBytes }
-        : {}),
+      ...(manifestResult.tarballSizeBytes === undefined
+        ? {}
+        : { tarballSizeBytes: manifestResult.tarballSizeBytes }),
       permissionDiff,
       verificationStatus,
       detectedAt: this.opts.now(),

--- a/packages/gateway/src/extensions/verify-extensions.ts
+++ b/packages/gateway/src/extensions/verify-extensions.ts
@@ -300,16 +300,16 @@ function evaluateDependencyRow(
   } catch {
     satisfies = false;
   }
-  if (!satisfies) {
-    return {
-      extensionId: r.extension_id,
-      reason: "dependency_unsatisfied",
-      missingDepId: r.depends_on_id,
-      requiredRange: r.range,
-      ...(depVersion !== undefined ? { observedVersion: depVersion } : {}),
-    };
+  if (satisfies) {
+    return null;
   }
-  return null;
+  return {
+    extensionId: r.extension_id,
+    reason: "dependency_unsatisfied",
+    missingDepId: r.depends_on_id,
+    requiredRange: r.range,
+    ...(depVersion !== undefined ? { observedVersion: depVersion } : {}),
+  };
 }
 
 function completenessGuard(

--- a/packages/ui/src/components/PendingUpdates.tsx
+++ b/packages/ui/src/components/PendingUpdates.tsx
@@ -24,6 +24,17 @@ interface PendingUpdatesProps {
   readonly pollIntervalMs?: number;
 }
 
+function formatApplyResult(applyResult: {
+  readonly id: string;
+  readonly result: UpdateApplyResultUi;
+}): string {
+  if (applyResult.result.applied) {
+    return `Updated ${applyResult.id}`;
+  }
+  const hintSuffix = applyResult.result.hint === undefined ? "" : ` — ${applyResult.result.hint}`;
+  return `Update failed: ${applyResult.result.reason}${hintSuffix}`;
+}
+
 const DEFAULT_POLL_MS = 5 * 60_000;
 
 export function PendingUpdates({
@@ -83,11 +94,7 @@ export function PendingUpdates({
           className={`text-sm ${applyResult.result.applied ? "text-green-700" : "text-red-600"}`}
           data-testid={`apply-result-${applyResult.id}`}
         >
-          {applyResult.result.applied
-            ? `Updated ${applyResult.id}`
-            : `Update failed: ${applyResult.result.reason}${
-                applyResult.result.hint === undefined ? "" : ` — ${applyResult.result.hint}`
-              }`}
+          {formatApplyResult(applyResult)}
         </p>
       )}
       <ul className="flex flex-col gap-2">


### PR DESCRIPTION
Knocks out the actionable SonarCloud stragglers on `main` (post #466–#470), in one small PR. Behaviour-preserving throughout.

## Fixed (5 findings)
- **c:S5350 ×2** (`main.c`): const-qualify the read-only `addr_ptr` passed to `inet_ntop`'s `const void *src`, in the IPv4 and IPv6 accept-rule paths. These two were introduced by #462's `main.c` cognitive-complexity refactor. **Compile-verified** with the Makefile's exact `-Wall -Wextra -Werror -std=c99 -D_GNU_SOURCE` flags in Docker + `libcap-dev` (binary builds and runs).
- **typescript:S7735** (`verify-extensions` `evaluateDependencyRow`): flip the negated guard → `if (satisfies) return null; return {…}`.
- **typescript:S7735** (`auto-update` detection): invert the `tarballSizeBytes` conditional-spread to a positive `=== undefined ? {} : {…}` (removes the negation without degrading the idiom).
- **typescript:S3358** (`ui/PendingUpdates`): extract the nested apply-result message ternary into a `formatApplyResult()` helper.

## Verification
- `bun run preflight:fast` — **PASSED** (all 16 gates incl. `audit:invariants` — `main.c` is the I15 sandbox helper).
- gateway `tsc` clean + 28 verify-extensions/auto-update tests pass; ui `tsc` clean + 7 PendingUpdates vitest pass; biome clean; Docker `-Werror` C compile clean.

## Deliberately not fixed
- **typescript:S7787** (`sandbox-probe` `export {}`): this is the module marker PR1 added so its `S7785` top-level-await fix would type-check. Removing it just brings `S7785` back — a TS-idiom-vs-Sonar-rule wash (net-zero), so left as-is.
- The remaining ~22 are the documented intentional-defer set (`S5914` placeholder-test asserts, `S3735` placeholder voids, `S6564` back-compat alias, `S7763` re-export, `S5843` security-reviewed regex, `S6606` github-actions dist-drift zone, sdk/client/vscode `S4325`, `S2301` architectural).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
