### PR TITLE
feat(gateway): route ask through local LLM providers

### DIFF
--- a/.claude/commands/nimbus-commands.md
+++ b/.claude/commands/nimbus-commands.md
@@ -299,6 +299,7 @@ NIMBUS_DEV_UPDATER_PUBLIC_KEY=<base64> # override embedded Ed25519 public key (t
 Resolution priority: env > `[llm]` TOML > hardcoded default.
 Bare model ids work; the engine auto-prefixes for Mastra (`claude-*` → `anthropic/...`, `gpt-*` / `o1-*` / `o3-*` / `o4-*` → `openai/...`).
 
+Local model ids are passed to the local router. With Ollama running on `http://127.0.0.1:11434`, set `[llm].local_model` to any pulled model name and `[llm].prefer_local = true`; `nimbus ask` can then answer open-ended questions from indexed context even when no remote classifier key is configured.
 ```
 NIMBUS_AGENT_MODEL=claude-sonnet-4-6                # overrides [llm].remote_model       (Mastra agent)
 NIMBUS_CLASSIFIER_MODEL=claude-haiku-4-5-20251001   # overrides [llm].classifier_model   (Anthropic intent classifier)

--- a/.claude/commands/nimbus-ipc.md
+++ b/.claude/commands/nimbus-ipc.md
@@ -108,8 +108,8 @@ interface HitlAction {
 |---|---|---|
 | `llm.listModels` | request | Merged list from Ollama tags + `llm_models` SQLite table |
 | `llm.pullModel` | request | Triggers Ollama pull; streams `llm.pullProgress` notifications |
-| `llm.loadModel` | request | Spawns llama-server for a GGUF file |
-| `llm.unloadModel` | request | Terminates llama-server for a model |
+| `llm.loadModel` | request | Loads or warms a local provider model; Ollama auto-loads on first generate |
+| `llm.unloadModel` | request | Unloads a local provider model when the provider supports it |
 | `llm.setDefault` | request | Sets `is_default = 1` for a model id |
 | `llm.getRouterStatus` | request | Current routing decision per task type |
 | `llm.listLocalModels` | request | Scans model dir for GGUF files (including subdirs + symlinks) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ When changing a wiring site, update both the test and `SECURITY-INVARIANTS.md` i
 
 **PAL:** All OS-specific logic lives under `packages/gateway/src/platform/` and is accessed via `PlatformServices` — never import `win32` / `darwin` / `linux` from business logic.
 
-**Prerequisites:** Bun v1.2+; Rust for building the Tauri UI (`packages/ui/src-tauri`).
+**Prerequisites:** Bun v1.2+; Rust for building the Tauri UI (`packages/ui/src-tauri`). Local `nimbus ask` can run through Ollama on `http://127.0.0.1:11434` with `[llm].prefer_local = true` and `[llm].local_model` set to any pulled model name.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -323,7 +323,7 @@ Gateway binaries built with `bun build --compile` bundle JavaScript into a singl
 | Feature | Requirement | How to install |
 |---|---|---|
 | **Local LLM (Ollama)** | [Ollama](https://ollama.com/download) running on `localhost:11434`, plus at least one pulled model (e.g. `ollama pull llama3.2`) | Default endpoint: `http://127.0.0.1:11434`. Set the local model with `nimbus config set llm.local_model <model>` and prefer it with `nimbus config set llm.prefer_local true`. |
-| **Local LLM (llama.cpp)** | A `llama-server` HTTP endpoint reachable from the Gateway | Default endpoint: `http://127.0.0.1:8080`; override with `nimbus config set llm.llamacpp_server_path http://127.0.0.1:8080`. |
+| **Local LLM (llama.cpp)** | A `llama-server` HTTP endpoint reachable from the Gateway | Default endpoint: `http://127.0.0.1:8080`; override with `nimbus config set llm.llamacpp_server_path http://127.0.0.1:8080`. The key stores the HTTP base URL, not the binary path. |
 | **Cloud LLM (Anthropic)** | Anthropic API key | Export `ANTHROPIC_API_KEY=…` in the Gateway's environment, then `nimbus config set llm.remote_model claude-sonnet-4-6` (provider is inferred from the model id; `claude-*` → Anthropic). |
 | **Cloud LLM (OpenAI)** | OpenAI API key | Export `OPENAI_API_KEY=…`, then `nimbus config set llm.remote_model gpt-4o` (provider is inferred; `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI). |
 | **Voice — STT (`nimbus voice listen`)** | `whisper-cli` (whisper.cpp) on PATH, plus `ffmpeg` for audio capture | Build whisper.cpp from source or install via `brew install whisper-cpp`; `ffmpeg` via your distro/`brew`. Set `voice.whisper_path` if not on PATH. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -322,8 +322,8 @@ Gateway binaries built with `bun build --compile` bundle JavaScript into a singl
 
 | Feature | Requirement | How to install |
 |---|---|---|
-| **Local LLM (Ollama)** | [Ollama](https://ollama.com/download) running on `localhost:11434`, plus at least one pulled model (e.g. `ollama pull llama3.1:8b`) | Default endpoint: `http://127.0.0.1:11434`. Set the local model with `nimbus config set llm.local_model llama3.1:8b`. |
-| **Local LLM (llama.cpp)** | A `llama-server` HTTP endpoint reachable from the Gateway | `nimbus config set llm.llamacpp_server_path /usr/local/bin/llama-server` — see `docs/architecture.md`. |
+| **Local LLM (Ollama)** | [Ollama](https://ollama.com/download) running on `localhost:11434`, plus at least one pulled model (e.g. `ollama pull llama3.2`) | Default endpoint: `http://127.0.0.1:11434`. Set the local model with `nimbus config set llm.local_model <model>` and prefer it with `nimbus config set llm.prefer_local true`. |
+| **Local LLM (llama.cpp)** | A `llama-server` HTTP endpoint reachable from the Gateway | Default endpoint: `http://127.0.0.1:8080`; override with `nimbus config set llm.llamacpp_server_path http://127.0.0.1:8080`. |
 | **Cloud LLM (Anthropic)** | Anthropic API key | Export `ANTHROPIC_API_KEY=…` in the Gateway's environment, then `nimbus config set llm.remote_model claude-sonnet-4-6` (provider is inferred from the model id; `claude-*` → Anthropic). |
 | **Cloud LLM (OpenAI)** | OpenAI API key | Export `OPENAI_API_KEY=…`, then `nimbus config set llm.remote_model gpt-4o` (provider is inferred; `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI). |
 | **Voice — STT (`nimbus voice listen`)** | `whisper-cli` (whisper.cpp) on PATH, plus `ffmpeg` for audio capture | Build whisper.cpp from source or install via `brew install whisper-cpp`; `ffmpeg` via your distro/`brew`. Set `voice.whisper_path` if not on PATH. |
@@ -448,7 +448,7 @@ The first time the Gateway starts it creates a default `nimbus.toml` in the plat
 
 Override either with `NIMBUS_CONFIG_DIR` / `NIMBUS_DATA_DIR` if you need separate trees per profile or per environment. Most TOML keys also have a corresponding `NIMBUS_`-prefixed env var override that wins over the file (e.g. `NIMBUS_AGENT_MODEL`, `NIMBUS_CLASSIFIER_MODEL`, `NIMBUS_TELEMETRY_ENABLED`) — see [`cli-reference.md`](./cli-reference.md#environment-variables).
 
-Pick an LLM before running your first `nimbus ask` — without one, the agent has no reasoning surface. The provider is inferred from the model id: `claude-*` → Anthropic, `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI, anything else falls through to the local provider.
+Pick an LLM before running your first `nimbus ask` — without one, the agent has no reasoning surface. Remote model ids are inferred from the model id: `claude-*` → Anthropic, `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI. Local model ids are passed to Ollama or llama.cpp through `[llm].local_model`.
 
 ```bash
 # Cloud (default — fastest path to a working install).
@@ -459,8 +459,8 @@ nimbus config set llm.remote_model      claude-sonnet-4-6
 nimbus config set llm.classifier_model  claude-haiku-4-5-20251001
 
 # OR fully local (no network calls; requires Ollama running)
-ollama pull llama3.1:8b
-nimbus config set llm.local_model llama3.1:8b
+ollama pull llama3.2
+nimbus config set llm.local_model llama3.2
 nimbus config set llm.prefer_local true
 ```
 
@@ -595,7 +595,7 @@ nimbus extension list
 | **IPC** | JSON-RPC 2.0 over Domain Socket / Named Pipe — local-only, no TCP surface |
 | **CLI** | Bun + [@clack/prompts](https://github.com/natemoo-re/clack) |
 | **Desktop UI** | [Tauri 2.0](https://tauri.app) + React 19 (~5MB native shell) |
-| **LLM** | Anthropic Claude (default) / configurable via Mastra model abstraction |
+| **LLM** | Local Ollama / llama.cpp via the Nimbus router, or Anthropic/OpenAI via the Mastra agent path |
 | **Embeddings** | `@xenova/transformers` (local, no API key) / OpenAI (opt-in) |
 | **Extension SDK** | `@nimbus-dev/sdk` (MIT-licensed npm package) |
 | **Client Library** | `@nimbus-dev/client` (MIT-licensed npm package) — typed IPC wrapper; `MockClient` for scripts and extensions |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -954,20 +954,21 @@ These subsystems are active development in Phase 4 (Presence). They extend the e
 
 ### Model Router (Local LLM)
 
-The Model Router sits between the IPC layer and the Engine. It selects the inference backend for each invocation based on task type and available models.
+The Model Router is assembled with the Gateway platform services and exposed to the Engine and the `llm.*` IPC namespace. It selects the inference backend for each invocation based on task type and available models.
 
 | Task | Default backend | Air-gapped mode |
 |---|---|---|
-| Intent classification | Local (Ollama/llama.cpp) if loaded; remote otherwise | Local only |
-| Task planning + multi-step reasoning | Remote (`claude-sonnet-4-6`) | Local (degraded) |
-| Response summarization | Remote | Local |
+| Intent classification | Remote classifier when an API key is available; local indexed-context fallback for open-ended `ask` when it is not | Local only |
+| Open-ended `nimbus ask` answers | Local (Ollama/llama.cpp) when `prefer_local = true`; remote Mastra agent otherwise | Local |
+| Task planning + multi-step actions | Remote (`claude-sonnet-4-6`) for Mastra tool use | Local indexed-context answer only |
+| Response summarization | Local if preferred; remote otherwise | Local |
 
 **Supported backends:**
 
 | Backend | Discovery | `nimbus.toml` key |
 |---|---|---|
-| Ollama | Default `http://127.0.0.1:11434` | `[llm].local_model` (e.g. `"llama3.2"`); `prefer_local = true` to route to it |
-| llama.cpp (GGUF) | `llama-server` HTTP endpoint | `[llm].llamacpp_server_path` |
+| Ollama | Default `http://127.0.0.1:11434` | `[llm].local_model` set to any pulled Ollama model name; `prefer_local = true` to route to it |
+| llama.cpp (GGUF) | `llama-server` HTTP endpoint, default `http://127.0.0.1:8080` | `[llm].llamacpp_server_path` |
 | Anthropic (remote) | `ANTHROPIC_API_KEY` in env | `[llm].remote_model = "claude-sonnet-4-6"` (provider inferred from `claude-*` prefix) |
 | OpenAI (remote) | `OPENAI_API_KEY` in env | `[llm].remote_model = "gpt-4o"` (provider inferred from `gpt-*` / `o1-*` / `o3-*` / `o4-*` prefix) |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -968,7 +968,7 @@ The Model Router is assembled with the Gateway platform services and exposed to 
 | Backend | Discovery | `nimbus.toml` key |
 |---|---|---|
 | Ollama | Default `http://127.0.0.1:11434` | `[llm].local_model` set to any pulled Ollama model name; `prefer_local = true` to route to it |
-| llama.cpp (GGUF) | `llama-server` HTTP endpoint, default `http://127.0.0.1:8080` | `[llm].llamacpp_server_path` |
+| llama.cpp (GGUF) | `llama-server` HTTP endpoint, default `http://127.0.0.1:8080` | `[llm].llamacpp_server_path` stores the HTTP base URL, not the binary path |
 | Anthropic (remote) | `ANTHROPIC_API_KEY` in env | `[llm].remote_model = "claude-sonnet-4-6"` (provider inferred from `claude-*` prefix) |
 | OpenAI (remote) | `OPENAI_API_KEY` in env | `[llm].remote_model = "gpt-4o"` (provider inferred from `gpt-*` / `o1-*` / `o3-*` / `o4-*` prefix) |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -71,6 +71,8 @@ nimbus status --json
 
 Ask the agent a natural-language question or give it a task. The agent answers from the local index; it only calls live APIs when freshness is required. Any destructive or outgoing action requires HITL consent before it executes.
 
+If `[llm].prefer_local = true` and a local provider is available, `nimbus ask` routes open-ended conversational answers through the local model. With Ollama, set `[llm].local_model` to any pulled model name; if no remote classifier API key is configured, Nimbus falls back to local indexed-context answering instead of failing before the local model can run.
+
 ```bash
 nimbus ask "Find all PDFs I received last month that I haven't opened"
 nimbus ask "Which of my open PRs mention payment-service and have failing CI?"
@@ -699,6 +701,8 @@ nimbus config set sync.intervalSeconds 300
 nimbus config set telemetry.enabled false
 nimbus config set llm.remote_model      claude-sonnet-4-6
 nimbus config set llm.classifier_model  claude-haiku-4-5-20251001
+nimbus config set llm.local_model       llama3.2
+nimbus config set llm.prefer_local      true
 ```
 
 The provider is inferred from the model id: `claude-*` → Anthropic, `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI. Already-prefixed forms (`anthropic/...`, `openai/...`) are accepted as-is.
@@ -757,8 +761,8 @@ remote_model       = "claude-sonnet-4-6"
 classifier_model   = "claude-haiku-4-5-20251001"
 # Local-LLM routing (Phase 4 LLM router).
 prefer_local       = true
-local_model        = "llama3.2"
-# llamacpp_server_path = "/usr/local/bin/llama-server"
+local_model        = "llama3.2" # Any pulled Ollama model name
+# llamacpp_server_path = "http://127.0.0.1:8080"
 # enforce_air_gap   = false
 # max_agent_depth   = 3              # 1–10
 # max_tool_calls_per_session = 20    # 1–200

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -762,6 +762,7 @@ classifier_model   = "claude-haiku-4-5-20251001"
 # Local-LLM routing (Phase 4 LLM router).
 prefer_local       = true
 local_model        = "llama3.2" # Any pulled Ollama model name
+# llama.cpp HTTP base URL; not the filesystem path to the llama-server binary.
 # llamacpp_server_path = "http://127.0.0.1:8080"
 # enforce_air_gap   = false
 # max_agent_depth   = 3              # 1–10

--- a/packages/docs/src/content/docs/faq.mdx
+++ b/packages/docs/src/content/docs/faq.mdx
@@ -13,7 +13,7 @@ Air-gap mode (`[llm] enforce_air_gap = true`) blocks all outbound HTTP for the d
 
 ### Can I run Nimbus offline?
 
-Yes — with a local LLM. Install Ollama or llama.cpp, configure the model in `nimbus.toml`, and Nimbus will route all inference locally. Connector sync pauses automatically while the machine is offline and resumes on reconnect without data loss. Queries against already-indexed data continue working in full during an outage. The Tauri desktop UI shows an offline banner so you always know the current network state.
+Yes — with a local LLM. Install Ollama or llama.cpp, configure `[llm].local_model` in `nimbus.toml` to any local model name you have pulled, and set `[llm].prefer_local = true`. Nimbus routes open-ended `ask` answers through the local router and can answer from already-indexed context even when no remote classifier key is configured. Connector sync pauses automatically while the machine is offline and resumes on reconnect without data loss. Queries against already-indexed data continue working in full during an outage. The Tauri desktop UI shows an offline banner so you always know the current network state.
 
 ### What's the difference between Nimbus and ChatGPT or Claude?
 

--- a/packages/gateway/src/config/nimbus-toml-llm.test.ts
+++ b/packages/gateway/src/config/nimbus-toml-llm.test.ts
@@ -41,10 +41,10 @@ describe("parseNimbusTomlLlmSection", () => {
     expect(parseNimbusTomlLlmSection(src)).toEqual({ localModel: "llama3.2" });
   });
 
-  test("parses llamacpp_server_path string", () => {
-    const src = `[llm]\nllamacpp_server_path = "/usr/local/bin/llama-server"\n`;
+  test("parses llamacpp_server_path endpoint string", () => {
+    const src = `[llm]\nllamacpp_server_path = "http://127.0.0.1:8080"\n`;
     expect(parseNimbusTomlLlmSection(src)).toEqual({
-      llamacppServerPath: "/usr/local/bin/llama-server",
+      llamacppServerPath: "http://127.0.0.1:8080",
     });
   });
 

--- a/packages/gateway/src/engine/run-ask.test.ts
+++ b/packages/gateway/src/engine/run-ask.test.ts
@@ -59,9 +59,9 @@ function fakeConversationalAgent(reply = "agent reply"): Agent {
   } as unknown as Agent;
 }
 
-function fakeLocalRouter(calls: string[], reply = "local reply"): LlmRouter {
+function fakeLocalRouter(calls: string[], reply = "local reply", preferLocal = true): LlmRouter {
   return {
-    prefersLocal: () => true,
+    prefersLocal: () => preferLocal,
     generate: async (opts: { prompt: string }) => {
       calls.push(opts.prompt);
       return {
@@ -219,6 +219,138 @@ describe("runAsk", () => {
     expect(prompts[0]).toContain('"indexedType":"issue"');
     expect(prompts[0]).toContain('"title":"add a smoke test"');
     expect(prompts[0]).toContain("Create a basic smoke test");
+    localIndex.close();
+  });
+
+  test("uses quoted issue titles to build local context for long prompts", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url, modified_at, synced_at)
+       VALUES ('github:zaalgol/helpdesk#issue-1', 'github', 'issue', 'zaalgol/helpdesk#issue-1', 'add a smoke test', 'Testing Nimbus GitHub sync, local indexing, search, and agent usage.', 'https://github.com/zaalgol/helpdesk/issues/1', 1, 1)`,
+    );
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url, modified_at, synced_at)
+       VALUES ('github:zaalgol/helpdesk#issue-2', 'github', 'issue', 'zaalgol/helpdesk#issue-2', 'add API test', 'Add tests for the API''s', 'https://github.com/zaalgol/helpdesk/issues/2', 2, 2)`,
+    );
+    for (let i = 0; i < 10; i += 1) {
+      db.run(
+        `INSERT INTO item (id, service, type, external_id, title, body_preview, modified_at, synced_at)
+         VALUES (?, 'github_actions', 'workflow_run', ?, ?, 'unrelated workflow run', ?, ?)`,
+        [`github_actions:run-${i}`, `run-${i}`, `workflow run ${i}`, 100 + i, 100 + i],
+      );
+    }
+    const localIndex = new LocalIndex(db);
+    const prompts: string[] = [];
+
+    await runAsk({
+      input:
+        "Using only the local indexed Nimbus GitHub context for zaalgol/helpdesk, find the issues titled 'add a smoke test' and 'add API test'. Summarize each issue.",
+      stream: false,
+      clientId: "test-client",
+      paths: stubPaths,
+      consentCoordinator: stubConsent,
+      localIndex,
+      dispatcher: stubDispatcher,
+      sendChunk: () => {},
+      llmRouter: fakeLocalRouter(prompts),
+      classify: async () => {
+        throw new GatewayAgentUnavailableError({ reason: "no_api_key" });
+      },
+    });
+
+    expect(prompts[0]).toContain('"title":"add a smoke test"');
+    expect(prompts[0]).toContain('"title":"add API test"');
+    expect(prompts[0]).toContain("Testing Nimbus GitHub sync");
+    expect(prompts[0]).toContain("Add tests for the API");
+    localIndex.close();
+  });
+
+  test("local indexed GitHub context prompts bypass file-search planning and include repo issues", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url, modified_at, synced_at)
+       VALUES ('github:zaalgol/helpdesk#issue-1', 'github', 'issue', 'zaalgol/helpdesk#issue-1', 'add a smoke test', 'Testing Nimbus GitHub sync, local indexing, search, and agent usage.', 'https://github.com/zaalgol/helpdesk/issues/1', 1, 1)`,
+    );
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url, modified_at, synced_at)
+       VALUES ('github:zaalgol/helpdesk#issue-2', 'github', 'issue', 'zaalgol/helpdesk#issue-2', 'add API test', 'Add tests for the API''s', 'https://github.com/zaalgol/helpdesk/issues/2', 2, 2)`,
+    );
+    const localIndex = new LocalIndex(db);
+    const prompts: string[] = [];
+    let dispatched = false;
+    const dispatcher: ConnectorDispatcher = {
+      async dispatch(): Promise<unknown> {
+        dispatched = true;
+        return null;
+      },
+    };
+
+    const out = await runAsk({
+      input:
+        "Using only the local indexed Nimbus GitHub context for zaalgol/helpdesk, find all the open issues",
+      stream: false,
+      clientId: "test-client",
+      paths: stubPaths,
+      consentCoordinator: stubConsent,
+      localIndex,
+      dispatcher,
+      sendChunk: () => {},
+      llmRouter: fakeLocalRouter(prompts, "found local issues"),
+      classify: async () => ({
+        intent: "file_search",
+        entities: { pattern: "open issues" },
+        requiresHITL: false,
+        confidence: 0.95,
+      }),
+    });
+
+    expect(out.reply).toBe("found local issues");
+    expect(dispatched).toBe(false);
+    expect(prompts[0]).toContain('"title":"add a smoke test"');
+    expect(prompts[0]).toContain('"title":"add API test"');
+    localIndex.close();
+  });
+
+  test("does not prebuild indexed context for the default remote conversational path", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, modified_at, synced_at)
+       VALUES ('github:issue-1', 'github', 'issue', 'issue-1', 'add API test', 'Add API tests.', 1, 1)`,
+    );
+    const localIndex = new LocalIndex(db);
+    let searchedForContext = false;
+    const originalSearchRankedAsync = localIndex.searchRankedAsync.bind(localIndex);
+    localIndex.searchRankedAsync = async (...args) => {
+      searchedForContext = true;
+      return await originalSearchRankedAsync(...args);
+    };
+    const routerPrompts: string[] = [];
+
+    const out = await runAsk({
+      input: "Summarize the API test issue.",
+      stream: false,
+      clientId: "test-client",
+      paths: stubPaths,
+      consentCoordinator: stubConsent,
+      localIndex,
+      dispatcher: stubDispatcher,
+      sendChunk: () => {},
+      conversationalAgent: fakeConversationalAgent("remote agent answer"),
+      llmRouter: fakeLocalRouter(routerPrompts, "local answer", false),
+      classify: async () => ({
+        intent: "unknown",
+        entities: {},
+        requiresHITL: false,
+        confidence: 0,
+      }),
+    });
+
+    expect(out.reply).toBe("remote agent answer");
+    expect(searchedForContext).toBe(false);
+    expect(routerPrompts).toEqual([]);
     localIndex.close();
   });
 });

--- a/packages/gateway/src/engine/run-ask.test.ts
+++ b/packages/gateway/src/engine/run-ask.test.ts
@@ -6,9 +6,11 @@ import type { Agent } from "@mastra/core/agent";
 
 import { LocalIndex } from "../index/local-index.ts";
 import type { ConsentCoordinator } from "../ipc/consent.ts";
+import type { LlmRouter } from "../llm/router.ts";
 import type { SessionChunk, SessionMemoryStore } from "../memory/session-memory-store.ts";
 import type { PlatformPaths } from "../platform/paths.ts";
 import { agentRequestContext } from "./agent-request-context.ts";
+import { GatewayAgentUnavailableError } from "./gateway-agent-error.ts";
 import { runAsk } from "./run-ask.ts";
 import type { ConnectorDispatcher } from "./types.ts";
 
@@ -55,6 +57,23 @@ function fakeConversationalAgent(reply = "agent reply"): Agent {
       text: Promise.resolve(reply),
     }),
   } as unknown as Agent;
+}
+
+function fakeLocalRouter(calls: string[], reply = "local reply"): LlmRouter {
+  return {
+    prefersLocal: () => true,
+    generate: async (opts: { prompt: string }) => {
+      calls.push(opts.prompt);
+      return {
+        text: reply,
+        tokensIn: 1,
+        tokensOut: 2,
+        modelUsed: "local-test-model:latest",
+        isLocal: true,
+        provider: "ollama" as const,
+      };
+    },
+  } as unknown as LlmRouter;
 }
 
 function spySessionMemoryStore(): {
@@ -164,6 +183,42 @@ describe("runAsk", () => {
     });
 
     expect(appended.length).toBe(0);
+    localIndex.close();
+  });
+
+  test("uses local LLM router when remote classifier has no API key", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url, modified_at, synced_at)
+       VALUES ('github:zaalgol/helpdesk#issue-1', 'github', 'issue', 'zaalgol/helpdesk#issue-1', 'add a smoke test', 'Create a basic smoke test for the helpdesk app.', 'https://github.com/zaalgol/helpdesk/issues/1', 1, 1)`,
+    );
+    const localIndex = new LocalIndex(db);
+    const prompts: string[] = [];
+
+    const out = await runAsk({
+      input: "What should I do for the smoke test issue?",
+      stream: false,
+      clientId: "test-client",
+      paths: stubPaths,
+      consentCoordinator: stubConsent,
+      localIndex,
+      dispatcher: stubDispatcher,
+      sendChunk: () => {},
+      llmRouter: fakeLocalRouter(prompts, "Use the GitHub issue context."),
+      classify: async () => {
+        throw new GatewayAgentUnavailableError({ reason: "no_api_key" });
+      },
+    });
+
+    expect(out.reply).toBe("Use the GitHub issue context.");
+    expect(out.modelMeta?.isLocal).toBe(true);
+    expect(prompts[0]).toContain("Indexed Nimbus context");
+    expect(prompts[0]).toContain('<tool_output service="nimbus" tool="localIndex.searchRanked">');
+    expect(prompts[0]).toContain('"service":"github"');
+    expect(prompts[0]).toContain('"indexedType":"issue"');
+    expect(prompts[0]).toContain('"title":"add a smoke test"');
+    expect(prompts[0]).toContain("Create a basic smoke test");
     localIndex.close();
   });
 });

--- a/packages/gateway/src/engine/run-ask.ts
+++ b/packages/gateway/src/engine/run-ask.ts
@@ -1,8 +1,12 @@
 import type { Database } from "bun:sqlite";
 import type { Agent } from "@mastra/core/agent";
+import pino from "pino";
 
 import type { LocalIndex } from "../index/local-index.ts";
+import type { RankedIndexItem } from "../index/ranked-item.ts";
 import type { ConsentCoordinator } from "../ipc/consent.ts";
+import type { LlmRouter } from "../llm/router.ts";
+import type { LlmGenerateResult } from "../llm/types.ts";
 import type { SessionMemoryStore } from "../memory/session-memory-store.ts";
 import type { PlatformPaths } from "../platform/paths.ts";
 import { getAgentRequestSessionId } from "./agent-request-context.ts";
@@ -11,7 +15,13 @@ import { GatewayAgentUnavailableError } from "./gateway-agent-error.ts";
 import { type PlanResult, planFromIntent } from "./planner.ts";
 import { type ClassifiedIntent, classifyIntent } from "./router.ts";
 import { runConversationalAgent } from "./run-conversational-agent.ts";
+import { wrapToolOutput } from "./tool-output-envelope.ts";
 import type { ConnectorDispatcher, PlannedAction } from "./types.ts";
+
+const runAskLog = pino({
+  name: "run-ask",
+  level: process.env["NIMBUS_LOG_LEVEL"] ?? "info",
+});
 
 export type RunAskParams = {
   input: string;
@@ -23,6 +33,7 @@ export type RunAskParams = {
   dispatcher: ConnectorDispatcher;
   sendChunk: (text: string) => void;
   conversationalAgent?: Agent;
+  llmRouter?: LlmRouter;
   sessionMemoryStore?: SessionMemoryStore;
   classify?: (input: string) => Promise<ClassifiedIntent>;
 };
@@ -101,6 +112,37 @@ async function classifyIntentForAsk(input: string): Promise<ClassifiedIntent> {
   }
 }
 
+function canUseConversation(p: RunAskParams): boolean {
+  return p.conversationalAgent !== undefined || p.llmRouter?.prefersLocal() === true;
+}
+
+async function classifyIntentForAskWithLocalFallback(p: RunAskParams): Promise<ClassifiedIntent> {
+  try {
+    return await (p.classify ?? classifyIntentForAsk)(p.input);
+  } catch (e) {
+    if (
+      p.llmRouter === undefined ||
+      !p.llmRouter.prefersLocal() ||
+      !(e instanceof GatewayAgentUnavailableError)
+    ) {
+      throw e;
+    }
+    if (e.reason !== "no_api_key" && e.reason !== "invalid_api_key") {
+      throw e;
+    }
+    runAskLog.warn(
+      { reason: e.reason, provider: e.provider },
+      "remote intent classifier unavailable; falling back to local indexed-context answer",
+    );
+    return {
+      intent: "unknown",
+      entities: {},
+      requiresHITL: false,
+      confidence: 0,
+    };
+  }
+}
+
 async function runActionsPlan(
   p: RunAskParams,
   actions: PlannedAction[],
@@ -146,6 +188,81 @@ async function dispatchPlan(p: RunAskParams, plan: PlanResult): Promise<{ reply:
   return await runActionsPlan(p, plan.actions);
 }
 
+const LOCAL_CONTEXT_ITEM_LIMIT = 8;
+const LOCAL_CONTEXT_PREVIEW_MAX_CHARS = 900;
+
+type LocalContextItem = {
+  rank: number;
+  service: string;
+  indexedType: string;
+  title: string;
+  preview?: string;
+  url?: string;
+};
+
+function cleanContextText(text: string): string {
+  return text.replaceAll(/\s+/g, " ").trim();
+}
+
+function clipContextText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars - 3)}...`;
+}
+
+function formatContextItem(
+  localIndex: LocalIndex,
+  item: RankedIndexItem,
+  idx: number,
+): LocalContextItem {
+  const title = cleanContextText(item.name);
+  const preview = cleanContextText(
+    item.semanticSnippet ?? localIndex.getBodyPreview(item.indexPrimaryKey) ?? "",
+  );
+  const url = cleanContextText(item.canonicalUrl ?? item.url ?? "");
+  return {
+    rank: idx + 1,
+    service: item.service,
+    indexedType: item.indexedType,
+    title,
+    ...(preview === ""
+      ? {}
+      : { preview: clipContextText(preview, LOCAL_CONTEXT_PREVIEW_MAX_CHARS) }),
+    ...(url === "" ? {} : { url }),
+  };
+}
+
+async function buildLocalIndexedContext(
+  localIndex: LocalIndex,
+  input: string,
+): Promise<string | undefined> {
+  const query = input.trim();
+  if (query === "") {
+    return undefined;
+  }
+  try {
+    let results = await localIndex.searchRankedAsync(
+      { name: query, limit: LOCAL_CONTEXT_ITEM_LIMIT },
+      { semantic: true, contextChunks: 2 },
+    );
+    if (results.length === 0) {
+      results = localIndex.searchRanked({ limit: LOCAL_CONTEXT_ITEM_LIMIT });
+    }
+    if (results.length === 0) {
+      return undefined;
+    }
+    const contextItems = results.map((item, idx) => formatContextItem(localIndex, item, idx));
+    return `Indexed Nimbus context:\n${wrapToolOutput(
+      { service: "nimbus", tool: "localIndex.searchRanked" },
+      contextItems,
+    )}`;
+  } catch (e) {
+    runAskLog.warn({ err: e }, "failed to build local indexed context for local LLM");
+    return undefined;
+  }
+}
+
 async function loadRecentConversationHistory(
   store: SessionMemoryStore | undefined,
   sessionId: string | undefined,
@@ -189,28 +306,33 @@ async function persistConversationTurn(
   }
 }
 
-export async function runAsk(p: RunAskParams): Promise<{ reply: string }> {
+export async function runAsk(
+  p: RunAskParams,
+): Promise<{ reply: string; modelMeta?: LlmGenerateResult }> {
   const indexed = countIndexedItems(p.localIndex);
   const empty = emptyIndexGuidanceIfNeeded(p, indexed);
   if (empty !== undefined) {
     return empty;
   }
 
-  const classified = await (p.classify ?? classifyIntentForAsk)(p.input);
+  const classified = await classifyIntentForAskWithLocalFallback(p);
 
-  const conversationalAgent = p.conversationalAgent;
   const shouldUseConversational = classified.intent === "unknown" || classified.confidence < 0.6;
 
-  if (conversationalAgent !== undefined && shouldUseConversational) {
+  if (canUseConversation(p) && shouldUseConversational) {
     const sessionId = getAgentRequestSessionId();
     const priorTurns = await loadRecentConversationHistory(p.sessionMemoryStore, sessionId);
+    const localContext =
+      p.llmRouter === undefined ? undefined : await buildLocalIndexedContext(p.localIndex, p.input);
 
     const result = await runConversationalAgent({
-      agent: conversationalAgent,
       input: p.input,
       stream: p.stream,
       sendChunk: p.sendChunk,
       priorTurns,
+      ...(p.conversationalAgent === undefined ? {} : { agent: p.conversationalAgent }),
+      ...(p.llmRouter === undefined ? {} : { llmRouter: p.llmRouter }),
+      ...(localContext === undefined ? {} : { localContext }),
     });
 
     await persistConversationTurn(p.sessionMemoryStore, sessionId, p.input, result.reply);

--- a/packages/gateway/src/engine/run-ask.ts
+++ b/packages/gateway/src/engine/run-ask.ts
@@ -116,6 +116,23 @@ function canUseConversation(p: RunAskParams): boolean {
   return p.conversationalAgent !== undefined || p.llmRouter?.prefersLocal() === true;
 }
 
+function shouldBuildLocalContext(p: RunAskParams): boolean {
+  if (p.llmRouter === undefined) {
+    return false;
+  }
+  if (p.conversationalAgent === undefined) {
+    return true;
+  }
+  return p.llmRouter.prefersLocal();
+}
+
+function shouldAnswerFromLocalIndexedContext(p: RunAskParams): boolean {
+  return (
+    p.llmRouter?.prefersLocal() === true &&
+    /\b(local indexed|indexed nimbus|nimbus github context|indexed github context)\b/i.test(p.input)
+  );
+}
+
 async function classifyIntentForAskWithLocalFallback(p: RunAskParams): Promise<ClassifiedIntent> {
   try {
     return await (p.classify ?? classifyIntentForAsk)(p.input);
@@ -190,8 +207,10 @@ async function dispatchPlan(p: RunAskParams, plan: PlanResult): Promise<{ reply:
 
 const LOCAL_CONTEXT_ITEM_LIMIT = 8;
 const LOCAL_CONTEXT_PREVIEW_MAX_CHARS = 900;
+const LOCAL_CONTEXT_QUOTED_QUERY_LIMIT = 4;
 
 type LocalContextItem = {
+  sourceId: string;
   rank: number;
   service: string;
   indexedType: string;
@@ -211,18 +230,47 @@ function clipContextText(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars - 3)}...`;
 }
 
+function extractQuotedSearchQueries(input: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const match of input.matchAll(/["'`]([^"'`]{3,120})["'`]/g)) {
+    const query = cleanContextText(match[1] ?? "");
+    const key = query.toLowerCase();
+    if (query !== "" && !seen.has(key)) {
+      seen.add(key);
+      out.push(query);
+    }
+    if (out.length >= LOCAL_CONTEXT_QUOTED_QUERY_LIMIT) {
+      break;
+    }
+  }
+  return out;
+}
+
+function extractGithubRepoSlugs(input: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const match of input.matchAll(/\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\b/g)) {
+    const slug = (match[1] ?? "").toLowerCase();
+    if (slug !== "" && !seen.has(slug)) {
+      seen.add(slug);
+      out.push(slug);
+    }
+  }
+  return out;
+}
+
 function formatContextItem(
   localIndex: LocalIndex,
   item: RankedIndexItem,
-  idx: number,
-): LocalContextItem {
+): Omit<LocalContextItem, "rank"> {
   const title = cleanContextText(item.name);
   const preview = cleanContextText(
     item.semanticSnippet ?? localIndex.getBodyPreview(item.indexPrimaryKey) ?? "",
   );
   const url = cleanContextText(item.canonicalUrl ?? item.url ?? "");
   return {
-    rank: idx + 1,
+    sourceId: item.indexPrimaryKey,
     service: item.service,
     indexedType: item.indexedType,
     title,
@@ -231,6 +279,49 @@ function formatContextItem(
       : { preview: clipContextText(preview, LOCAL_CONTEXT_PREVIEW_MAX_CHARS) }),
     ...(url === "" ? {} : { url }),
   };
+}
+
+type GithubIssueContextRow = {
+  id: string;
+  service: string;
+  type: string;
+  title: string;
+  body_preview: string | null;
+  url: string | null;
+};
+
+function githubIssueContextItemsForRepo(
+  localIndex: LocalIndex,
+  repoSlug: string,
+): Array<Omit<LocalContextItem, "rank">> {
+  const like = `${repoSlug}#issue-%`;
+  const urlLike = `%github.com/${repoSlug}/issues/%`;
+  const rows = localIndex
+    .getDatabase()
+    .query(
+      `SELECT id, service, type, title, body_preview, url
+       FROM item
+       WHERE service = 'github'
+         AND type = 'issue'
+         AND (lower(external_id) LIKE ? OR lower(url) LIKE ?)
+       ORDER BY modified_at DESC, synced_at DESC, title ASC
+       LIMIT ?`,
+    )
+    .all(like, urlLike, LOCAL_CONTEXT_ITEM_LIMIT) as GithubIssueContextRow[];
+  return rows.map((row) => {
+    const preview = cleanContextText(row.body_preview ?? "");
+    const url = cleanContextText(row.url ?? "");
+    return {
+      sourceId: row.id,
+      service: row.service,
+      indexedType: row.type,
+      title: cleanContextText(row.title),
+      ...(preview === ""
+        ? {}
+        : { preview: clipContextText(preview, LOCAL_CONTEXT_PREVIEW_MAX_CHARS) }),
+      ...(url === "" ? {} : { url }),
+    };
+  });
 }
 
 async function buildLocalIndexedContext(
@@ -242,17 +333,47 @@ async function buildLocalIndexedContext(
     return undefined;
   }
   try {
-    let results = await localIndex.searchRankedAsync(
-      { name: query, limit: LOCAL_CONTEXT_ITEM_LIMIT },
-      { semantic: true, contextChunks: 2 },
+    const byId = new Map<string, Omit<LocalContextItem, "rank">>();
+    const addRankedResults = (items: RankedIndexItem[]): void => {
+      for (const item of items) {
+        if (!byId.has(item.indexPrimaryKey)) {
+          byId.set(item.indexPrimaryKey, formatContextItem(localIndex, item));
+        }
+      }
+    };
+    const addContextItems = (items: Array<Omit<LocalContextItem, "rank">>): void => {
+      for (const item of items) {
+        if (!byId.has(item.sourceId)) {
+          byId.set(item.sourceId, item);
+        }
+      }
+    };
+    addRankedResults(
+      await localIndex.searchRankedAsync(
+        { name: query, limit: LOCAL_CONTEXT_ITEM_LIMIT },
+        { semantic: true, contextChunks: 2 },
+      ),
     );
-    if (results.length === 0) {
-      results = localIndex.searchRanked({ limit: LOCAL_CONTEXT_ITEM_LIMIT });
+    for (const quotedQuery of extractQuotedSearchQueries(query)) {
+      addRankedResults(
+        localIndex.searchRanked({ name: quotedQuery, limit: LOCAL_CONTEXT_ITEM_LIMIT }),
+      );
     }
-    if (results.length === 0) {
+    for (const repoSlug of extractGithubRepoSlugs(query)) {
+      addContextItems(githubIssueContextItemsForRepo(localIndex, repoSlug));
+    }
+    if (byId.size === 0) {
+      addRankedResults(localIndex.searchRanked({ name: query, limit: LOCAL_CONTEXT_ITEM_LIMIT }));
+    }
+    if (byId.size === 0) {
+      addRankedResults(localIndex.searchRanked({ limit: LOCAL_CONTEXT_ITEM_LIMIT }));
+    }
+    if (byId.size === 0) {
       return undefined;
     }
-    const contextItems = results.map((item, idx) => formatContextItem(localIndex, item, idx));
+    const contextItems = [...byId.values()]
+      .slice(0, LOCAL_CONTEXT_ITEM_LIMIT)
+      .map((item, idx) => ({ ...item, rank: idx + 1 }));
     return `Indexed Nimbus context:\n${wrapToolOutput(
       { service: "nimbus", tool: "localIndex.searchRanked" },
       contextItems,
@@ -317,13 +438,17 @@ export async function runAsk(
 
   const classified = await classifyIntentForAskWithLocalFallback(p);
 
-  const shouldUseConversational = classified.intent === "unknown" || classified.confidence < 0.6;
+  const shouldUseConversational =
+    shouldAnswerFromLocalIndexedContext(p) ||
+    classified.intent === "unknown" ||
+    classified.confidence < 0.6;
 
   if (canUseConversation(p) && shouldUseConversational) {
     const sessionId = getAgentRequestSessionId();
     const priorTurns = await loadRecentConversationHistory(p.sessionMemoryStore, sessionId);
-    const localContext =
-      p.llmRouter === undefined ? undefined : await buildLocalIndexedContext(p.localIndex, p.input);
+    const localContext = shouldBuildLocalContext(p)
+      ? await buildLocalIndexedContext(p.localIndex, p.input)
+      : undefined;
 
     const result = await runConversationalAgent({
       input: p.input,

--- a/packages/gateway/src/engine/run-conversational-agent.test.ts
+++ b/packages/gateway/src/engine/run-conversational-agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { Agent } from "@mastra/core/agent";
 
+import type { LlmRouter } from "../llm/router.ts";
 import { GatewayAgentUnavailableError } from "./gateway-agent-error.ts";
 import { runConversationalAgent } from "./run-conversational-agent.ts";
 
@@ -57,6 +58,81 @@ describe("runConversationalAgent", () => {
     });
     expect(chunks.join("")).toBe("ab");
     expect(r.reply).toBe("full");
+  });
+
+  test("local router path uses indexed context and returns model metadata", async () => {
+    const generate = mock(async (opts: { prompt: string }) => ({
+      text: "local answer",
+      tokensIn: 10,
+      tokensOut: 2,
+      modelUsed: "local-test-model:latest",
+      isLocal: true,
+      provider: "ollama" as const,
+      promptEcho: opts.prompt,
+    }));
+    const router = { generate, prefersLocal: () => true } as unknown as LlmRouter;
+    const r = await runConversationalAgent({
+      llmRouter: router,
+      input: "what happened?",
+      stream: false,
+      sendChunk: () => undefined,
+      localContext: "Indexed Nimbus context:\n1. github/issue: add a smoke test",
+    });
+    expect(r.reply).toBe("local answer");
+    expect(r.modelMeta?.modelUsed).toBe("local-test-model:latest");
+    const firstCall = generate.mock.calls[0]?.[0] as { prompt?: string } | undefined;
+    expect(firstCall?.prompt).toContain("Indexed Nimbus context");
+    expect(firstCall?.prompt).toContain("what happened?");
+  });
+
+  test("local router streaming forwards provider tokens", async () => {
+    const chunks: string[] = [];
+    const generate = mock(async (opts: { onToken?: (token: string) => void }) => {
+      opts.onToken?.("hel");
+      opts.onToken?.("lo");
+      return {
+        text: "hello",
+        tokensIn: 1,
+        tokensOut: 1,
+        modelUsed: "local-test-model:latest",
+        isLocal: true,
+        provider: "ollama" as const,
+      };
+    });
+    const router = { generate, prefersLocal: () => true } as unknown as LlmRouter;
+    const r = await runConversationalAgent({
+      llmRouter: router,
+      input: "say hello",
+      stream: true,
+      sendChunk: (text) => chunks.push(text),
+    });
+    expect(chunks.join("")).toBe("hello");
+    expect(r.reply).toBe("hello");
+  });
+
+  test("uses Mastra agent when local routing is not preferred", async () => {
+    const agent = {
+      generate: mock(async () => ({ text: "remote answer" })),
+    } as unknown as Agent;
+    const generate = mock(async () => ({
+      text: "local answer",
+      tokensIn: 1,
+      tokensOut: 1,
+      modelUsed: "local-test-model:latest",
+      isLocal: true,
+      provider: "ollama" as const,
+    }));
+    const router = { generate, prefersLocal: () => false } as unknown as LlmRouter;
+    const r = await runConversationalAgent({
+      agent,
+      llmRouter: router,
+      input: "hello",
+      stream: false,
+      sendChunk: () => undefined,
+    });
+    expect(r.reply).toBe("remote answer");
+    expect(generate).not.toHaveBeenCalled();
+    expect(agent.generate).toHaveBeenCalled();
   });
 
   test("maps API key errors to GatewayAgentUnavailableError", async () => {

--- a/packages/gateway/src/engine/run-conversational-agent.test.ts
+++ b/packages/gateway/src/engine/run-conversational-agent.test.ts
@@ -110,6 +110,27 @@ describe("runConversationalAgent", () => {
     expect(r.reply).toBe("hello");
   });
 
+  test("local router streaming emits final text when provider does not stream tokens", async () => {
+    const chunks: string[] = [];
+    const generate = mock(async () => ({
+      text: "llama.cpp final text",
+      tokensIn: 1,
+      tokensOut: 3,
+      modelUsed: "local-test-model.gguf",
+      isLocal: true,
+      provider: "llamacpp" as const,
+    }));
+    const router = { generate, prefersLocal: () => true } as unknown as LlmRouter;
+    const r = await runConversationalAgent({
+      llmRouter: router,
+      input: "say hello",
+      stream: true,
+      sendChunk: (text) => chunks.push(text),
+    });
+    expect(chunks.join("")).toBe("llama.cpp final text");
+    expect(r.reply).toBe("llama.cpp final text");
+  });
+
   test("uses Mastra agent when local routing is not preferred", async () => {
     const agent = {
       generate: mock(async () => ({ text: "remote answer" })),

--- a/packages/gateway/src/engine/run-conversational-agent.ts
+++ b/packages/gateway/src/engine/run-conversational-agent.ts
@@ -93,6 +93,16 @@ export async function runConversationalAgent(
         typeof promptArg === "string"
           ? promptArg
           : promptArg.map((m) => `${m.role}: ${m.content}`).join("\n\n");
+      let streamedAnyToken = false;
+      const onToken =
+        p.stream === true
+          ? (token: string): void => {
+              if (token.length > 0) {
+                streamedAnyToken = true;
+                p.sendChunk(token);
+              }
+            }
+          : undefined;
       try {
         const result = await llmRouter.generate({
           task: "agent_step",
@@ -102,8 +112,11 @@ export async function runConversationalAgent(
           maxTokens: 2048,
           temperature: 0.2,
           stream: p.stream,
-          ...(p.stream ? { onToken: p.sendChunk } : {}),
+          ...(onToken === undefined ? {} : { onToken }),
         });
+        if (p.stream && !streamedAnyToken && result.text.length > 0) {
+          p.sendChunk(result.text);
+        }
         return { reply: result.text, modelMeta: result };
       } catch (e) {
         if (p.agent === undefined) {

--- a/packages/gateway/src/engine/run-conversational-agent.ts
+++ b/packages/gateway/src/engine/run-conversational-agent.ts
@@ -2,6 +2,8 @@ import type { Agent } from "@mastra/core/agent";
 import pino from "pino";
 
 import { Config } from "../config.ts";
+import type { LlmRouter } from "../llm/router.ts";
+import type { LlmGenerateResult } from "../llm/types.ts";
 import { agentErrorFromCaughtError } from "./gateway-agent-error.ts";
 import { sanitizeExternalError } from "./sanitize-external-error.ts";
 
@@ -11,11 +13,13 @@ const conversationalLog = pino({
 });
 
 export type RunConversationalAgentParams = {
-  agent: Agent;
+  agent?: Agent;
+  llmRouter?: LlmRouter;
   input: string;
   stream: boolean;
   sendChunk: (text: string) => void;
   priorTurns?: ReadonlyArray<{ role: "user" | "assistant" | "tool"; text: string }>;
+  localContext?: string;
 };
 
 function isTextDeltaChunk(chunk: unknown): chunk is {
@@ -37,9 +41,19 @@ function isTextDeltaChunk(chunk: unknown): chunk is {
   return typeof text === "string";
 }
 
+function shouldUseLocalRouter(p: RunConversationalAgentParams): boolean {
+  if (p.llmRouter === undefined) {
+    return false;
+  }
+  if (p.agent === undefined) {
+    return true;
+  }
+  return p.llmRouter.prefersLocal();
+}
+
 export async function runConversationalAgent(
   p: RunConversationalAgentParams,
-): Promise<{ reply: string }> {
+): Promise<{ reply: string; modelMeta?: LlmGenerateResult }> {
   const maxSteps = Config.conversationalAgentMaxSteps;
   const trimmed = p.input.trim();
   if (trimmed === "") {
@@ -58,17 +72,51 @@ export async function runConversationalAgent(
   const prompt = incidentOrGraph
     ? `The user may be asking about relationships between indexed items (including incidents). If you have a concrete item id from searchLocalIndex, call traverseGraph before answering.\n\n${trimmed}`
     : trimmed;
+  const promptWithContext =
+    p.localContext === undefined || p.localContext.trim() === ""
+      ? prompt
+      : `${p.localContext.trim()}\n\nUser question:\n${prompt}`;
 
   const priorTurns = p.priorTurns ?? [];
   const promptArg: string | Array<{ role: "user" | "assistant" | "tool"; content: string }> =
     priorTurns.length > 0
       ? [
           ...priorTurns.map((t) => ({ role: t.role, content: t.text })),
-          { role: "user" as const, content: prompt },
+          { role: "user" as const, content: promptWithContext },
         ]
-      : prompt;
+      : promptWithContext;
 
   try {
+    const llmRouter = p.llmRouter;
+    if (llmRouter !== undefined && shouldUseLocalRouter(p)) {
+      const routerPrompt =
+        typeof promptArg === "string"
+          ? promptArg
+          : promptArg.map((m) => `${m.role}: ${m.content}`).join("\n\n");
+      try {
+        const result = await llmRouter.generate({
+          task: "agent_step",
+          prompt: routerPrompt,
+          systemPrompt:
+            "You are Nimbus, a local-first assistant. Answer from the provided indexed context when it is relevant. If the context is insufficient, say what is missing instead of inventing details.",
+          maxTokens: 2048,
+          temperature: 0.2,
+          stream: p.stream,
+          ...(p.stream ? { onToken: p.sendChunk } : {}),
+        });
+        return { reply: result.text, modelMeta: result };
+      } catch (e) {
+        if (p.agent === undefined) {
+          throw e;
+        }
+        conversationalLog.warn({ err: e }, "local LLM router failed; falling back to agent");
+      }
+    }
+
+    if (p.agent === undefined) {
+      throw new Error("No conversational agent or local LLM router configured");
+    }
+
     if (!p.stream) {
       const out = await p.agent.generate(promptArg, { maxSteps });
       return { reply: out.text };

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -72,6 +72,7 @@ async function main(): Promise<void> {
       localIndex: platform.localIndex,
       dispatcher,
       conversationalAgent: resolveEngineAgent(ctx.agent),
+      llmRouter: platform.llmRegistry.llmRouter,
       ...(platform.sessionMemoryStore === undefined
         ? {}
         : { sessionMemoryStore: platform.sessionMemoryStore }),

--- a/packages/gateway/src/index/index.test.ts
+++ b/packages/gateway/src/index/index.test.ts
@@ -130,6 +130,26 @@ describe("LocalIndex", () => {
     expect(ranked[0]?.duplicates?.includes("github")).toBe(true);
   });
 
+  test("getBodyPreview returns indexed preview by primary key", () => {
+    const idx = openMemoryIndex();
+    const db = idx.getDatabase();
+    const t = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "issue",
+      externalId: "zaalgol/helpdesk#issue-1",
+      title: "add a smoke test",
+      bodyPreview: "Create a basic smoke test for the helpdesk app.",
+      modifiedAt: t,
+      syncedAt: t,
+    });
+
+    expect(idx.getBodyPreview("github:zaalgol/helpdesk#issue-1")).toBe(
+      "Create a basic smoke test for the helpdesk app.",
+    );
+    expect(idx.getBodyPreview("github:missing")).toBeUndefined();
+  });
+
   test("search filters by service and itemType", () => {
     const idx = openMemoryIndex();
     idx.upsert({

--- a/packages/gateway/src/index/local-index.ts
+++ b/packages/gateway/src/index/local-index.ts
@@ -459,6 +459,17 @@ export class LocalIndex {
     return rows.map(rowToItem);
   }
 
+  getBodyPreview(indexPrimaryKey: string): string | undefined {
+    const row = this.db
+      .query("SELECT body_preview FROM item WHERE id = ?")
+      .get(indexPrimaryKey) as { body_preview: string | null } | null;
+    const preview = row?.body_preview;
+    if (typeof preview === "string" && preview.trim() !== "") {
+      return preview;
+    }
+    return undefined;
+  }
+
   traverseGraph(
     startRef: string,
     options?: TraverseGraphOptions,

--- a/packages/gateway/src/ipc/agent-invoke.ts
+++ b/packages/gateway/src/ipc/agent-invoke.ts
@@ -1,3 +1,5 @@
+import type { LlmGenerateResult } from "../llm/types.ts";
+
 export type AgentInvokeContext = {
   clientId: string;
   input: string;
@@ -7,4 +9,9 @@ export type AgentInvokeContext = {
   agent?: string;
 };
 
-export type AgentInvokeHandler = (ctx: AgentInvokeContext) => Promise<{ reply: string }>;
+export type AgentInvokeResult = {
+  reply: string;
+  modelMeta?: LlmGenerateResult;
+};
+
+export type AgentInvokeHandler = (ctx: AgentInvokeContext) => Promise<AgentInvokeResult>;

--- a/packages/gateway/src/ipc/engine-ask-stream-handler.test.ts
+++ b/packages/gateway/src/ipc/engine-ask-stream-handler.test.ts
@@ -39,6 +39,7 @@ describe("createAskStreamHandler", () => {
       agentInvokeHandler: async (ctx) => {
         ctx.sendChunk?.("hello");
         ctx.sendChunk?.(" world");
+        return { reply: "hello world" };
       },
     };
     const handler = createAskStreamHandler(deps);
@@ -50,6 +51,39 @@ describe("createAskStreamHandler", () => {
     expect(tokens[0]?.params).toMatchObject({ streamId: "stream-test-1", text: "hello" });
     const done = notifications.find((n) => n.method === "engine.streamDone");
     expect(done).toBeDefined();
+  });
+
+  test("emits typed model metadata when handler returns it", async () => {
+    const registry = makeRegistry();
+    const notifications: { method: string; params: Record<string, unknown> }[] = [];
+    const deps: AskStreamHandlerDeps = {
+      registry,
+      randomId: () => "stream-meta-1",
+      sessionWriteNotification: (n) => notifications.push(n),
+      runWithRequestContext: async (_ctx, fn) => fn(),
+      agentInvokeHandler: async () => ({
+        reply: "ok",
+        modelMeta: {
+          text: "ok",
+          tokensIn: 3,
+          tokensOut: 1,
+          modelUsed: "local-test-model:latest",
+          isLocal: true,
+          provider: "ollama",
+        },
+      }),
+    };
+    const handler = createAskStreamHandler(deps);
+    await handler("client-1", { input: "say hi" });
+    await new Promise((r) => setTimeout(r, 10));
+    const done = notifications.find((n) => n.method === "engine.streamDone");
+    expect(done?.params["meta"]).toMatchObject({
+      modelUsed: "local-test-model:latest",
+      isLocal: true,
+      provider: "ollama",
+      tokensIn: 3,
+      tokensOut: 1,
+    });
   });
 
   test("emits engine.streamError when handler throws", async () => {
@@ -88,6 +122,7 @@ describe("createAskStreamHandler", () => {
           }
           await new Promise((r) => setTimeout(r, 1));
         }
+        return { reply: "done" };
       },
     };
     const handler = createAskStreamHandler(deps);
@@ -108,7 +143,7 @@ describe("createAskStreamHandler", () => {
       randomId: () => "stream-cleanup-1",
       sessionWriteNotification: () => undefined,
       runWithRequestContext: async (_c, fn) => fn(),
-      agentInvokeHandler: async () => undefined,
+      agentInvokeHandler: async () => ({ reply: "done" }),
     };
     const handler = createAskStreamHandler(deps);
     await handler("client-1", { input: "" });

--- a/packages/gateway/src/ipc/engine-ask-stream.ts
+++ b/packages/gateway/src/ipc/engine-ask-stream.ts
@@ -1,3 +1,6 @@
+import type { LlmGenerateResult } from "../llm/types.ts";
+import type { AgentInvokeResult } from "./agent-invoke.ts";
+
 export type StreamNotification = {
   jsonrpc: "2.0";
   method: string;
@@ -28,7 +31,7 @@ export type AskStreamHandlerDeps = {
   randomId: () => string;
   sessionWriteNotification: (n: StreamNotification) => void;
   runWithRequestContext: <T>(ctx: RequestContextLike, fn: () => Promise<T>) => Promise<T>;
-  agentInvokeHandler: (ctx: AgentInvokeContextLike) => Promise<unknown>;
+  agentInvokeHandler: (ctx: AgentInvokeContextLike) => Promise<AgentInvokeResult>;
 };
 
 export type AskStreamParams = {
@@ -37,6 +40,16 @@ export type AskStreamParams = {
 };
 
 export type AskStreamResult = { streamId: string };
+
+function streamMetaFromModelMeta(meta: LlmGenerateResult): Record<string, unknown> {
+  return {
+    modelUsed: meta.modelUsed,
+    isLocal: meta.isLocal,
+    provider: meta.provider,
+    tokensIn: meta.tokensIn,
+    tokensOut: meta.tokensOut,
+  };
+}
 
 export function createAskStreamHandler(
   deps: AskStreamHandlerDeps,
@@ -57,6 +70,7 @@ export function createAskStreamHandler(
 
     void (async (): Promise<void> => {
       try {
+        let modelMeta: LlmGenerateResult | undefined;
         const ctx: RequestContextLike = {};
         if (params.sessionId !== undefined) ctx.sessionId = params.sessionId;
         await deps.runWithRequestContext(ctx, async () => {
@@ -68,7 +82,8 @@ export function createAskStreamHandler(
             signal: ac.signal,
           };
           if (params.sessionId !== undefined) payload.sessionId = params.sessionId;
-          await deps.agentInvokeHandler(payload);
+          const invokeResult = await deps.agentInvokeHandler(payload);
+          modelMeta = invokeResult.modelMeta;
         });
         if (ac.signal.aborted) {
           deps.sessionWriteNotification({
@@ -82,7 +97,10 @@ export function createAskStreamHandler(
             method: "engine.streamDone",
             params: {
               streamId,
-              meta: { modelUsed: "default", isLocal: false, provider: "remote" },
+              meta:
+                modelMeta === undefined
+                  ? { modelUsed: "default", isLocal: false, provider: "remote" }
+                  : streamMetaFromModelMeta(modelMeta),
             },
           });
         }

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -43,6 +43,10 @@ export class LlmRouter {
     this.providerMeta.set(provider.providerId, meta);
   }
 
+  prefersLocal(): boolean {
+    return this.config.preferLocal;
+  }
+
   async selectProvider(task: LlmTaskType): Promise<LlmProvider | undefined> {
     const orderedIds = this.providerPriority(task);
     for (const id of orderedIds) {

--- a/packages/gateway/src/platform/assemble.test.ts
+++ b/packages/gateway/src/platform/assemble.test.ts
@@ -79,6 +79,7 @@ describe("assemblePlatformServices — in-process assembly", () => {
         "[llm]",
         'remote_model = "claude-sonnet-4-6"',
         'classifier_model = "claude-haiku-4-5-20251001"',
+        'local_model = "local-test-model:latest"',
         "",
         "[openapi]",
         "enabled = true",
@@ -90,6 +91,7 @@ describe("assemblePlatformServices — in-process assembly", () => {
     expect(typeof services.vault.get).toBe("function");
     expect(typeof services.ipc.stop).toBe("function");
     expect(typeof services.localIndex).toBe("object");
+    expect(typeof services.llmRegistry.getRouterStatus).toBe("function");
     expect(typeof services.disposeSidecars).toBe("function");
     expect(await services.autostart.isEnabled()).toBe(false);
     await services.autostart.enable();

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -11,6 +11,7 @@ import {
   loadNimbusAutomationFromConfigDir,
   loadNimbusEmbeddingFromPath,
   loadNimbusExtensionsFromConfigDir,
+  loadNimbusLlmFromPath,
   loadNimbusLlmPartialFromPath,
   loadNimbusPagerdutyFromConfigDir,
   loadNimbusUpdaterFromConfigDir,
@@ -48,6 +49,9 @@ import { resumePendingRemovals } from "../ipc/connector-rpc-handlers/index.ts";
 import { startReadOnlyHttpServer } from "../ipc/http-server.ts";
 import { createIpcServer } from "../ipc/index.ts";
 import { startMetricsServer } from "../ipc/metrics-server.ts";
+import { LlamaCppProvider } from "../llm/llamacpp-provider.ts";
+import { OllamaProvider } from "../llm/ollama-provider.ts";
+import { LlmRegistry } from "../llm/registry.ts";
 import { SessionMemoryStore } from "../memory/session-memory-store.ts";
 import { ProviderRateLimiter } from "../sync/rate-limiter.ts";
 import { SyncScheduler } from "../sync/scheduler.ts";
@@ -305,6 +309,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
   const rateLimiter = new ProviderRateLimiter();
   const activeTomlPath = resolveNimbusTomlForProfile(paths.configDir);
   const sessionToml = loadNimbusSessionFromPath(activeTomlPath);
+  const llmToml = loadNimbusLlmFromPath(activeTomlPath);
   const llmTomlPartial = loadNimbusLlmPartialFromPath(activeTomlPath);
   const llmOverrides: { agentModel?: string; classifierModel?: string } = {};
   if (llmTomlPartial.remoteModel !== undefined) {
@@ -314,6 +319,21 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     llmOverrides.classifierModel = llmTomlPartial.classifierModel;
   }
   applyLlmTomlOverrides(llmOverrides);
+  const llmRegistry = new LlmRegistry({
+    db,
+    config: {
+      preferLocal: llmToml.preferLocal,
+      remoteModel: llmToml.remoteModel,
+      localModel: llmToml.localModel,
+      minReasoningParams: llmToml.minReasoningParams,
+      enforceAirGap: llmToml.enforceAirGap,
+    },
+  });
+  llmRegistry.addProvider(new OllamaProvider("http://127.0.0.1:11434", llmToml.localModel));
+  const llamacppBaseUrl = llmToml.llamacppServerPath.trim();
+  llmRegistry.addProvider(
+    new LlamaCppProvider(llamacppBaseUrl === "" ? undefined : llamacppBaseUrl, llmToml.localModel),
+  );
 
   const { localIndex, scheduleItemEmbedding, rt } = await createLocalIndexWithEmbeddingRuntime(
     db,
@@ -382,6 +402,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     syncScheduler,
     connectorMesh,
     sandboxRunner,
+    llmRegistry,
     ...(autoUpdateRuntime === undefined ? {} : { extensionsAutoUpdate: autoUpdateRuntime.deps }),
     ...(autoUpdateRuntime === undefined
       ? {}
@@ -450,6 +471,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     notifications,
     openUrl: openUrlInDefaultBrowser,
     sandboxRunner,
+    llmRegistry,
     ...(sessionMemoryStore === undefined ? {} : { sessionMemoryStore }),
     disposeSidecars(): void {
       for (const s of sidecarStops) {

--- a/packages/gateway/src/platform/types.ts
+++ b/packages/gateway/src/platform/types.ts
@@ -1,6 +1,7 @@
 import type { LazyConnectorMesh } from "../connectors/lazy-mesh/index.ts";
 import type { LocalIndex } from "../index/local-index.ts";
 import type { IPCServer } from "../ipc/index.ts";
+import type { LlmRegistry } from "../llm/registry.ts";
 import type { SessionMemoryStore } from "../memory/session-memory-store.ts";
 import type { SyncScheduler } from "../sync/scheduler.ts";
 import type { NimbusVault } from "../vault/index.ts";
@@ -28,6 +29,7 @@ export interface PlatformServices {
   notifications: NotificationService;
   openUrl(url: string): Promise<void>;
   sessionMemoryStore?: SessionMemoryStore;
+  llmRegistry: LlmRegistry;
   sandboxRunner: SandboxRunner;
   disposeSidecars?: () => void;
 }


### PR DESCRIPTION
Wire the existing LLM registry into gateway startup and allow nimbus ask to use local Ollama/llama.cpp models for open-ended indexed-context answers. Fall back to local answering when the remote classifier has no configured key, while preserving the Mastra agent path when local routing is not preferred.

Also thread typed model metadata through ask streaming, wrap local index context with the LLM tool-output envelope, add LocalIndex body-preview access, and document local model setup without coupling tests or docs to a specific model.

## Summary

<!-- What does this PR do? One paragraph or a short bullet list. -->

## Related Issue

<!-- Link the issue this PR addresses: "Closes #123" or "Relates to #456" -->

Closes #

## Linked Discussion

<!-- Optional but encouraged. If this PR implements an idea agreed in Discussions Ideas, answers a Q&A, or addresses something flagged in General, paste the discussion URL here so a maintainer can update or mark-answered the thread after merge. Note: GitHub does NOT auto-close Discussions from PR merges (only Issues via `Closes #N`); this is a manual maintainer follow-up. -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactor (no behaviour change)
- [ ] Test improvement
- [ ] Documentation only
- [ ] CI / tooling

## Non-Negotiables Checklist

<!-- Every PR must satisfy these. A failed item blocks merge. -->

- [ ] `bun run typecheck` passes with zero errors
- [ ] `bun run lint` passes (Biome — format + lint)
- [ ] All existing tests pass (`bun test`)
- [ ] New behaviour is covered by tests
- [ ] No `any` types introduced — `unknown` is used for external data
- [ ] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [ ] Platform-specific code is behind the `PlatformServices` abstraction (no OS checks in business logic)
- [ ] The HITL consent gate has not been weakened, bypassed, or made configurable
- [ ] If this PR touches `docs/README.md`, a screenshot of the rendered page (light + dark) is attached in the Screenshots / Output section below

## Coverage (if engine/ or vault/ was changed)

<!-- CI enforces: Engine ≥85%, Vault ≥90%. Paste coverage output or confirm it passes. -->

- [ ] `bun run test:coverage:engine` passes (Engine ≥85%) — if `engine/` was modified
- [ ] `bun run test:coverage:vault` passes (Vault ≥90%) — if `vault/` was modified

## Testing

<!-- Describe what you tested and how. Include platform(s) tested if relevant. -->

<!-- Desktop E2E (Tauri + Playwright) on PRs: add the `ci:e2e-desktop` label to run the optional Ubuntu job after `pr-quality`. -->

## Screenshots / Output

<!-- Optional — include terminal output, logs, or screenshots if helpful for review. -->

## Notes for Reviewers

<!-- Anything the reviewer should know: tricky areas, intentional trade-offs, follow-up issues. -->
