### PR TITLE
fix(llm): report fallback provider in `llm status`, fix reason labels, reuse IPC helper

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -893,7 +893,11 @@ nimbus llm status [--json]
 | Provider  | `ollama`, `llamacpp`, or `remote` |
 | Model     | Model name from config (`llm.local_model` or `llm.remote_model`) |
 | Available | Whether the provider responded to an availability check |
-| Reason    | `prefer-local`, `prefer-remote`, `air-gap`, `no-local-provider`, or `no-remote-provider` |
+| Reason    | `prefer-local`, `prefer-remote`, `air-gap`, `no-local-provider`, `no-remote-provider`, or `local-below-reasoning-floor` |
+
+The Provider/Model/Reason columns describe the **preferred** provider for each task (the
+configured intent). When that provider is unavailable, the Reason cell also names the provider
+the router would actually fall back to at generation time — `… (falls back to remote/<model>)`.
 
 **Flags:**
 
@@ -907,7 +911,7 @@ nimbus llm status [--json]
 Task type      Provider   Model                    Available  Reason
 -------------------------------------------------------------------------------
 classification ollama     llama3.2                 yes        prefer-local
-reasoning      ollama     llama3.2                 yes        prefer-local
+reasoning      ollama     llama3.2                 no         prefer-local (falls back to remote/claude-sonnet-4-6)
 summarisation  ollama     llama3.2                 yes        prefer-local
 agent_step     —          —                        no         unavailable
 ```
@@ -921,9 +925,19 @@ agent_step     —          —                        no         unavailable
     "modelName": "llama3.2",
     "isAvailable": true,
     "reason": "prefer-local"
+  },
+  "reasoning": {
+    "providerId": "ollama",
+    "modelName": "llama3.2",
+    "isAvailable": false,
+    "reason": "prefer-local",
+    "fallback": { "providerId": "remote", "modelName": "claude-sonnet-4-6" }
   }
 }
 ```
+
+The `fallback` field is present only when the preferred provider is unavailable but another
+provider can serve the task.
 
 ---
 

--- a/packages/cli/src/commands/llm.test.ts
+++ b/packages/cli/src/commands/llm.test.ts
@@ -58,6 +58,25 @@ describe("runLlmStatusImpl", () => {
     expect(out.stdout).toContain("unavailable");
   });
 
+  it("notes the fallback provider when the preferred provider is unavailable", async () => {
+    const ipc = createMockIpcClient([
+      {
+        decisions: {
+          ...MOCK_DECISIONS,
+          classification: {
+            providerId: "ollama",
+            modelName: "llama3.2",
+            isAvailable: false,
+            reason: "prefer-local",
+            fallback: { providerId: "remote", modelName: "claude-sonnet-4-6" },
+          },
+        },
+      },
+    ]);
+    await runLlmStatusImpl(ipc.client, { json: false });
+    expect(out.stdout).toContain("falls back to remote/claude-sonnet-4-6");
+  });
+
   it("emits JSON when --json flag is set", async () => {
     const ipc = createMockIpcClient([{ decisions: MOCK_DECISIONS }]);
     await runLlmStatusImpl(ipc.client, { json: true });
@@ -105,9 +124,8 @@ describe("runLlm (dispatcher)", () => {
     expect(out.stdout).toContain("nimbus llm");
   });
 
-  it("prints error for unknown subcommand", async () => {
-    await runLlm(["bogus"]);
-    expect(out.stderr).toContain("Unknown llm subcommand: bogus");
+  it("throws for unknown subcommand", async () => {
+    await expect(runLlm(["bogus"])).rejects.toThrow("Unknown llm subcommand: bogus");
   });
 
   it("runs status when gateway is running", async () => {
@@ -121,10 +139,9 @@ describe("runLlm (dispatcher)", () => {
     expect(out.stdout).toContain("classification");
   });
 
-  it("prints error when gateway is not running", async () => {
+  it("throws when gateway is not running", async () => {
     setFixture({});
-    await runLlm(["status"]);
-    expect(out.stderr).toContain("Gateway: not running");
+    await expect(runLlm(["status"])).rejects.toThrow("Gateway is not running");
   });
 
   it("passes --json to status", async () => {

--- a/packages/cli/src/commands/llm.ts
+++ b/packages/cli/src/commands/llm.ts
@@ -1,6 +1,5 @@
-import { IPCClient } from "../ipc-client/index.ts";
-import { readGatewayState } from "../lib/gateway-process.ts";
-import { getCliPlatformPaths } from "../paths.ts";
+import type { IPCClient } from "../ipc-client/index.ts";
+import { withGatewayIpc } from "../lib/with-gateway-ipc.ts";
 
 type LlmTaskType = "classification" | "reasoning" | "summarisation" | "agent_step";
 
@@ -9,6 +8,7 @@ type TaskDecision = {
   modelName: string;
   isAvailable: boolean;
   reason: string;
+  fallback?: { providerId: string; modelName: string };
 };
 
 type RouterStatusResponse = {
@@ -50,12 +50,15 @@ function printStatusTable(decisions: Record<LlmTaskType, TaskDecision | undefine
           "unavailable",
       );
     } else {
+      const reason = d.fallback
+        ? `${d.reason} (falls back to ${d.fallback.providerId}/${d.fallback.modelName})`
+        : d.reason;
       console.log(
         pad(task, COL_WIDTHS.task) +
           pad(d.providerId, COL_WIDTHS.provider) +
           pad(d.modelName || "—", COL_WIDTHS.model) +
           pad(d.isAvailable ? "yes" : "no", COL_WIDTHS.available) +
-          d.reason,
+          reason,
       );
     }
   }
@@ -92,23 +95,9 @@ export async function runLlm(args: string[]): Promise<void> {
 
   if (subcommand === "status") {
     const json = rest.includes("--json");
-    const paths = getCliPlatformPaths();
-    const state = await readGatewayState(paths);
-    if (state === undefined) {
-      console.error("Gateway: not running (no state file)");
-      process.exitCode = 1;
-      return;
-    }
-    const client = new IPCClient(state.socketPath);
-    try {
-      await client.connect();
-      await runLlmStatusImpl(client, { json });
-    } finally {
-      await client.disconnect().catch(() => {});
-    }
+    await withGatewayIpc((c) => runLlmStatusImpl(c, { json }));
     return;
   }
 
-  console.error(`Unknown llm subcommand: ${subcommand}`);
-  process.exitCode = 1;
+  throw new Error(`Unknown llm subcommand: ${subcommand}`);
 }

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -284,6 +284,64 @@ describe("LlmRouter.getStatus", () => {
       "summarisation",
     ]);
   });
+
+  test("reports the fallback generate() would use when the preferred provider is down", async () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerProvider(makeFakeProvider("ollama", false));
+    router.registerProvider(makeFakeProvider("remote", true));
+    const status = await router.getStatus();
+    expect(status.classification?.providerId).toBe("ollama");
+    expect(status.classification?.isAvailable).toBe(false);
+    expect(status.classification?.fallback).toEqual({
+      providerId: "remote",
+      modelName: DEFAULT_CONFIG.remoteModel,
+    });
+  });
+
+  test("no fallback when the preferred provider is available", async () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerProvider(makeFakeProvider("remote", true));
+    const status = await router.getStatus();
+    expect(status.classification?.isAvailable).toBe(true);
+    expect(status.classification?.fallback).toBeUndefined();
+  });
+
+  test("no fallback when the preferred is down and nothing else is available", async () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerProvider(makeFakeProvider("ollama", false));
+    const status = await router.getStatus();
+    expect(status.classification?.isAvailable).toBe(false);
+    expect(status.classification?.fallback).toBeUndefined();
+  });
+
+  test("reason is local-below-reasoning-floor when local exists but misses the floor", async () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerProvider(makeFakeProvider("ollama", true), { parameterCount: 1 });
+    router.registerProvider(makeFakeProvider("remote", true));
+    const status = await router.getStatus();
+    // reasoning carries a capability floor; ollama (1B < minReasoningParams) is skipped → remote.
+    expect(status.reasoning?.providerId).toBe("remote");
+    expect(status.reasoning?.reason).toBe("local-below-reasoning-floor");
+    // classification has no floor, so ollama is still the local pick there.
+    expect(status.classification?.providerId).toBe("ollama");
+    expect(status.classification?.reason).toBe("prefer-local");
+  });
+
+  test("probes each provider's availability at most once across all four tasks", async () => {
+    let ollamaProbes = 0;
+    const ollama: LlmProvider = {
+      ...makeFakeProvider("ollama", true),
+      isAvailable: async () => {
+        ollamaProbes += 1;
+        return true;
+      },
+    };
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerProvider(ollama);
+    await router.getStatus();
+    expect(ollamaProbes).toBe(1);
+  });
 });
 
 describe("midTruncate", () => {

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -19,6 +19,16 @@ export type ProviderMeta = {
   contextWindow?: number;
 };
 
+export type LlmTaskStatus = {
+  providerId: LlmProviderKind;
+  modelName: string;
+  isAvailable: boolean;
+  reason: string;
+  // Populated only when the preferred provider is unavailable: the provider generate() would
+  // actually fall back to, so the status reflects real routing rather than just config intent.
+  fallback?: { providerId: LlmProviderKind; modelName: string };
+};
+
 const LOCAL_PROVIDER_IDS: ReadonlySet<LlmProviderKind> = new Set(["ollama", "llamacpp"]);
 const CONTEXT_OVERFLOW_THRESHOLD = 0.85;
 const TOKENS_PER_CHAR = 4;
@@ -48,23 +58,32 @@ export class LlmRouter {
   }
 
   async selectProvider(task: LlmTaskType): Promise<LlmProvider | undefined> {
-    const orderedIds = this.providerPriority(task);
-    for (const id of orderedIds) {
-      if (this.config.enforceAirGap && !LOCAL_PROVIDER_IDS.has(id)) {
-        continue;
-      }
-      if (!this.meetsCapabilityFloor(id, task)) {
-        continue;
-      }
+    return this.firstAvailable(task, (p) => this.probeAvailable(p));
+  }
+
+  // Walks the task's provider priority order (respecting air-gap and the capability floor) and
+  // returns the first provider whose availability check resolves true. The check is injected so
+  // callers can share a memoized probe across many tasks (see getStatus).
+  private async firstAvailable(
+    task: LlmTaskType,
+    isAvailable: (provider: LlmProvider) => Promise<boolean>,
+  ): Promise<LlmProvider | undefined> {
+    for (const id of this.providerPriority(task)) {
+      if (this.config.enforceAirGap && !LOCAL_PROVIDER_IDS.has(id)) continue;
+      if (!this.meetsCapabilityFloor(id, task)) continue;
       const provider = this.providers.get(id);
       if (provider === undefined) continue;
-      try {
-        if (await provider.isAvailable()) return provider;
-      } catch {
-        /* treat availability check failure as unavailable */
-      }
+      if (await isAvailable(provider)) return provider;
     }
     return undefined;
+  }
+
+  private async probeAvailable(provider: LlmProvider): Promise<boolean> {
+    try {
+      return await provider.isAvailable();
+    } catch {
+      return false; // treat availability check failure as unavailable
+    }
   }
 
   async generate(opts: LlmGenerateOptions): Promise<LlmGenerateResult> {
@@ -146,14 +165,30 @@ export class LlmRouter {
     return LOCAL_PROVIDER_IDS.has(providerId) ? this.config.localModel : this.config.remoteModel;
   }
 
-  private reasonFor(providerId: LlmProviderKind): string {
+  private reasonFor(task: LlmTaskType, providerId: LlmProviderKind): string {
     const isLocal = LOCAL_PROVIDER_IDS.has(providerId);
     if (this.config.enforceAirGap && isLocal) return "air-gap";
     if (this.config.preferLocal && isLocal) return "prefer-local";
     if (!this.config.preferLocal && !isLocal) return "prefer-remote";
-    // Preference could not be satisfied (no matching provider registered).
-    if (this.config.preferLocal && !isLocal) return "no-local-provider";
+    // The preferred provider does not match the configured preference.
+    if (this.config.preferLocal && !isLocal) {
+      // A local provider may be registered but skipped because it falls below the reasoning
+      // capability floor — distinguish that from "no local provider registered at all".
+      return this.localProviderBelowFloor(task)
+        ? "local-below-reasoning-floor"
+        : "no-local-provider";
+    }
     return "no-remote-provider";
+  }
+
+  // True when a local provider is registered for this task but was excluded by the reasoning
+  // capability floor (only reasoning/agent_step carry a floor).
+  private localProviderBelowFloor(task: LlmTaskType): boolean {
+    for (const id of this.providers.keys()) {
+      if (!LOCAL_PROVIDER_IDS.has(id)) continue;
+      if (!this.meetsCapabilityFloor(id, task)) return true;
+    }
+    return false;
   }
 
   // Finds the highest-priority provider for a task based on config (priority order, capability
@@ -170,45 +205,46 @@ export class LlmRouter {
     return undefined;
   }
 
-  async getStatus(): Promise<
-    Record<
-      LlmTaskType,
-      | { providerId: LlmProviderKind; modelName: string; isAvailable: boolean; reason: string }
-      | undefined
-    >
-  > {
+  async getStatus(): Promise<Record<LlmTaskType, LlmTaskStatus | undefined>> {
     const tasks: LlmTaskType[] = ["classification", "reasoning", "summarisation", "agent_step"];
-    const out: Partial<
-      Record<
-        LlmTaskType,
-        | { providerId: LlmProviderKind; modelName: string; isAvailable: boolean; reason: string }
-        | undefined
-      >
-    > = {};
+    const out: Partial<Record<LlmTaskType, LlmTaskStatus | undefined>> = {};
+    // Probe each provider's availability at most once for the whole call.
+    const availabilityCache = new Map<LlmProviderKind, Promise<boolean>>();
+    const cachedAvailable = (provider: LlmProvider): Promise<boolean> => {
+      let probe = availabilityCache.get(provider.providerId);
+      if (probe === undefined) {
+        probe = this.probeAvailable(provider);
+        availabilityCache.set(provider.providerId, probe);
+      }
+      return probe;
+    };
     for (const t of tasks) {
       const preferred = this.findPreferred(t);
       if (preferred === undefined) {
         out[t] = undefined;
         continue;
       }
-      let isAvailable = false;
-      try {
-        isAvailable = await preferred.isAvailable();
-      } catch {
-        /* treat availability check failure as unavailable */
-      }
-      out[t] = {
+      const isAvailable = await cachedAvailable(preferred);
+      const entry: LlmTaskStatus = {
         providerId: preferred.providerId,
         modelName: this.modelNameFor(preferred.providerId),
         isAvailable,
-        reason: this.reasonFor(preferred.providerId),
+        reason: this.reasonFor(t, preferred.providerId),
       };
+      if (!isAvailable) {
+        // The preferred provider is down; report the provider generate() would actually fall
+        // back to (next available in priority order) so status matches real routing.
+        const actual = await this.firstAvailable(t, cachedAvailable);
+        if (actual !== undefined && actual.providerId !== preferred.providerId) {
+          entry.fallback = {
+            providerId: actual.providerId,
+            modelName: this.modelNameFor(actual.providerId),
+          };
+        }
+      }
+      out[t] = entry;
     }
-    return out as Record<
-      LlmTaskType,
-      | { providerId: LlmProviderKind; modelName: string; isAvailable: boolean; reason: string }
-      | undefined
-    >;
+    return out as Record<LlmTaskType, LlmTaskStatus | undefined>;
   }
 
   private providerPriority(_task: LlmTaskType): LlmProviderKind[] {


### PR DESCRIPTION
@
## Summary

Follow-up to the merged `nimbus llm status` work (#489), addressing review findings on that PR.

- **Show both preferred + fallback (`getStatus`):** the status still reports the *preferred* provider per task (config intent) and its `isAvailable`, but when the preferred provider is down it now also reports the provider `generate()` would actually fall back to. Previously the status could show an unavailable provider as the "decision" while generation silently used a different one — the two now agree.
  - CLI table: `prefer-local (falls back to remote/claude-sonnet-4-6)`
  - JSON: optional `fallback: { providerId, modelName }` field (present only when the preferred is unavailable and another provider can serve the task)
- **Reason mislabel fix:** a local provider skipped by the reasoning capability floor now reports `local-below-reasoning-floor` instead of the misleading `no-local-provider`. `reasonFor` takes the task and consults `localProviderBelowFloor`.
- **Availability memoization:** `getStatus` now probes each provider at most once per call (was up to one probe per task for the same provider). `selectProvider` and `getStatus` share one priority-walk (`firstAvailable`) with the availability check injected.
- **Reuse `withGatewayIpc` (CLI):** `runLlm` drops the duplicated `readGatewayState`/connect/`finally` disconnect boilerplate and throws on errors, matching the `telemetry.ts`/`config.ts` convention where `main()` prints the message and sets the exit code.

Docs (`cli-reference.md`) updated for the new reason value and fallback semantics.

The desktop UI (`RouterStatus.tsx`, consuming the back-compat `llm.getRouterStatus`) is untouched — it ignores the additive fields, so nothing regresses.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (no behaviour change) — `withGatewayIpc` reuse, shared priority-walk

## Testing

- `bun test` gateway router + llm-rpc: 50 pass · CLI llm: 11 pass · registry/help drift: 12 pass
- New tests cover fallback rendering (CLI + router), the `local-below-reasoning-floor` reason, the no-fallback cases, and the single-probe-per-provider guarantee
- `bun run typecheck`: 0 errors across all packages
- `bun run lint` (Biome): clean across the source tree (verified with `--vcs-enabled=false`; the worktree lives under `.claude/`, which Biome ignores, so the in-worktree `biome check .` reports zero files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@