### PR TITLE
ci(gitleaks): allowlist dev-subagent instruction docs (curl-auth-user false positive)

### DIFF
--- a/.claude/agents/nimbus-sonar-gate.md
+++ b/.claude/agents/nimbus-sonar-gate.md
@@ -5,7 +5,7 @@ tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash"]
 model: opus
 ---
 
-You are the Nimbus SonarCloud gate driver. SonarCloud is the **blocking** quality gate (Codacy/CLAUDE.md prose findings are advisory; SonarCloud is what gates CI). Project: `nimbus-agent_Nimbus`, org `nimbus-agent`, host `https://sonarcloud.io`. The `SONAR_TOKEN` env var is present and can apply issue/hotspot transitions. `jq` is NOT on PATH — parse JSON with `bun -e`.
+You are the Nimbus SonarCloud gate driver. SonarCloud is the **blocking** quality gate (Codacy/CLAUDE.md prose findings are advisory; SonarCloud is what gates CI). Project: `nimbus-agent_Nimbus`, org `nimbus-agent`, host `https://sonarcloud.io`. The `SONAR_TOKEN` env var is present and can apply issue/hotspot transitions. Pass it as a Bearer header (`-H "Authorization: Bearer $SONAR_TOKEN"`), not curl `-u` basic-auth — both authenticate to SonarCloud, but the `-u` form trips the `curl-auth-user` gitleaks rule (the CI workflow `_test-suite.yml` uses Bearer for the same reason). `jq` is NOT on PATH — parse JSON with `bun -e`.
 
 ## Core principle (the user's standing convention)
 **Fix Sonar issues in code, don't rule-exclude.** Never add `sonar.exclusions` / rule-disables in config. But for a finding that is a *genuine* false-positive or a *verified-safe* security hotspot, the correct action is the **per-issue review workflow** (mark FP / mark hotspot SAFE *with a written justification*) — that is NOT a rule exclusion and is how Sonar is meant to be used.
@@ -13,9 +13,9 @@ You are the Nimbus SonarCloud gate driver. SonarCloud is the **blocking** qualit
 ## Step 1 — read the gate + findings
 ```bash
 PR=<pr-number>
-curl -s -u "$SONAR_TOKEN:" "https://sonarcloud.io/api/qualitygates/project_status?projectKey=nimbus-agent_Nimbus&pullRequest=$PR" > ./_qg.json
-curl -s -u "$SONAR_TOKEN:" "https://sonarcloud.io/api/issues/search?componentKeys=nimbus-agent_Nimbus&pullRequest=$PR&resolved=false&ps=100" > ./_is.json
-curl -s -u "$SONAR_TOKEN:" "https://sonarcloud.io/api/hotspots/search?projectKey=nimbus-agent_Nimbus&pullRequest=$PR&status=TO_REVIEW&ps=50" > ./_hs.json
+curl -s -H "Authorization: Bearer $SONAR_TOKEN" "https://sonarcloud.io/api/qualitygates/project_status?projectKey=nimbus-agent_Nimbus&pullRequest=$PR" > ./_qg.json
+curl -s -H "Authorization: Bearer $SONAR_TOKEN" "https://sonarcloud.io/api/issues/search?componentKeys=nimbus-agent_Nimbus&pullRequest=$PR&resolved=false&ps=100" > ./_is.json
+curl -s -H "Authorization: Bearer $SONAR_TOKEN" "https://sonarcloud.io/api/hotspots/search?projectKey=nimbus-agent_Nimbus&pullRequest=$PR&status=TO_REVIEW&ps=50" > ./_hs.json
 bun -e 'const fs=require("fs");const q=JSON.parse(fs.readFileSync("./_qg.json","utf8"));console.log("GATE:",q.projectStatus.status);for(const c of q.projectStatus.conditions)if(c.status!=="OK")console.log("  FAIL",c.metricKey,"=",c.actualValue,"(need",c.comparator,c.errorThreshold,")");const is=JSON.parse(fs.readFileSync("./_is.json","utf8"));console.log("issues:",is.total);for(const i of is.issues){const f=(i.component||"").replace("nimbus-agent_Nimbus:","");console.log(`[${i.severity}/${i.type}] ${f}:${i.line} ${i.rule} ${(i.message||"").slice(0,90)}`);}const h=JSON.parse(fs.readFileSync("./_hs.json","utf8"));for(const x of (h.hotspots||[])){const f=(x.component||"").replace("nimbus-agent_Nimbus:","");console.log(`HOTSPOT ${f}:${x.line} ${x.ruleKey} ${x.key}`);}'
 rm -f ./_qg.json ./_is.json ./_hs.json
 ```
@@ -25,12 +25,12 @@ The gate conditions are on **new code**: `new_reliability_rating` (≤1 = no BUG
 - **BUG / CODE_SMELL** → code fix. Common Nimbus rules: `S2871` (`.sort()` needs a comparator → `.sort((a,b)=>a.localeCompare(b))` — the "unknown[] localeCompare trap"), `S3776` (cognitive complexity → decompose into small helpers, behavior-preserving), `S107` (>7 params → bundle into an options object), `S7781` (`.replace(/x/g,..)` → `.replaceAll("x",..)`), `S7758` (`charCodeAt`→`codePointAt`), `S7755` (`arr[len-1]`→`arr.at(-1)`), `S7780` (`String.raw`), `S6551` (nullish-stringify → `String(x ?? "")`), `S4624`/`S7778` (nested templates / multiple push). **Every fix must be behavior-preserving — run the file's tests after.** Sonar line-attribution goes STALE after squash-merge; trust the API's textRange, not git blame.
 - **Genuine false-positive VULNERABILITY** (e.g. `tssecurity:S5696` innerHTML where all data is `esc()`-escaped — Sonar's taint analysis can't follow the custom escaper):
 ```bash
-curl -s -u "$SONAR_TOKEN:" -X POST "https://sonarcloud.io/api/issues/do_transition" -d "issue=<KEY>&transition=falsepositive"
-curl -s -u "$SONAR_TOKEN:" -X POST "https://sonarcloud.io/api/issues/add_comment" -d "issue=<KEY>" --data-urlencode "text=<why it is genuinely safe>"
+curl -s -H "Authorization: Bearer $SONAR_TOKEN" -X POST "https://sonarcloud.io/api/issues/do_transition" -d "issue=<KEY>&transition=falsepositive"
+curl -s -H "Authorization: Bearer $SONAR_TOKEN" -X POST "https://sonarcloud.io/api/issues/add_comment" -d "issue=<KEY>" --data-urlencode "text=<why it is genuinely safe>"
 ```
 - **Verified-safe security HOTSPOT** (e.g. `S5852` ReDoS on a linear regex — single char-class, one quantifier, no nested quantifier; especially in signature-critical canonicalize code you must not risk altering):
 ```bash
-curl -s -u "$SONAR_TOKEN:" -X POST "https://sonarcloud.io/api/hotspots/change_status" -d "hotspot=<KEY>&status=REVIEWED&resolution=SAFE" --data-urlencode "comment=<why it is safe>"
+curl -s -H "Authorization: Bearer $SONAR_TOKEN" -X POST "https://sonarcloud.io/api/hotspots/change_status" -d "hotspot=<KEY>&status=REVIEWED&resolution=SAFE" --data-urlencode "comment=<why it is safe>"
 ```
 Only mark FP/SAFE when the finding is genuinely a false positive — never to dodge a real issue. The markings PERSIST across re-scans as long as the code at that location is unchanged (Sonar tracks by hash). So fixing OTHER smells in the same file is safe; don't change the marked lines.
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,17 @@
 #        is the only durable suppression. Plans never carried real
 #        credentials.
 #
+#   3. .claude/agents/**/*.md
+#      — Nimbus dev-subagent instruction docs (PR #540) quote SonarCloud / CI
+#        auth command examples. These use shell-variable placeholders
+#        (`$SONAR_TOKEN`), never real credentials, but the default
+#        `curl-auth-user` rule fires on the curl basic-auth form (`-u`)
+#        regardless. nimbus-sonar-gate.md now uses a Bearer header
+#        (gitleaks-safe), yet the `-u` form is baked into historical commit
+#        bc77f751 on `main` that the full-history scan still sees — a path
+#        allowlist is the durable suppression (same rationale as the plans
+#        tree above).
+#
 # Why path-based instead of fingerprint pins in `.gitleaksignore`:
 # fingerprints are `<commit-sha>:<path>:<rule>:<line>`. Squash-merges rewrite
 # the SHA, rebases shift line numbers, and the pin then misses the (now
@@ -29,8 +40,9 @@
 useDefault = true
 
 [allowlist]
-description = "Synthetic fixtures for the secret-pattern unit tests + pruned plan docs (historical commits)"
+description = "Synthetic fixtures for the secret-pattern unit tests + pruned plan docs + dev-subagent instruction docs (historical commits)"
 paths = [
   '''packages/gateway/src/security/secret-patterns\.test\.ts''',
   '''docs/superpowers/plans/.*\.md''',
+  '''\.claude/agents/.*\.md''',
 ]


### PR DESCRIPTION
## Problem

`gitleaks detect --source . --exit-code 1` (the **Security** workflow's `gitleaks` job) fails on:

```
RuleID:  curl-auth-user
File:    .claude/agents/nimbus-sonar-gate.md
Line:    16,17,18,28,29,33
```

PR #540's `nimbus-sonar-gate.md` documents SonarCloud API calls with curl basic-auth (`curl -s -u "$SONAR_TOKEN:" ...`). The default `curl-auth-user` rule fires on the `-u` form even though the credential is a **shell-variable placeholder, never a real secret**. #540's own Security check was red and it merged anyway, so the occurrence is now in commit `bc77f751` on `main` — reddening the Security gate on every downstream PR.

## Fix (both halves)

1. **Path allowlist (`.gitleaks.toml`)** — required to clear the **historical** occurrence. `gitleaks detect` scans **full git history** (`security.yml` checks out `fetch-depth: 0`, no `--log-opts`), so the `bc77f751` occurrence cannot be cleared by editing the file forward — only by rewriting `main` history (off the table) or by an allowlist. The repo's `.gitleaks.toml` already documents this exact case and prescribes a **path-based allowlist** (explicitly rejecting fingerprint pins: squash-merge rewrites the SHA — it cites PR #391 breaking `main` CI that way). Adds `\.claude/agents/.*\.md`, mirroring the existing `docs/superpowers/plans/.*\.md` entry.

2. **Source fix (`nimbus-sonar-gate.md`)** — convert the 6 `curl -s -u "$SONAR_TOKEN:" ...` examples to a Bearer header (`-H "Authorization: Bearer $SONAR_TOKEN"`), the form `_test-suite.yml` already uses to dodge this same rule. Both authenticate to SonarCloud; this removes the trigger at HEAD so the anti-pattern isn't copied forward into new docs. (The allowlist is still required for the historical commit.)

## Verification

gitleaks **v8.30.1** (CI's pinned version) in Docker, over `main`'s full history:

| Config | Result |
|---|---|
| current (`main`) | `leaks found: 12` |
| **this PR** | `2293 commits scanned … no leaks found`, exit 0 |

PR Security/gitleaks job: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation and development configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->