### PR TITLE
test(coverage): B2 — gateway/identity to ≥80% branch (Sub-project B)

### DIFF
--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-06-08T15:16:41.264Z",
+  "generated_at": "2026-06-09T17:56:01.856Z",
   "files": {
     "packages/cli/src/commands/audit.ts": {
       "min_line_pct": 80,
@@ -461,26 +461,6 @@
     "packages/gateway/src/graph/graph-populator.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 79.79
-    },
-    "packages/gateway/src/identity/deprovision.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 50
-    },
-    "packages/gateway/src/identity/identity-boot.ts": {
-      "min_line_pct": 79.41,
-      "min_branch_pct": 62.5
-    },
-    "packages/gateway/src/identity/identity-runtime.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 61.11
-    },
-    "packages/gateway/src/identity/oidc-device-flow.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 73.08
-    },
-    "packages/gateway/src/identity/verifier.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 69.57
     },
     "packages/gateway/src/index/drift-hints.ts": {
       "min_line_pct": 80,

--- a/packages/gateway/src/identity/deprovision.test.ts
+++ b/packages/gateway/src/identity/deprovision.test.ts
@@ -53,6 +53,33 @@ describe("deprovisionUser", () => {
     expect(ids.getScimUser("u-alice")?.active).toBe(false);
   });
 
+  test("skips continue branch for namespaces where peer has no active grant", () => {
+    const db = freshDb();
+    const ns = new NamespaceStore(db);
+    const ids = new IdentityStore(db);
+    // Publish two namespaces; grant the peer only in ns:has (ns:none has no grant).
+    ns.publish("ns:has", [{ kind: "service", value: "github" }]);
+    ns.publish("ns:none", [{ kind: "service", value: "github" }]);
+    ns.grant("ns:has", "peer:alice", "viewer", true);
+    ids.upsertScimUser(
+      { externalId: "u-alice", userName: "alice", email: "a@acme.com", active: true, attrs: {} },
+      1,
+    );
+    ids.bind("u-alice", "peer:alice", "admin", 1);
+
+    const revoked = deprovisionUser({ db, store: ns, identity: ids, nowMs: 2 }, "u-alice");
+
+    // The peer is still returned even though ns:none was skipped via continue.
+    expect(revoked).toContain("peer:alice");
+    // The grant in ns:has was revoked (continue was NOT taken here).
+    expect(ns.getActiveGrant("ns:has", "peer:alice")).toBeUndefined();
+    // The SCIM user was deactivated.
+    expect(ids.getScimUser("u-alice")?.active).toBe(false);
+    // ns:none had no grant, so the continue branch was taken — revoke was never called for it.
+    // Confirm it remains undefined (nothing to revoke, nothing changed).
+    expect(ns.getActiveGrant("ns:none", "peer:alice")).toBeUndefined();
+  });
+
   test("rolls back atomically — a mid-cascade failure leaves NO grant revoked (review P1)", () => {
     const db = freshDb();
     const ids = new IdentityStore(db);

--- a/packages/gateway/src/identity/identity-boot.test.ts
+++ b/packages/gateway/src/identity/identity-boot.test.ts
@@ -5,11 +5,21 @@ import type { NimbusIdentityToml, NimbusScimToml } from "../config/nimbus-toml.t
 import { LocalIndex } from "../index/local-index.ts";
 import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
 import type { LongRunningEmit } from "../ipc/_lib/long-running.ts";
-import { buildIdentityBoot } from "./identity-boot.ts";
+import { buildIdentityBoot, refreshTokens } from "./identity-boot.ts";
 import type { IdentityRuntimeDeps } from "./identity-runtime.ts";
 import { fakeVault, makeSignedJwt } from "./identity-test-helpers.ts";
 import { IDENTITY_ID_TOKEN_KEY, IDENTITY_SCIM_BEARER_KEY } from "./identity-vault.ts";
 import type { DeviceAuthResponse, OidcDiscovery, TokenResponse, ValidatedClaims } from "./types.ts";
+
+// Shared discovery doc for the refreshTokens + opts.log tests (B2 branch coverage).
+const DISCO: OidcDiscovery = {
+  issuer: "https://acme",
+  deviceAuthorizationEndpoint: "https://acme/device",
+  tokenEndpoint: "https://acme/token",
+  jwksUri: "https://acme/jwks",
+};
+const jsonOk = (b: unknown): Response =>
+  new Response(JSON.stringify(b), { status: 200, headers: { "content-type": "application/json" } });
 
 const CFG: NimbusIdentityToml = {
   enabled: true,
@@ -163,5 +173,37 @@ describe("buildIdentityBoot", () => {
     expect(seenUrls.some((u) => u.endsWith("/jwks"))).toBe(true);
     expect(boot.store.getSession(issuer)?.externalId).toBe("user-boot");
     expect(store.get(IDENTITY_ID_TOKEN_KEY)).toBe(jwt);
+  });
+
+  // --- B2 branch-coverage additions ---
+
+  test("refreshTokens success — res.ok=true branch, returns parsed TokenResponse", async () => {
+    let capturedUrl: string | undefined;
+    const fakeFetch = (async (input: string | URL | Request): Promise<Response> => {
+      capturedUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      return jsonOk({ id_token: "new-id", refresh_token: "new-rt", expires_in: 3600 });
+    }) as unknown as typeof fetch;
+
+    const result = await refreshTokens(DISCO, "c1", "old-rt", fakeFetch);
+
+    expect(capturedUrl).toBe("https://acme/token");
+    expect(result.idToken).toBe("new-id");
+    expect(result.refreshToken).toBe("new-rt");
+  });
+
+  test("refreshTokens failure — res.ok=false branch, throws with status", async () => {
+    const fakeFetch = (async (): Promise<Response> =>
+      new Response("", { status: 500 })) as unknown as typeof fetch;
+
+    await expect(refreshTokens(DISCO, "c1", "old-rt", fakeFetch)).rejects.toThrow(
+      /token refresh failed \(500\)/,
+    );
+  });
+
+  test("buildIdentityBoot with opts.log — log branch at line 150", () => {
+    const { vault } = fakeVault();
+    const boot = buildIdentityBoot(CFG, SCIM, freshIndex(), vault, { log: () => {} });
+    expect(boot.enabled).toBe(true);
   });
 });

--- a/packages/gateway/src/identity/identity-boot.ts
+++ b/packages/gateway/src/identity/identity-boot.ts
@@ -55,8 +55,9 @@ function realSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** `grant_type=refresh_token` POST mirroring the device-flow form helper. */
-async function refreshTokens(
+/** `grant_type=refresh_token` POST mirroring the device-flow form helper.
+ *  Exported for direct branch-coverage testing (B2); still used internally by buildProductionDeps. */
+export async function refreshTokens(
   d: OidcDiscovery,
   clientId: string,
   refreshToken: string,

--- a/packages/gateway/src/identity/identity-runtime.test.ts
+++ b/packages/gateway/src/identity/identity-runtime.test.ts
@@ -173,4 +173,310 @@ describe("IdentityRuntime.revalidateSession", () => {
     expect(isOperatorValid(store, "https://acme", 1500, 1)).toBe(true);
     expect(isOperatorValid(store, "https://acme", 3000, 1)).toBe(false);
   });
+
+  // (A) Throttle guard — lines 73,74,77
+  test("(A) throttle: second call with same timestamp skips refresh (lastRevalidateMs !== null, delta < interval)", async () => {
+    const db = freshDb();
+    const store = new IdentityStore(db);
+    // expiresAt=1_000_000, skew=300s → near-expiry threshold = 700_000; nowMs=800_000 > threshold
+    store.upsertSession({
+      issuer: "https://acme",
+      externalId: "s",
+      email: null,
+      validatedAt: 0,
+      expiresAt: 1_000_000,
+      status: "active",
+    });
+    const { vault } = fakeVault();
+    await vault.set("identity.oidc.refresh_token", "rt");
+    let refreshCount = 0;
+    const nowMs = 800_000;
+    const rt = new IdentityRuntime({
+      cfg: CFG,
+      store,
+      vault,
+      now: () => nowMs,
+      deps: {
+        discover: async () => ({
+          issuer: "https://acme",
+          deviceAuthorizationEndpoint: "d",
+          tokenEndpoint: "t",
+          jwksUri: "j",
+        }),
+        requestDeviceCode: async () => {
+          throw new Error("n/a");
+        },
+        pollDeviceToken: async () => {
+          throw new Error("n/a");
+        },
+        validateIdToken: async () => ({
+          sub: "s",
+          iss: "https://acme",
+          aud: "c1",
+          exp: 9999,
+          raw: {},
+        }),
+        refreshTokens: async () => {
+          refreshCount++;
+          return { idToken: "new", refreshToken: "rt2", expiresIn: 3600 };
+        },
+      },
+    });
+    // First call: lastRevalidateMs is null → throttle passes, refresh runs
+    await rt.revalidateSession();
+    expect(refreshCount).toBe(1);
+    // Second call: same nowMs → t - lastRevalidateMs = 0 < interval*1000 → throttle fires, returns early
+    await rt.revalidateSession();
+    expect(refreshCount).toBe(1); // NOT incremented — throttle short-circuited
+  });
+
+  // (B) Session not active — line 80
+  test("(B) non-active session: returns early without calling refreshTokens", async () => {
+    const db = freshDb();
+    const store = new IdentityStore(db);
+    store.upsertSession({
+      issuer: "https://acme",
+      externalId: "s",
+      email: null,
+      validatedAt: 0,
+      expiresAt: 1_000_000,
+      status: "expired",
+    });
+    const { vault } = fakeVault();
+    await vault.set("identity.oidc.refresh_token", "rt");
+    let refreshCount = 0;
+    const rt = new IdentityRuntime({
+      cfg: CFG,
+      store,
+      vault,
+      now: () => 800_000,
+      deps: {
+        discover: async () => ({
+          issuer: "https://acme",
+          deviceAuthorizationEndpoint: "d",
+          tokenEndpoint: "t",
+          jwksUri: "j",
+        }),
+        requestDeviceCode: async () => {
+          throw new Error("n/a");
+        },
+        pollDeviceToken: async () => {
+          throw new Error("n/a");
+        },
+        validateIdToken: async () => ({
+          sub: "s",
+          iss: "https://acme",
+          aud: "c1",
+          exp: 9999,
+          raw: {},
+        }),
+        refreshTokens: async () => {
+          refreshCount++;
+          return { idToken: "new", refreshToken: "rt2", expiresIn: 3600 };
+        },
+      },
+    });
+    await rt.revalidateSession();
+    expect(refreshCount).toBe(0); // early-returned at status !== "active" guard
+  });
+
+  // (C) Not near expiry — line 81
+  test("(C) not near expiry: returns early without calling refreshTokens", async () => {
+    const db = freshDb();
+    const store = new IdentityStore(db);
+    // expiresAt far in the future; now=1000, skew=300s → threshold=expiresAt-300_000 >> 1000
+    store.upsertSession({
+      issuer: "https://acme",
+      externalId: "s",
+      email: null,
+      validatedAt: 0,
+      expiresAt: 10_000_000,
+      status: "active",
+    });
+    const { vault } = fakeVault();
+    await vault.set("identity.oidc.refresh_token", "rt");
+    let refreshCount = 0;
+    const rt = new IdentityRuntime({
+      cfg: CFG,
+      store,
+      vault,
+      now: () => 1000,
+      deps: {
+        discover: async () => ({
+          issuer: "https://acme",
+          deviceAuthorizationEndpoint: "d",
+          tokenEndpoint: "t",
+          jwksUri: "j",
+        }),
+        requestDeviceCode: async () => {
+          throw new Error("n/a");
+        },
+        pollDeviceToken: async () => {
+          throw new Error("n/a");
+        },
+        validateIdToken: async () => ({
+          sub: "s",
+          iss: "https://acme",
+          aud: "c1",
+          exp: 9999,
+          raw: {},
+        }),
+        refreshTokens: async () => {
+          refreshCount++;
+          return { idToken: "new", refreshToken: "rt2", expiresIn: 3600 };
+        },
+      },
+    });
+    await rt.revalidateSession();
+    expect(refreshCount).toBe(0); // early-returned at "not near expiry" guard
+  });
+
+  // (D) No refreshTokens dep — line 82
+  test("(D) no refreshTokens dep: resolves without throw", async () => {
+    const db = freshDb();
+    const store = new IdentityStore(db);
+    store.upsertSession({
+      issuer: "https://acme",
+      externalId: "s",
+      email: null,
+      validatedAt: 0,
+      expiresAt: 1_000_000,
+      status: "active",
+    });
+    const { vault } = fakeVault();
+    await vault.set("identity.oidc.refresh_token", "rt");
+    const rt = new IdentityRuntime({
+      cfg: CFG,
+      store,
+      vault,
+      now: () => 800_000,
+      deps: {
+        // refreshTokens intentionally omitted
+        discover: async () => ({
+          issuer: "https://acme",
+          deviceAuthorizationEndpoint: "d",
+          tokenEndpoint: "t",
+          jwksUri: "j",
+        }),
+        requestDeviceCode: async () => {
+          throw new Error("n/a");
+        },
+        pollDeviceToken: async () => {
+          throw new Error("n/a");
+        },
+        validateIdToken: async () => ({
+          sub: "s",
+          iss: "https://acme",
+          aud: "c1",
+          exp: 9999,
+          raw: {},
+        }),
+      },
+    });
+    // Must resolve without throwing
+    await expect(rt.revalidateSession()).resolves.toBeUndefined();
+  });
+
+  // (E) No refresh token in vault — line 84
+  test("(E) no refresh token in vault: returns early without calling refreshTokens", async () => {
+    const db = freshDb();
+    const store = new IdentityStore(db);
+    store.upsertSession({
+      issuer: "https://acme",
+      externalId: "s",
+      email: null,
+      validatedAt: 0,
+      expiresAt: 1_000_000,
+      status: "active",
+    });
+    // Vault has NO identity.oidc.refresh_token stored
+    const { vault } = fakeVault();
+    let refreshCount = 0;
+    const rt = new IdentityRuntime({
+      cfg: CFG,
+      store,
+      vault,
+      now: () => 800_000,
+      deps: {
+        discover: async () => ({
+          issuer: "https://acme",
+          deviceAuthorizationEndpoint: "d",
+          tokenEndpoint: "t",
+          jwksUri: "j",
+        }),
+        requestDeviceCode: async () => {
+          throw new Error("n/a");
+        },
+        pollDeviceToken: async () => {
+          throw new Error("n/a");
+        },
+        validateIdToken: async () => ({
+          sub: "s",
+          iss: "https://acme",
+          aud: "c1",
+          exp: 9999,
+          raw: {},
+        }),
+        refreshTokens: async () => {
+          refreshCount++;
+          return { idToken: "new", refreshToken: "rt2", expiresIn: 3600 };
+        },
+      },
+    });
+    await rt.revalidateSession();
+    expect(refreshCount).toBe(0); // early-returned at readRefreshToken === null guard
+  });
+
+  // (F) Non-Error rejection covers String(e) branch — line 93
+  test("(F) non-Error rejection: no throw, log sink contains String(e) and grace window message", async () => {
+    const db = freshDb();
+    const store = new IdentityStore(db);
+    store.upsertSession({
+      issuer: "https://acme",
+      externalId: "s",
+      email: null,
+      validatedAt: 0,
+      expiresAt: 1_000_000,
+      status: "active",
+    });
+    const { vault } = fakeVault();
+    await vault.set("identity.oidc.refresh_token", "rt");
+    const warnings: string[] = [];
+    const rt = new IdentityRuntime({
+      cfg: CFG,
+      store,
+      vault,
+      now: () => 800_000,
+      log: (m) => warnings.push(m),
+      deps: {
+        discover: async () => ({
+          issuer: "https://acme",
+          deviceAuthorizationEndpoint: "d",
+          tokenEndpoint: "t",
+          jwksUri: "j",
+        }),
+        requestDeviceCode: async () => {
+          throw new Error("n/a");
+        },
+        pollDeviceToken: async () => {
+          throw new Error("n/a");
+        },
+        validateIdToken: async () => ({
+          sub: "s",
+          iss: "https://acme",
+          aud: "c1",
+          exp: 9999,
+          raw: {},
+        }),
+        // Throws a plain string (non-Error) to exercise the String(e) branch
+        refreshTokens: async () => {
+          throw "offline-string"; // non-Error value: covers the String(e) path in the catch block
+        },
+      },
+    });
+    await rt.revalidateSession(); // must not throw
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("relying on grace window");
+    expect(warnings[0]).toContain("offline-string");
+  });
 });

--- a/packages/gateway/src/identity/oidc-device-flow.test.ts
+++ b/packages/gateway/src/identity/oidc-device-flow.test.ts
@@ -25,6 +25,13 @@ describe("requestDeviceCode", () => {
     expect(r.deviceCode).toBe("dc");
     expect(r.userCode).toBe("ABCD");
   });
+
+  test("throws when the device authorization endpoint returns a non-ok status", async () => {
+    const fetchLike = async () => new Response("", { status: 500 });
+    await expect(requestDeviceCode(DISCOVERY, "c1", ["openid"], fetchLike)).rejects.toThrow(
+      /device authorization failed \(500\)/,
+    );
+  });
 });
 
 describe("pollDeviceToken", () => {
@@ -89,5 +96,55 @@ describe("pollDeviceToken", () => {
         onPoll: () => {},
       }),
     ).rejects.toThrow(/access_denied — user rejected the request \(https:\/\/acme\/help\)/);
+  });
+
+  test("throws with code 'unknown' when error body is a non-object (covers asRecord :{}, err not string, no desc, no uri)", async () => {
+    // body is a JSON number → asRecord returns {}, err undefined → code "unknown", desc "", uri ""
+    const fetchLike = async () => new Response(JSON.stringify(123), { status: 400 });
+    await expect(
+      pollDeviceToken(DISCOVERY, "client-1", "dc", {
+        fetchLike,
+        sleep: async () => {},
+        intervalSeconds: 1,
+        deadlineMs: Number.POSITIVE_INFINITY,
+        now: () => 0,
+        onPoll: () => {},
+      }),
+    ).rejects.toThrow(/device token error: unknown$/);
+  });
+
+  test("applies slow_down backoff of intervalMs + 5000 then returns the token", async () => {
+    const bodies: Response[] = [
+      new Response(JSON.stringify({ error: "slow_down" }), { status: 400 }),
+      new Response(JSON.stringify({ id_token: "h.p.s" }), { status: 200 }),
+    ];
+    let i = 0;
+    const sleeps: number[] = [];
+    const tok = await pollDeviceToken(DISCOVERY, "client-1", "dc", {
+      fetchLike: async () => bodies[i++] as Response,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      intervalSeconds: 1,
+      deadlineMs: Number.POSITIVE_INFINITY,
+      now: () => 0,
+      onPoll: () => {},
+    });
+    // normalizeIntervalMs(1) = 1000; slow_down adds 5000 → 6000
+    expect(sleeps).toEqual([6000]);
+    expect(tok.idToken).toBe("h.p.s");
+  });
+
+  test("throws when deadline is exceeded before the first poll", async () => {
+    await expect(
+      pollDeviceToken(DISCOVERY, "client-1", "dc", {
+        fetchLike: async () => new Response("{}", { status: 200 }),
+        sleep: async () => {},
+        intervalSeconds: 1,
+        deadlineMs: 5,
+        now: () => 10,
+        onPoll: () => {},
+      }),
+    ).rejects.toThrow(/device code expired before authorization/);
   });
 });

--- a/packages/gateway/src/identity/verifier.test.ts
+++ b/packages/gateway/src/identity/verifier.test.ts
@@ -5,7 +5,21 @@ import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
 import { IdentityStore } from "./identity-store.ts";
 import { makeSignedJwt } from "./identity-test-helpers.ts";
 import { JwksCache } from "./jwks-cache.ts";
-import { IdTokenVerifier, isOperatorValid } from "./verifier.ts";
+import { IdTokenValidationError, IdTokenVerifier, isOperatorValid } from "./verifier.ts";
+
+/** Inline base64url encoder for crafting hand-built JWT segments in tests. */
+function b64urlEncode(s: string): string {
+  return Buffer.from(new TextEncoder().encode(s))
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+/** Build a raw 3-segment JWT string without signing — for testing parse/alg/kid errors. */
+function rawJwt(header: unknown, payload: unknown, sig = "fakesig"): string {
+  return `${b64urlEncode(JSON.stringify(header))}.${b64urlEncode(JSON.stringify(payload))}.${sig}`;
+}
 
 function freshDb(): Database {
   const db = new Database(":memory:");
@@ -74,6 +88,258 @@ describe("IdTokenVerifier", () => {
       jwksUri: "https://acme/jwks",
     });
     await expect(v.validateIdToken(jwt, now)).rejects.toThrow();
+  });
+
+  // Branch 1: parseJwt — fewer than 3 segments
+  test("rejects a JWT without exactly 3 dot-separated segments", async () => {
+    const db = freshDb();
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    await expect(v.validateIdToken("a.b", 1_000_000)).rejects.toThrow(/malformed JWT/);
+    await expect(v.validateIdToken("a.b", 1_000_000)).rejects.toBeInstanceOf(
+      IdTokenValidationError,
+    );
+  });
+
+  // Branch 2: b64urlToJson — segment decodes to a non-object (JSON array)
+  test("rejects a JWT whose header decodes to a JSON array", async () => {
+    const db = freshDb();
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    // Header segment encodes a JSON array — b64urlToJson must throw
+    const jwt = rawJwt([1, 2, 3], { iss: "https://acme" });
+    await expect(v.validateIdToken(jwt, 1_000_000)).rejects.toThrow(/JWT segment is not an object/);
+  });
+
+  // Branch 3: verifySignature — unsupported alg
+  test("rejects a JWT with alg HS256 instead of RS256", async () => {
+    const db = freshDb();
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    const jwt = rawJwt({ alg: "HS256", kid: "k1" }, { iss: "https://acme" });
+    await expect(v.validateIdToken(jwt, 1_000_000)).rejects.toThrow(/unsupported alg/);
+  });
+
+  // Branch 4: verifySignature — missing kid
+  test("rejects a JWT with alg RS256 but no kid in header", async () => {
+    const db = freshDb();
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    const jwt = rawJwt({ alg: "RS256" }, { iss: "https://acme" });
+    await expect(v.validateIdToken(jwt, 1_000_000)).rejects.toThrow(/missing kid/);
+  });
+
+  // Branch 5: verifySignature — no usable signing key (JWKS returns empty keys array)
+  test("rejects when JWKS has no key matching the token kid", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    const { jwt } = await makeSignedJwt(
+      { iss: "https://acme", aud: "client-1", sub: "s", exp: now / 1000 + 3600 },
+      "k1",
+    );
+    // Serve empty JWKS — no key for kid "k1"
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    await expect(v.validateIdToken(jwt, now)).rejects.toThrow(/no usable signing key/);
+  });
+
+  // Branch 6: verifySignature — signature verification failed (key mismatch, same kid)
+  test("rejects when the JWKS serves a different key for the same kid", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    // Sign with pair A
+    const { jwt } = await makeSignedJwt(
+      { iss: "https://acme", aud: "client-1", sub: "s", exp: now / 1000 + 3600 },
+      "k1",
+    );
+    // Mint pair B — same kid "k1", different key material
+    const { jwk: wrongJwk } = await makeSignedJwt(
+      { iss: "https://acme", aud: "client-1", sub: "s", exp: now / 1000 + 3600 },
+      "k1",
+    );
+    // Serve pair B's JWK for kid "k1"
+    const cache = new JwksCache(
+      db,
+      async () => new Response(JSON.stringify({ keys: [wrongJwk] })),
+      { maxAgeSeconds: 3600 },
+    );
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    await expect(v.validateIdToken(jwt, now)).rejects.toThrow(/signature verification failed/);
+  });
+
+  // Branch 7: assertIssuerAudience — issuer mismatch
+  test("rejects a token whose iss does not match cfg.issuer", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    // Sign with iss "https://evil" but serve the matching JWK so signature passes
+    const { jwt, jwk } = await makeSignedJwt(
+      { iss: "https://evil", aud: "client-1", sub: "s", exp: now / 1000 + 3600 },
+      "k1",
+    );
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [jwk] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme", // different from token iss
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    await expect(v.validateIdToken(jwt, now)).rejects.toThrow(/issuer mismatch/);
+  });
+
+  // Branch 8: assertIssuerAudience — array aud that includes clientId → accepted
+  test("accepts a token whose aud is an array containing the clientId", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    const { jwt, jwk } = await makeSignedJwt(
+      {
+        iss: "https://acme",
+        aud: ["other-client", "client-1"],
+        sub: "sub-array",
+        exp: now / 1000 + 3600,
+      },
+      "k1",
+    );
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [jwk] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    const claims = await v.validateIdToken(jwt, now);
+    expect(claims.sub).toBe("sub-array");
+    expect(claims.aud).toBe("client-1");
+  });
+
+  // Branch 9: assertTimeWindow — nbf in the future (not yet valid)
+  test("rejects a token with nbf far in the future", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    const nowSec = now / 1000;
+    const { jwt, jwk } = await makeSignedJwt(
+      {
+        iss: "https://acme",
+        aud: "client-1",
+        sub: "s",
+        exp: nowSec + 3600,
+        nbf: nowSec + 7200, // well past clock_skew of 60s
+      },
+      "k1",
+    );
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [jwk] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    await expect(v.validateIdToken(jwt, now)).rejects.toThrow(/token not yet valid/);
+  });
+
+  // Branch 10: assertTimeWindow — nbf present and in the past → accepted, claims include nbf
+  test("accepts a token with a past nbf and returns nbf in claims", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    const nowSec = now / 1000;
+    const nbfVal = nowSec - 100;
+    const { jwt, jwk } = await makeSignedJwt(
+      {
+        iss: "https://acme",
+        aud: "client-1",
+        sub: "sub-nbf",
+        exp: nowSec + 3600,
+        nbf: nbfVal,
+      },
+      "k1",
+    );
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [jwk] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    const claims = await v.validateIdToken(jwt, now);
+    expect(claims.sub).toBe("sub-nbf");
+    expect(claims.nbf).toBe(nbfVal);
+  });
+
+  // Branch 11: validateClaims — missing sub (empty string)
+  test("rejects a token with an empty sub claim", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    const { jwt, jwk } = await makeSignedJwt(
+      { iss: "https://acme", aud: "client-1", sub: "", exp: now / 1000 + 3600 },
+      "k1",
+    );
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [jwk] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    await expect(v.validateIdToken(jwt, now)).rejects.toThrow(/missing sub/);
+  });
+
+  // Branch 12: validateClaims — no email claim → claims.email is undefined
+  test("accepts a token without email and returns claims.email as undefined", async () => {
+    const db = freshDb();
+    const now = 1_000_000;
+    const { jwt, jwk } = await makeSignedJwt(
+      { iss: "https://acme", aud: "client-1", sub: "sub-no-email", exp: now / 1000 + 3600 },
+      "k1",
+    );
+    const cache = new JwksCache(db, async () => new Response(JSON.stringify({ keys: [jwk] })), {
+      maxAgeSeconds: 3600,
+    });
+    const v = new IdTokenVerifier(cache, {
+      issuer: "https://acme",
+      clientId: "client-1",
+      jwksUri: "https://acme/jwks",
+    });
+    const claims = await v.validateIdToken(jwt, now);
+    expect(claims.sub).toBe("sub-no-email");
+    expect(claims.email).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Sub-project B, PR 2 (after #534/B0 and #536/B1). Adds branch-coverage tests for the 5 `gateway/identity` files below the dual line+branch floor and reseeds the baseline (Linux-authoritative Docker). Net: baseline **176 → 171** — all five identity files clear both floors and drop out.

## Files raised to ≥80% (line + branch)
| File | was (branch/line) | now |
|---|---|---|
| `verifier.ts` (I18 RS256) | 69.57 / 80 | 100 / 100 |
| `deprovision.ts` | 50 / 80 | ≥80 / ≥80 |
| `identity-runtime.ts` | 61.11 / 80 | ≥80 / ≥80 |
| `identity-boot.ts` | 62.5 / 79.41 | ≥80 / ≥80 |
| `oidc-device-flow.ts` | 73.08 / 80 | ≥80 / ≥80 |

## What the new tests cover
- **verifier.ts**: malformed JWT, non-object segment, unsupported alg, missing kid, no usable key, signature-verify failure, issuer mismatch, array-aud success, nbf not-yet-valid, nbf-present return, missing sub, no-email branch.
- **deprovision.ts**: the namespace-with-no-grant `continue` branch.
- **identity-runtime.ts**: `revalidateSession` guards — throttle, non-active session, not-near-expiry, no refresh dep, no vault token, and the non-Error (`String(e)`) refresh-failure branch.
- **identity-boot.ts**: `refreshTokens` res.ok/!res.ok + the `opts.log` branch.
- **oidc-device-flow.ts**: requestDeviceCode non-ok, non-object error body, `slow_down` backoff, deadline-exceeded.

## One minimal production seam
`identity-boot.ts`: `async function refreshTokens` → `export async function refreshTokens` (visibility-only; still used internally by `buildProductionDeps`). It is reachable in production only via the runtime revalidate path that `buildIdentityBoot` does not expose, so exporting it is the minimal way to cover its branches — mirrors the B1 `delegated-request-remote` DI-seam precedent. No behavior change; static invariant audit (I18/D14) passes.

No `any`, no `mock.module` (all DI). `tsc --noEmit` clean. 83 identity tests pass. Lines 55/103/104/137 of identity-boot (realSleep + the production refresh closure) remain Sub-project D candidates — line coverage still clears 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for identity management operations, including token refresh, device flow authorization, session revalidation, user deprovisioning, and token verification scenarios.

* **Refactor**
  * Adjusted internal function visibility to improve testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->