### PR TITLE
refactor(sonar): clear all 26 open code smells + harden chatops ReDoS hotspot

### DIFF
--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -280,15 +280,22 @@ interface MergedAuditRow {
   timestamp?: unknown;
 }
 
+/** Audit rows arrive as untyped JSON — render only primitive cells, never "[object Object]". */
+function cellText(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return "";
+}
+
 /** Renders the merged team-audit timeline as a fixed-width table (timestamp, peer, action, hitl, hash). */
 function renderAuditTable(entries: MergedAuditRow[]): string {
   const header = ["TIMESTAMP", "PEER", "ACTION", "HITL", "HASH"];
   const rows = entries.map((e) => [
-    typeof e.timestamp === "number" ? new Date(e.timestamp).toISOString() : String(e.timestamp),
-    String(e.peerId ?? ""),
-    String(e.actionType ?? ""),
-    String(e.hitlStatus ?? ""),
-    String(e.hash ?? "").slice(0, 12),
+    typeof e.timestamp === "number" ? new Date(e.timestamp).toISOString() : cellText(e.timestamp),
+    cellText(e.peerId),
+    cellText(e.actionType),
+    cellText(e.hitlStatus),
+    cellText(e.hash).slice(0, 12),
   ]);
   const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)));
   const fmt = (cols: string[]): string => cols.map((c, i) => c.padEnd(widths[i] ?? 0)).join("  ");

--- a/packages/gateway/src/chatops/command-parser.ts
+++ b/packages/gateway/src/chatops/command-parser.ts
@@ -7,17 +7,18 @@ import type { ParsedCommand } from "./types.ts";
  * backticks, non-breaking spaces, collapsed whitespace.
  */
 export function normalizeChatText(raw: string): string {
-  let s = raw.replace(/ /g, " ");
+  let s = raw.replaceAll("\u00A0", " ");
   // smart quotes -> ASCII
   s = s.replace(/[“”]/g, '"').replace(/[‘’]/g, "'");
-  // slack link <url|label> -> label ; <url> -> url
-  s = s.replace(/<([^|>]+)\|([^>]+)>/g, "$2").replace(/<(https?:[^>]+)>/g, "$1");
+  // slack link <url|label> -> label ; <url> -> url (classes exclude `<` so backtracking stays
+  // linear; Slack escapes a literal `<` as &lt; inside tokens, so nothing real is missed)
+  s = s.replace(/<([^<|>]+)\|([^<>]+)>/g, "$2").replace(/<(https?:[^<>]+)>/g, "$1");
   // user/channel mention tokens -> drop the wrapping; <#C123|name> -> name, <@U123> -> ""
-  s = s.replace(/<#[^|>]+\|([^>]+)>/g, "$1").replace(/<@[^>]+>/g, "");
+  s = s.replace(/<#[^<|>]+\|([^<>]+)>/g, "$1").replace(/<@[^<>]+>/g, "");
   // leading bot mention
   s = s.replace(/^\s*(?:@nimbus|<at>\s*nimbus\s*<\/at>)\s*/i, "");
   // strip backticks (inline code / fences)
-  s = s.replace(/```/g, "").replace(/`/g, "");
+  s = s.replaceAll("```", "").replaceAll("`", "");
   return s.replace(/\s+/g, " ").trim();
 }
 

--- a/packages/gateway/src/chatops/identity-mapper.ts
+++ b/packages/gateway/src/chatops/identity-mapper.ts
@@ -64,7 +64,7 @@ export class ChatopsIdentityMapper {
 
     // Authorization is ALWAYS live + local — never cached.
     const scim = this.deps.findScimByEmail(email);
-    if (scim === undefined || !scim.active) return { kind: "unmapped" };
+    if (!scim?.active) return { kind: "unmapped" };
     if (!this.deps.isOperatorValid(scim.issuer)) return { kind: "unmapped" };
     return {
       kind: "mapped",

--- a/packages/gateway/src/chatops/transport/slack-socket-adapter.ts
+++ b/packages/gateway/src/chatops/transport/slack-socket-adapter.ts
@@ -51,7 +51,7 @@ export class SlackEventNormalizer {
     if (f["type"] !== "events_api") return undefined;
     const payload = f["payload"] as Record<string, unknown> | undefined;
     const event = payload?.["event"] as Record<string, unknown> | undefined;
-    if (event === undefined || event["type"] !== "app_mention") return undefined;
+    if (event?.["type"] !== "app_mention") return undefined;
     const channel = event["channel"];
     const user = event["user"];
     const text = event["text"];

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -982,7 +982,16 @@ const HITL_QUORUM_TABLE_PREFIX = '[hitl.quorum."';
  * silently ignored. Returns an empty map when the section is absent (quorum off).
  */
 export function parseQuorumConfig(source: string): QuorumConfig {
-  // Accumulate raw kv strings per action-type id.
+  const out = new Map<string, QuorumRule>();
+  for (const [actionType, kv] of collectQuorumKvSections(source).entries()) {
+    const rule = toQuorumRule(kv);
+    if (rule !== undefined) out.set(actionType, rule);
+  }
+  return out;
+}
+
+/** Accumulates raw kv strings per `[hitl.quorum."<action-type>"]` sub-table. */
+function collectQuorumKvSections(source: string): Map<string, Record<string, string>> {
   const accum = new Map<string, Record<string, string>>();
   let currentId: string | undefined;
 
@@ -990,37 +999,51 @@ export function parseQuorumConfig(source: string): QuorumConfig {
     const trimmed = stripComment(line).trim();
     if (trimmed === "") continue;
     if (isTableHeader(trimmed)) {
-      currentId = undefined;
-      if (trimmed.startsWith(HITL_QUORUM_TABLE_PREFIX) && trimmed.endsWith('"]')) {
-        const id = trimmed.slice(HITL_QUORUM_TABLE_PREFIX.length, -2);
-        if (id.length > 0) {
-          if (!accum.has(id)) accum.set(id, {});
-          currentId = id;
-        }
-      }
+      currentId = beginQuorumTable(accum, trimmed);
       continue;
     }
     if (currentId === undefined) continue;
-    const kv = splitKeyValue(trimmed);
-    if (kv !== undefined) {
-      const bucket = accum.get(currentId);
-      if (bucket !== undefined) bucket[kv.key] = kv.valRaw;
-    }
+    applyQuorumKvLine(accum.get(currentId), trimmed);
   }
 
-  const out = new Map<string, QuorumRule>();
-  for (const [actionType, kv] of accum.entries()) {
-    const approversRaw = kv["approvers"];
-    const windowRaw = kv["window_seconds"];
-    if (approversRaw === undefined || windowRaw === undefined) continue;
-    const approvers = parseIntDec(approversRaw);
-    const windowSeconds = parseIntDec(windowRaw);
-    if (approvers === undefined || windowSeconds === undefined) continue;
-    if (approvers < 1 || windowSeconds <= 0) continue;
-    out.set(actionType, { approvers, windowSeconds });
-  }
+  return accum;
+}
 
-  return out;
+/**
+ * If `trimmed` is a `[hitl.quorum."<action-type>"]` header with a non-empty id,
+ * ensures a bucket exists in `accum` and returns the id; otherwise returns undefined.
+ */
+function beginQuorumTable(
+  accum: Map<string, Record<string, string>>,
+  trimmed: string,
+): string | undefined {
+  if (!trimmed.startsWith(HITL_QUORUM_TABLE_PREFIX) || !trimmed.endsWith('"]')) return undefined;
+  const id = trimmed.slice(HITL_QUORUM_TABLE_PREFIX.length, -2);
+  if (id.length === 0) return undefined;
+  if (!accum.has(id)) accum.set(id, {});
+  return id;
+}
+
+/** Records a `key = value` line into the current sub-table's bucket, if any. */
+function applyQuorumKvLine(bucket: Record<string, string> | undefined, trimmed: string): void {
+  if (bucket === undefined) return;
+  const kv = splitKeyValue(trimmed);
+  if (kv !== undefined) bucket[kv.key] = kv.valRaw;
+}
+
+/**
+ * Validates one sub-table's raw kv strings into a QuorumRule, or undefined when
+ * malformed (missing/non-numeric values, approvers < 1, window_seconds <= 0).
+ */
+function toQuorumRule(kv: Record<string, string>): QuorumRule | undefined {
+  const approversRaw = kv["approvers"];
+  const windowRaw = kv["window_seconds"];
+  if (approversRaw === undefined || windowRaw === undefined) return undefined;
+  const approvers = parseIntDec(approversRaw);
+  const windowSeconds = parseIntDec(windowRaw);
+  if (approvers === undefined || windowSeconds === undefined) return undefined;
+  if (approvers < 1 || windowSeconds <= 0) return undefined;
+  return { approvers, windowSeconds };
 }
 
 export function loadNimbusQuorumFromPath(tomlPath: string): QuorumConfig {

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -256,6 +256,83 @@ function syncFilesystemPackageDeps(
   return { upserted, bytes };
 }
 
+function readFileTextOrUndefined(fp: string): string | undefined {
+  try {
+    return readFileSync(fp, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function fileMtimeOrFallback(fp: string, fallback: number): number {
+  try {
+    return statSync(fp).mtimeMs;
+  } catch {
+    return fallback;
+  }
+}
+
+function upsertCodeSymbolsForFile(
+  ctx: SyncContext,
+  src: string,
+  symbols: readonly { name: string; kind: string }[],
+  root: string,
+  relNorm: string,
+  rk: string,
+  mtime: number,
+  now: number,
+): { upserted: number; blameRanges: BlameRange[] } {
+  let upserted = 0;
+  const blameRanges: BlameRange[] = [];
+  for (const sym of symbols) {
+    const extId = `sym:${rk}:${relNorm}:${sym.name}:${sym.kind}`;
+    const { text: excerpt, startLine } = excerptWithStartLine(src, sym.name, 380);
+    const bodyPreview = excerpt === "" ? relNorm : `${relNorm}\n${excerpt}`;
+    const metadata: Record<string, unknown> = {
+      name: sym.name,
+      kind: sym.kind,
+      file: relNorm,
+      repoRoot: root,
+    };
+    if (startLine !== null) {
+      metadata["excerptStartLine"] = startLine;
+      blameRanges.push({ from: startLine, to: startLine + excerpt.split("\n").length - 1 });
+    }
+    upsertIndexedItemForSync(ctx, {
+      service: SERVICE_ID,
+      type: "code_symbol",
+      externalId: extId,
+      title: `${sym.name} (${sym.kind})`,
+      bodyPreview,
+      url: null,
+      canonicalUrl: null,
+      modifiedAt: mtime,
+      authorId: null,
+      metadata,
+      pinned: false,
+      syncedAt: now,
+    });
+    upserted += 1;
+  }
+  return { upserted, blameRanges };
+}
+
+// Blame the indexed excerpt ranges so a security-scan finding can be attributed
+// to the commit that introduced the line. Git-only; bounded by MAX_BLAME_LINES.
+async function blameIndexedExcerptRanges(
+  ctx: SyncContext,
+  root: string,
+  relNorm: string,
+  blameRanges: readonly BlameRange[],
+): Promise<void> {
+  const merged = mergeRanges(blameRanges);
+  const covered = merged.reduce((n, r) => n + (r.to - r.from + 1), 0);
+  if (covered <= MAX_BLAME_LINES) {
+    const rows = await gitBlameLinePorcelain(root, relNorm, merged);
+    if (rows.length > 0) upsertBlameLines(ctx.db, root, relNorm, rows);
+  }
+}
+
 async function syncFilesystemCodeSymbolsForRoot(
   ctx: SyncContext,
   root: string,
@@ -268,62 +345,18 @@ async function syncFilesystemCodeSymbolsForRoot(
   const gitAware = isGitRepo(root);
   const files = listCodeFiles(root, exclude, 120);
   for (const fp of files) {
-    let src: string;
-    try {
-      src = readFileSync(fp, "utf8");
-    } catch {
+    const src = readFileTextOrUndefined(fp);
+    if (src === undefined) {
       continue;
     }
     bytes += src.length;
-    const rel = relative(root, fp);
-    const relNorm = rel.replaceAll("\\", "/");
+    const relNorm = relative(root, fp).replaceAll("\\", "/");
     const symbols = extractExportedSymbols(src, fp);
-    let mtime = now;
-    try {
-      mtime = statSync(fp).mtimeMs;
-    } catch {
-      /* keep now */
-    }
-    const blameRanges: BlameRange[] = [];
-    for (const sym of symbols) {
-      const extId = `sym:${rk}:${relNorm}:${sym.name}:${sym.kind}`;
-      const { text: excerpt, startLine } = excerptWithStartLine(src, sym.name, 380);
-      const bodyPreview = excerpt === "" ? relNorm : `${relNorm}\n${excerpt}`;
-      const metadata: Record<string, unknown> = {
-        name: sym.name,
-        kind: sym.kind,
-        file: relNorm,
-        repoRoot: root,
-      };
-      if (startLine !== null) {
-        metadata["excerptStartLine"] = startLine;
-        blameRanges.push({ from: startLine, to: startLine + excerpt.split("\n").length - 1 });
-      }
-      upsertIndexedItemForSync(ctx, {
-        service: SERVICE_ID,
-        type: "code_symbol",
-        externalId: extId,
-        title: `${sym.name} (${sym.kind})`,
-        bodyPreview,
-        url: null,
-        canonicalUrl: null,
-        modifiedAt: mtime,
-        authorId: null,
-        metadata,
-        pinned: false,
-        syncedAt: now,
-      });
-      upserted += 1;
-    }
-    // Blame the indexed excerpt ranges so a security-scan finding can be attributed
-    // to the commit that introduced the line. Git-only; bounded by MAX_BLAME_LINES.
-    if (gitAware && blameRanges.length > 0) {
-      const merged = mergeRanges(blameRanges);
-      const covered = merged.reduce((n, r) => n + (r.to - r.from + 1), 0);
-      if (covered <= MAX_BLAME_LINES) {
-        const rows = await gitBlameLinePorcelain(root, relNorm, merged);
-        if (rows.length > 0) upsertBlameLines(ctx.db, root, relNorm, rows);
-      }
+    const mtime = fileMtimeOrFallback(fp, now);
+    const fileResult = upsertCodeSymbolsForFile(ctx, src, symbols, root, relNorm, rk, mtime, now);
+    upserted += fileResult.upserted;
+    if (gitAware && fileResult.blameRanges.length > 0) {
+      await blameIndexedExcerptRanges(ctx, root, relNorm, fileResult.blameRanges);
     }
   }
   return { upserted, bytes };

--- a/packages/gateway/src/db/tool-call-log-retention.test.ts
+++ b/packages/gateway/src/db/tool-call-log-retention.test.ts
@@ -164,7 +164,8 @@ describe("startToolCallLogRetention", () => {
       nowMs: () => now,
     });
     handle.stop();
-    expect(true).toBe(true);
+    // The throwing tick was swallowed AND its transaction rolled back: the row survives.
+    expect(countCalls(db)).toBe(1);
   });
 
   test("retentionDays = 0 starts no timer and prunes nothing", () => {

--- a/packages/gateway/src/engine/delegated-request-remote.ts
+++ b/packages/gateway/src/engine/delegated-request-remote.ts
@@ -29,7 +29,7 @@ export function buildDelegatedRequestRemote(
     const delegate = deps.store.activeDelegateePeer(actionType, service, now);
     if (delegate === undefined) return { kind: "timeout" };
     const row = deps.index.listLanPeers().find((r) => r.peer_id === delegate);
-    if (row === undefined || row.host_ip === null || row.host_port === null) {
+    if (row?.host_ip == null || row.host_port === null) {
       return { kind: "timeout" };
     }
     try {

--- a/packages/gateway/src/engine/executor.ts
+++ b/packages/gateway/src/engine/executor.ts
@@ -210,6 +210,20 @@ export class ToolExecutor {
     return outcome === "fallback_to_owner" ? "fallback" : outcome;
   }
 
+  /** Resolve a HITL action's approval: a delegated answer when one applies (I20), otherwise the
+   *  local owner consent prompt (payload shown redacted, for display only). */
+  private async resolveHitlApproval(action: PlannedAction): Promise<boolean> {
+    const delegated = await this.tryDelegatedApproval(action);
+    if (delegated === "fallback") {
+      const details =
+        action.payload === undefined
+          ? undefined
+          : (redactPayloadForConsentDisplay(action.payload) as Record<string, unknown>);
+      return this.consent.requestApproval(formatConsentPrompt(action), details);
+    }
+    return delegated === "approved";
+  }
+
   async gate(action: PlannedAction): Promise<ActionResult | "proceed"> {
     const requiresHITL = HITL_REQUIRED.has(action.type);
 
@@ -219,17 +233,7 @@ export class ToolExecutor {
 
     try {
       if (requiresHITL) {
-        const delegated = await this.tryDelegatedApproval(action);
-        let approved: boolean;
-        if (delegated === "fallback") {
-          const details =
-            action.payload === undefined
-              ? undefined
-              : (redactPayloadForConsentDisplay(action.payload) as Record<string, unknown>);
-          approved = await this.consent.requestApproval(formatConsentPrompt(action), details);
-        } else {
-          approved = delegated === "approved";
-        }
+        const approved = await this.resolveHitlApproval(action);
         hitlStatus = approved ? "approved" : "rejected";
         if (!approved) rejectReason = "User declined consent gate.";
       } else {

--- a/packages/gateway/src/federation/query-gate.ts
+++ b/packages/gateway/src/federation/query-gate.ts
@@ -83,6 +83,65 @@ function emptyAnswer(ctx: QueryGateCtx, q: InboundQuery): AnswerResult {
   return { kind: "ok", response: { items: [] } };
 }
 
+/** Consent step: standing grant never prompts; otherwise use session cache or prompt with a
+ *  timeout. Returns the audited error result on denial/timeout, or undefined to proceed. */
+async function enforceConsent(
+  ctx: QueryGateCtx,
+  q: InboundQuery,
+  grant: { readonly standingConsent: boolean; readonly role: string },
+): Promise<AnswerResult | undefined> {
+  if (grant.standingConsent) {
+    return undefined;
+  }
+  const cached = ctx.consentCache.get(q.peerId, q.request.namespace);
+  if (cached === false) {
+    audit(ctx, q, "consent_denied");
+    return { kind: "error", error: "consent_denied" };
+  }
+  if (cached === undefined) {
+    const decision = await withTimeout(
+      ctx.prompt({
+        peerId: q.peerId,
+        namespace: q.request.namespace,
+        purpose: q.request.purpose,
+        role: grant.role,
+      }),
+      ctx.consentTimeoutMs,
+    );
+    if (decision === "timeout") {
+      audit(ctx, q, "timeout");
+      return { kind: "error", error: "timeout_waiting_for_consent" };
+    }
+    const approved = decision === "approved";
+    ctx.consentCache.set(q.peerId, q.request.namespace, approved);
+    if (!approved) {
+      audit(ctx, q, "consent_denied");
+      return { kind: "error", error: "consent_denied" };
+    }
+  }
+  return undefined;
+}
+
+/** Leak-proof effective-type computation. Returns the type filter to compile into the read, or
+ *  undefined when the peer requested ONLY undeclared types (caller must answer empty — never
+ *  reveal those items exist). [] means "unrestricted within declared services". */
+function computeEffectiveTypes(
+  declaredTypes: readonly string[],
+  requested: readonly string[] | undefined,
+): readonly string[] | undefined {
+  if (requested === undefined) {
+    // No peer narrowing: share the declared types. [] here means "unrestricted within declared services".
+    return declaredTypes;
+  }
+  if (declaredTypes.length === 0) {
+    // Namespace places no type restriction: narrow to exactly what the peer asked for.
+    return requested;
+  }
+  // Namespace restricts types: intersect requested with declared.
+  const intersected = declaredTypes.filter((t) => requested.includes(t));
+  return intersected.length === 0 ? undefined : intersected;
+}
+
 /**
  * I17 — the ONLY path that answers an inbound federated query. Enforces grant + role + consent +
  * the namespace's declared filter; returns only declared item types as FederatedItem; audits every outcome.
@@ -111,33 +170,9 @@ export async function answerFederatedQuery(
   }
 
   // Consent: standing grant never prompts; otherwise use session cache or prompt with a timeout.
-  if (!grant.standingConsent) {
-    const cached = ctx.consentCache.get(q.peerId, q.request.namespace);
-    if (cached === false) {
-      audit(ctx, q, "consent_denied");
-      return { kind: "error", error: "consent_denied" };
-    }
-    if (cached === undefined) {
-      const decision = await withTimeout(
-        ctx.prompt({
-          peerId: q.peerId,
-          namespace: q.request.namespace,
-          purpose: q.request.purpose,
-          role: grant.role,
-        }),
-        ctx.consentTimeoutMs,
-      );
-      if (decision === "timeout") {
-        audit(ctx, q, "timeout");
-        return { kind: "error", error: "timeout_waiting_for_consent" };
-      }
-      const approved = decision === "approved";
-      ctx.consentCache.set(q.peerId, q.request.namespace, approved);
-      if (!approved) {
-        audit(ctx, q, "consent_denied");
-        return { kind: "error", error: "consent_denied" };
-      }
-    }
+  const consentRefusal = await enforceConsent(ctx, q, grant);
+  if (consentRefusal !== undefined) {
+    return consentRefusal;
   }
 
   // --- LEAK-PROOF SCOPE COMPILATION ---
@@ -146,22 +181,11 @@ export async function answerFederatedQuery(
   // empty effective type set must be handled here, NOT passed through, or we'd leak undeclared items.
   const declaredServices = ctx.store.declaredServices(q.request.namespace);
   const declaredTypes = ctx.store.declaredTypes(q.request.namespace);
-  const requested = q.request.types;
 
-  let effectiveTypes: readonly string[];
-  if (requested === undefined) {
-    // No peer narrowing: share the declared types. [] here means "unrestricted within declared services".
-    effectiveTypes = declaredTypes;
-  } else if (declaredTypes.length === 0) {
-    // Namespace places no type restriction: narrow to exactly what the peer asked for.
-    effectiveTypes = requested;
-  } else {
-    // Namespace restricts types: intersect requested with declared.
-    effectiveTypes = declaredTypes.filter((t) => requested.includes(t));
-    if (effectiveTypes.length === 0) {
-      // Peer requested ONLY undeclared types -> empty (never reveal those items exist).
-      return emptyAnswer(ctx, q);
-    }
+  const effectiveTypes = computeEffectiveTypes(declaredTypes, q.request.types);
+  if (effectiveTypes === undefined) {
+    // Peer requested ONLY undeclared types -> empty (never reveal those items exist).
+    return emptyAnswer(ctx, q);
   }
 
   // Safety: a read with NO service filter AND NO type filter is an unconstrained full-index dump.

--- a/packages/gateway/src/ipc/hitl-rpc.ts
+++ b/packages/gateway/src/ipc/hitl-rpc.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { delegatedApprovalBroker } from "../engine/delegated-approval-broker.ts";
-import { type DelegationScopeKind, DelegationStore } from "../engine/delegation-store.ts";
+import { DelegationStore } from "../engine/delegation-store.ts";
 import { dispatchByMethod, type RpcMissOrHit } from "./_lib/dispatch-by-method.ts";
 
 export class HitlRpcError extends Error {
@@ -58,7 +58,7 @@ export async function dispatchHitlRpc(
       }
       const id = store.create({
         delegatePeer: str(r, "delegatePeer"),
-        scopeKind: scopeKind as DelegationScopeKind,
+        scopeKind,
         scopeValue: str(r, "scopeValue"),
         expiresAt,
         nowMs: now,

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -410,8 +410,9 @@ async function dispatchReadOnlyGet(
   return new Response("Not Found", { status: 404 });
 }
 
-type ScimWriteDeps = NonNullable<Parameters<typeof dispatchWriteRoute>[1]["scim"]>;
-type PolicyWriteDeps = NonNullable<Parameters<typeof dispatchWriteRoute>[1]["policy"]>;
+type WriteRouteDeps = Parameters<typeof dispatchWriteRoute>[1];
+type ScimWriteDeps = NonNullable<WriteRouteDeps["scim"]>;
+type PolicyWriteDeps = NonNullable<WriteRouteDeps["policy"]>;
 
 // SCIM provisioning seam — present only when a SCIM bearer resolver is wired.
 async function resolveScimWriteDeps(
@@ -442,6 +443,38 @@ async function resolvePolicyWriteDeps(
   };
 }
 
+// Assembles the full I13 dispatcher dependency set. Each write seam (deployment token, SCIM,
+// policy, messaging) is resolved independently — a gateway can enable any surface alone.
+async function resolveWriteRouteDeps(
+  writeDb: Database,
+  rateLimiter: HttpWriteRateLimiter,
+  opts: ReadOnlyHttpServerOptions,
+): Promise<WriteRouteDeps> {
+  const expectedToken =
+    opts.resolveDeploymentToken === undefined ? "" : await opts.resolveDeploymentToken();
+  const cfgDir = opts.configDir;
+  const knownServices =
+    cfgDir === undefined
+      ? (): readonly string[] => []
+      : (): readonly string[] => Array.from(loadNimbusServiceConfigsFromConfigDir(cfgDir).keys());
+  const scim = await resolveScimWriteDeps(writeDb, opts);
+  const policy = await resolvePolicyWriteDeps(opts);
+  const messaging =
+    opts.resolveTeamsEventsSurface === undefined
+      ? undefined
+      : await opts.resolveTeamsEventsSurface();
+  return {
+    writeDb,
+    expectedToken,
+    rateLimiter,
+    nowMs: opts.nowMs ?? ((): number => Date.now()),
+    knownServices,
+    ...(scim === undefined ? {} : { scim }),
+    ...(policy === undefined ? {} : { policy }),
+    ...(messaging === undefined ? {} : { messaging }),
+  };
+}
+
 // Every HTTP write (deployment annotation + SCIM provisioning) flows through the single I13
 // dispatcher. The deployment token and the SCIM seam are resolved independently — a gateway can
 // enable either surface alone — and dispatchWriteRoute selects per route.
@@ -455,29 +488,7 @@ async function handleWrite(
     return new Response("Method Not Allowed", { status: 405, headers: { Allow: "GET" } });
   }
   try {
-    const expectedToken =
-      opts.resolveDeploymentToken === undefined ? "" : await opts.resolveDeploymentToken();
-    const cfgDir = opts.configDir;
-    const knownServices =
-      cfgDir === undefined
-        ? (): readonly string[] => []
-        : (): readonly string[] => Array.from(loadNimbusServiceConfigsFromConfigDir(cfgDir).keys());
-    const scim = await resolveScimWriteDeps(writeDb, opts);
-    const policy = await resolvePolicyWriteDeps(opts);
-    const messaging =
-      opts.resolveTeamsEventsSurface === undefined
-        ? undefined
-        : await opts.resolveTeamsEventsSurface();
-    return await dispatchWriteRoute(req, {
-      writeDb,
-      expectedToken,
-      rateLimiter,
-      nowMs: opts.nowMs ?? ((): number => Date.now()),
-      knownServices,
-      ...(scim === undefined ? {} : { scim }),
-      ...(policy === undefined ? {} : { policy }),
-      ...(messaging === undefined ? {} : { messaging }),
-    });
+    return await dispatchWriteRoute(req, await resolveWriteRouteDeps(writeDb, rateLimiter, opts));
   } catch {
     return json({ error: "internal_error" }, 500);
   }

--- a/packages/gateway/src/ipc/http-write-routes.ts
+++ b/packages/gateway/src/ipc/http-write-routes.ts
@@ -166,73 +166,96 @@ function recordRejection(
   }
 }
 
+function notFound(): Response {
+  return new Response("Not Found", { status: 404 });
+}
+
+/** `POST /v1/deployments` (always-on surface; bearer = `http_api.deployment_token`). */
+function resolveDeploymentRoute(method: string, ctx: WriteRouteContext): ResolvedRoute | Response {
+  if (method !== "POST") return methodNotAllowed("POST");
+  return {
+    key: ROUTE_DEPLOY,
+    kind: "deployment",
+    expectedToken: ctx.expectedToken,
+    disabledHint: DEPLOY_DISABLED_HINT,
+    rejectAction: DEPLOY_REJECT_ACTION,
+    hasBody: true,
+  };
+}
+
+/** `PUT /v1/admin/policy` (404 unless the policy seam is enabled). */
+function resolvePolicyRoute(method: string, ctx: WriteRouteContext): ResolvedRoute | Response {
+  if (method !== "PUT") return methodNotAllowed("PUT");
+  if (ctx.policy === undefined) return notFound();
+  return {
+    key: ROUTE_ADMIN_POLICY,
+    kind: "policy",
+    expectedToken: ctx.policy.token,
+    disabledHint: POLICY_DISABLED_HINT,
+    rejectAction: POLICY_REJECT_ACTION,
+    hasBody: true,
+  };
+}
+
+/** `POST /scim/v2/Users` (404 unless the SCIM seam is enabled). */
+function resolveScimCreateRoute(method: string, ctx: WriteRouteContext): ResolvedRoute | Response {
+  if (method !== "POST") return methodNotAllowed("POST");
+  if (ctx.scim === undefined) return notFound();
+  return {
+    key: ROUTE_SCIM_CREATE,
+    kind: "scim",
+    expectedToken: ctx.scim.token,
+    disabledHint: SCIM_DISABLED_HINT,
+    rejectAction: SCIM_REJECT_ACTION,
+    hasBody: true,
+  };
+}
+
+/** `POST /v1/messaging/teams/events` (404 unless the ChatOps Teams seam is enabled). */
+function resolveTeamsEventsRoute(method: string, ctx: WriteRouteContext): ResolvedRoute | Response {
+  if (method !== "POST") return methodNotAllowed("POST");
+  if (ctx.messaging === undefined) return notFound();
+  return {
+    key: ROUTE_TEAMS_EVENTS,
+    kind: "teamsEvents",
+    // Auth is the Bot Framework JWT (validated in runTeamsEventsRoute); no static bearer.
+    expectedToken: "",
+    disabledHint: TEAMS_EVENTS_DISABLED_HINT,
+    rejectAction: TEAMS_EVENTS_REJECT_ACTION,
+    hasBody: true,
+  };
+}
+
+/** `PATCH|DELETE /scim/v2/Users/{id}` (404 unless the SCIM seam is enabled). */
+function resolveScimItemRoute(
+  method: string,
+  id: string,
+  ctx: WriteRouteContext,
+): ResolvedRoute | Response {
+  if (method !== "PATCH" && method !== "DELETE") return methodNotAllowed("PATCH, DELETE");
+  if (ctx.scim === undefined) return notFound();
+  return {
+    key: method === "PATCH" ? ROUTE_SCIM_PATCH : ROUTE_SCIM_DELETE,
+    kind: "scim",
+    expectedToken: ctx.scim.token,
+    disabledHint: SCIM_DISABLED_HINT,
+    rejectAction: SCIM_REJECT_ACTION,
+    hasBody: method === "PATCH",
+    id,
+  };
+}
+
 /** Resolves the request to an allowlisted route, or a 404/405 Response. Does NOT consult auth. */
 function resolveRoute(req: Request, url: URL, ctx: WriteRouteContext): ResolvedRoute | Response {
   const { method } = req;
   const path = url.pathname;
-  if (path === "/v1/deployments") {
-    if (method !== "POST") return methodNotAllowed("POST");
-    return {
-      key: ROUTE_DEPLOY,
-      kind: "deployment",
-      expectedToken: ctx.expectedToken,
-      disabledHint: DEPLOY_DISABLED_HINT,
-      rejectAction: DEPLOY_REJECT_ACTION,
-      hasBody: true,
-    };
-  }
-  if (path === "/v1/admin/policy") {
-    if (method !== "PUT") return methodNotAllowed("PUT");
-    if (ctx.policy === undefined) return new Response("Not Found", { status: 404 });
-    return {
-      key: ROUTE_ADMIN_POLICY,
-      kind: "policy",
-      expectedToken: ctx.policy.token,
-      disabledHint: POLICY_DISABLED_HINT,
-      rejectAction: POLICY_REJECT_ACTION,
-      hasBody: true,
-    };
-  }
-  if (path === "/scim/v2/Users") {
-    if (method !== "POST") return methodNotAllowed("POST");
-    if (ctx.scim === undefined) return new Response("Not Found", { status: 404 });
-    return {
-      key: ROUTE_SCIM_CREATE,
-      kind: "scim",
-      expectedToken: ctx.scim.token,
-      disabledHint: SCIM_DISABLED_HINT,
-      rejectAction: SCIM_REJECT_ACTION,
-      hasBody: true,
-    };
-  }
-  if (path === "/v1/messaging/teams/events") {
-    if (method !== "POST") return methodNotAllowed("POST");
-    if (ctx.messaging === undefined) return new Response("Not Found", { status: 404 });
-    return {
-      key: ROUTE_TEAMS_EVENTS,
-      kind: "teamsEvents",
-      // Auth is the Bot Framework JWT (validated in runTeamsEventsRoute); no static bearer.
-      expectedToken: "",
-      disabledHint: TEAMS_EVENTS_DISABLED_HINT,
-      rejectAction: TEAMS_EVENTS_REJECT_ACTION,
-      hasBody: true,
-    };
-  }
+  if (path === "/v1/deployments") return resolveDeploymentRoute(method, ctx);
+  if (path === "/v1/admin/policy") return resolvePolicyRoute(method, ctx);
+  if (path === "/scim/v2/Users") return resolveScimCreateRoute(method, ctx);
+  if (path === "/v1/messaging/teams/events") return resolveTeamsEventsRoute(method, ctx);
   const item = SCIM_ITEM_RE.exec(path);
-  if (item !== null) {
-    if (method !== "PATCH" && method !== "DELETE") return methodNotAllowed("PATCH, DELETE");
-    if (ctx.scim === undefined) return new Response("Not Found", { status: 404 });
-    return {
-      key: method === "PATCH" ? ROUTE_SCIM_PATCH : ROUTE_SCIM_DELETE,
-      kind: "scim",
-      expectedToken: ctx.scim.token,
-      disabledHint: SCIM_DISABLED_HINT,
-      rejectAction: SCIM_REJECT_ACTION,
-      hasBody: method === "PATCH",
-      id: item[1] as string,
-    };
-  }
-  return new Response("Not Found", { status: 404 });
+  if (item !== null) return resolveScimItemRoute(method, item[1] as string, ctx);
+  return notFound();
 }
 
 type AuthOk = { fingerprint: string };

--- a/packages/gateway/src/ipc/server/dispatchers.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.ts
@@ -674,11 +674,11 @@ export function tryDispatchAdminRpc(ctx: ServerCtx, method: string, _params: unk
   return buildStatus(ctx.options.statusReaders);
 }
 
-export async function tryDispatchPhase4Rpc(
+/** First group of the phase-4 chain: llm → agents → voice → updater → audit → security → federation. */
+async function dispatchPhase4CoreGroup(
   ctx: ServerCtx,
   method: string,
   params: unknown,
-  clientId: string,
 ): Promise<unknown> {
   const llmOutcome = await tryDispatchLlmRpc(ctx, method, params);
   if (llmOutcome !== phase4RpcSkipped) return llmOutcome;
@@ -692,8 +692,20 @@ export async function tryDispatchPhase4Rpc(
   if (auditOutcome !== phase4RpcSkipped) return auditOutcome;
   const securityOutcome = await tryDispatchSecurityRpc(ctx, method, params);
   if (securityOutcome !== phase4RpcSkipped) return securityOutcome;
-  const federationOutcome = await tryDispatchFederationRpc(ctx, method, params);
-  if (federationOutcome !== phase4RpcSkipped) return federationOutcome;
+  return tryDispatchFederationRpc(ctx, method, params);
+}
+
+/**
+ * Second group: teamvault → hitl → identity → metrics → preflight → deployment → data.
+ * Metrics/preflight/deployment carry their own skip sentinels (unique symbols), so a
+ * non-sentinel outcome can never collide with `phase4RpcSkipped` in the caller.
+ */
+async function dispatchPhase4TeamMetricsGroup(
+  ctx: ServerCtx,
+  method: string,
+  params: unknown,
+  clientId: string,
+): Promise<unknown> {
   const teamVaultOutcome = await tryDispatchTeamVaultRpc(ctx, method, params, clientId);
   if (teamVaultOutcome !== phase4RpcSkipped) return teamVaultOutcome;
   const hitlOutcome = await tryDispatchHitlRpc(ctx, method, params);
@@ -706,8 +718,15 @@ export async function tryDispatchPhase4Rpc(
   if (preflightOutcome !== preflightRpcSkipped) return preflightOutcome;
   const deploymentOutcome = await tryDispatchDeploymentRpc(ctx, method, params);
   if (deploymentOutcome !== deploymentRpcSkipped) return deploymentOutcome;
-  const dataOutcome = await tryDispatchDataRpc(ctx, method, params, clientId);
-  if (dataOutcome !== phase4RpcSkipped) return dataOutcome;
+  return tryDispatchDataRpc(ctx, method, params, clientId);
+}
+
+/** Third group: lan → profile → index-reembed → policy → chatops → admin. */
+async function dispatchPhase4PlatformGroup(
+  ctx: ServerCtx,
+  method: string,
+  params: unknown,
+): Promise<unknown> {
   const lanOutcome = await tryDispatchLanRpc(ctx, method, params);
   if (lanOutcome !== phase4RpcSkipped) return lanOutcome;
   const profileOutcome = await tryDispatchProfileRpc(ctx, method, params);
@@ -718,8 +737,21 @@ export async function tryDispatchPhase4Rpc(
   if (policyOutcome !== phase4RpcSkipped) return policyOutcome;
   const chatopsOutcome = await tryDispatchChatopsRpc(ctx, method, params);
   if (chatopsOutcome !== phase4RpcSkipped) return chatopsOutcome;
-  const adminOutcome = tryDispatchAdminRpc(ctx, method, params);
-  if (adminOutcome !== phase4RpcSkipped) return adminOutcome;
+  return tryDispatchAdminRpc(ctx, method, params);
+}
+
+export async function tryDispatchPhase4Rpc(
+  ctx: ServerCtx,
+  method: string,
+  params: unknown,
+  clientId: string,
+): Promise<unknown> {
+  const coreOutcome = await dispatchPhase4CoreGroup(ctx, method, params);
+  if (coreOutcome !== phase4RpcSkipped) return coreOutcome;
+  const teamMetricsOutcome = await dispatchPhase4TeamMetricsGroup(ctx, method, params, clientId);
+  if (teamMetricsOutcome !== phase4RpcSkipped) return teamMetricsOutcome;
+  const platformOutcome = await dispatchPhase4PlatformGroup(ctx, method, params);
+  if (platformOutcome !== phase4RpcSkipped) return platformOutcome;
   return tryDispatchReindexRpc(ctx, method, params, clientId);
 }
 

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -78,7 +78,7 @@ import { readIndexedUserVersion } from "../index/migrations/runner.ts";
 import type { StatusReaders } from "../ipc/admin-status-rpc.ts";
 import { resumePendingRemovals } from "../ipc/connector-rpc-handlers/index.ts";
 import { HTTP_API_DEPLOYMENT_TOKEN_VAULT_KEY } from "../ipc/http-auth.ts";
-import { startReadOnlyHttpServer } from "../ipc/http-server.ts";
+import { type ReadOnlyHttpServerOptions, startReadOnlyHttpServer } from "../ipc/http-server.ts";
 import { createIpcServer } from "../ipc/index.ts";
 import { startMetricsServer } from "../ipc/metrics-server.ts";
 import type { PolicyRpcCtx } from "../ipc/policy-rpc.ts";
@@ -370,39 +370,52 @@ interface HttpSidecarOpts {
   authorPolicy?: (toml: string) => Promise<AuthorResult>;
 }
 
+/** Parse a sidecar port from a raw env value: a positive finite integer, else undefined. */
+function parseSidecarPortEnv(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === "") {
+    return undefined;
+  }
+  const port = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(port) && port > 0 ? port : undefined;
+}
+
+/** Assemble the read-only HTTP server options, spreading only the seams the caller wired. */
+function buildReadOnlyHttpServerOpts(
+  configDir: string,
+  httpOpts: HttpSidecarOpts,
+): ReadOnlyHttpServerOptions {
+  return {
+    configDir,
+    ...(httpOpts.resolveScimToken === undefined
+      ? {}
+      : { resolveScimToken: httpOpts.resolveScimToken }),
+    ...(httpOpts.statusReaders === undefined ? {} : { statusReaders: httpOpts.statusReaders }),
+    ...(httpOpts.resolveAdminToken === undefined
+      ? {}
+      : { resolveAdminToken: httpOpts.resolveAdminToken }),
+    ...(httpOpts.authorPolicy === undefined ? {} : { authorPolicy: httpOpts.authorPolicy }),
+  };
+}
+
 function collectSidecarsFromEnv(
   db: Database,
   paths: PlatformPaths,
   sidecarStops: Array<() => void>,
   httpOpts: HttpSidecarOpts = {},
 ): void {
-  const httpPortRaw = processEnvGet("NIMBUS_HTTP_PORT");
-  if (httpPortRaw !== undefined && httpPortRaw.trim() !== "") {
-    const hp = Number.parseInt(httpPortRaw.trim(), 10);
-    if (Number.isFinite(hp) && hp > 0) {
-      sidecarStops.push(
-        startReadOnlyHttpServer(join(paths.dataDir, "nimbus.db"), hp, {
-          configDir: paths.configDir,
-          ...(httpOpts.resolveScimToken === undefined
-            ? {}
-            : { resolveScimToken: httpOpts.resolveScimToken }),
-          ...(httpOpts.statusReaders === undefined
-            ? {}
-            : { statusReaders: httpOpts.statusReaders }),
-          ...(httpOpts.resolveAdminToken === undefined
-            ? {}
-            : { resolveAdminToken: httpOpts.resolveAdminToken }),
-          ...(httpOpts.authorPolicy === undefined ? {} : { authorPolicy: httpOpts.authorPolicy }),
-        }).stop,
-      );
-    }
+  const httpPort = parseSidecarPortEnv(processEnvGet("NIMBUS_HTTP_PORT"));
+  if (httpPort !== undefined) {
+    sidecarStops.push(
+      startReadOnlyHttpServer(
+        join(paths.dataDir, "nimbus.db"),
+        httpPort,
+        buildReadOnlyHttpServerOpts(paths.configDir, httpOpts),
+      ).stop,
+    );
   }
-  const metricsPortRaw = processEnvGet("NIMBUS_METRICS_PORT");
-  if (metricsPortRaw !== undefined && metricsPortRaw.trim() !== "") {
-    const mp = Number.parseInt(metricsPortRaw.trim(), 10);
-    if (Number.isFinite(mp) && mp > 0) {
-      sidecarStops.push(startMetricsServer(() => db, mp).stop);
-    }
+  const metricsPort = parseSidecarPortEnv(processEnvGet("NIMBUS_METRICS_PORT"));
+  if (metricsPort !== undefined) {
+    sidecarStops.push(startMetricsServer(() => db, metricsPort).stop);
   }
 }
 
@@ -602,18 +615,50 @@ async function bootFederationIntoIpcOpts(
   return delegationDep;
 }
 
-export async function assemblePlatformServices(paths: PlatformPaths): Promise<PlatformServices> {
-  const assemblyStartedMs = performance.now();
-  const sidecarStops: Array<() => void> = [];
-  await ensurePlatformDirectories(paths);
-  const vault = await createNimbusVault(paths);
-  const sandboxRunner = await createSandboxRunner();
-  const db = openGatewaySqlite(paths.dataDir, sidecarStops);
-  const notifications = createStubNotifications();
-  const syncLogger: Logger = createGatewayPinoLogger(paths.logDir);
-  const rateLimiter = new ProviderRateLimiter();
-  const activeTomlPath = resolveNimbusTomlForProfile(paths.configDir);
-  const sessionToml = loadNimbusSessionFromPath(activeTomlPath);
+/** Org policy boot (I22): the gate rehydrates last-valid from the store (ungoverned when none). The
+ *  baseline is the local floor policy can only TIGHTEN. `policyGate` is the shared instance reused
+ *  by the retention floor (Task 8), quorum (Task 9), and the audit shipper (Task 19) — keep it in
+ *  scope even though Part C of this task only consumes `enforced().connectorAllow`. Also enforces
+ *  the connector allowlist: audits + blocks connectors not permitted by policy. */
+function bootPolicyGateWithConnectorAllowlist(
+  db: Database,
+  configDir: string,
+  auditCfg: ReturnType<typeof loadNimbusAuditFromConfigDir>,
+): {
+  policyStore: PolicyStore;
+  policyGate: PolicyGate;
+  isConnectorAllowed: (serviceId: string) => boolean;
+} {
+  const policyStore = new PolicyStore(db);
+  const policyGate = buildPolicyGate(db, policyStore, {
+    retentionDays: auditCfg.toolCallLogRetentionDays,
+    hitlRequired: new Set<string>(),
+    quorum: loadNimbusQuorumFromConfigDir(configDir),
+  });
+  const enforcedConnectorAllow = policyGate.enforced().connectorAllow;
+  const { blocked: blockedConnectors } = partitionByAllowlist(
+    [...CONNECTOR_SERVICE_IDS],
+    enforcedConnectorAllow,
+  );
+  const blockedAt = Date.now();
+  for (const id of blockedConnectors) {
+    appendAuditEntry(db, {
+      actionType: "policy.connector.blocked",
+      hitlStatus: "not_required",
+      actionJson: JSON.stringify({ connector: id }),
+      timestamp: blockedAt,
+    });
+  }
+  const isConnectorAllowed = (serviceId: string): boolean => {
+    const allow = policyGate.enforced().connectorAllow;
+    return allow === undefined || allow.includes(serviceId);
+  };
+  return { policyStore, policyGate, isConnectorAllowed };
+}
+
+/** Load the [llm] config from the active TOML, apply the model overrides, and build the provider
+ *  registry (Ollama + llama.cpp local providers). */
+function buildLlmRegistryFromToml(db: Database, activeTomlPath: string): LlmRegistry {
   const llmToml = loadNimbusLlmFromPath(activeTomlPath);
   const llmTomlPartial = loadNimbusLlmPartialFromPath(activeTomlPath);
   const llmOverrides: { agentModel?: string; classifierModel?: string } = {};
@@ -639,6 +684,209 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
   llmRegistry.addProvider(
     new LlamaCppProvider(llamacppBaseUrl === "" ? undefined : llamacppBaseUrl, llmToml.localModel),
   );
+  return llmRegistry;
+}
+
+/** Start the extensions auto-update daemon when `NIMBUS_EXTENSIONS_REGISTRY_URL` enables it (and
+ *  `NIMBUS_EXTENSIONS_DISABLE_AUTO_UPDATE` does not veto). Returns the runtime (undefined when not
+ *  started) plus the disable flag for the IPC diag surface. */
+function maybeStartAutoUpdateRuntime(deps: {
+  db: Database;
+  vault: NimbusVault;
+  paths: PlatformPaths;
+  connectorMesh: LazyConnectorMesh;
+  sidecarStops: Array<() => void>;
+}): { runtime: AutoUpdateRuntime | undefined; disabled: boolean } {
+  const { db, vault, paths, connectorMesh, sidecarStops } = deps;
+  let autoUpdateRuntime: AutoUpdateRuntime | undefined;
+  const autoUpdateRegistryUrl = (process.env["NIMBUS_EXTENSIONS_REGISTRY_URL"] ?? "").trim();
+  const autoUpdateDisabled = process.env["NIMBUS_EXTENSIONS_DISABLE_AUTO_UPDATE"] === "1";
+  if (autoUpdateRegistryUrl !== "" && !autoUpdateDisabled) {
+    const extensionsCfg = loadNimbusExtensionsFromConfigDir(paths.configDir);
+    autoUpdateRuntime = createAutoUpdateRuntime({
+      db,
+      vault,
+      extensionsDir: paths.extensionsDir,
+      dataDir: paths.dataDir,
+      registryBaseUrl: autoUpdateRegistryUrl,
+      intervalHours: extensionsCfg.updateCheckIntervalHours,
+      enforceAirGap: false,
+      stopExtensionClient: (id) => connectorMesh.stopExtensionClient(id),
+    });
+    void autoUpdateRuntime.daemon.start();
+    sidecarStops.push(() => {
+      autoUpdateRuntime?.abortController.abort();
+      void autoUpdateRuntime?.daemon.stop();
+    });
+  }
+  return { runtime: autoUpdateRuntime, disabled: autoUpdateDisabled };
+}
+
+/** The auto-update slices of the IPC server options; empty when the daemon is not running. */
+function autoUpdateIpcOpts(
+  runtime: AutoUpdateRuntime | undefined,
+  configDir: string,
+  airGapBlocked: boolean,
+): Pick<
+  Parameters<typeof createIpcServer>[0],
+  "extensionsAutoUpdate" | "extensionsAutoUpdateDiag"
+> {
+  if (runtime === undefined) {
+    return {};
+  }
+  const autoUpdateDeps = runtime.deps;
+  return {
+    extensionsAutoUpdate: autoUpdateDeps,
+    extensionsAutoUpdateDiag: {
+      cachedUpdatesCount: (): number => autoUpdateDeps.cache.list().length,
+      intervalHours: loadNimbusExtensionsFromConfigDir(configDir).updateCheckIntervalHours,
+      airGapBlocked,
+    },
+  };
+}
+
+/** Identity & Access (Phase 6 Slice 3). Mirrors the federation block: build the boot, wire the
+ *  IPC-facing seams onto ipcOpts, and (when [scim].enabled) hand the SCIM bearer resolver to the
+ *  read-only HTTP server so the SCIM provisioning surface authenticates. */
+function bootIdentityIntoIpcOpts(deps: {
+  configDir: string;
+  localIndex: LocalIndex;
+  vault: NimbusVault;
+  syncLogger: Logger;
+  ipcOpts: Parameters<typeof createIpcServer>[0];
+  httpSidecarOpts: HttpSidecarOpts;
+}): ReturnType<typeof buildIdentityBoot> | undefined {
+  const { configDir, localIndex, vault, syncLogger, ipcOpts, httpSidecarOpts } = deps;
+  const identityCfg = loadNimbusIdentityFromConfigDir(configDir);
+  const scimCfg = loadNimbusScimFromConfigDir(configDir);
+  let identityBoot: ReturnType<typeof buildIdentityBoot> | undefined;
+  if (identityCfg.enabled && localIndex !== undefined) {
+    identityBoot = buildIdentityBoot(identityCfg, scimCfg, localIndex, vault, {
+      log: (m: string) => syncLogger.warn(m),
+    });
+    ipcOpts.identityStore = identityBoot.store;
+    ipcOpts.identityIssuer = identityBoot.issuer;
+    ipcOpts.identityGraceSeconds = identityBoot.graceSeconds;
+    ipcOpts.identityStartLogin = identityBoot.startLogin;
+    ipcOpts.identityVault = vault;
+    if (scimCfg.enabled) {
+      httpSidecarOpts.resolveScimToken = identityBoot.resolveScimToken;
+    }
+  }
+  return identityBoot;
+}
+
+/** Build the policy.* + team.purge IPC context (Task 26, Lanes A–G integration hub). The local IPC
+ *  socket is operator/owner-trusted, so isAnchor is true for local calls (signing makes this gateway
+ *  an anchor; a purge is operator-only). The GDPR purge deps wire the REAL local-side capabilities:
+ *    resolvePeer            → identity binding store (externalId → active peer ids; first wins)
+ *    revokeAllGrants        → NamespaceStore.revokeAllForPeer (confirmed grant-revocation sweep)
+ *    deleteLocalContributions → same sweep's count (item-level row deletion has no confirmed accessor;
+ *                               grant-revocation is the confirmed local effect — see report)
+ *    knownPeers             → localIndex.listLanPeers (paired peers fan out one purge request each)
+ *  resolvePeer returns undefined when identity is disabled / unbound → startPurge throws (fail-closed). */
+function buildPolicyRpcCtx(deps: {
+  db: Database;
+  vault: NimbusVault;
+  localIndex: LocalIndex;
+  policyStore: PolicyStore;
+  policyGate: PolicyGate;
+  identityBoot: ReturnType<typeof buildIdentityBoot> | undefined;
+}): PolicyRpcCtx {
+  const { db, vault, localIndex, policyStore, policyGate, identityBoot } = deps;
+  const purgeNamespaceStore = new NamespaceStore(db);
+  const purgeJobStore = new GdprPurgeStore(db);
+  let purgeJobCounter = 0;
+  return {
+    showPolicy: () => policyGate.status(),
+    trustPubkey: ({ pubkey }) => trustAnchorPubkey(policyStore, pubkey, Date.now()),
+    refetch: () =>
+      refreshPolicy({
+        store: policyStore,
+        gate: policyGate,
+        pinnedPubkey: policyStore.getAnchorPubkey() ?? "",
+        nowMs: Date.now(),
+        // Best-effort: no inbound anchor bundle source is wired at the IPC layer, so refetch is a
+        // local no-op (returns the locally-served bundle, or null when ungoverned). The over-the-wire
+        // peer fetch is the federation runtime's job; here we surface "no_bundle" rather than fabricate.
+        fetch: async () => servePolicy(policyStore),
+      }),
+    signPolicy: async ({ toml }) => {
+      const { privkeyB64, pubkeyB64 } = await ensureAnchorKeypair(vault);
+      const r = authorPolicy(
+        { store: policyStore, gate: policyGate, db, privkeyB64, pubkeyB64, nowMs: Date.now() },
+        toml,
+      );
+      if (!r.ok) throw new Error(r.error);
+      return { org: r.org, version: r.version };
+    },
+    purge: ({ externalId }) =>
+      startPurge(
+        {
+          store: purgeJobStore,
+          resolvePeer: (extId) => identityBoot?.store.activePeerIdsFor(extId)[0],
+          // Grant revocation is the confirmed local effect of a purge; performed once in
+          // deleteLocalContributions (which returns the count). No separate item-level
+          // deletion accessor exists yet, so revokeAllGrants is a no-op to avoid double-sweeping.
+          revokeAllGrants: () => {},
+          deleteLocalContributions: (peerId) =>
+            purgeNamespaceStore.revokeAllForPeer(peerId, Date.now()),
+          knownPeers: () => localIndex.listLanPeers().map((p) => p.peer_id),
+          newJobId: () => {
+            purgeJobCounter += 1;
+            return `gdpr-${Date.now()}-${purgeJobCounter}`;
+          },
+          nowMs: () => Date.now(),
+        },
+        externalId,
+      ),
+    // Local IPC socket is operator/owner-trusted (see ipc/server): treat local calls as the anchor.
+    isAnchor: true,
+  };
+}
+
+/** Build the updater from config (when [updater] enables one), hand it to the IPC server, and run
+ *  the best-effort startup check. */
+function wireUpdaterIntoIpc(
+  configDir: string,
+  ipc: ReturnType<typeof createIpcServer>,
+  syncLogger: Logger,
+): void {
+  const updaterCfg = loadNimbusUpdaterFromConfigDir(configDir);
+  const updater = createUpdaterFromConfig({
+    updaterCfg,
+    currentVersion: GATEWAY_VERSION,
+    emit: (name, payload) => ipc.broadcast(name, payload ?? {}),
+    logger: syncLogger,
+  });
+  if (updater !== undefined) {
+    ipc.setUpdater(updater);
+    if (updaterCfg.checkOnStartup) {
+      void updater
+        .checkNow()
+        .catch((err: unknown) =>
+          syncLogger.warn(
+            { err: redactUrlUserinfo(err instanceof Error ? err.message : String(err)) },
+            "updater startup check failed",
+          ),
+        );
+    }
+  }
+}
+
+export async function assemblePlatformServices(paths: PlatformPaths): Promise<PlatformServices> {
+  const assemblyStartedMs = performance.now();
+  const sidecarStops: Array<() => void> = [];
+  await ensurePlatformDirectories(paths);
+  const vault = await createNimbusVault(paths);
+  const sandboxRunner = await createSandboxRunner();
+  const db = openGatewaySqlite(paths.dataDir, sidecarStops);
+  const notifications = createStubNotifications();
+  const syncLogger: Logger = createGatewayPinoLogger(paths.logDir);
+  const rateLimiter = new ProviderRateLimiter();
+  const activeTomlPath = resolveNimbusTomlForProfile(paths.configDir);
+  const sessionToml = loadNimbusSessionFromPath(activeTomlPath);
+  const llmRegistry = buildLlmRegistryFromToml(db, activeTomlPath);
 
   const { localIndex, scheduleItemEmbedding, rt } = await createLocalIndexWithEmbeddingRuntime(
     db,
@@ -662,36 +910,13 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
 
   const auditCfg = loadNimbusAuditFromConfigDir(paths.configDir);
 
-  // Org policy (I22): the gate rehydrates last-valid from the store (ungoverned when none). The
-  // baseline is the local floor policy can only TIGHTEN. `policyGate` is the shared instance reused
-  // by the retention floor (Task 8), quorum (Task 9), and the audit shipper (Task 19) — keep it in
-  // scope even though Part C of this task only consumes `enforced().connectorAllow`. Built BEFORE
-  // the retention sidecar so the latter can honor `enforced().retentionDays` (the monotonic floor).
-  const policyStore = new PolicyStore(db);
-  const policyGate = buildPolicyGate(db, policyStore, {
-    retentionDays: auditCfg.toolCallLogRetentionDays,
-    hitlRequired: new Set<string>(),
-    quorum: loadNimbusQuorumFromConfigDir(paths.configDir),
-  });
-  // Connector allowlist enforcement: audit + block connectors not permitted by policy.
-  const enforcedConnectorAllow = policyGate.enforced().connectorAllow;
-  const { blocked: blockedConnectors } = partitionByAllowlist(
-    [...CONNECTOR_SERVICE_IDS],
-    enforcedConnectorAllow,
+  // Org policy (I22): built BEFORE the retention sidecar so the latter can honor
+  // `enforced().retentionDays` (the monotonic floor).
+  const { policyStore, policyGate, isConnectorAllowed } = bootPolicyGateWithConnectorAllowlist(
+    db,
+    paths.configDir,
+    auditCfg,
   );
-  const blockedAt = Date.now();
-  for (const id of blockedConnectors) {
-    appendAuditEntry(db, {
-      actionType: "policy.connector.blocked",
-      hitlStatus: "not_required",
-      actionJson: JSON.stringify({ connector: id }),
-      timestamp: blockedAt,
-    });
-  }
-  const isConnectorAllowed = (serviceId: string): boolean => {
-    const allow = policyGate.enforced().connectorAllow;
-    return allow === undefined || allow.includes(serviceId);
-  };
 
   // Retention floor (Task 8): effective retention = max(local config, policy floor); policy can only
   // LENGTHEN retention. Started after the gate so it can read `enforced().retentionDays`.
@@ -739,27 +964,13 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
 
   await verifyExtensionsBestEffort(db, syncLogger, connectorMesh, { vault });
 
-  let autoUpdateRuntime: AutoUpdateRuntime | undefined;
-  const autoUpdateRegistryUrl = (process.env["NIMBUS_EXTENSIONS_REGISTRY_URL"] ?? "").trim();
-  const autoUpdateDisabled = process.env["NIMBUS_EXTENSIONS_DISABLE_AUTO_UPDATE"] === "1";
-  if (autoUpdateRegistryUrl !== "" && !autoUpdateDisabled) {
-    const extensionsCfg = loadNimbusExtensionsFromConfigDir(paths.configDir);
-    autoUpdateRuntime = createAutoUpdateRuntime({
-      db,
-      vault,
-      extensionsDir: paths.extensionsDir,
-      dataDir: paths.dataDir,
-      registryBaseUrl: autoUpdateRegistryUrl,
-      intervalHours: extensionsCfg.updateCheckIntervalHours,
-      enforceAirGap: false,
-      stopExtensionClient: (id) => connectorMesh.stopExtensionClient(id),
-    });
-    void autoUpdateRuntime.daemon.start();
-    sidecarStops.push(() => {
-      autoUpdateRuntime?.abortController.abort();
-      void autoUpdateRuntime?.daemon.stop();
-    });
-  }
+  const { runtime: autoUpdateRuntime, disabled: autoUpdateDisabled } = maybeStartAutoUpdateRuntime({
+    db,
+    vault,
+    paths,
+    connectorMesh,
+    sidecarStops,
+  });
 
   rt?.startBackgroundJobs();
   const ipcOpts: Parameters<typeof createIpcServer>[0] = {
@@ -775,17 +986,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     connectorMesh,
     sandboxRunner,
     llmRegistry,
-    ...(autoUpdateRuntime === undefined ? {} : { extensionsAutoUpdate: autoUpdateRuntime.deps }),
-    ...(autoUpdateRuntime === undefined
-      ? {}
-      : {
-          extensionsAutoUpdateDiag: {
-            cachedUpdatesCount: (): number => autoUpdateRuntime?.deps.cache.list().length ?? 0,
-            intervalHours: loadNimbusExtensionsFromConfigDir(paths.configDir)
-              .updateCheckIntervalHours,
-            airGapBlocked: autoUpdateDisabled,
-          },
-        }),
+    ...autoUpdateIpcOpts(autoUpdateRuntime, paths.configDir, autoUpdateDisabled),
   };
   if (sessionMemoryStore !== undefined) {
     ipcOpts.sessionMemoryStore = sessionMemoryStore;
@@ -808,26 +1009,15 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     policyGate,
   });
 
-  // Identity & Access (Phase 6 Slice 3). Mirrors the federation block: build the boot, wire the
-  // IPC-facing seams onto ipcOpts, and (when [scim].enabled) hand the SCIM bearer resolver to the
-  // read-only HTTP server so the SCIM provisioning surface authenticates.
-  const identityCfg = loadNimbusIdentityFromConfigDir(paths.configDir);
-  const scimCfg = loadNimbusScimFromConfigDir(paths.configDir);
-  let identityBoot: ReturnType<typeof buildIdentityBoot> | undefined;
   const httpSidecarOpts: HttpSidecarOpts = {};
-  if (identityCfg.enabled && localIndex !== undefined) {
-    identityBoot = buildIdentityBoot(identityCfg, scimCfg, localIndex, vault, {
-      log: (m: string) => syncLogger.warn(m),
-    });
-    ipcOpts.identityStore = identityBoot.store;
-    ipcOpts.identityIssuer = identityBoot.issuer;
-    ipcOpts.identityGraceSeconds = identityBoot.graceSeconds;
-    ipcOpts.identityStartLogin = identityBoot.startLogin;
-    ipcOpts.identityVault = vault;
-    if (scimCfg.enabled) {
-      httpSidecarOpts.resolveScimToken = identityBoot.resolveScimToken;
-    }
-  }
+  const identityBoot = bootIdentityIntoIpcOpts({
+    configDir: paths.configDir,
+    localIndex,
+    vault,
+    syncLogger,
+    ipcOpts,
+    httpSidecarOpts,
+  });
 
   // Observability snapshot (Task 15). Cheap, synchronous readers assembled here where every
   // subsystem is in scope. Wired into BOTH the IPC server (admin.status) and the read-only HTTP
@@ -860,65 +1050,15 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     );
   };
 
-  // policy.* + team.purge IPC namespace (Task 26, Lanes A–G integration hub). The local IPC socket is
-  // operator/owner-trusted, so isAnchor is true for local calls (signing makes this gateway an anchor;
-  // a purge is operator-only). The GDPR purge deps wire the REAL local-side capabilities:
-  //   resolvePeer            → identity binding store (externalId → active peer ids; first wins)
-  //   revokeAllGrants        → NamespaceStore.revokeAllForPeer (confirmed grant-revocation sweep)
-  //   deleteLocalContributions → same sweep's count (item-level row deletion has no confirmed accessor;
-  //                              grant-revocation is the confirmed local effect — see report)
-  //   knownPeers             → localIndex.listLanPeers (paired peers fan out one purge request each)
-  // resolvePeer returns undefined when identity is disabled / unbound → startPurge throws (fail-closed).
-  const purgeNamespaceStore = new NamespaceStore(db);
-  const purgeJobStore = new GdprPurgeStore(db);
-  let purgeJobCounter = 0;
-  const policyRpcCtx: PolicyRpcCtx = {
-    showPolicy: () => policyGate.status(),
-    trustPubkey: ({ pubkey }) => trustAnchorPubkey(policyStore, pubkey, Date.now()),
-    refetch: () =>
-      refreshPolicy({
-        store: policyStore,
-        gate: policyGate,
-        pinnedPubkey: policyStore.getAnchorPubkey() ?? "",
-        nowMs: Date.now(),
-        // Best-effort: no inbound anchor bundle source is wired at the IPC layer, so refetch is a
-        // local no-op (returns the locally-served bundle, or null when ungoverned). The over-the-wire
-        // peer fetch is the federation runtime's job; here we surface "no_bundle" rather than fabricate.
-        fetch: async () => servePolicy(policyStore),
-      }),
-    signPolicy: async ({ toml }) => {
-      const { privkeyB64, pubkeyB64 } = await ensureAnchorKeypair(vault);
-      const r = authorPolicy(
-        { store: policyStore, gate: policyGate, db, privkeyB64, pubkeyB64, nowMs: Date.now() },
-        toml,
-      );
-      if (!r.ok) throw new Error(r.error);
-      return { org: r.org, version: r.version };
-    },
-    purge: ({ externalId }) =>
-      startPurge(
-        {
-          store: purgeJobStore,
-          resolvePeer: (extId) => identityBoot?.store.activePeerIdsFor(extId)[0],
-          // Grant revocation is the confirmed local effect of a purge; performed once in
-          // deleteLocalContributions (which returns the count). No separate item-level
-          // deletion accessor exists yet, so revokeAllGrants is a no-op to avoid double-sweeping.
-          revokeAllGrants: () => {},
-          deleteLocalContributions: (peerId) =>
-            purgeNamespaceStore.revokeAllForPeer(peerId, Date.now()),
-          knownPeers: () => localIndex.listLanPeers().map((p) => p.peer_id),
-          newJobId: () => {
-            purgeJobCounter += 1;
-            return `gdpr-${Date.now()}-${purgeJobCounter}`;
-          },
-          nowMs: () => Date.now(),
-        },
-        externalId,
-      ),
-    // Local IPC socket is operator/owner-trusted (see ipc/server): treat local calls as the anchor.
-    isAnchor: true,
-  };
-  ipcOpts.policyRpcCtx = policyRpcCtx;
+  // policy.* + team.purge IPC namespace (Task 26, Lanes A–G integration hub) — see buildPolicyRpcCtx.
+  ipcOpts.policyRpcCtx = buildPolicyRpcCtx({
+    db,
+    vault,
+    localIndex,
+    policyStore,
+    policyGate,
+    identityBoot,
+  });
 
   collectSidecarsFromEnv(db, paths, sidecarStops, httpSidecarOpts);
 
@@ -941,26 +1081,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
   // Bind the live broadcast so identity.loginProgress/Done/Error reach subscribers (see identity-boot.ts).
   identityBoot?.bindLoginNotify((method, payload) => ipc.broadcast(method, payload));
 
-  const updaterCfg = loadNimbusUpdaterFromConfigDir(paths.configDir);
-  const updater = createUpdaterFromConfig({
-    updaterCfg,
-    currentVersion: GATEWAY_VERSION,
-    emit: (name, payload) => ipc.broadcast(name, payload ?? {}),
-    logger: syncLogger,
-  });
-  if (updater !== undefined) {
-    ipc.setUpdater(updater);
-    if (updaterCfg.checkOnStartup) {
-      void updater
-        .checkNow()
-        .catch((err: unknown) =>
-          syncLogger.warn(
-            { err: redactUrlUserinfo(err instanceof Error ? err.message : String(err)) },
-            "updater startup check failed",
-          ),
-        );
-    }
-  }
+  wireUpdaterIntoIpc(paths.configDir, ipc, syncLogger);
 
   const gatewayAssemblyMs = Math.max(0, Math.round(performance.now() - assemblyStartedMs));
   const telemetryStop = startTelemetryFlushScheduler({

--- a/packages/gateway/src/policy/chatops-policy.ts
+++ b/packages/gateway/src/policy/chatops-policy.ts
@@ -21,9 +21,9 @@ function literalPrefixLen(pattern: string): number {
 function globMatches(pattern: string, value: string): boolean {
   const re = new RegExp(
     `^${pattern
-      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-      .replace(/\*/g, ".*")
-      .replace(/\?/g, ".")}$`,
+      .replace(/[.+^${}()|[\]\\]/g, String.raw`\$&`)
+      .replaceAll("*", ".*")
+      .replaceAll("?", ".")}$`,
   );
   return re.test(value);
 }

--- a/packages/gateway/src/security/scan.ts
+++ b/packages/gateway/src/security/scan.ts
@@ -89,6 +89,86 @@ function absoluteLineFor(item: ScanItem, body: string, offset: number): number |
 
 const NO_OPTIONS: ScanOptions = { allowlist: new Set<string>() };
 
+/** Resolve indexed blame for a match (code_symbol items only), in snake_case finding shape. */
+function resolveFindingBlame(
+  row: ScanItem,
+  body: string,
+  offset: number,
+  options: ScanOptions,
+): FindingBlame | null {
+  const absLine = absoluteLineFor(row, body, offset);
+  if (absLine === null || options.resolveBlame === undefined) return null;
+  const b = options.resolveBlame(row, absLine);
+  if (b === null) return null;
+  return {
+    commit_sha: b.commitSha,
+    author_name: b.authorName,
+    author_email: b.authorEmail,
+    author_time_ms: b.authorTimeMs,
+  };
+}
+
+/** Build the finding for one regex match, or null when its fingerprint is allowlisted (muted). */
+function buildFindingForMatch(
+  row: ScanItem,
+  body: string,
+  externalId: string,
+  pattern: SecretPattern,
+  match: RegExpExecArray,
+  options: ScanOptions,
+): SecurityFinding | null {
+  const offset = match.index ?? 0;
+  const raw = match[0];
+  const matchRedacted = redactSecret(raw);
+  const contextSnippet = buildContextSnippet(body, offset, raw.length);
+  const fingerprint = computeFindingFingerprint({
+    service: row.service,
+    externalId,
+    patternName: pattern.name,
+    matchRedacted,
+    contextSnippet,
+  });
+  if (options.allowlist.has(fingerprint)) return null;
+  return {
+    item_id: row.id,
+    service: row.service,
+    type: row.type,
+    title: row.title,
+    pattern_name: pattern.name,
+    pattern_category: pattern.category,
+    match_redacted: matchRedacted,
+    match_offset: offset,
+    context_snippet: contextSnippet,
+    modified_at_ms: row.modified_at,
+    url: row.url,
+    fingerprint,
+    external_id: externalId,
+    blame: resolveFindingBlame(row, body, offset, options),
+  };
+}
+
+/** Scan one row against all patterns, pushing findings into `sink`; returns the muted count. */
+function scanRowForSecrets(
+  row: ScanItem,
+  patterns: readonly SecretPattern[],
+  options: ScanOptions,
+  sink: SecurityFinding[],
+): number {
+  const body = row.body_preview;
+  if (body === null || body.length === 0) return 0;
+  const externalId = row.external_id ?? row.id;
+  let muted = 0;
+  for (const pattern of patterns) {
+    pattern.regex.lastIndex = 0;
+    for (const match of body.matchAll(pattern.regex)) {
+      const finding = buildFindingForMatch(row, body, externalId, pattern, match, options);
+      if (finding === null) muted += 1;
+      else sink.push(finding);
+    }
+  }
+  return muted;
+}
+
 export function scanItemsForSecrets(
   rows: Iterable<ScanItem>,
   patterns: readonly SecretPattern[],
@@ -101,59 +181,7 @@ export function scanItemsForSecrets(
 
   for (const row of rows) {
     items_scanned += 1;
-    const body = row.body_preview;
-    if (body === null || body.length === 0) continue;
-    const externalId = row.external_id ?? row.id;
-    for (const pattern of patterns) {
-      pattern.regex.lastIndex = 0;
-      for (const match of body.matchAll(pattern.regex)) {
-        const offset = match.index ?? 0;
-        const raw = match[0];
-        const matchRedacted = redactSecret(raw);
-        const contextSnippet = buildContextSnippet(body, offset, raw.length);
-        const fingerprint = computeFindingFingerprint({
-          service: row.service,
-          externalId,
-          patternName: pattern.name,
-          matchRedacted,
-          contextSnippet,
-        });
-        if (options.allowlist.has(fingerprint)) {
-          muted_count += 1;
-          continue;
-        }
-        const absLine = absoluteLineFor(row, body, offset);
-        const b =
-          absLine !== null && options.resolveBlame !== undefined
-            ? options.resolveBlame(row, absLine)
-            : null;
-        const blame: FindingBlame | null =
-          b === null
-            ? null
-            : {
-                commit_sha: b.commitSha,
-                author_name: b.authorName,
-                author_email: b.authorEmail,
-                author_time_ms: b.authorTimeMs,
-              };
-        findings.push({
-          item_id: row.id,
-          service: row.service,
-          type: row.type,
-          title: row.title,
-          pattern_name: pattern.name,
-          pattern_category: pattern.category,
-          match_redacted: matchRedacted,
-          match_offset: offset,
-          context_snippet: contextSnippet,
-          modified_at_ms: row.modified_at,
-          url: row.url,
-          fingerprint,
-          external_id: externalId,
-          blame,
-        });
-      }
-    }
+    muted_count += scanRowForSecrets(row, patterns, options, findings);
   }
 
   return {

--- a/packages/gateway/src/teamvault/team-tool-spawn.ts
+++ b/packages/gateway/src/teamvault/team-tool-spawn.ts
@@ -53,7 +53,9 @@ export async function spawnTeamToolAndCall(req: TeamToolSpawnRequest): Promise<u
     sandboxCwd: req.sandboxCwd,
     clearLazyIdle: () => {},
     getLazyClient: (key) => clients.get(key),
-    setLazyClient: (key, client) => void clients.set(key, client),
+    setLazyClient: (key, client) => {
+      clients.set(key, client);
+    },
     bumpToolsEpoch: () => {},
     scheduleLazyDisconnect: () => {},
   };


### PR DESCRIPTION
## Summary

SonarCloud `nimbus-agent_Nimbus` main went red after the ChatOps (#559) / Slice 4 (#538) merges: quality gate **ERROR** on `new_security_hotspots_reviewed` (75%), plus **26 open code smells** (0 bugs, 0 vulnerabilities). This PR clears all of them in code — fix-not-exclude, no rule tuning, no new NOSONAR.

### Hotspot (ReDoS, chatops/command-parser.ts)
The slack-token regexes (`<url|label>`, `<#C|name>`, …) used char classes that allowed `<`, giving polynomial backtracking on adversarial chat input. Classes now exclude `<` → linear scan. Behavior unchanged for real input: Slack escapes a literal `<` as `&lt;` inside tokens.

### S3776 cognitive complexity ×10 (18–32 → <15)
Pure helper extraction, same-file module-private helpers, behavior and check order identical:
- `engine/executor.ts` `gate()` (I2/I3/I4 — HITL membership check + hitlStatus writes untouched)
- `federation/query-gate.ts` (I17 — consent step + leak-proof effective-type computation extracted, all in-module, D13 audit green)
- `platform/assemble.ts` ×2, `ipc/http-write-routes.ts` (I13 route resolver), `ipc/http-server.ts`, `config/nimbus-toml.ts` (quorum sub-table parser), `ipc/server/dispatchers.ts` (phase-4 dispatch groups), `connectors/filesystem-v2-sync.ts`, `security/scan.ts`

### Mechanical smells
- S7781 ×5 `replaceAll` + S7780 `String.raw` (command-parser, chatops-policy)
- S6582 ×3 optional chains (identity-mapper, slack-socket-adapter, delegated-request-remote)
- S6551 ×4 `cli team.ts` audit table → primitive-only `cellText` (never `[object Object]`)
- S4325 redundant cast (hitl-rpc), S3735 `void` operator (team-tool-spawn), S5914 always-true assertion → asserts prune-rollback outcome (tool-call-log-retention test)

## Verification
- `tsc --noEmit` clean (gateway, cli); biome check clean on all touched files
- `security-invariants.test.ts` 66 pass; `check-nimbus-invariants.ts` (D13/D16/D17 static audits) pass
- All touched-area tests green: chatops/policy/db/teamvault/engine 191 pass, ipc server 186, config 145, platform 79, security 62, cli team 13, federation per-file all green (`consent-broker.test.ts` excluded locally — known pre-existing Windows-only unref-timer hang, file untouched, green on Linux CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI output displaying "[object Object]" for complex values in audit tables.
  * Improved validation for peer host configuration handling.
  * Enhanced identity mapper to properly handle inactive users.

* **Refactors**
  * Streamlined internal code organization across gateway services for better maintainability.
  * Improved chat platform syntax normalization for consistent message parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->