### PR TITLE
ci: report required PR checks on docs-only PRs (unblock docs merges)

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -19,6 +19,14 @@ on:
         description: Build headless bundle and Linux installers after tests (Ubuntu only)
         type: boolean
         default: false
+      run-tests:
+        description: >-
+          Run the actual test/static jobs. Defaults true. The PR caller sets
+          this to false on docs-only PRs so every job skips (reported as a
+          passing "skipped" required check) without doing test work. Push and
+          release callers leave it true.
+        type: boolean
+        default: true
     secrets:
       SONAR_TOKEN:
         description: |
@@ -38,6 +46,7 @@ jobs:
   # path on ubuntu PRs.
   static:
     name: Static — ${{ inputs.runner }}
+    if: inputs.run-tests
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     permissions:
@@ -95,6 +104,7 @@ jobs:
   # coverage-gates matrix and the per-file coverage floor consume.
   unit-coverage:
     name: Unit + Coverage — ${{ inputs.runner }}
+    if: inputs.run-tests
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 60
     permissions:
@@ -463,6 +473,7 @@ jobs:
   # ── Integration tests ──────────────────────────────────────────────────────
   integration:
     name: Integration — ${{ inputs.runner }}
+    if: inputs.run-tests
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     permissions:
@@ -532,6 +543,7 @@ jobs:
   # ── E2E Gateway tests ──────────────────────────────────────────────────────
   e2e-gateway:
     name: E2E Gateway — ${{ inputs.runner }}
+    if: inputs.run-tests
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     permissions:
@@ -601,6 +613,7 @@ jobs:
   # ── E2E CLI tests ──────────────────────────────────────────────────────────
   e2e-cli:
     name: E2E CLI — ${{ inputs.runner }}
+    if: inputs.run-tests
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     permissions:
@@ -673,7 +686,7 @@ jobs:
   # (distinct from the per-package `bun run build` validated by `static`).
   packaging:
     name: Packaging — ${{ inputs.runner }}
-    if: inputs.run-packaging
+    if: inputs.run-packaging && inputs.run-tests
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     permissions:
@@ -834,6 +847,7 @@ jobs:
 
   client-node-compat:
     name: Client node-compat (${{ matrix.os }})
+    if: inputs.run-tests
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,21 @@ jobs:
   # TS/Bun test suite — ubuntu only, runs in parallel with pr-quality-rust
   pr-quality-ts:
     name: PR quality — TS/Bun (ubuntu-24.04)
-    if: github.event_name == 'pull_request' && needs.filter.outputs.code-changed == 'true'
+    # Always run on PRs so the required reusable-workflow child checks
+    # (`… / Static`, `… / Unit + Coverage`, … `/ Packaging`) always REPORT a
+    # status. On docs-only PRs we pass run-tests=false, which skips every child
+    # job — a skipped required check counts as passing. Gating the *caller* on
+    # `code-changed` instead (the old behavior) meant the reusable workflow
+    # never ran, so the 6 child contexts were never created and sat
+    # "Expected — Waiting for status to be reported" forever, blocking the merge.
+    # Test execution on code PRs is unchanged (code-changed=true → run-tests=true).
+    if: github.event_name == 'pull_request'
     needs: filter
     uses: ./.github/workflows/_test-suite.yml
     with:
       runner: ubuntu-24.04
       run-packaging: true
+      run-tests: ${{ needs.filter.outputs.code-changed == 'true' }}
     secrets:
       # Optional; the reusable workflow silently skips the SonarQube step
       # when this is unset (e.g. on fork PRs).
@@ -182,11 +191,14 @@ jobs:
   pr-quality-cross-platform:
     name: PR quality — Cross-platform (${{ matrix.pkg }}, ${{ matrix.os }})
     # The filter always emits the full 4-entry matrix on `pull_request`
-    # events (see ci.yml#Detect-changed-paths). The `code-changed` gate
-    # above already short-circuits docs-only PRs at the filter, so this
-    # job just needs to confirm the PR event + non-doc trigger before
-    # expanding the matrix.
-    if: github.event_name == 'pull_request' && needs.filter.outputs.code-changed == 'true'
+    # events (see ci.yml#Detect-changed-paths). Branch-protection rulesets
+    # require the expanded check names (`PR quality — Cross-platform
+    # (cli, macos-15)` etc.), so this job must RUN on every PR — even
+    # docs-only ones — or those 4 required checks never post and sit
+    # "Expected — Waiting for status to be reported" forever. The expensive
+    # steps below are individually gated on `code-changed`, so a docs-only PR
+    # spins up the 4 matrix legs but does no test work (they report success).
+    if: github.event_name == 'pull_request'
     needs: filter
     strategy:
       fail-fast: false
@@ -209,15 +221,16 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bun and install dependencies
+        if: needs.filter.outputs.code-changed == 'true'
         uses: ./.github/actions/setup-nimbus-ci
 
       - name: macOS — Strip quarantine from native SQLite extensions
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && needs.filter.outputs.code-changed == 'true'
         shell: bash
         run: find node_modules -name "*.dylib" -print0 2>/dev/null | xargs -0 xattr -d com.apple.quarantine 2>/dev/null || true
 
       - name: macOS — Create and unlock CI Keychain
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && needs.filter.outputs.code-changed == 'true'
         shell: bash
         run: |
           security create-keychain -p "" nimbus-ci.keychain
@@ -232,11 +245,11 @@ jobs:
       # quirks still surface on the gateway entry. Client build is only needed
       # for vscode-extension typecheck, which only runs alongside typecheck.
       - name: Build @nimbus-dev/client (for vscode-extension typecheck)
-        if: matrix.pkg == 'gateway'
+        if: matrix.pkg == 'gateway' && needs.filter.outputs.code-changed == 'true'
         run: cd packages/client && bun run build
 
       - name: Typecheck (catches host-specific TS quirks)
-        if: matrix.pkg == 'gateway'
+        if: matrix.pkg == 'gateway' && needs.filter.outputs.code-changed == 'true'
         shell: bash
         # @nimbus/docs is excluded here: it has no host-specific TS surface and
         # its astro-sync content-type generation flakes a 60s Vite timeout on slow
@@ -254,6 +267,7 @@ jobs:
           done
 
       - name: ${{ matrix.pkg }} unit tests (retry once on slow runners)
+        if: needs.filter.outputs.code-changed == 'true'
         shell: bash
         # `--timeout 60000` matches every other Bun test invocation in the repo
         # (`_test-suite.yml` runs these SAME gateway/cli suites at 60 s on the


### PR DESCRIPTION
## Problem

Docs-only PRs are **unmergeable**. Branch protection requires 10 check contexts that never report on a docs-only PR, leaving them at *"Expected — Waiting for status to be reported"* forever:

- `PR quality — Cross-platform (cli|gateway, macos-15|windows-2025)` ×4
- `PR quality — TS/Bun (ubuntu-24.04) / {Static, Unit + Coverage, Integration, E2E CLI, E2E Gateway, Packaging}` ×6

### Root cause

`ci.yml`'s **Detect changes** sets `code-changed=false` when every changed file is `docs/` / `*.md` / `LICENSE` / `CHANGELOG`. Both `pr-quality-ts` and `pr-quality-cross-platform` were gated on `code-changed == 'true'` at the **job** level, so they skipped entirely.

A *single-name* gated job (e.g. `PR quality — Duplication scan`) posts a **skipped** status that branch protection counts as passing. But a skipped **matrix** job and a skipped **reusable-workflow caller** never expand their per-entry / child check names — so those 10 contexts are never created at all → permanent block. (The workflow's own comment at the cross-platform job already noted the matrix must always emit its 4 entries for exactly this reason; the residual job-level gate defeated it.)

## Fix

Run both jobs on **every** PR so the required contexts always *report*, and push the skip down one level so **no test work runs on docs PRs** (execution unchanged from today):

- **`pr-quality-ts`** — always run on PR; pass `run-tests: ${{ code-changed == 'true' }}` into `_test-suite.yml`.
- **`_test-suite.yml`** — new `run-tests` input (**default `true`**, so push + release callers are unaffected). `static` / `unit-coverage` / `integration` / `e2e-gateway` / `e2e-cli` / `packaging` / `client-node-compat` gate on it → they post a passing **skipped** status. `coverage-gates` auto-skips via `needs: unit-coverage`.
- **`pr-quality-cross-platform`** — always run the (already-4-entry) matrix; gate the expensive steps (setup / build / typecheck / unit tests) on `code-changed` so each leg reports **success** with no work.

## Verification

- Both workflow files parse as valid YAML; no `if: always()` job depends on a now-gated job.
- This PR touches `.github/workflows/*`, which intentionally sets `code-changed=true` → the **full suite runs here** and all 10 contexts post for real, self-validating the change.
- After merge, rebasing #565 onto main will let the docs PR pick up the new logic and report all 10 as passing-skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline efficiency by conditionally executing tests and build operations only when code changes are detected.
  * Improved pull request workflow to maintain required status checks visibility while preventing unnecessary resource-intensive operations on documentation-only pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->