### PR TITLE
test(coverage): B3b — gateway/ipc part 2 to ≥80% branch (8 files, 155→147)

### DIFF
--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-06-11T06:29:46.886Z",
+  "generated_at": "2026-06-11T08:00:07.170Z",
   "files": {
     "packages/cli/src/commands/audit.ts": {
       "min_line_pct": 80,
@@ -100,11 +100,11 @@
     },
     "packages/gateway/src/agents/expert.ts": {
       "min_line_pct": 80,
-      "min_branch_pct": 67.24
+      "min_branch_pct": 68.97
     },
     "packages/gateway/src/agents/impact.ts": {
       "min_line_pct": 80,
-      "min_branch_pct": 77.27
+      "min_branch_pct": 78.79
     },
     "packages/gateway/src/commands/data-delete.ts": {
       "min_line_pct": 80,
@@ -473,38 +473,6 @@
     "packages/gateway/src/index/sqlite-vec-load.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 68.42
-    },
-    "packages/gateway/src/ipc/_lib/dispatch-by-method.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 75
-    },
-    "packages/gateway/src/ipc/agents-rpc.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 77.33
-    },
-    "packages/gateway/src/ipc/data-rpc.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 75.36
-    },
-    "packages/gateway/src/ipc/federation-rpc.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 77.66
-    },
-    "packages/gateway/src/ipc/hitl-rpc.ts": {
-      "min_line_pct": 74.19,
-      "min_branch_pct": 80
-    },
-    "packages/gateway/src/ipc/http-write-routes.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 77.69
-    },
-    "packages/gateway/src/ipc/security-rpc.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 78.69
-    },
-    "packages/gateway/src/ipc/teamvault-rpc.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 77.78
     },
     "packages/gateway/src/llm/llamacpp-provider.ts": {
       "min_line_pct": 80,

--- a/packages/gateway/src/ipc/_lib/dispatch-by-method.test.ts
+++ b/packages/gateway/src/ipc/_lib/dispatch-by-method.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { dispatchByMethod } from "./dispatch-by-method.ts";
+import { dispatchByMethod, type RpcMethodHandlerMap } from "./dispatch-by-method.ts";
 
 describe("dispatchByMethod", () => {
   test("returns hit envelope with the handler value when method is registered", async () => {
@@ -53,6 +53,15 @@ describe("dispatchByMethod", () => {
     const proto = { "evil.method": () => "PWNED" };
     const handlers = Object.create(proto) as Record<string, () => unknown>;
     const result = await dispatchByMethod("evil.method", undefined, undefined, handlers);
+    expect(result).toEqual({ kind: "miss" });
+  });
+
+  test("returns miss when own property exists but its value is undefined (handler === undefined branch)", async () => {
+    // Object.hasOwn returns true for "ghost" but handlers["ghost"] is undefined,
+    // exercising the `if (handler === undefined)` true arm (BRDA line 21 block 1 branch 0).
+    // Cast through unknown because RpcMethodHandlerMap forbids undefined values at the type level.
+    const handlers = { ghost: undefined } as unknown as RpcMethodHandlerMap<undefined>;
+    const result = await dispatchByMethod("ghost", undefined, undefined, handlers);
     expect(result).toEqual({ kind: "miss" });
   });
 });

--- a/packages/gateway/src/ipc/agents-rpc.test.ts
+++ b/packages/gateway/src/ipc/agents-rpc.test.ts
@@ -35,6 +35,26 @@ function freshDb(): Database {
   return db;
 }
 
+/**
+ * Polls a ctx.notify mock until `eventName` is observed or the deadline passes.
+ * Deterministic replacement for fixed sleeps (the briefReady notify may fire
+ * after the dispatch promise resolves; a fixed wait flakes under load).
+ */
+async function waitForNotify(
+  notify: unknown,
+  eventName: string,
+  timeoutMs = 5_000,
+): Promise<boolean> {
+  // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
+  const calls = (notify as ReturnType<typeof mock>).mock.calls;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (calls.some((c) => c[0] === eventName)) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return false;
+}
+
 describe("dispatchAgentsRpc", () => {
   test("returns kind:miss for unknown methods", async () => {
     const out = await dispatchAgentsRpc("agents.unknown", {}, makeCtx(freshDb()));
@@ -76,10 +96,7 @@ describe("dispatchAgentsRpc", () => {
   test("agents.expert eventually emits expert.briefReady", async () => {
     const ctx = makeCtx(freshDb());
     await dispatchAgentsRpc("agents.expert", { topicOrFile: "x" }, ctx);
-    await new Promise((r) => setTimeout(r, 50));
-    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
-    const briefReady = calls.find((c) => c[0] === "expert.briefReady");
-    expect(briefReady).toBeDefined();
+    expect(await waitForNotify(ctx.notify, "expert.briefReady")).toBe(true);
   });
 });
 
@@ -134,10 +151,7 @@ describe("dispatchAgentsRpc — agents.impact", () => {
   test("agents.impact eventually emits impact.briefReady", async () => {
     const ctx = makeCtx(freshDb());
     await dispatchAgentsRpc("agents.impact", { fileOrPrUrl: "x" }, ctx);
-    await new Promise((r) => setTimeout(r, 50));
-    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
-    const briefReady = calls.find((c) => c[0] === "impact.briefReady");
-    expect(briefReady).toBeDefined();
+    expect(await waitForNotify(ctx.notify, "impact.briefReady")).toBe(true);
   });
 });
 
@@ -425,18 +439,14 @@ describe("dispatchAgentsRpc — llm-present branches", () => {
     const out = await dispatchAgentsRpc("agents.expert", { topicOrFile: "src/x.ts" }, ctx);
     expect(out.kind).toBe("hit");
     // briefReady is emitted; the llm-present arm was taken (no error = correct branch)
-    await new Promise((r) => setTimeout(r, 50));
-    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
-    expect(calls.some((c) => c[0] === "expert.briefReady")).toBe(true);
+    expect(await waitForNotify(ctx.notify, "expert.briefReady")).toBe(true);
   });
 
   test("agents.impact with llm set takes the llm-present context arm", async () => {
     const ctx = makeCtx(freshDb(), { llm: fakeLlm() });
     const out = await dispatchAgentsRpc("agents.impact", { fileOrPrUrl: "src/x.ts" }, ctx);
     expect(out.kind).toBe("hit");
-    await new Promise((r) => setTimeout(r, 50));
-    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
-    expect(calls.some((c) => c[0] === "impact.briefReady")).toBe(true);
+    expect(await waitForNotify(ctx.notify, "impact.briefReady")).toBe(true);
   });
 
   test("agents.catchup with llm set takes the llm-present context arm", async () => {

--- a/packages/gateway/src/ipc/agents-rpc.test.ts
+++ b/packages/gateway/src/ipc/agents-rpc.test.ts
@@ -1,13 +1,32 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SynthesizerLlm } from "../agents/_lib/synthesize.ts";
 import { LocalIndex } from "../index/local-index.ts";
 import { AgentsRpcError, dispatchAgentsRpc } from "./agents-rpc.ts";
 
-function makeCtx(db: Database) {
+function makeCtx(db: Database, extras?: { llm?: SynthesizerLlm; configDir?: string }) {
   return {
     db,
     notify: mock(() => {}),
+    ...extras,
   };
+}
+
+/** Returns a fake SynthesizerLlm that immediately resolves to null (no synthesis). */
+function fakeLlm(): SynthesizerLlm {
+  return {
+    generateMarkdown: (_prompt: string) => Promise.resolve(null),
+  };
+}
+
+/** Creates a tmpdir with a nimbus.toml containing a [user] me_person_id entry. */
+function makeTmpConfigDir(mePersonId: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-agents-"));
+  writeFileSync(join(dir, "nimbus.toml"), `[user]\nme_person_id = "${mePersonId}"\n`, "utf8");
+  return dir;
 }
 
 function freshDb(): Database {
@@ -184,5 +203,287 @@ describe("dispatchAgentsRpc — agents.catchup", () => {
     const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
     const briefReady = calls.find((c) => c[0] === "catchup.briefReady");
     expect(briefReady).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch-coverage additions — True Coverage Program B3b
+// ---------------------------------------------------------------------------
+
+describe("dispatchAgentsRpc — agents.expert limit validation", () => {
+  test("valid integer limit is accepted and forwarded (limit defined arm)", async () => {
+    const out = await dispatchAgentsRpc(
+      "agents.expert",
+      { topicOrFile: "src/x.ts", limit: 5 },
+      makeCtx(freshDb()),
+    );
+    expect(out.kind).toBe("hit");
+  });
+
+  test("limit: 0 (below 1) rejects with limit message", async () => {
+    await expect(
+      dispatchAgentsRpc("agents.expert", { topicOrFile: "src/x.ts", limit: 0 }, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("limit must be an integer"),
+    });
+  });
+
+  test("limit: 1.5 (non-integer) rejects with limit message", async () => {
+    await expect(
+      dispatchAgentsRpc(
+        "agents.expert",
+        { topicOrFile: "src/x.ts", limit: 1.5 },
+        makeCtx(freshDb()),
+      ),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("limit must be an integer"),
+    });
+  });
+
+  test("limit: 99 (above MAX_LIMIT=25) rejects with limit message", async () => {
+    await expect(
+      dispatchAgentsRpc(
+        "agents.expert",
+        { topicOrFile: "src/x.ts", limit: 99 },
+        makeCtx(freshDb()),
+      ),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("limit must be an integer"),
+    });
+  });
+
+  test("limit: non-number (typed as unknown) rejects with limit message", async () => {
+    const params: unknown = { topicOrFile: "src/x.ts", limit: "x" };
+    await expect(
+      dispatchAgentsRpc("agents.expert", params, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("limit must be an integer"),
+    });
+  });
+});
+
+describe("dispatchAgentsRpc — agents.impact depth+service validation", () => {
+  test("valid depth (3) is accepted", async () => {
+    const out = await dispatchAgentsRpc(
+      "agents.impact",
+      { fileOrPrUrl: "src/x.ts", depth: 3 },
+      makeCtx(freshDb()),
+    );
+    expect(out.kind).toBe("hit");
+  });
+
+  test("valid service is accepted", async () => {
+    const out = await dispatchAgentsRpc(
+      "agents.impact",
+      { fileOrPrUrl: "src/x.ts", service: "github" },
+      makeCtx(freshDb()),
+    );
+    expect(out.kind).toBe("hit");
+  });
+
+  test("depth: 0 (below MIN_DEPTH=1) rejects with depth message", async () => {
+    await expect(
+      dispatchAgentsRpc("agents.impact", { fileOrPrUrl: "src/x.ts", depth: 0 }, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("depth must be an integer"),
+    });
+  });
+
+  test("depth: 6 (above MAX_IMPACT_DEPTH=5) rejects with depth message", async () => {
+    await expect(
+      dispatchAgentsRpc("agents.impact", { fileOrPrUrl: "src/x.ts", depth: 6 }, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("depth must be an integer"),
+    });
+  });
+
+  test("depth: 1.5 (non-integer) rejects with depth message", async () => {
+    await expect(
+      dispatchAgentsRpc(
+        "agents.impact",
+        { fileOrPrUrl: "src/x.ts", depth: 1.5 },
+        makeCtx(freshDb()),
+      ),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("depth must be an integer"),
+    });
+  });
+
+  test("service: empty string rejects with service message", async () => {
+    await expect(
+      dispatchAgentsRpc(
+        "agents.impact",
+        { fileOrPrUrl: "src/x.ts", service: "" },
+        makeCtx(freshDb()),
+      ),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("service must be a non-empty string"),
+    });
+  });
+
+  test("service: >64 chars rejects with service message", async () => {
+    await expect(
+      dispatchAgentsRpc(
+        "agents.impact",
+        { fileOrPrUrl: "src/x.ts", service: "a".repeat(65) },
+        makeCtx(freshDb()),
+      ),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("service must be a non-empty string"),
+    });
+  });
+
+  test("service: non-string (typed as unknown) rejects with service message", async () => {
+    const params: unknown = { fileOrPrUrl: "src/x.ts", service: 42 };
+    await expect(
+      dispatchAgentsRpc("agents.impact", params, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("service must be a non-empty string"),
+    });
+  });
+});
+
+describe("dispatchAgentsRpc — agents.catchup sinceMs+service validation", () => {
+  test("valid sinceMs (1000) is accepted", async () => {
+    const out = await dispatchAgentsRpc("agents.catchup", { sinceMs: 1000 }, makeCtx(freshDb()));
+    expect(out.kind).toBe("hit");
+  });
+
+  test("valid service is accepted", async () => {
+    const out = await dispatchAgentsRpc(
+      "agents.catchup",
+      { service: "github" },
+      makeCtx(freshDb()),
+    );
+    expect(out.kind).toBe("hit");
+  });
+
+  test("sinceMs: negative rejects with sinceMs message", async () => {
+    await expect(
+      dispatchAgentsRpc("agents.catchup", { sinceMs: -1 }, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("sinceMs must be"),
+    });
+  });
+
+  test("sinceMs: above 90 days rejects with sinceMs message", async () => {
+    await expect(
+      dispatchAgentsRpc(
+        "agents.catchup",
+        { sinceMs: 91 * 24 * 60 * 60 * 1000 },
+        makeCtx(freshDb()),
+      ),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("sinceMs must be"),
+    });
+  });
+
+  test("sinceMs: non-integer rejects with sinceMs message", async () => {
+    await expect(
+      dispatchAgentsRpc("agents.catchup", { sinceMs: 1.5 }, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("sinceMs must be"),
+    });
+  });
+
+  test("service: empty string rejects with service message", async () => {
+    await expect(
+      dispatchAgentsRpc("agents.catchup", { service: "" }, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("service must be"),
+    });
+  });
+
+  test("service: non-string (typed as unknown) rejects with service message", async () => {
+    const params: unknown = { service: 123 };
+    await expect(
+      dispatchAgentsRpc("agents.catchup", params, makeCtx(freshDb())),
+    ).rejects.toMatchObject({
+      rpcCode: -32602,
+      message: expect.stringContaining("service must be"),
+    });
+  });
+});
+
+describe("dispatchAgentsRpc — llm-present branches", () => {
+  test("agents.expert with llm set takes the llm-present context arm", async () => {
+    const ctx = makeCtx(freshDb(), { llm: fakeLlm() });
+    const out = await dispatchAgentsRpc("agents.expert", { topicOrFile: "src/x.ts" }, ctx);
+    expect(out.kind).toBe("hit");
+    // briefReady is emitted; the llm-present arm was taken (no error = correct branch)
+    await new Promise((r) => setTimeout(r, 50));
+    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
+    expect(calls.some((c) => c[0] === "expert.briefReady")).toBe(true);
+  });
+
+  test("agents.impact with llm set takes the llm-present context arm", async () => {
+    const ctx = makeCtx(freshDb(), { llm: fakeLlm() });
+    const out = await dispatchAgentsRpc("agents.impact", { fileOrPrUrl: "src/x.ts" }, ctx);
+    expect(out.kind).toBe("hit");
+    await new Promise((r) => setTimeout(r, 50));
+    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
+    expect(calls.some((c) => c[0] === "impact.briefReady")).toBe(true);
+  });
+
+  test("agents.catchup with llm set takes the llm-present context arm", async () => {
+    const ctx = makeCtx(freshDb(), { llm: fakeLlm() });
+    const out = await dispatchAgentsRpc("agents.catchup", {}, ctx);
+    expect(out.kind).toBe("hit");
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
+      if (calls.some((c) => c[0] === "catchup.briefReady")) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
+    expect(calls.some((c) => c[0] === "catchup.briefReady")).toBe(true);
+  });
+});
+
+describe("dispatchAgentsRpc — agents.catchup configDir + mePersonId arms", () => {
+  test("configDir defined + me_person_id set → mePersonIdOverride arm taken", async () => {
+    const configDir = makeTmpConfigDir("person-abc-123");
+    const ctx = makeCtx(freshDb(), { configDir });
+    const out = await dispatchAgentsRpc("agents.catchup", {}, ctx);
+    expect(out.kind).toBe("hit");
+    // Confirm the brief was emitted (agent ran with mePersonIdOverride)
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
+      if (calls.some((c) => c[0] === "catchup.briefReady")) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const calls = (ctx.notify as ReturnType<typeof mock>).mock.calls; // NOSONAR S4325: cast exposes the bun mock's .mock.calls (ctx.notify is typed as a plain fn)
+    expect(calls.some((c) => c[0] === "catchup.briefReady")).toBe(true);
+  });
+
+  test("configDir undefined → userToml = {} arm taken (mePersonId stays undefined)", async () => {
+    // ctx has no configDir — tests the ctx.configDir === undefined arm
+    const ctx = makeCtx(freshDb());
+    const out = await dispatchAgentsRpc("agents.catchup", {}, ctx);
+    expect(out.kind).toBe("hit");
+  });
+
+  test("configDir defined but no me_person_id → mePersonId undefined arm taken", async () => {
+    // toml with [user] section but no me_person_id key → mePersonId stays undefined
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-agents-"));
+    writeFileSync(join(dir, "nimbus.toml"), "[user]\n# no me_person_id here\n", "utf8");
+    const ctx = makeCtx(freshDb(), { configDir: dir });
+    const out = await dispatchAgentsRpc("agents.catchup", {}, ctx);
+    expect(out.kind).toBe("hit");
   });
 });

--- a/packages/gateway/src/ipc/data-rpc.test.ts
+++ b/packages/gateway/src/ipc/data-rpc.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { memVault, newIndex } from "../../test/fixtures/data-test-helpers.ts";
 import { _addTestKdfProfile } from "../db/data-vault-crypto.ts";
+import { packBundle, unpackBundle } from "../db/tar-bundle.ts";
 import type { ToolExecutor } from "../engine/executor.ts";
 import { DataRpcError, dispatchDataRpc } from "./data-rpc.ts";
 
@@ -313,5 +314,296 @@ describe("data.import emits progress notifications", () => {
     expect(out.kind).toBe("hit");
     expect(notifications.some((n) => n.method === "data.importProgress")).toBe(true);
     expect(notifications.some((n) => n.method === "data.importCompleted")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch-coverage additions (True Coverage B3b)
+// ---------------------------------------------------------------------------
+
+describe("DataRpcError constructor", () => {
+  test("sets rpcData when provided (line 32 TRUE arm)", () => {
+    // Directly exercises the `if (rpcData !== undefined)` TRUE branch.
+    const err = new DataRpcError(-32010, "version mismatch", {
+      kind: "version_incompatible",
+      archiveSchemaVersion: 0,
+    });
+    expect(err.rpcCode).toBe(-32010);
+    expect(err.rpcData).toEqual({ kind: "version_incompatible", archiveSchemaVersion: 0 });
+  });
+
+  test("rpcData is undefined when not provided (line 32 FALSE arm — existing, explicit)", () => {
+    const err = new DataRpcError(-32602, "bad param");
+    expect(err.rpcData).toBeUndefined();
+  });
+});
+
+describe("asRecord null-params branch (line 39)", () => {
+  test("data.export with null params returns -32602 Missing param: output (line 39 TRUE)", async () => {
+    // asRecord(null) → {} → output param missing → DataRpcError -32602
+    await expect(
+      dispatchDataRpc("data.export", null, {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.0.0-test",
+        kdfParams: testKdf,
+        toolExecutor: approvingExecutor(),
+      }),
+    ).rejects.toMatchObject({ rpcCode: -32602, message: "Missing param: output" });
+  });
+});
+
+describe("requireDeps missing index/vault (line 44)", () => {
+  test("data.import with emptyCtx rejects -32603 (line 44 TRUE)", async () => {
+    // emptyCtx() has index=undefined, vault=undefined → requireDeps throws
+    const err = await dispatchDataRpc(
+      "data.import",
+      { bundlePath: "/tmp/x.tar.gz" },
+      emptyCtx(),
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DataRpcError);
+    expect((err as DataRpcError).rpcCode).toBe(-32603);
+    expect((err as DataRpcError).message).toContain("index or vault not configured");
+  });
+});
+
+describe("handleDataImport param validation (line 100)", () => {
+  test("data.import with empty bundlePath rejects -32602 (line 100)", async () => {
+    await expect(
+      dispatchDataRpc(
+        "data.import",
+        { bundlePath: "" },
+        { ...emptyCtx(), index: newIndex(), vault: memVault() },
+      ),
+    ).rejects.toMatchObject({ rpcCode: -32602, message: "Missing param: bundlePath" });
+  });
+});
+
+describe("data.import passphrase/recoverySeed conditional spreads (lines 106-107)", () => {
+  test("import with recoverySeed (no passphrase) succeeds — covers recoverySeed-present + passphrase-absent arms", async () => {
+    // Export first to get a real bundle and the recovery seed
+    const exportDir = mkdtempSync(join(tmpdir(), "nimbus-rpc-seed-"));
+    const bundlePath = join(exportDir, "bundle.tar.gz");
+    const exportOut = await dispatchDataRpc(
+      "data.export",
+      { output: bundlePath, passphrase: "pw-for-seed-test", includeIndex: false },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.1.0",
+        kdfParams: testKdf,
+        toolExecutor: approvingExecutor(),
+      },
+    );
+    expect(exportOut.kind).toBe("hit");
+    if (exportOut.kind !== "hit") return;
+    const { recoverySeed } = exportOut.value as { recoverySeed: string };
+    expect(recoverySeed.split(" ")).toHaveLength(24);
+
+    // Import using recoverySeed only (no passphrase) — covers:
+    //   line 106: passphrase-absent arm  → spread `{}`
+    //   line 107: recoverySeed-present arm → spread `{ recoverySeed }`
+    const importOut = await dispatchDataRpc(
+      "data.import",
+      { bundlePath, recoverySeed },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.1.0",
+        kdfParams: testKdf,
+      },
+    );
+    expect(importOut.kind).toBe("hit");
+  });
+});
+
+describe("data.import error branches (line 114)", () => {
+  test("import of version-mismatched bundle throws DataRpcError -32010 (line 114 TRUE)", async () => {
+    // Export a valid bundle, then tamper its manifest to use schema_version=0
+    // (which differs from CURRENT_SCHEMA_VERSION=37) → DataImportVersionError → DataRpcError -32010
+    const exportDir = mkdtempSync(join(tmpdir(), "nimbus-rpc-ver-"));
+    const bundlePath = join(exportDir, "bundle.tar.gz");
+    await dispatchDataRpc(
+      "data.export",
+      { output: bundlePath, passphrase: "pw", includeIndex: false },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.1.0",
+        kdfParams: testKdf,
+        toolExecutor: approvingExecutor(),
+      },
+    );
+
+    // Unpack, tamper the schema_version, repack
+    const stageDir = mkdtempSync(join(tmpdir(), "nimbus-rpc-ver-stage-"));
+    await unpackBundle(bundlePath, stageDir);
+    const manifestPath = join(stageDir, "manifest.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+    // Patch to schema_version=0 so archive < current → archive_older_unsupported
+    manifest["schema_version"] = 0;
+    // Also patch the hash for manifest.json so verifyManifest passes
+    // Strategy: remove manifest.json from hashes (verifyManifest only checks listed hashes)
+    const hashes = manifest["hashes"] as Record<string, string>;
+    delete hashes["manifest.json"];
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    const tamperedBundle = join(exportDir, "tampered.tar.gz");
+    await packBundle(stageDir, tamperedBundle);
+
+    await expect(
+      dispatchDataRpc(
+        "data.import",
+        { bundlePath: tamperedBundle, passphrase: "pw" },
+        {
+          index: newIndex(),
+          vault: memVault(),
+          platform: "linux",
+          nimbusVersion: "0.1.0",
+          kdfParams: testKdf,
+        },
+      ),
+    ).rejects.toMatchObject({
+      rpcCode: -32010,
+      rpcData: { kind: "version_incompatible" },
+    });
+  });
+
+  test("import of nonexistent bundle rethrows (line 114 FALSE — non-version error)", async () => {
+    // A non-existent path causes unpackBundle to throw a plain Error (not DataImportVersionError),
+    // which must be rethrown as-is (not wrapped in DataRpcError -32010).
+    const err = await dispatchDataRpc(
+      "data.import",
+      { bundlePath: "/nonexistent/no-such-bundle.tar.gz" },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.0.0-test",
+        kdfParams: testKdf,
+      },
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    // Must NOT be wrapped as a DataRpcError -32010
+    expect(err).not.toMatchObject({ rpcCode: -32010 });
+  });
+});
+
+describe("data.delete non-dryRun branches (lines 135-144)", () => {
+  test("data.delete dryRun=false with approvingExecutor performs real delete (line 135 TRUE)", async () => {
+    const idx = newIndex();
+    idx.rawDb.run(
+      `INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at, pinned)
+       VALUES ('github-del-1', 'github', 'test', 'ext-del', 't', ?, ?, 0)`,
+      [Date.now(), Date.now()],
+    );
+    const out = await dispatchDataRpc(
+      "data.delete",
+      { service: "github", dryRun: false },
+      {
+        index: idx,
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.1.0",
+        kdfParams: testKdf,
+        toolExecutor: approvingExecutor(),
+      },
+    );
+    expect(out.kind).toBe("hit");
+    if (out.kind === "hit") {
+      const v = out.value as { deleted: boolean; preflight: { itemsToDelete: number } };
+      expect(v.deleted).toBe(true);
+      expect(v.preflight.itemsToDelete).toBe(1);
+    }
+    // Item must actually be gone
+    expect(
+      idx.rawDb.query(`SELECT COUNT(*) AS c FROM item WHERE service = 'github'`).get(),
+    ).toEqual({ c: 0 });
+  });
+
+  test("data.delete non-dryRun without toolExecutor rejects -32603 (line 137 TRUE)", async () => {
+    const err = await dispatchDataRpc(
+      "data.delete",
+      { service: "github", dryRun: false },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.0.0-test",
+        kdfParams: testKdf,
+        // no toolExecutor
+      },
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DataRpcError);
+    expect((err as DataRpcError).rpcCode).toBe(-32603);
+    expect((err as DataRpcError).message).toContain("requires a toolExecutor");
+  });
+
+  test("data.delete non-dryRun rejected by HITL returns gateResult (line 144 TRUE)", async () => {
+    const rejectingExecutor = {
+      gate: async () => ({ status: "rejected" as const, reason: "blocked" }),
+      execute: async () => ({ status: "rejected" as const, reason: "n/a" }),
+    } as unknown as ToolExecutor;
+    const r = await dispatchDataRpc(
+      "data.delete",
+      { service: "github", dryRun: false },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.0.0-test",
+        kdfParams: testKdf,
+        toolExecutor: rejectingExecutor,
+      },
+    );
+    expect(r).toEqual({ kind: "hit", value: { status: "rejected", reason: "blocked" } });
+  });
+});
+
+describe("data.getDeletePreflight with live index (lines 202 + 210)", () => {
+  test("itemCount is 0 via ?? 0 when service has no items (line 202 nullish arm)", async () => {
+    // Insert a github item, but query for gitlab → itemCountByService["gitlab"] is undefined → ?? 0
+    const idx = newIndex();
+    idx.rawDb.run(
+      `INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at, pinned)
+       VALUES ('github-1', 'github', 'test', 'ext-1', 't', ?, ?, 0)`,
+      [Date.now(), Date.now()],
+    );
+    const ctx = { ...emptyCtx(), index: idx, vault: memVault() };
+    const r = await dispatchDataRpc("data.getDeletePreflight", { service: "gitlab" }, ctx);
+    expect(r.kind).toBe("hit");
+    if (r.kind === "hit") {
+      const v = r.value as { itemCount: number; vaultKeyCount: number };
+      expect(v.itemCount).toBe(0);
+      // gitlab is a known service, so vaultKeyCount > 0
+      expect(v.vaultKeyCount).toBeGreaterThan(0);
+    }
+  });
+
+  test("vaultKeyCount is 0 for unknown service via live index (line 210 null arm)", async () => {
+    // normalizeConnectorServiceId("unknown_xyz") returns null → vaultKeyCount = 0
+    // Needs a LIVE index so execution reaches line 210 (not the early return at line 196-198).
+    const idx = newIndex();
+    idx.rawDb.run(
+      `INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at, pinned)
+       VALUES ('github-1', 'github', 'test', 'ext-1', 't', ?, ?, 0)`,
+      [Date.now(), Date.now()],
+    );
+    const ctx = { ...emptyCtx(), index: idx, vault: memVault() };
+    const r = await dispatchDataRpc(
+      "data.getDeletePreflight",
+      { service: "unknown_xyz_service" },
+      ctx,
+    );
+    expect(r.kind).toBe("hit");
+    if (r.kind === "hit") {
+      const v = r.value as { itemCount: number; vaultKeyCount: number };
+      expect(v.itemCount).toBe(0);
+      expect(v.vaultKeyCount).toBe(0); // null serviceId → 0
+    }
   });
 });

--- a/packages/gateway/src/ipc/data-rpc.test.ts
+++ b/packages/gateway/src/ipc/data-rpc.test.ts
@@ -359,7 +359,7 @@ describe("requireDeps missing index/vault (line 44)", () => {
     // emptyCtx() has index=undefined, vault=undefined → requireDeps throws
     const err = await dispatchDataRpc(
       "data.import",
-      { bundlePath: "/tmp/x.tar.gz" },
+      { bundlePath: join(tmpdir(), "x.tar.gz") },
       emptyCtx(),
     ).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(DataRpcError);
@@ -478,7 +478,12 @@ describe("data.import error branches (line 114)", () => {
     // which must be rethrown as-is (not wrapped in DataRpcError -32010).
     const err = await dispatchDataRpc(
       "data.import",
-      { bundlePath: "/nonexistent/no-such-bundle.tar.gz" },
+      {
+        bundlePath: join(
+          mkdtempSync(join(tmpdir(), "nimbus-rpc-missing-")),
+          "no-such-bundle.tar.gz",
+        ),
+      },
       {
         index: newIndex(),
         vault: memVault(),

--- a/packages/gateway/src/ipc/federation-rpc.test.ts
+++ b/packages/gateway/src/ipc/federation-rpc.test.ts
@@ -768,3 +768,221 @@ test("federation.auditExport returns the metadata-only slice for a standing gran
     expect(v.entries.some((e) => e.actionType.startsWith("federation."))).toBe(true);
   }
 });
+
+// ---------------------------------------------------------------------------
+// B3b branch-coverage additions — residual guard arms
+// ---------------------------------------------------------------------------
+
+// line 86: asRecord null TRUE → object expected
+test("asRecord: null params rejects with 'object expected' (line 86 null arm)", async () => {
+  const nullParam: unknown = null;
+  await expect(
+    dispatchFederationRpc("federation.consentRespond", nullParam, ctx()),
+  ).rejects.toThrow(/object expected/);
+});
+
+// line 129: parseFilters !Array.isArray TRUE → filters[]
+test("parseFilters: non-array filters rejects (line 129 !isArray arm)", async () => {
+  await expect(
+    dispatchFederationRpc(
+      "federation.namespace.publish",
+      { name: "ns-filtertype", filters: "nope" },
+      ctx(),
+    ),
+  ).rejects.toThrow(/filters/);
+});
+
+// line 164: requireAskTarget row === undefined TRUE → ERR_UNKNOWN_PEER (peer absent entirely)
+test("federation.ask: unknown peer (absent from index) rejects ERR_UNKNOWN_PEER (line 164 row-absent arm)", async () => {
+  const emptyDb = new Database(":memory:");
+  runIndexedSchemaMigrations(emptyDb, 33);
+  const emptyIndex = new LocalIndex(emptyDb);
+  const selfKp = generateBoxKeypair();
+  const askCtx: FederationRpcContext = {
+    db: emptyDb,
+    consentTimeoutMs: 200,
+    notify: () => {},
+    discovery: new InMemoryDiscoveryProvider(),
+    pairing: new PeerPairing(emptyIndex),
+    index: emptyIndex,
+    selfIdentity: selfKp,
+  };
+  try {
+    await expect(
+      dispatchFederationRpc(
+        "federation.ask",
+        { peerId: "peer:ghost", namespace: "ns", purpose: "p" },
+        askCtx,
+      ),
+    ).rejects.toThrow(/ERR_UNKNOWN_PEER/);
+  } finally {
+    emptyIndex.close();
+  }
+});
+
+// line 191: federation.pair port default (typeof rec["port"] !== "number") → 7475 then throws "not wired"
+test("federation.pair: missing port defaults to 7475 and propagates 'not wired' (line 191 default-port arm)", async () => {
+  // No port supplied → the FALSE arm runs (defaults to 7475), then initiatePair throws "not wired".
+  await expect(
+    dispatchFederationRpc("federation.pair", { host: "gateway-b.test", code: "xyz" }, ctx()),
+  ).rejects.toThrow(/not wired/);
+});
+
+// line 240: federation.query identityGuard defined → identity spread executes
+test("federation.query: identityGuard defined — identity spread executes (line 240 identity arm)", async () => {
+  const c: FederationRpcContext = {
+    ...ctx(),
+    consentTimeoutMs: 200,
+    identityGuard: { enabled: true, isOperatorValid: () => true },
+  };
+  await dispatchFederationRpc(
+    "federation.namespace.publish",
+    { name: "ns-idguard", filters: [{ kind: "type", value: "pull_request" }] },
+    c,
+  );
+  // no_grant path: the identity spread executed; gate returns an error shape (still a hit)
+  const res = await dispatchFederationRpc(
+    "federation.query",
+    { peerId: "peer:idguard", namespace: "ns-idguard", purpose: "p" },
+    c,
+  );
+  expect(res.kind).toBe("hit");
+});
+
+// line 261: federation.auditExport identityGuard defined → identity spread executes
+test("federation.auditExport: identityGuard defined — identity spread executes (line 261 identity arm)", async () => {
+  const c: FederationRpcContext = {
+    ...ctx(),
+    consentTimeoutMs: 200,
+    identityGuard: { enabled: true, isOperatorValid: () => true },
+  };
+  await dispatchFederationRpc(
+    "federation.namespace.publish",
+    { name: "ns-ax-idguard", filters: [{ kind: "type", value: "pull_request" }] },
+    c,
+  );
+  // no_grant path: the identity spread executed; gate returns an error shape (still a hit)
+  const res = await dispatchFederationRpc(
+    "federation.auditExport",
+    { peerId: "peer:axidguard", namespace: "ns-ax-idguard", purpose: "audit" },
+    c,
+  );
+  expect(res.kind).toBe("hit");
+});
+
+// line 317: federation.consentRespond approved non-boolean TRUE → rejects
+test("federation.consentRespond: non-boolean approved rejects (line 317 non-bool arm)", async () => {
+  await expect(
+    dispatchFederationRpc("federation.consentRespond", { requestId: "x", approved: "yes" }, ctx()),
+  ).rejects.toThrow(/approved must be a boolean/);
+});
+
+// line 400: federation.invoke teamVault undefined → ERR_TEAMVAULT_UNAVAILABLE
+test("federation.invoke: no teamVault rejects ERR_TEAMVAULT_UNAVAILABLE (line 400 tv-undefined arm)", async () => {
+  await expect(
+    dispatchFederationRpc(
+      "federation.invoke",
+      { peerId: "p", entry: "e", toolId: "t", purpose: "q" },
+      ctx(), // ctx() has no teamVault
+    ),
+  ).rejects.toThrow(/ERR_TEAMVAULT_UNAVAILABLE/);
+});
+
+// line 429: federation.quorumRespond non-boolean TRUE → rejects
+test("federation.quorumRespond: non-boolean approved rejects (line 429 non-bool arm)", async () => {
+  await expect(
+    dispatchFederationRpc(
+      "federation.quorumRespond",
+      { requestId: "r", peerId: "p", approved: 1 },
+      ctx(),
+    ),
+  ).rejects.toThrow(/approved must be a boolean/);
+});
+
+// line 442: federation.approvalRespond non-boolean TRUE → rejects; and boolean TRUE + unknown id → matched:false
+test("federation.approvalRespond: non-boolean rejected; boolean + unknown id returns matched:false (line 442 both arms)", async () => {
+  // Non-boolean arm:
+  await expect(
+    dispatchFederationRpc(
+      "federation.approvalRespond",
+      { requestId: "r", peerId: "p", approved: "x" },
+      ctx(),
+    ),
+  ).rejects.toThrow(/approved must be a boolean/);
+
+  // Boolean arm — unknown requestId → matched:false:
+  const res = await dispatchFederationRpc(
+    "federation.approvalRespond",
+    { requestId: "unknown-req", peerId: "p", approved: true },
+    ctx(),
+  );
+  expect(res.kind).toBe("hit");
+  if (res.kind === "hit") {
+    const v = res.value as { ok: boolean; matched: boolean };
+    expect(v.ok).toBe(true);
+    expect(v.matched).toBe(false);
+  }
+});
+
+// lines 459 + 473: federation.requestApproval — delegateApproval absent (nullish default → false)
+// and delegateApproval present → true
+test("federation.requestApproval: absent delegateApproval → approved:false; present → approved:true (lines 459+473)", async () => {
+  // (a) No delegateApproval wired → nullish default ?? (async () => false) → approved:false
+  const resA = await dispatchFederationRpc(
+    "federation.requestApproval",
+    { peerId: "peer:owner", actionType: "file.read" },
+    ctx(), // no delegateApproval
+  );
+  expect(resA.kind).toBe("hit");
+  if (resA.kind === "hit") {
+    const v = resA.value as { approved: boolean };
+    expect(v.approved).toBe(false);
+  }
+
+  // (b) delegateApproval always returns true → approved:true
+  const ctxWithDelegate: FederationRpcContext = {
+    ...ctx(),
+    delegateApproval: async () => true,
+  };
+  const resB = await dispatchFederationRpc(
+    "federation.requestApproval",
+    { peerId: "peer:owner", actionType: "file.read" },
+    ctxWithDelegate,
+  );
+  expect(resB.kind).toBe("hit");
+  if (resB.kind === "hit") {
+    const v = resB.value as { approved: boolean };
+    expect(v.approved).toBe(true);
+  }
+});
+
+// line 537: federation.purge nullish arm (no deletePurgeContributions) → deletedCount:0 (line 537 ?? arm)
+test("federation.purge APPROVE: no deletePurgeContributions → deletedCount 0 (line 537 nullish arm)", async () => {
+  federationConsent.setBroadcast((_m, params) => {
+    const rid = (params as { requestId: string }).requestId;
+    queueMicrotask(() => federationConsent.respond(rid, true));
+  });
+  const kp = generateEd25519Keypair();
+  // Build a ctx like purgeCtx but WITHOUT deletePurgeContributions
+  const noDeleteCtx: FederationRpcContext = {
+    db,
+    consentTimeoutMs: 1000,
+    notify: (method, params) => notes.push({ method, params }),
+    discovery: new InMemoryDiscoveryProvider(),
+    pairing: new PeerPairing(index),
+    purgeSign: { privkeyB64: encodeBase64(kp.privkey), selfPeerId: "peer:self" },
+    // deletePurgeContributions intentionally omitted
+  };
+  const res = await dispatchFederationRpc(
+    "federation.purge",
+    { peerId: "peer:home", externalId: "user-99" },
+    noDeleteCtx,
+  );
+  expect(res.kind).toBe("hit");
+  if (res.kind === "hit") {
+    const v = res.value as { kind: string; record: { deletedCount: number }; sig: string };
+    expect(v.kind).toBe("ok");
+    expect(v.record.deletedCount).toBe(0);
+    expect(typeof v.sig).toBe("string");
+  }
+});

--- a/packages/gateway/src/ipc/hitl-rpc.test.ts
+++ b/packages/gateway/src/ipc/hitl-rpc.test.ts
@@ -80,6 +80,7 @@ describe("hitl-rpc", () => {
     if (result.kind === "hit") {
       const { pending } = result.value as { pending: unknown[] };
       expect(Array.isArray(pending)).toBe(true);
+      expect(pending).toHaveLength(0);
     }
   });
 

--- a/packages/gateway/src/ipc/hitl-rpc.test.ts
+++ b/packages/gateway/src/ipc/hitl-rpc.test.ts
@@ -35,4 +35,100 @@ describe("hitl-rpc", () => {
       ),
     ).rejects.toThrow(/expiresAt/i);
   });
+
+  // lines 68-71: hitl.revokeDelegation body
+  it("revokeDelegation removes the delegation from the active list", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    // Create a delegation using action_type scopeKind (exercises that valid branch too)
+    const created = await dispatchHitlRpc(
+      "hitl.delegate",
+      {
+        delegatePeer: "peer:carol",
+        scopeKind: "action_type",
+        scopeValue: "shell.run",
+        expiresAt: 99999,
+      },
+      ctx(db),
+    );
+    expect(created.kind).toBe("hit");
+    if (created.kind !== "hit") return;
+    const delegationId = (created.value as { delegationId: string }).delegationId;
+
+    // Revoke it — lines 68-71
+    const revoked = await dispatchHitlRpc("hitl.revokeDelegation", { delegationId }, ctx(db));
+    expect(revoked.kind).toBe("hit");
+    if (revoked.kind === "hit") {
+      expect(revoked.value).toEqual({ ok: true });
+    }
+
+    // Confirm it no longer appears in the active list
+    const listed = await dispatchHitlRpc("hitl.listDelegations", {}, ctx(db));
+    expect(listed.kind).toBe("hit");
+    if (listed.kind === "hit") {
+      const { delegations } = listed.value as { delegations: unknown[] };
+      expect(delegations.length).toBe(0);
+    }
+  });
+
+  // line 77: hitl.pendingQueue body
+  it("pendingQueue returns an empty array when no delegated approvals are in flight", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    const result = await dispatchHitlRpc("hitl.pendingQueue", {}, ctx(db));
+    expect(result.kind).toBe("hit");
+    if (result.kind === "hit") {
+      const { pending } = result.value as { pending: unknown[] };
+      expect(Array.isArray(pending)).toBe(true);
+    }
+  });
+
+  // line 21, block 0, branch 0: rec() null/non-object path
+  it("rejects null params with ERR_INVALID_PARAMS: object expected", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    await expect(dispatchHitlRpc("hitl.revokeDelegation", null, ctx(db))).rejects.toThrow(
+      /ERR_INVALID_PARAMS: object expected/,
+    );
+  });
+
+  // line 28, block 2, branch 0: str() missing/empty-string path
+  it("rejects delegate with missing delegatePeer (empty string) with ERR_INVALID_PARAMS", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    await expect(
+      dispatchHitlRpc(
+        "hitl.delegate",
+        { delegatePeer: "", scopeKind: "service", scopeValue: "aws", expiresAt: 99999 },
+        ctx(db),
+      ),
+    ).rejects.toThrow(/ERR_INVALID_PARAMS/);
+  });
+
+  // line 35, block 4, branch 0: num() non-number path
+  // scopeKind str check runs first, then scopeKind validity, then expiresAt num()
+  it("rejects delegate with non-number expiresAt with 'must be a number'", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    await expect(
+      dispatchHitlRpc(
+        "hitl.delegate",
+        { delegatePeer: "peer:dave", scopeKind: "service", scopeValue: "gcp", expiresAt: "soon" },
+        ctx(db),
+      ),
+    ).rejects.toThrow(/must be a number/);
+  });
+
+  // line 52, block 7, branch 0: bad scopeKind path
+  it("rejects delegate with unrecognised scopeKind with 'bad scopeKind'", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    await expect(
+      dispatchHitlRpc(
+        "hitl.delegate",
+        { delegatePeer: "peer:eve", scopeKind: "bogus", scopeValue: "anything", expiresAt: 99999 },
+        ctx(db),
+      ),
+    ).rejects.toThrow(/bad scopeKind/);
+  });
 });

--- a/packages/gateway/src/ipc/http-write-routes.test.ts
+++ b/packages/gateway/src/ipc/http-write-routes.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "bun:test";
 import { openSeededInMemoryDb } from "../../test/helpers/migrated-db-seed.ts";
 import { NamespaceStore } from "../federation/namespace-store.ts";
 import { IdentityStore } from "../identity/identity-store.ts";
+import { ScimError } from "../identity/scim-service.ts";
 import { HttpWriteRateLimiter } from "./http-rate-limit.ts";
 import { dispatchWriteRoute, WRITE_ROUTE_ALLOWLIST } from "./http-write-routes.ts";
 
@@ -296,5 +297,441 @@ describe("dispatchWriteRoute — PUT /v1/admin/policy (anchor policy write)", ()
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("org");
+  });
+
+  // line 188 branch: method !== "PUT" → 405 + Allow: PUT
+  it("405 + Allow: PUT when the policy route receives a non-PUT method", async () => {
+    const ctx = policyContext([]);
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/v1/admin/policy", {
+        method: "POST",
+        headers: { authorization: "Bearer admin-secret", "content-type": "application/json" },
+        body: JSON.stringify({ toml: "org" }),
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("PUT");
+  });
+});
+
+// ── Method-not-allowed / disabled branches (lines 202, 216, 235, 236) ─────────────────────────
+
+describe("dispatchWriteRoute — SCIM / Teams 405 and 404 method/disabled branches", () => {
+  // line 202: resolveScimCreateRoute method !== "POST" → 405
+  it("405 + Allow: POST when a PUT hits /scim/v2/Users with SCIM enabled", async () => {
+    const ctx = scimContext();
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/scim/v2/Users", {
+        method: "PUT",
+        headers: { authorization: "Bearer scim-secret", "content-type": "application/json" },
+        body: JSON.stringify({ externalId: "u1" }),
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST");
+  });
+
+  // line 216: resolveTeamsEventsRoute method !== "POST" → 405
+  it("405 when a GET hits /v1/messaging/teams/events with messaging enabled", async () => {
+    const ctx = {
+      ...scimContext(),
+      messaging: {
+        teamsBotAppId: "app-1",
+        validateBotJwt: async () => true,
+        onActivity: async () => {},
+      },
+    };
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/v1/messaging/teams/events", { method: "GET" }),
+      ctx,
+    );
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST");
+  });
+
+  // line 235: resolveScimItemRoute method !== "PATCH" && !== "DELETE" → 405
+  it("405 + Allow: PATCH, DELETE when a POST hits a SCIM item path with SCIM enabled", async () => {
+    const ctx = scimContext();
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/scim/v2/Users/abc", {
+        method: "POST",
+        headers: { authorization: "Bearer scim-secret", "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("PATCH, DELETE");
+  });
+
+  // line 236: resolveScimItemRoute ctx.scim === undefined → 404
+  it("404 when PATCH hits a SCIM item path but SCIM surface is not wired", async () => {
+    const { scim: _scim, ...noScim } = scimContext();
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/scim/v2/Users/abc", {
+        method: "PATCH",
+        headers: { authorization: "Bearer scim-secret", "content-type": "application/json" },
+        body: JSON.stringify({ Operations: [] }),
+      }),
+      noScim,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── parseBody — actual body-size limit (line 339) ─────────────────────────────────────────────
+
+describe("dispatchWriteRoute — parseBody body-size cap (line 339)", () => {
+  // line 339: bodyBytes.byteLength > MAX_BODY_BYTES without a content-length trip (line 317).
+  // A ReadableStream body omits the content-length header so the pre-read check at line 316 is
+  // skipped; the actual ArrayBuffer read at line 339 then catches the oversize.
+  it("413 payload_too_large when body is >8 KB via ReadableStream (no content-length)", async () => {
+    const ctx = scimContext();
+    const bigPayload = "x".repeat(8 * 1024 + 1);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(bigPayload));
+        controller.close();
+      },
+    });
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/scim/v2/Users", {
+        method: "POST",
+        headers: { authorization: "Bearer scim-secret" },
+        body: stream,
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("payload_too_large");
+  });
+});
+
+// ── extractService branches (lines 363, 365) ──────────────────────────────────────────────────
+
+// We need a valid deployment body that passes all annotate validations.
+function validDeployBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    service: "payment-service",
+    provider: "github-actions",
+    environment: "prod",
+    sha: "abc1234",
+    ref: "main",
+    status: "success",
+    started_at_ms: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function deployContext() {
+  const db = openSeededInMemoryDb(28);
+  return {
+    writeDb: db,
+    expectedToken: "hunter2",
+    rateLimiter: new HttpWriteRateLimiter({ maxRequests: 60, windowMs: 60_000 }),
+    nowMs: () => 1_700_000_000_000,
+    knownServices: () => ["payment-service"] as readonly string[],
+  };
+}
+
+describe("dispatchWriteRoute — extractService branches + checkServiceAllowlist", () => {
+  // line 363 FALSE arm: body is an object WITHOUT a "service" key → extractService returns undefined
+  // line 376 TRUE arm: svc is undefined → checkServiceAllowlist returns undefined (no 400)
+  it("proceeds (not a 400 unknown_service) when the deployment body has no service key", async () => {
+    const ctx = deployContext();
+    // Send a body without service — it will still fail validation for missing service field
+    // (DeploymentRpcError with field="service"), but we confirm unknown_service is NOT the error.
+    const bodyNoService: Record<string, unknown> = {
+      provider: "github-actions",
+      environment: "prod",
+      sha: "abc1234",
+      ref: "main",
+      status: "success",
+      started_at_ms: 1_700_000_000_000,
+    };
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/v1/deployments", {
+        method: "POST",
+        headers: { authorization: "Bearer hunter2", "content-type": "application/json" },
+        body: JSON.stringify(bodyNoService),
+      }),
+      ctx,
+    );
+    // DeploymentRpcError for missing service field → 400 invalid_request, NOT unknown_service
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; details: Array<{ field?: string }> };
+    expect(body.error).toBe("invalid_request");
+    expect(body.details[0]?.field).toBe("service");
+  });
+
+  // line 365 FALSE arm: body has a "service" key but value is non-string → extractService returns undefined
+  // svc will be undefined → checkServiceAllowlist returns undefined (no 400 unknown_service)
+  it("proceeds (not a 400 unknown_service) when service is a non-string value", async () => {
+    const ctx = deployContext();
+    const bodyBadService: Record<string, unknown> = {
+      service: 123,
+      provider: "github-actions",
+      environment: "prod",
+      sha: "abc1234",
+      ref: "main",
+      status: "success",
+      started_at_ms: 1_700_000_000_000,
+    };
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/v1/deployments", {
+        method: "POST",
+        headers: { authorization: "Bearer hunter2", "content-type": "application/json" },
+        body: JSON.stringify(bodyBadService),
+      }),
+      ctx,
+    );
+    // Service is numeric → extractService returns undefined → no allowlist check → annotate
+    // fails on invalid service field → 400 invalid_request (not unknown_service)
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_request");
+  });
+});
+
+// ── runDeploymentRoute — happy path + DeploymentRpcError branches ──────────────────────────────
+
+describe("dispatchWriteRoute — runDeploymentRoute branches", () => {
+  // line 408 FALSE arm: ctx.deployEnvironments IS defined → spread into dispatchDeploymentRpc opts
+  it("200 with deployEnvironments defined — hit arm returns annotation", async () => {
+    const ctx = {
+      ...deployContext(),
+      deployEnvironments: ["production", "staging"] as readonly string[],
+      knownServices: () => ["payment-service"] as readonly string[],
+    };
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/v1/deployments", {
+        method: "POST",
+        headers: { authorization: "Bearer hunter2", "content-type": "application/json" },
+        body: JSON.stringify(validDeployBody({ environment: "production" })),
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { service: string; dora_eligible: boolean };
+    expect(body.service).toBe("payment-service");
+    expect(body.dora_eligible).toBe(true);
+  });
+
+  // lines 423 TRUE + 428 (e.field !== undefined): DeploymentRpcError WITH a field
+  // and line 429: service IS a string → service spread in recordRejection
+  it("400 invalid_request with field details when annotate fails a named-field validation", async () => {
+    const ctx = {
+      ...deployContext(),
+      // knownServices allows "payment-service" so we get past the allowlist
+      knownServices: () => ["payment-service"] as readonly string[],
+    };
+    // Send an invalid status to trigger AnnotateError on "status" field
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/v1/deployments", {
+        method: "POST",
+        headers: { authorization: "Bearer hunter2", "content-type": "application/json" },
+        body: JSON.stringify(validDeployBody({ status: "bad_status" })),
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      details: Array<{ field: string; reason: string }>;
+    };
+    expect(body.error).toBe("invalid_request");
+    expect(body.details[0]?.field).toBe("status");
+    expect(typeof body.details[0]?.reason).toBe("string");
+  });
+
+  // lines 423 TRUE + 435 (e.field === undefined): DeploymentRpcError WITHOUT a field
+  // Triggered when params is not an object (requireParams throws with no field).
+  it("400 invalid_request with no field when body is a non-object (array)", async () => {
+    const ctx = deployContext();
+    const res = await dispatchWriteRoute(
+      new Request("http://127.0.0.1/v1/deployments", {
+        method: "POST",
+        headers: { authorization: "Bearer hunter2", "content-type": "application/json" },
+        body: JSON.stringify([1, 2, 3]),
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      details: Array<{ reason: string; field?: string }>;
+    };
+    expect(body.error).toBe("invalid_request");
+    // field must be absent (the undefined-field branch → [{ reason: e.message }])
+    expect(body.details[0]?.field).toBeUndefined();
+    expect(typeof body.details[0]?.reason).toBe("string");
+  });
+});
+
+// ── runScimRoute — ScimError status branches (lines 455/456/457, 488, 494/507) ────────────────
+
+// A fake ScimWriteSurface whose runScimWrite can be forced to throw a specific ScimError.
+// We inject it by overriding the scim surface's store/identity with a throwing proxy.
+// The simplest approach: provide a store whose upsertScimUser throws the desired ScimError.
+
+function scimContextThrowing(errorToThrow: unknown) {
+  const db = openSeededInMemoryDb(34);
+  const realIdentity = new IdentityStore(db);
+  // Wrap realIdentity so upsertScimUser throws our chosen error
+  const throwingIdentity: IdentityStore = new Proxy(realIdentity, {
+    get(target, prop) {
+      if (prop === "upsertScimUser") {
+        return () => {
+          throw errorToThrow;
+        };
+      }
+      return (target as unknown as Record<string, unknown>)[prop as string];
+    },
+  });
+  return {
+    writeDb: db,
+    expectedToken: "deploy-token",
+    rateLimiter: new HttpWriteRateLimiter({ maxRequests: 60, windowMs: 60_000 }),
+    nowMs: () => 1_700_000_000_000,
+    knownServices: (): readonly string[] => [],
+    scim: {
+      token: "scim-secret",
+      store: new NamespaceStore(db),
+      identity: throwingIdentity,
+    },
+  };
+}
+
+describe("dispatchWriteRoute — runScimRoute ScimError / generic-error branches", () => {
+  // line 455: scimReason status === 400 → "invalid_request"
+  // line 488 TRUE: e instanceof ScimError
+  // line 494 TRUE: route.id === undefined (POST /scim/v2/Users — create route, no id)
+  it("400 with scim_reason=invalid_request when ScimError(400) thrown on create (no route.id)", async () => {
+    const err = new ScimError("bad body", 400);
+    const ctx = scimContextThrowing(err);
+    const res = await dispatchWriteRoute(
+      scimReq("POST", "/scim/v2/Users", "scim-secret", { externalId: "u1", userName: "alice" }),
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { detail: string; status: number };
+    expect(body.status).toBe(400);
+    expect(body.detail).toBe("bad body");
+  });
+
+  // line 456: scimReason status === 404 → "not_found"
+  // line 507 FALSE: route.id IS defined (PATCH /scim/v2/Users/{id} — item route, id = "u1")
+  it("404 with scim_reason=not_found when ScimError(404) thrown on item route (route.id defined)", async () => {
+    // For PATCH we need to first create the user so the token check passes;
+    // but we inject throwing identity to force the error during applyScimPatch.
+    // Use a separate context for the patch that has the throwing identity.
+    const err = new ScimError("not found", 404);
+    const db = openSeededInMemoryDb(34);
+    // Normal identity for the create, throwing for the patch
+    const realIdentity = new IdentityStore(db);
+    // Wrap: getScimUser and setScimActive throw; we simulate PATCH path via parseScimPatchActive
+    // which calls into identity. Actually the error needs to come from inside runScimWrite.
+    // Since PATCH → applyScimPatch → deprovisionUser or identity.setScimActive, we can
+    // make identity.setScimActive throw for active=true case.
+    const throwingIdentity: IdentityStore = new Proxy(realIdentity, {
+      get(target, prop) {
+        if (prop === "setScimActive" || prop === "upsertScimUser") {
+          return () => {
+            throw err;
+          };
+        }
+        return (target as unknown as Record<string, unknown>)[prop as string];
+      },
+    });
+    const ctx = {
+      writeDb: db,
+      expectedToken: "deploy-token",
+      rateLimiter: new HttpWriteRateLimiter({ maxRequests: 60, windowMs: 60_000 }),
+      nowMs: () => 1_700_000_000_000,
+      knownServices: (): readonly string[] => [],
+      scim: {
+        token: "scim-secret",
+        store: new NamespaceStore(db),
+        identity: throwingIdentity,
+      },
+    };
+    const res = await dispatchWriteRoute(
+      scimReq("PATCH", "/scim/v2/Users/u1", "scim-secret", {
+        Operations: [{ op: "replace", path: "active", value: true }],
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { detail: string; status: number };
+    expect(body.status).toBe(404);
+    expect(body.detail).toBe("not found");
+  });
+
+  // line 457: scimReason status === 409 → "conflict"
+  it("409 with scim_reason=conflict when ScimError(409) thrown on create", async () => {
+    const err = new ScimError("conflict", 409);
+    const ctx = scimContextThrowing(err);
+    const res = await dispatchWriteRoute(
+      scimReq("POST", "/scim/v2/Users", "scim-secret", { externalId: "u1", userName: "alice" }),
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { status: number };
+    expect(body.status).toBe(409);
+  });
+
+  // line 488 FALSE + line 502-509: non-ScimError thrown → generic 500 internal_error
+  // line 494 TRUE: create route, route.id undefined
+  it("500 internal_error when a non-ScimError is thrown from the SCIM handler (create route)", async () => {
+    const nonScimErr: unknown = new Error("unexpected db failure");
+    const ctx = scimContextThrowing(nonScimErr);
+    const res = await dispatchWriteRoute(
+      scimReq("POST", "/scim/v2/Users", "scim-secret", { externalId: "u1", userName: "alice" }),
+      ctx,
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("internal_error");
+  });
+
+  // line 507 FALSE (item route, route.id IS defined): non-ScimError on item PATCH → 500
+  it("500 internal_error when a non-ScimError is thrown from the SCIM handler (item route)", async () => {
+    const nonScimErr: unknown = new Error("unexpected db failure on patch");
+    const db = openSeededInMemoryDb(34);
+    const realIdentity = new IdentityStore(db);
+    const throwingIdentity: IdentityStore = new Proxy(realIdentity, {
+      get(target, prop) {
+        if (prop === "setScimActive" || prop === "upsertScimUser") {
+          return () => {
+            throw nonScimErr;
+          };
+        }
+        return (target as unknown as Record<string, unknown>)[prop as string];
+      },
+    });
+    const ctx = {
+      writeDb: db,
+      expectedToken: "deploy-token",
+      rateLimiter: new HttpWriteRateLimiter({ maxRequests: 60, windowMs: 60_000 }),
+      nowMs: () => 1_700_000_000_000,
+      knownServices: (): readonly string[] => [],
+      scim: {
+        token: "scim-secret",
+        store: new NamespaceStore(db),
+        identity: throwingIdentity,
+      },
+    };
+    const res = await dispatchWriteRoute(
+      scimReq("PATCH", "/scim/v2/Users/u99", "scim-secret", {
+        Operations: [{ op: "replace", path: "active", value: true }],
+      }),
+      ctx,
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("internal_error");
   });
 });

--- a/packages/gateway/src/ipc/security-rpc.test.ts
+++ b/packages/gateway/src/ipc/security-rpc.test.ts
@@ -261,5 +261,257 @@ describe("dispatchSecurityRpc — long-running job", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Branch-coverage additions (True Coverage Program, Sub-project B3b)
+// ---------------------------------------------------------------------------
+
+describe("blameResolverFor — metadata guard branches", () => {
+  // line 126: metadata present but lacks repoRoot/file fields
+  // absoluteLineFor succeeds (excerptStartLine present, offset past header),
+  // resolveBlame is invoked, blameResolverFor inner fn hits the
+  // `typeof repoRoot !== "string" || typeof file !== "string"` TRUE branch → returns null.
+  test("blame resolver returns null when metadata has no repoRoot/file", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    seedSyncState(db, "filesystem", "summary");
+    seedItem(db, {
+      id: "filesystem:sym:r:src/a.ts:foo:function",
+      service: "filesystem",
+      type: "code_symbol",
+      external_id: "sym:r:src/a.ts:foo:function",
+      // metadata has excerptStartLine (needed for absoluteLineFor in scan.ts to succeed)
+      // but deliberately omits repoRoot and file → hits line 126 TRUE in blameResolverFor
+      metadata: JSON.stringify({ excerptStartLine: 1 }),
+      body_preview: "src/a.ts\nconst K = 'AKIAIOSFODNN7EXAMPLE'",
+    });
+    const v = await runSecurityScan(db, { nowMs: 1 });
+    // finding IS produced but blame is null because repoRoot/file are missing
+    expect(v.findings_count).toBe(1);
+    expect(v.findings[0]!.blame).toBeNull();
+  });
+
+  // line 117: item.metadata === null → resolveBlame inner fn returns null immediately.
+  // NOTE: this branch is NOT reachable through runSecurityScan / scanItemsForSecrets
+  // because absoluteLineFor() in scan.ts also checks `item.metadata === null` and returns
+  // null first, so resolveBlame is never called for null-metadata items.
+  // Flagged as Sub-project D candidate (unreachable defensive guard).
+});
+
+describe("runSecurityScan — early abort on pre-aborted signal", () => {
+  // line 193: `if (signal?.aborted === true) break` TRUE arm
+  test("pre-aborted signal stops scan before processing any item", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    seedSyncState(db, "filesystem", "summary");
+    seedItem(db, {
+      id: "filesystem:src/a.ts",
+      service: "filesystem",
+      body_preview: "k='AKIAIOSFODNN7EXAMPLE'",
+    });
+    const signal = AbortSignal.abort();
+    const v = await runSecurityScan(db, { nowMs: 1 }, undefined, signal);
+    // signal was already aborted → loop breaks on first iteration → 0 items scanned
+    expect(v.items_scanned).toBe(0);
+    expect(v.findings_count).toBe(0);
+  });
+});
+
+describe("runSecurityScan — progress callback", () => {
+  // line 227: final `if (progress !== undefined) progress(...)` — covers the callback path
+  // (the every-200 arm at line 198 is impractical to hit without seeding 200 items;
+  // see Sub-project D candidate note below)
+  test("progress callback receives a final progress event with correct totals", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    seedSyncState(db, "filesystem", "summary");
+    seedItem(db, {
+      id: "filesystem:src/a.ts",
+      service: "filesystem",
+      body_preview: "k='AKIAIOSFODNN7EXAMPLE'",
+    });
+    const events: Array<Record<string, unknown>> = [];
+    const v = await runSecurityScan(db, { nowMs: 1 }, (p) => events.push(p));
+    // at least the final progress event (line 227) must have been emitted
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const last = events[events.length - 1]!;
+    expect(last["scanned"]).toBe(v.items_scanned);
+    expect(last["total"]).toBe(v.items_scanned);
+  });
+
+  // line 198 `items_scanned % 200 === 0` TRUE arm: requires seeding 200 items, which is
+  // impractical for an in-memory unit test. Flagged as Sub-project D candidate.
+});
+
+describe("parseScanParams — null / array / non-object params", () => {
+  // line 239: `params === null || typeof params !== "object" || Array.isArray(params)` TRUE
+  test("null params → scan starts with no service/extended filter", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    const notifications: Array<{ m: string; p: Record<string, unknown> }> = [];
+    const r = await dispatchSecurityRpc("security.scan", null, {
+      db,
+      nowMs: () => 1,
+      notify: (m, p) => notifications.push({ m, p }),
+    });
+    if (r.kind !== "hit") throw new Error("expected hit");
+    const jobId = (r.value as { jobId: string }).jobId;
+    await awaitSecurityScanJob(jobId);
+    const done = notifications.find((e) => e.m === "security.scanDone");
+    expect(done).toBeDefined();
+    // no items → scan completed cleanly
+    expect(done!.p["items_scanned"]).toBe(0);
+  });
+
+  test("array params → scan starts with no service/extended filter (array is rejected)", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    const notifications: Array<{ m: string; p: Record<string, unknown> }> = [];
+    const r = await dispatchSecurityRpc("security.scan", ["a", "b"], {
+      db,
+      nowMs: () => 1,
+      notify: (m, p) => notifications.push({ m, p }),
+    });
+    if (r.kind !== "hit") throw new Error("expected hit");
+    const jobId = (r.value as { jobId: string }).jobId;
+    await awaitSecurityScanJob(jobId);
+    const done = notifications.find((e) => e.m === "security.scanDone");
+    expect(done).toBeDefined();
+    expect(done!.p["items_scanned"]).toBe(0);
+  });
+});
+
+describe("parseScanParams — service and extended field branches", () => {
+  // line 242 TRUE arm: service is a non-empty string → opts.service is set
+  test("service non-empty string is passed through to the scan options", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    seedSyncState(db, "github", "summary");
+    seedSyncState(db, "obsidian", "summary");
+    seedItem(db, {
+      id: "github:pr-1",
+      service: "github",
+      body_preview: "k='AKIAIOSFODNN7EXAMPLE'",
+    });
+    seedItem(db, {
+      id: "obsidian:note-1",
+      service: "obsidian",
+      body_preview: "k='AKIAIOSFODNN7EXAMPLE'",
+    });
+    const notifications: Array<{ m: string; p: Record<string, unknown> }> = [];
+    const r = await dispatchSecurityRpc(
+      "security.scan",
+      { service: "github" },
+      { db, nowMs: () => 1, notify: (m, p) => notifications.push({ m, p }) },
+    );
+    if (r.kind !== "hit") throw new Error("expected hit");
+    const jobId = (r.value as { jobId: string }).jobId;
+    await awaitSecurityScanJob(jobId);
+    const done = notifications.find((e) => e.m === "security.scanDone");
+    expect(done).toBeDefined();
+    // only the github item should have been scanned
+    expect(done!.p["items_scanned"]).toBe(1);
+    const findings = done!.p["findings"] as Array<{ service: string }>;
+    expect(findings[0]?.service).toBe("github");
+  });
+
+  // line 242 FALSE arm (service === ""): empty-string service is ignored → no service filter
+  test("empty-string service is ignored — both items are scanned", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    seedSyncState(db, "github", "summary");
+    seedSyncState(db, "obsidian", "summary");
+    seedItem(db, {
+      id: "github:pr-1",
+      service: "github",
+      body_preview: "k='AKIAIOSFODNN7EXAMPLE'",
+    });
+    seedItem(db, {
+      id: "obsidian:note-1",
+      service: "obsidian",
+      body_preview: "k='AKIAIOSFODNN7EXAMPLE'",
+    });
+    const notifications: Array<{ m: string; p: Record<string, unknown> }> = [];
+    const r = await dispatchSecurityRpc(
+      "security.scan",
+      { service: "" },
+      { db, nowMs: () => 1, notify: (m, p) => notifications.push({ m, p }) },
+    );
+    if (r.kind !== "hit") throw new Error("expected hit");
+    const jobId = (r.value as { jobId: string }).jobId;
+    await awaitSecurityScanJob(jobId);
+    const done = notifications.find((e) => e.m === "security.scanDone");
+    expect(done).toBeDefined();
+    // empty service → no filter → both items scanned
+    expect(done!.p["items_scanned"]).toBe(2);
+  });
+
+  // line 243: extended === true → opts.extended is set
+  test("extended: true is passed through to the scan options", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    const notifications: Array<{ m: string; p: Record<string, unknown> }> = [];
+    const r = await dispatchSecurityRpc(
+      "security.scan",
+      { extended: true },
+      { db, nowMs: () => 1, notify: (m, p) => notifications.push({ m, p }) },
+    );
+    if (r.kind !== "hit") throw new Error("expected hit");
+    const jobId = (r.value as { jobId: string }).jobId;
+    await awaitSecurityScanJob(jobId);
+    const done = notifications.find((e) => e.m === "security.scanDone");
+    expect(done).toBeDefined();
+    // scan completed (no items → 0 scanned); the extended flag was accepted
+    expect(done!.p["items_scanned"]).toBe(0);
+  });
+});
+
+describe("security.scanCancel — params guard branch", () => {
+  // line 254: `params !== null && typeof params === "object"` FALSE arm (null params)
+  // → rec is {} → jobId is not a string → throws SecurityRpcError
+  test("scanCancel with null params throws params.jobId is required", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    await expect(dispatchSecurityRpc("security.scanCancel", null, { db })).rejects.toThrow(
+      "params.jobId is required",
+    );
+  });
+
+  // scanCancel happy path with a valid (but unknown) jobId → {cancelled: false}
+  test("scanCancel with unknown jobId returns cancelled false", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    const r = await dispatchSecurityRpc(
+      "security.scanCancel",
+      { jobId: "secscan-unknown" },
+      { db },
+    );
+    if (r.kind !== "hit") throw new Error("expected hit");
+    expect((r.value as { cancelled: boolean }).cancelled).toBe(false);
+  });
+});
+
+describe("dispatchSecurityRpc — conditional-spread defined arms (lines 267-269)", () => {
+  // lines 267-269: the DEFINED arms of the three conditional spreads
+  // (`configDir`, `service`, `extended`). Hit by passing all three in one call.
+  test("configDir + service + extended are all forwarded into RunSecurityScanOptions", async () => {
+    const db = openSeededInMemoryDb(TARGET_SCHEMA);
+    seedSyncState(db, "github", "summary");
+    seedItem(db, {
+      id: "github:pr-99",
+      service: "github",
+      body_preview: "k='AKIAIOSFODNN7EXAMPLE'",
+    });
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sec-"));
+    const notifications: Array<{ m: string; p: Record<string, unknown> }> = [];
+    const r = await dispatchSecurityRpc(
+      "security.scan",
+      { service: "github", extended: true },
+      {
+        db,
+        configDir: dir, // defined → configDir spread arm fires
+        nowMs: () => 1,
+        notify: (m, p) => notifications.push({ m, p }),
+      },
+    );
+    if (r.kind !== "hit") throw new Error("expected hit");
+    const jobId = (r.value as { jobId: string }).jobId;
+    await awaitSecurityScanJob(jobId);
+    const done = notifications.find((e) => e.m === "security.scanDone");
+    expect(done).toBeDefined();
+    // service filter applied → only the github item → 1 scanned
+    expect(done!.p["items_scanned"]).toBe(1);
+  });
+});
+
 // Keep the exported result type referenced so it stays part of the module's surface.
 export type _SecurityScanResultSurface = SecurityScanResult;

--- a/packages/gateway/src/ipc/teamvault-rpc.test.ts
+++ b/packages/gateway/src/ipc/teamvault-rpc.test.ts
@@ -116,4 +116,68 @@ describe("teamvault-rpc", () => {
       /ERR_INVALID_PARAMS/,
     );
   });
+
+  // line 33 block 2 branch 0: str() TRUE path — field is empty string
+  it("rejects teamvault.grant when entry is an empty string", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    const vault = new Map<string, string>();
+    await expect(
+      dispatchTeamVaultRpc(
+        "teamvault.grant",
+        { entry: "", peerId: "peer:abc", toolId: "aws.ec2.instance.stop" },
+        ctx(db, vault),
+      ),
+    ).rejects.toThrow(/ERR_INVALID_PARAMS/);
+  });
+
+  // line 51 block 4 branch 0: secrets === null TRUE path
+  it("rejects teamvault.put when secrets is null", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    const vault = new Map<string, string>();
+    await expect(
+      dispatchTeamVaultRpc(
+        "teamvault.put",
+        { entry: "prod-aws", service: "aws", secrets: null },
+        ctx(db, vault),
+      ),
+    ).rejects.toThrow(/secrets object required/);
+  });
+
+  // line 55 block 6 branch 0: secret value typeof v !== "string" TRUE path
+  it("rejects teamvault.put when a secret value is not a string", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    const vault = new Map<string, string>();
+    const badSecrets: Record<string, unknown> = { good: "x", bad: 123 };
+    await expect(
+      dispatchTeamVaultRpc(
+        "teamvault.put",
+        { entry: "prod-aws", service: "aws", secrets: badSecrets },
+        ctx(db, vault),
+      ),
+    ).rejects.toThrow(/must be a string/);
+  });
+
+  // line 67 block 7 branch 1: Array.isArray(keys) FALSE path — keys absent
+  it("teamvault.delete returns ok and deletes nothing when keys is absent", async () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 35);
+    const vault = new Map<string, string>();
+    await dispatchTeamVaultRpc(
+      "teamvault.put",
+      { entry: "prod-aws", service: "aws", secrets: { "aws.access_key_id": "x" } },
+      ctx(db, vault),
+    );
+    const sizeBefore = vault.size;
+    const out = await dispatchTeamVaultRpc(
+      "teamvault.delete",
+      { entry: "prod-aws" },
+      ctx(db, vault),
+    );
+    expect(out.kind).toBe("hit");
+    if (out.kind === "hit") expect(out.value).toEqual({ ok: true });
+    expect(vault.size).toBe(sizeBefore);
+  });
 });


### PR DESCRIPTION
## True Coverage — Sub-project B3b: gateway/ipc part 2

Closes the remaining below-floor `gateway/ipc` branch-coverage gaps (the part-2 slice after B3a/#562). Tests only — **no production source changed**. Baseline shrinks **155 → 147**.

### Files lifted to the 80% floor (8)

| File | Was | Now (Linux lcov) |
|---|---|---|
| `ipc/_lib/dispatch-by-method.ts` | B75.00 | **B100 / L100** |
| `ipc/teamvault-rpc.ts` | B77.78 | **B100 / L100** |
| `ipc/hitl-rpc.ts` | L74.19 (line debt) | **B100 / L100** |
| `ipc/agents-rpc.ts` | B77.33 | **B100 / L100** |
| `ipc/security-rpc.ts` | B78.69 | **B93.44 / L97.47** |
| `ipc/data-rpc.ts` | B75.36 | **B97.10 / L100** |
| `ipc/federation-rpc.ts` | B77.66 | **B92.55 / L95.33** |
| `ipc/http-write-routes.ts` | B77.69 | **B97.52 / L91.91** |

`agents/expert.ts` + `agents/impact.ts` ratchet up via incidental coverage from the agents-rpc tests (real `emitExpertBrief`/`emitImpactBrief`).

### Approach

- **TDD per file** via subagent-driven-development (fresh agent per file), targeting the exact uncovered `BRDA`/`DA` lines from the CI merge lcov.
- **No `any`, no `mock.module`, no `biome-ignore`** — real in-memory SQLite + `ctx`-injected DI fakes (`SynthesizerLlm`, executor, `identityGuard`/`delegateApproval`/`teamVault`/`purgeSign`, scim/policy/messaging seams, an `IdentityStore` Proxy for `ScimError` injection). Non-Error throws use `const x: unknown = …; throw x`.
- **`federation-rpc.ts` (I17–I20) and `http-write-routes.ts` (I13) source unchanged** — every branch reached through the existing DI seams.
- Final opus code-review: clean (all reachability-sensitive tests verified to hit their target branch; no resource leaks).

### Genuinely-unreachable / infra-only branches left as Sub-project D candidates (spec §5.2)

`COUNT(*) ?? 0` defensive nullish arms; the `blameResolverFor` double-guard; the 200-item progress modulo; the deployment `miss`/non-domain-throw arms; `extractAuditEntries` malformed-wire guards (need a custom LAN peer); the argon2 default-KDF export path. None fabricated, none `istanbul-ignore`d.

### Reseed

Baseline is a best-effort hardened-Docker (`oven/bun:latest`, bun 1.3.14) Linux reseed; per the round-2 method the committed baseline will be re-derived from this PR's own merge `coverage-lcov-merged` artifact if the gate surfaces incidental sibling-coverage drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and hardened test coverage for gateway RPCs: more validation, error, notification and configuration-branch scenarios across agents, data, federation, HITL, HTTP routes, security scans, and team-vault flows.

* **Chores**
  * Updated coverage baseline metadata and adjusted coverage thresholds; removed several IPC entries from the baseline to reflect current test scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->