### PR TITLE
test(coverage): B4 — gateway/db to ≥80% branch (9 files, 147→138)

### DIFF
--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-06-11T08:00:07.170Z",
+  "generated_at": "2026-06-11T11:09:20.094Z",
   "files": {
     "packages/cli/src/commands/audit.ts": {
       "min_line_pct": 80,
@@ -353,42 +353,6 @@
     "packages/gateway/src/connectors/zoom-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 77.88
-    },
-    "packages/gateway/src/db/audit-verify.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 75
-    },
-    "packages/gateway/src/db/backup-manifest.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 75
-    },
-    "packages/gateway/src/db/latency-ring-buffer.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 78.13
-    },
-    "packages/gateway/src/db/metrics.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 77.78
-    },
-    "packages/gateway/src/db/query-guard.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 66.67
-    },
-    "packages/gateway/src/db/repair.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 66.67
-    },
-    "packages/gateway/src/db/snapshot.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 62.96
-    },
-    "packages/gateway/src/db/verify.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 74.07
-    },
-    "packages/gateway/src/db/write.ts": {
-      "min_line_pct": 76.19,
-      "min_branch_pct": 80
     },
     "packages/gateway/src/embedding/chunker.ts": {
       "min_line_pct": 80,

--- a/packages/gateway/src/db/audit-verify.test.ts
+++ b/packages/gateway/src/db/audit-verify.test.ts
@@ -1,6 +1,8 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { LocalIndex } from "../index/local-index.ts";
+import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
+import { appendAuditEntry } from "./audit-chain.ts";
 import { verifyAuditChain } from "./audit-verify.ts";
 
 function newIndex(): LocalIndex {
@@ -38,6 +40,69 @@ describe("verifyAuditChain", () => {
     idx.recordAudit({ actionType: "b", hitlStatus: "approved", actionJson: "{}", timestamp: 2 });
     const result = verifyAuditChain(idx, { fromId: idx.getAuditVerifiedThroughId() });
     expect(result.ok).toBe(true);
+    expect(result.verifiedRows).toBe(1);
+  });
+
+  // --- Branch coverage additions ---
+
+  // line 20 FALSE arm: audit_log without federation_json (pre-V33 schema)
+  test("verifies intact chain on a pre-V33 db (no federation_json column)", () => {
+    // Migrate only up to V32 so audit_log lacks the V33 federation_json column.
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 32);
+    appendAuditEntry(db, {
+      actionType: "legacy.a",
+      hitlStatus: "not_required",
+      actionJson: "{}",
+      timestamp: 10,
+    });
+    appendAuditEntry(db, {
+      actionType: "legacy.b",
+      hitlStatus: "not_required",
+      actionJson: "{}",
+      timestamp: 20,
+    });
+    // Confirm the column really is absent (guards our premise).
+    const cols = db
+      .query<{ name: string }, []>(`PRAGMA table_info(audit_log)`)
+      .all()
+      .map((c) => c.name);
+    expect(cols).not.toContain("federation_json");
+
+    // verifyAuditChain must take the FALSE arm of auditLogHasFederationJson.
+    const idx = new LocalIndex(db);
+    const result = verifyAuditChain(idx, { fromId: 0 });
+    expect(result.ok).toBe(true);
+    expect(result.verifiedRows).toBe(2);
+    expect(result.firstBreakAtId).toBeUndefined();
+  });
+
+  // line 39 ?? GENESIS_HASH arm: fromId > 0 but the row does not exist in the table
+  test("falls back to GENESIS_HASH when fromId points to a missing row", () => {
+    // Empty table — no row with id = 99 exists.
+    const idx = newIndex();
+    // fromId = 99 → SELECT row_hash … WHERE id = 99 returns undefined → ?? GENESIS_HASH.
+    // No rows with id > 99 either, so the chain trivially verifies.
+    const result = verifyAuditChain(idx, { fromId: 99 });
+    expect(result.ok).toBe(true);
+    expect(result.verifiedRows).toBe(0);
+    // lastVerifiedId is initialised to fromId when there are no rows to walk.
+    expect(result.lastVerifiedId).toBe(99);
+  });
+
+  // line 50 TRUE arm: prev_hash mismatch → early-exit with ok: false
+  test("detects a tampered prev_hash and reports the break", () => {
+    const idx = newIndex();
+    idx.recordAudit({ actionType: "a", hitlStatus: "approved", actionJson: "{}", timestamp: 1 });
+    idx.recordAudit({ actionType: "b", hitlStatus: "approved", actionJson: "{}", timestamp: 2 });
+    idx.recordAudit({ actionType: "c", hitlStatus: "approved", actionJson: "{}", timestamp: 3 });
+    // Directly corrupt the prev_hash of row 2 so it no longer points at row 1's hash.
+    idx.rawDb.run(`UPDATE audit_log SET prev_hash = ? WHERE id = 2`, ["badf00d".padEnd(64, "0")]);
+    const result = verifyAuditChain(idx, { fromId: 0 });
+    expect(result.ok).toBe(false);
+    expect(result.firstBreakAtId).toBe(2);
+    expect(result.reason).toMatch(/prev_hash mismatch/);
+    // Row 1 was verified before the break.
     expect(result.verifiedRows).toBe(1);
   });
 });

--- a/packages/gateway/src/db/backup-manifest.test.ts
+++ b/packages/gateway/src/db/backup-manifest.test.ts
@@ -1,11 +1,24 @@
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { blake3HashFile, buildManifest, verifyManifest } from "./backup-manifest.ts";
 
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
 function tmp(): string {
-  return mkdtempSync(join(tmpdir(), "nimbus-backup-"));
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-backup-"));
+  tempDirs.push(dir);
+  return dir;
 }
 
 describe("backup manifest", () => {
@@ -113,5 +126,89 @@ describe("backup manifest", () => {
     const result = await verifyManifest(m, { "f.bin": p });
     expect(result.ok).toBe(false);
     expect(result.firstMismatch).toBe("f.bin");
+  });
+
+  test("verifyManifest returns ok:false with firstMismatch when a manifest file is missing from the files map", async () => {
+    // Covers line 64: the true arm of `if (actualPath === undefined)`
+    // The manifest lists "missing.bin" in hashes, but the files map does not contain that key.
+    const dir = tmp();
+    const p = join(dir, "present.bin");
+    writeFileSync(p, "data");
+    const presentHash = await blake3HashFile(p);
+    const manifest: import("./backup-manifest.ts").BackupManifest = {
+      version: 2,
+      nimbus_version: "0.1.0",
+      schema_version: 21,
+      created_at: "2026-01-01T00:00:00Z",
+      platform: "linux",
+      contents: {
+        index_rows: 0,
+        index_included: false,
+        vault_entries: 0,
+        watchers: 0,
+        workflows: 0,
+        extensions: 0,
+        profiles: 0,
+      },
+      hashes: {
+        "present.bin": presentHash,
+        "missing.bin": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+    };
+    // files map intentionally omits "missing.bin"
+    const result = await verifyManifest(manifest, { "present.bin": p });
+    expect(result.ok).toBe(false);
+    expect(result.firstMismatch).toBe("missing.bin");
+  });
+
+  test("verifyManifest returns ok:true when all hashes match (v2 manifest)", async () => {
+    // Happy path: every key in hashes is present in files and content matches
+    const dir = tmp();
+    const p1 = join(dir, "a.bin");
+    const p2 = join(dir, "b.bin");
+    writeFileSync(p1, "content-a");
+    writeFileSync(p2, "content-b");
+    const m = await buildManifest({
+      bundleDir: dir,
+      nimbusVersion: "0.1.0",
+      schemaVersion: 21,
+      platform: "linux",
+      contents: {
+        index_rows: 2,
+        vault_entries: 0,
+        watchers: 0,
+        workflows: 0,
+        extensions: 0,
+        profiles: 0,
+      },
+      files: { "a.bin": p1, "b.bin": p2 },
+      indexIncluded: false,
+    });
+    const result = await verifyManifest(m, { "a.bin": p1, "b.bin": p2 });
+    expect(result.ok).toBe(true);
+    expect(result.firstMismatch).toBeUndefined();
+  });
+
+  test("verifyManifest returns ok:true for an empty hashes record", async () => {
+    // Edge case: manifest with no files — loop body never executes, returns {ok:true}
+    const manifest: import("./backup-manifest.ts").BackupManifest = {
+      version: 2,
+      nimbus_version: "0.1.0",
+      schema_version: 21,
+      created_at: "2026-01-01T00:00:00Z",
+      platform: "linux",
+      contents: {
+        index_rows: 0,
+        index_included: false,
+        vault_entries: 0,
+        watchers: 0,
+        workflows: 0,
+        extensions: 0,
+        profiles: 0,
+      },
+      hashes: {},
+    };
+    const result = await verifyManifest(manifest, {});
+    expect(result.ok).toBe(true);
   });
 });

--- a/packages/gateway/src/db/latency-ring-buffer.test.ts
+++ b/packages/gateway/src/db/latency-ring-buffer.test.ts
@@ -1,0 +1,497 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  computeLatencyPercentilesMs,
+  DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+  flushLatencyBuffer,
+  LatencyRingBuffer,
+  latencyRingBuffer,
+  readLatencyPercentilesFromDb,
+  recordSlowQuery,
+  startLatencyFlushScheduler,
+} from "./latency-ring-buffer.ts";
+
+// Fixed epoch used so all clock-dependent branches are deterministic.
+const FIXED_NOW = 1_000_000_000;
+
+function fixedClock(): number {
+  return FIXED_NOW;
+}
+
+// ─── Schema helpers ──────────────────────────────────────────────────────────
+
+function createLatencyTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE query_latency_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      latency_ms INTEGER NOT NULL,
+      query_type TEXT NOT NULL,
+      recorded_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function createSlowQueryTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE slow_query_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      query_text TEXT,
+      latency_ms INTEGER NOT NULL,
+      query_type TEXT NOT NULL,
+      recorded_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function countRows(db: Database, table: string): number {
+  return (db.query(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c: number }).c;
+}
+
+// ─── LatencyRingBuffer ────────────────────────────────────────────────────────
+
+describe("LatencyRingBuffer.push + drainOrdered", () => {
+  test("empty buffer returns empty array and clears dirty flag", () => {
+    const buf = new LatencyRingBuffer();
+    expect(buf.isDirty()).toBe(false);
+    const out = buf.drainOrdered();
+    expect(out).toEqual([]);
+    expect(buf.isDirty()).toBe(false);
+  });
+
+  test("push marks buffer dirty", () => {
+    const buf = new LatencyRingBuffer();
+    buf.push({ latencyMs: 10, queryType: "sql", recordedAt: 1 });
+    expect(buf.isDirty()).toBe(true);
+  });
+
+  test("drainOrdered returns items in insertion order (FIFO)", () => {
+    const buf = new LatencyRingBuffer();
+    const s1 = { latencyMs: 10, queryType: "sql" as const, recordedAt: 1 };
+    const s2 = { latencyMs: 20, queryType: "fts" as const, recordedAt: 2 };
+    const s3 = { latencyMs: 30, queryType: "vector" as const, recordedAt: 3 };
+    buf.push(s1, s2, s3);
+    const out = buf.drainOrdered();
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual(s1);
+    expect(out[1]).toEqual(s2);
+    expect(out[2]).toEqual(s3);
+  });
+
+  test("drainOrdered clears the buffer so next drain is empty", () => {
+    const buf = new LatencyRingBuffer();
+    buf.push({ latencyMs: 5, queryType: "hybrid", recordedAt: 1 });
+    buf.drainOrdered();
+    expect(buf.isDirty()).toBe(false);
+    expect(buf.drainOrdered()).toEqual([]);
+  });
+
+  test("drainOrdered resets dirty to false", () => {
+    const buf = new LatencyRingBuffer();
+    buf.push({ latencyMs: 1, queryType: "sql", recordedAt: 1 });
+    buf.drainOrdered();
+    expect(buf.isDirty()).toBe(false);
+  });
+});
+
+describe("LatencyRingBuffer.snapshotOrdered", () => {
+  test("empty buffer returns empty snapshot", () => {
+    const buf = new LatencyRingBuffer();
+    expect(buf.snapshotOrdered()).toEqual([]);
+  });
+
+  test("snapshot preserves items without draining", () => {
+    const buf = new LatencyRingBuffer();
+    const s1 = { latencyMs: 10, queryType: "sql" as const, recordedAt: 1 };
+    const s2 = { latencyMs: 20, queryType: "fts" as const, recordedAt: 2 };
+    buf.push(s1, s2);
+    const snap = buf.snapshotOrdered();
+    expect(snap).toHaveLength(2);
+    expect(snap[0]).toEqual(s1);
+    expect(snap[1]).toEqual(s2);
+    // buffer is still intact
+    expect(buf.snapshotOrdered()).toHaveLength(2);
+    expect(buf.isDirty()).toBe(true);
+  });
+
+  test("snapshot after drain returns empty", () => {
+    const buf = new LatencyRingBuffer();
+    buf.push({ latencyMs: 5, queryType: "sql", recordedAt: 1 });
+    buf.drainOrdered();
+    expect(buf.snapshotOrdered()).toEqual([]);
+  });
+
+  test("push variadic multiple samples at once", () => {
+    const buf = new LatencyRingBuffer();
+    buf.push(
+      { latencyMs: 1, queryType: "sql", recordedAt: 1 },
+      { latencyMs: 2, queryType: "fts", recordedAt: 2 },
+      { latencyMs: 3, queryType: "vector", recordedAt: 3 },
+    );
+    expect(buf.snapshotOrdered()).toHaveLength(3);
+  });
+});
+
+// ─── computeLatencyPercentilesMs ─────────────────────────────────────────────
+
+describe("computeLatencyPercentilesMs", () => {
+  test("empty samples returns all zeros", () => {
+    expect(computeLatencyPercentilesMs([])).toEqual({ p50Ms: 0, p95Ms: 0, p99Ms: 0 });
+  });
+
+  test("single sample returns that value for all percentiles", () => {
+    const s = { latencyMs: 42, queryType: "sql" as const, recordedAt: 1 };
+    const result = computeLatencyPercentilesMs([s]);
+    expect(result.p50Ms).toBe(42);
+    expect(result.p95Ms).toBe(42);
+    expect(result.p99Ms).toBe(42);
+  });
+
+  test("two equal samples", () => {
+    const s = { latencyMs: 100, queryType: "sql" as const, recordedAt: 1 };
+    const result = computeLatencyPercentilesMs([s, s]);
+    expect(result.p50Ms).toBe(100);
+    expect(result.p95Ms).toBe(100);
+    expect(result.p99Ms).toBe(100);
+  });
+
+  test("known distribution — exact p50/p95/p99", () => {
+    // 100 samples: 1..100
+    const samples = Array.from({ length: 100 }, (_, i) => ({
+      latencyMs: i + 1,
+      queryType: "sql" as const,
+      recordedAt: i,
+    }));
+    const result = computeLatencyPercentilesMs(samples);
+    // sorted[49] = 50, sorted[94] = 95, sorted[98] = 99 (0-indexed 0..99)
+    expect(result.p50Ms).toBe(50.5); // interpolated midpoint
+    expect(result.p95Ms).toBeCloseTo(95.05, 5);
+    expect(result.p99Ms).toBeCloseTo(99.01, 5);
+  });
+
+  test("unsorted inputs are sorted before percentile calculation", () => {
+    const samples = [
+      { latencyMs: 300, queryType: "sql" as const, recordedAt: 1 },
+      { latencyMs: 100, queryType: "sql" as const, recordedAt: 2 },
+      { latencyMs: 200, queryType: "sql" as const, recordedAt: 3 },
+    ];
+    const result = computeLatencyPercentilesMs(samples);
+    // p50 of [100,200,300] at 0.5 → idx=1.0, lo=hi=1 → 200
+    expect(result.p50Ms).toBe(200);
+  });
+});
+
+// ─── flushLatencyBuffer ───────────────────────────────────────────────────────
+
+describe("flushLatencyBuffer", () => {
+  test("query_latency_log table absent: drains buffer and returns without inserting", () => {
+    const db = new Database(":memory:");
+    const buf = new LatencyRingBuffer();
+    buf.push({ latencyMs: 10, queryType: "sql", recordedAt: FIXED_NOW - 100 });
+    expect(buf.isDirty()).toBe(true);
+
+    flushLatencyBuffer(db, buf, fixedClock);
+
+    // buffer was drained
+    expect(buf.drainOrdered()).toEqual([]);
+    expect(buf.isDirty()).toBe(false);
+    db.close();
+  });
+
+  test("empty buffer with table present: returns early without touching DB", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+    const buf = new LatencyRingBuffer();
+    // push then drain to empty it
+    buf.drainOrdered();
+
+    flushLatencyBuffer(db, buf, fixedClock);
+
+    expect(countRows(db, "query_latency_log")).toBe(0);
+    db.close();
+  });
+
+  test("inserts samples into query_latency_log when table present", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+    const buf = new LatencyRingBuffer();
+    buf.push(
+      { latencyMs: 10, queryType: "sql", recordedAt: FIXED_NOW - 1000 },
+      { latencyMs: 20, queryType: "fts", recordedAt: FIXED_NOW - 2000 },
+    );
+
+    flushLatencyBuffer(db, buf, fixedClock);
+
+    expect(countRows(db, "query_latency_log")).toBe(2);
+    db.close();
+  });
+
+  test("slow_query_log absent (line 148 FALSE arm): no error, only latency table cleaned", () => {
+    const db = new Database(":memory:");
+    // Only create query_latency_log — NOT slow_query_log
+    createLatencyTable(db);
+    const buf = new LatencyRingBuffer();
+    buf.push({ latencyMs: 50, queryType: "sql", recordedAt: FIXED_NOW - 100 });
+
+    // Should not throw even though slow_query_log is absent
+    expect(() => flushLatencyBuffer(db, buf, fixedClock)).not.toThrow();
+    expect(countRows(db, "query_latency_log")).toBe(1);
+    db.close();
+  });
+
+  test("slow_query_log present (line 148 TRUE arm): DELETE runs on slow_query_log", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+    createSlowQueryTable(db);
+
+    // Insert an old slow-query row that should be pruned
+    const SLOW_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+    const oldRecordedAt = FIXED_NOW - SLOW_RETENTION_MS - 1;
+    db.exec(
+      `INSERT INTO slow_query_log (query_text, latency_ms, query_type, recorded_at) VALUES ('q', 600, 'sql', ${oldRecordedAt})`,
+    );
+    expect(countRows(db, "slow_query_log")).toBe(1);
+
+    const buf = new LatencyRingBuffer();
+    buf.push({ latencyMs: 100, queryType: "sql", recordedAt: FIXED_NOW - 100 });
+
+    flushLatencyBuffer(db, buf, fixedClock);
+
+    // Old slow query row must have been pruned
+    expect(countRows(db, "slow_query_log")).toBe(0);
+    db.close();
+  });
+
+  test("old latency rows are deleted by cutoff", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+
+    // Insert a row that is older than LATENCY_RETENTION_MS (24h)
+    const LATENCY_RETENTION_MS = 24 * 60 * 60 * 1000;
+    const oldRecordedAt = FIXED_NOW - LATENCY_RETENTION_MS - 1;
+    db.exec(
+      `INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (100, 'sql', ${oldRecordedAt})`,
+    );
+    expect(countRows(db, "query_latency_log")).toBe(1);
+
+    const buf = new LatencyRingBuffer();
+    // Push a new sample to trigger the flush (non-empty batch)
+    buf.push({ latencyMs: 50, queryType: "sql", recordedAt: FIXED_NOW });
+
+    flushLatencyBuffer(db, buf, fixedClock);
+
+    // The new sample was inserted (1) but old one deleted (1), net = 1
+    const rows = db.query("SELECT recorded_at FROM query_latency_log").all() as Array<{
+      recorded_at: number;
+    }>;
+    expect(rows.every((r) => r.recorded_at >= FIXED_NOW - LATENCY_RETENTION_MS)).toBe(true);
+    db.close();
+  });
+
+  test("large batch (>200 samples) uses chunking", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+    const buf = new LatencyRingBuffer();
+    for (let i = 0; i < 250; i += 1) {
+      buf.push({ latencyMs: i, queryType: "sql", recordedAt: FIXED_NOW - i });
+    }
+
+    flushLatencyBuffer(db, buf, fixedClock);
+
+    expect(countRows(db, "query_latency_log")).toBe(250);
+    db.close();
+  });
+});
+
+// ─── recordSlowQuery ──────────────────────────────────────────────────────────
+
+describe("recordSlowQuery", () => {
+  test("below threshold: returns without inserting", () => {
+    const db = new Database(":memory:");
+    createSlowQueryTable(db);
+
+    recordSlowQuery(db, {
+      queryText: "SELECT 1",
+      latencyMs: 100,
+      queryType: "sql",
+      recordedAt: FIXED_NOW,
+      thresholdMs: 500,
+    });
+
+    expect(countRows(db, "slow_query_log")).toBe(0);
+    db.close();
+  });
+
+  test("table absent: returns without error", () => {
+    const db = new Database(":memory:");
+    // No slow_query_log table
+
+    expect(() =>
+      recordSlowQuery(db, {
+        queryText: "SELECT 1",
+        latencyMs: 1000,
+        queryType: "sql",
+        recordedAt: FIXED_NOW,
+        thresholdMs: 500,
+      }),
+    ).not.toThrow();
+    db.close();
+  });
+
+  test("above threshold with table present: inserts row", () => {
+    const db = new Database(":memory:");
+    createSlowQueryTable(db);
+
+    recordSlowQuery(db, {
+      queryText: "SELECT expensive",
+      latencyMs: 1000,
+      queryType: "fts",
+      recordedAt: FIXED_NOW,
+      thresholdMs: DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+    });
+
+    expect(countRows(db, "slow_query_log")).toBe(1);
+    const row = db.query("SELECT * FROM slow_query_log").get() as {
+      query_text: string;
+      latency_ms: number;
+      query_type: string;
+    };
+    expect(row.query_text).toBe("SELECT expensive");
+    expect(row.latency_ms).toBe(1000);
+    expect(row.query_type).toBe("fts");
+    db.close();
+  });
+
+  test("null queryText is stored as null", () => {
+    const db = new Database(":memory:");
+    createSlowQueryTable(db);
+
+    recordSlowQuery(db, {
+      queryText: null,
+      latencyMs: 600,
+      queryType: "sql",
+      recordedAt: FIXED_NOW,
+      thresholdMs: 500,
+    });
+
+    const row = db.query("SELECT query_text FROM slow_query_log").get() as {
+      query_text: string | null;
+    };
+    expect(row.query_text).toBeNull();
+    db.close();
+  });
+
+  test("exactly at threshold: inserts (latencyMs >= thresholdMs)", () => {
+    const db = new Database(":memory:");
+    createSlowQueryTable(db);
+
+    recordSlowQuery(db, {
+      queryText: "q",
+      latencyMs: 500,
+      queryType: "sql",
+      recordedAt: FIXED_NOW,
+      thresholdMs: 500,
+    });
+
+    expect(countRows(db, "slow_query_log")).toBe(1);
+    db.close();
+  });
+});
+
+// ─── readLatencyPercentilesFromDb ─────────────────────────────────────────────
+
+describe("readLatencyPercentilesFromDb", () => {
+  test("table absent: returns all zeros", () => {
+    const db = new Database(":memory:");
+    const result = readLatencyPercentilesFromDb(db, fixedClock);
+    expect(result).toEqual({ p50Ms: 0, p95Ms: 0, p99Ms: 0 });
+    db.close();
+  });
+
+  test("table present but empty: returns all zeros", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+    const result = readLatencyPercentilesFromDb(db, fixedClock);
+    expect(result).toEqual({ p50Ms: 0, p95Ms: 0, p99Ms: 0 });
+    db.close();
+  });
+
+  test("rows within retention window: returns correct percentiles", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+
+    // Insert rows within the retention window (FIXED_NOW - 1h)
+    for (let i = 1; i <= 10; i += 1) {
+      db.exec(
+        `INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (${i * 10}, 'sql', ${FIXED_NOW - 3600000})`,
+      );
+    }
+
+    const result = readLatencyPercentilesFromDb(db, fixedClock);
+    expect(result.p50Ms).toBeGreaterThan(0);
+    expect(result.p95Ms).toBeGreaterThanOrEqual(result.p50Ms);
+    expect(result.p99Ms).toBeGreaterThanOrEqual(result.p95Ms);
+    db.close();
+  });
+
+  test("rows outside retention window are excluded", () => {
+    const db = new Database(":memory:");
+    createLatencyTable(db);
+    const LATENCY_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+    // Insert rows older than retention window
+    db.exec(
+      `INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (999, 'sql', ${FIXED_NOW - LATENCY_RETENTION_MS - 1})`,
+    );
+
+    const result = readLatencyPercentilesFromDb(db, fixedClock);
+    expect(result).toEqual({ p50Ms: 0, p95Ms: 0, p99Ms: 0 });
+    db.close();
+  });
+});
+
+// ─── startLatencyFlushScheduler ──────────────────────────────────────────────
+
+describe("startLatencyFlushScheduler", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    createLatencyTable(db);
+    // Drain the module singleton before each test to avoid cross-test bleed
+    latencyRingBuffer.drainOrdered();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  test("stop() calls flushLatencyBuffer and cleans up signal handlers", () => {
+    const sigTermListenersBefore = process.listenerCount("SIGTERM");
+    const sigIntListenersBefore = process.listenerCount("SIGINT");
+
+    // Use a real recent timestamp so the DELETE cutoff (real Date.now()) does not prune it.
+    latencyRingBuffer.push({ latencyMs: 42, queryType: "sql", recordedAt: Date.now() - 100 });
+
+    const scheduler = startLatencyFlushScheduler(db);
+
+    // Listeners should have been added
+    expect(process.listenerCount("SIGTERM")).toBe(sigTermListenersBefore + 1);
+    expect(process.listenerCount("SIGINT")).toBe(sigIntListenersBefore + 1);
+
+    scheduler.stop();
+
+    // Listeners should have been removed
+    expect(process.listenerCount("SIGTERM")).toBe(sigTermListenersBefore);
+    expect(process.listenerCount("SIGINT")).toBe(sigIntListenersBefore);
+
+    // The flush on stop should have inserted the sample
+    expect(countRows(db, "query_latency_log")).toBe(1);
+  });
+
+  test("stop() is idempotent: second stop does not throw", () => {
+    const scheduler = startLatencyFlushScheduler(db);
+    scheduler.stop();
+    expect(() => scheduler.stop()).not.toThrow();
+  });
+});

--- a/packages/gateway/src/db/latency-ring-buffer.test.ts
+++ b/packages/gateway/src/db/latency-ring-buffer.test.ts
@@ -11,6 +11,7 @@ import {
   recordSlowQuery,
   startLatencyFlushScheduler,
 } from "./latency-ring-buffer.ts";
+import { dbRun } from "./write.ts";
 
 // Fixed epoch used so all clock-dependent branches are deterministic.
 const FIXED_NOW = 1_000_000_000;
@@ -44,8 +45,14 @@ function createSlowQueryTable(db: Database): void {
   `);
 }
 
-function countRows(db: Database, table: string): number {
-  return (db.query(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c: number }).c;
+// Fixed identifier mapping — no interpolated identifiers (DB-safety rule applies to tests too).
+type CountableTable = "query_latency_log" | "slow_query_log";
+const COUNT_SQL: Record<CountableTable, string> = {
+  query_latency_log: "SELECT COUNT(*) AS c FROM query_latency_log",
+  slow_query_log: "SELECT COUNT(*) AS c FROM slow_query_log",
+};
+function countRows(db: Database, table: CountableTable): number {
+  return (db.query(COUNT_SQL[table]).get() as { c: number }).c;
 }
 
 // ─── LatencyRingBuffer ────────────────────────────────────────────────────────
@@ -247,8 +254,10 @@ describe("flushLatencyBuffer", () => {
     // Insert an old slow-query row that should be pruned
     const SLOW_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
     const oldRecordedAt = FIXED_NOW - SLOW_RETENTION_MS - 1;
-    db.exec(
-      `INSERT INTO slow_query_log (query_text, latency_ms, query_type, recorded_at) VALUES ('q', 600, 'sql', ${oldRecordedAt})`,
+    dbRun(
+      db,
+      "INSERT INTO slow_query_log (query_text, latency_ms, query_type, recorded_at) VALUES (?, ?, ?, ?)",
+      ["q", 600, "sql", oldRecordedAt],
     );
     expect(countRows(db, "slow_query_log")).toBe(1);
 
@@ -269,8 +278,10 @@ describe("flushLatencyBuffer", () => {
     // Insert a row that is older than LATENCY_RETENTION_MS (24h)
     const LATENCY_RETENTION_MS = 24 * 60 * 60 * 1000;
     const oldRecordedAt = FIXED_NOW - LATENCY_RETENTION_MS - 1;
-    db.exec(
-      `INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (100, 'sql', ${oldRecordedAt})`,
+    dbRun(
+      db,
+      "INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (?, ?, ?)",
+      [100, "sql", oldRecordedAt],
     );
     expect(countRows(db, "query_latency_log")).toBe(1);
 
@@ -422,8 +433,10 @@ describe("readLatencyPercentilesFromDb", () => {
 
     // Insert rows within the retention window (FIXED_NOW - 1h)
     for (let i = 1; i <= 10; i += 1) {
-      db.exec(
-        `INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (${i * 10}, 'sql', ${FIXED_NOW - 3600000})`,
+      dbRun(
+        db,
+        "INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (?, ?, ?)",
+        [i * 10, "sql", FIXED_NOW - 3600000],
       );
     }
 
@@ -440,8 +453,10 @@ describe("readLatencyPercentilesFromDb", () => {
     const LATENCY_RETENTION_MS = 24 * 60 * 60 * 1000;
 
     // Insert rows older than retention window
-    db.exec(
-      `INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (999, 'sql', ${FIXED_NOW - LATENCY_RETENTION_MS - 1})`,
+    dbRun(
+      db,
+      "INSERT INTO query_latency_log (latency_ms, query_type, recorded_at) VALUES (?, ?, ?)",
+      [999, "sql", FIXED_NOW - LATENCY_RETENTION_MS - 1],
     );
 
     const result = readLatencyPercentilesFromDb(db, fixedClock);

--- a/packages/gateway/src/db/latency-ring-buffer.ts
+++ b/packages/gateway/src/db/latency-ring-buffer.ts
@@ -116,7 +116,11 @@ function tableExists(db: Database, name: string): boolean {
   return row !== null;
 }
 
-export function flushLatencyBuffer(db: Database, buffer: LatencyRingBuffer): void {
+export function flushLatencyBuffer(
+  db: Database,
+  buffer: LatencyRingBuffer,
+  now: () => number = Date.now,
+): void {
   if (!tableExists(db, "query_latency_log")) {
     buffer.drainOrdered();
     return;
@@ -125,9 +129,9 @@ export function flushLatencyBuffer(db: Database, buffer: LatencyRingBuffer): voi
   if (batch.length === 0) {
     return;
   }
-  const now = Date.now();
-  const cutoffLatency = now - LATENCY_RETENTION_MS;
-  const cutoffSlow = now - SLOW_QUERY_RETENTION_MS;
+  const nowMs = now();
+  const cutoffLatency = nowMs - LATENCY_RETENTION_MS;
+  const cutoffSlow = nowMs - SLOW_QUERY_RETENTION_MS;
 
   db.transaction(() => {
     const chunkSize = 200;
@@ -174,7 +178,10 @@ export function recordSlowQuery(
   );
 }
 
-export function readLatencyPercentilesFromDb(db: Database): {
+export function readLatencyPercentilesFromDb(
+  db: Database,
+  now: () => number = Date.now,
+): {
   p50Ms: number;
   p95Ms: number;
   p99Ms: number;
@@ -182,7 +189,7 @@ export function readLatencyPercentilesFromDb(db: Database): {
   if (!tableExists(db, "query_latency_log")) {
     return { p50Ms: 0, p95Ms: 0, p99Ms: 0 };
   }
-  const since = Date.now() - LATENCY_RETENTION_MS;
+  const since = now() - LATENCY_RETENTION_MS;
   const rows = db
     .query(
       "SELECT latency_ms FROM query_latency_log WHERE recorded_at >= ? ORDER BY latency_ms ASC",

--- a/packages/gateway/src/db/metrics.test.ts
+++ b/packages/gateway/src/db/metrics.test.ts
@@ -1,0 +1,311 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { latencyRingBuffer } from "./latency-ring-buffer.ts";
+import { collectIndexMetrics } from "./metrics.ts";
+
+// ---------------------------------------------------------------------------
+// Minimal real-DB schema used by collectIndexMetrics (no full migration needed)
+// ---------------------------------------------------------------------------
+function createMinimalSchema(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS item (
+      id TEXT PRIMARY KEY,
+      service TEXT NOT NULL,
+      type TEXT NOT NULL,
+      external_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      modified_at INTEGER NOT NULL,
+      synced_at INTEGER NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE TABLE IF NOT EXISTS embedding_chunk (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_id TEXT NOT NULL,
+      chunk_index INTEGER NOT NULL,
+      chunk_text TEXT NOT NULL,
+      model TEXT NOT NULL,
+      dims INTEGER NOT NULL,
+      embedded_at INTEGER NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE TABLE IF NOT EXISTS sync_state (
+      connector_id TEXT PRIMARY KEY,
+      last_sync_at INTEGER
+    )
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: minimal fake Database-shaped objects for defensive-branch testing
+// ---------------------------------------------------------------------------
+
+// A fake .query(sql) that returns a statement-like object whose .all()/.get()
+// delegates to the provided impl keyed on the SQL string.
+type FakeQueryResult = Array<Record<string, unknown>> | undefined | null | Record<string, unknown>;
+
+function makeFakeDb(
+  queryImpl: (sql: string) => { all?: () => FakeQueryResult; get?: () => FakeQueryResult },
+): unknown {
+  return {
+    query(sql: string) {
+      const impl = queryImpl(sql);
+      return {
+        all: impl.all ?? (() => []),
+        get: impl.get ?? (() => null),
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Drain any in-flight ring-buffer samples before each test so latency fields
+// are stable (all zeros when no query_latency_log table exists).
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  latencyRingBuffer.drainOrdered();
+});
+
+afterEach(() => {
+  latencyRingBuffer.drainOrdered();
+});
+
+// ===========================================================================
+// Happy-path tests with real in-memory SQLite
+// ===========================================================================
+
+describe("collectIndexMetrics — real SQLite happy paths", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    createMinimalSchema(db);
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  test("empty index returns all-zero aggregates", () => {
+    const m = collectIndexMetrics(db);
+    expect(m.totalItems).toBe(0);
+    expect(m.itemCountByService).toEqual({});
+    // embeddingCoveragePercent: totalItems === 0 → 0 (covers the false arm of totalItems > 0)
+    expect(m.embeddingCoveragePercent).toBe(0);
+    expect(m.lastSuccessfulSyncByConnector).toEqual({});
+    expect(m.indexSizeBytes).toBeGreaterThanOrEqual(0);
+    expect(m.queryLatencyP50Ms).toBe(0);
+    expect(m.queryLatencyP95Ms).toBe(0);
+    expect(m.queryLatencyP99Ms).toBe(0);
+  });
+
+  test("items grouped by service are counted correctly", () => {
+    db.run(`INSERT INTO item VALUES ('i1','github','pr','e1','T1',1,1)`);
+    db.run(`INSERT INTO item VALUES ('i2','github','pr','e2','T2',2,2)`);
+    db.run(`INSERT INTO item VALUES ('i3','slack','message','e3','T3',3,3)`);
+
+    const m = collectIndexMetrics(db);
+    expect(m.totalItems).toBe(3);
+    expect(m.itemCountByService["github"]).toBe(2);
+    expect(m.itemCountByService["slack"]).toBe(1);
+  });
+
+  test("embeddingCoveragePercent is non-zero when items exist with embeddings", () => {
+    db.run(`INSERT INTO item VALUES ('i1','svc','note','e1','T1',1,1)`);
+    db.run(
+      `INSERT INTO embedding_chunk (item_id,chunk_index,chunk_text,model,dims,embedded_at) VALUES ('i1',0,'hello','test',384,1)`,
+    );
+
+    const m = collectIndexMetrics(db);
+    // 1 item with emb out of 1 total → 100%
+    expect(m.embeddingCoveragePercent).toBe(100);
+    // covers totalItems > 0 → true arm
+  });
+
+  test("embeddingCoveragePercent is 0 when items exist but no embeddings", () => {
+    db.run(`INSERT INTO item VALUES ('i1','svc','note','e1','T1',1,1)`);
+
+    const m = collectIndexMetrics(db);
+    // 0 emb out of 1 total → 0%
+    expect(m.embeddingCoveragePercent).toBe(0);
+  });
+
+  test("lastSuccessfulSyncByConnector: numeric last_sync_at → Date", () => {
+    const ts = 1_700_000_000_000;
+    db.run(`INSERT INTO sync_state VALUES ('github-connector', ${ts})`);
+
+    const m = collectIndexMetrics(db);
+    const d = m.lastSuccessfulSyncByConnector["github-connector"];
+    expect(d).toBeInstanceOf(Date);
+    expect((d as Date).getTime()).toBe(ts);
+  });
+
+  test("lastSuccessfulSyncByConnector: NULL last_sync_at → null", () => {
+    db.run(`INSERT INTO sync_state VALUES ('slack-connector', NULL)`);
+
+    const m = collectIndexMetrics(db);
+    expect(m.lastSuccessfulSyncByConnector["slack-connector"]).toBeNull();
+  });
+
+  test("indexSizeBytes is a non-negative integer", () => {
+    const m = collectIndexMetrics(db);
+    expect(m.indexSizeBytes).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(m.indexSizeBytes)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Defensive-branch tests via type-safe fake DB objects
+// ===========================================================================
+
+describe("collectIndexMetrics — defensive branches via type-safe fakes", () => {
+  // -------------------------------------------------------------------------
+  // line 34 — byServiceRows ?? [] — the ?? RIGHT arm: .all() returns undefined
+  // -------------------------------------------------------------------------
+  test("line 34: byServiceRows ?? [] right arm — .all() returns undefined → empty counts", () => {
+    const fake = makeFakeDb((sql) => {
+      if (sql.includes("GROUP BY service")) {
+        // Simulate the raw cast returning undefined (defensive guard)
+        return { all: () => undefined };
+      }
+      if (sql.includes("COUNT(DISTINCT")) {
+        return { get: () => ({ with_emb: 0 }) };
+      }
+      if (sql.includes("sync_state")) {
+        return { all: () => [] };
+      }
+      // pageStats + latency queries return safe defaults
+      return { get: () => ({ b: 0 }), all: () => [] };
+    });
+
+    const m = collectIndexMetrics(fake as unknown as Database);
+    expect(m.totalItems).toBe(0);
+    expect(m.itemCountByService).toEqual({});
+  });
+
+  // -------------------------------------------------------------------------
+  // line 46 — withEmbRow?.with_emb ?? 0 — the ?? 0 RIGHT arm: .get() returns null
+  // -------------------------------------------------------------------------
+  test("line 46: withEmbRow?.with_emb ?? 0 right arm — .get() returns null → withEmb = 0", () => {
+    const fake = makeFakeDb((sql) => {
+      if (sql.includes("GROUP BY service")) {
+        return { all: () => [{ service: "svc", c: 2 }] };
+      }
+      if (sql.includes("COUNT(DISTINCT")) {
+        // Simulate the raw cast returning null (defensive guard)
+        return { get: () => null };
+      }
+      if (sql.includes("sync_state")) {
+        return { all: () => [] };
+      }
+      return { get: () => ({ b: 8192 }), all: () => [] };
+    });
+
+    const m = collectIndexMetrics(fake as unknown as Database);
+    // totalItems = 2, withEmb falls back to 0 → coverage = 0%
+    expect(m.totalItems).toBe(2);
+    expect(m.embeddingCoveragePercent).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // line 53 — syncRows ?? [] — the ?? RIGHT arm: .all() returns undefined
+  // -------------------------------------------------------------------------
+  test("line 53: syncRows ?? [] right arm — .all() returns undefined → empty sync map", () => {
+    const fake = makeFakeDb((sql) => {
+      if (sql.includes("GROUP BY service")) {
+        return { all: () => [] };
+      }
+      if (sql.includes("COUNT(DISTINCT")) {
+        return { get: () => ({ with_emb: 0 }) };
+      }
+      if (sql.includes("sync_state")) {
+        // Simulate the raw cast returning undefined (defensive guard)
+        return { all: () => undefined };
+      }
+      return { get: () => ({ b: 4096 }), all: () => [] };
+    });
+
+    const m = collectIndexMetrics(fake as unknown as Database);
+    expect(m.lastSuccessfulSyncByConnector).toEqual({});
+  });
+
+  // -------------------------------------------------------------------------
+  // line 25 — pageStats: typeof b !== "number" guard → returns 0
+  // The row exists but b is a non-number (e.g. a string) — covers the false arm.
+  // -------------------------------------------------------------------------
+  test("line 25: pageStats false arm — row.b is not a number → indexSizeBytes = 0", () => {
+    const fake = makeFakeDb((sql) => {
+      if (sql.includes("pragma_page_count")) {
+        // b is a string, not a number → typeof b !== "number" → returns 0
+        return { get: () => ({ b: "not-a-number" }) };
+      }
+      if (sql.includes("GROUP BY service")) {
+        return { all: () => [] };
+      }
+      if (sql.includes("COUNT(DISTINCT")) {
+        return { get: () => ({ with_emb: 0 }) };
+      }
+      if (sql.includes("sync_state")) {
+        return { all: () => [] };
+      }
+      return { get: () => null, all: () => [] };
+    });
+
+    const m = collectIndexMetrics(fake as unknown as Database);
+    expect(m.indexSizeBytes).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // line 25 — pageStats: b is not finite (NaN) → covers Number.isFinite guard
+  // -------------------------------------------------------------------------
+  test("line 25: pageStats false arm — row.b is NaN (non-finite) → indexSizeBytes = 0", () => {
+    const fake = makeFakeDb((sql) => {
+      if (sql.includes("pragma_page_count")) {
+        return { get: () => ({ b: Number.NaN }) };
+      }
+      if (sql.includes("GROUP BY service")) {
+        return { all: () => [] };
+      }
+      if (sql.includes("COUNT(DISTINCT")) {
+        return { get: () => ({ with_emb: 0 }) };
+      }
+      if (sql.includes("sync_state")) {
+        return { all: () => [] };
+      }
+      return { get: () => null, all: () => [] };
+    });
+
+    const m = collectIndexMetrics(fake as unknown as Database);
+    expect(m.indexSizeBytes).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // line 25 — pageStats: row itself is null → b is undefined → covers false arm
+  // -------------------------------------------------------------------------
+  test("line 25: pageStats false arm — .get() returns null → b is undefined → indexSizeBytes = 0", () => {
+    const fake = makeFakeDb((sql) => {
+      if (sql.includes("pragma_page_count")) {
+        return { get: () => null };
+      }
+      if (sql.includes("GROUP BY service")) {
+        return { all: () => [] };
+      }
+      if (sql.includes("COUNT(DISTINCT")) {
+        return { get: () => ({ with_emb: 0 }) };
+      }
+      if (sql.includes("sync_state")) {
+        return { all: () => [] };
+      }
+      return { get: () => null, all: () => [] };
+    });
+
+    const m = collectIndexMetrics(fake as unknown as Database);
+    expect(m.indexSizeBytes).toBe(0);
+  });
+});

--- a/packages/gateway/src/db/query-guard.test.ts
+++ b/packages/gateway/src/db/query-guard.test.ts
@@ -1,13 +1,31 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { assertReadOnlySelectSql, runReadOnlySelect, SqlGuardError } from "./query-guard.ts";
 
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) {
+      // Best-effort: a just-terminated worker may still hold the sqlite file open
+      // on Windows (EBUSY); a leftover temp dir is harmless, a failed cleanup is not.
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* worker still releasing the db handle — leave the temp dir for the OS to reap */
+      }
+    }
+  }
+});
+
 function tempDbPath(): string {
   const dir = mkdtempSync(join(tmpdir(), "nimbus-guard-"));
+  tempDirs.push(dir);
   const path = join(dir, "test.db");
   const db = new Database(path);
   db.run("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
@@ -42,17 +60,126 @@ describe("query-guard PRAGMA allowlist (S5-F2)", () => {
   });
 });
 
+describe("assertReadOnlySelectSql — statement validation (S5-F1)", () => {
+  // line 27 TRUE arm: empty / whitespace-only SQL
+  test("rejects empty string", () => {
+    expect(() => assertReadOnlySelectSql("")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("")).toThrow("SQL statement is empty");
+  });
+
+  test("rejects whitespace-only string", () => {
+    expect(() => assertReadOnlySelectSql("   ")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("   ")).toThrow("SQL statement is empty");
+  });
+
+  test("rejects tab-only string", () => {
+    expect(() => assertReadOnlySelectSql("\t\n  ")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("\t\n  ")).toThrow("SQL statement is empty");
+  });
+
+  // line 30 FALSE arm: statement that doesn't start with SELECT or WITH
+  test("rejects INSERT statement", () => {
+    expect(() => assertReadOnlySelectSql("INSERT INTO t VALUES (1)")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("INSERT INTO t VALUES (1)")).toThrow(
+      "Only SELECT (or WITH … SELECT) statements are allowed",
+    );
+  });
+
+  test("rejects DELETE statement", () => {
+    expect(() => assertReadOnlySelectSql("DELETE FROM t")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("DELETE FROM t")).toThrow(
+      "Only SELECT (or WITH … SELECT) statements are allowed",
+    );
+  });
+
+  test("rejects DROP statement", () => {
+    expect(() => assertReadOnlySelectSql("DROP TABLE t")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("DROP TABLE t")).toThrow(
+      "Only SELECT (or WITH … SELECT) statements are allowed",
+    );
+  });
+
+  // line 33 TRUE arm: starts with SELECT but contains a FORBIDDEN keyword
+  test("rejects SELECT followed by a DELETE keyword", () => {
+    expect(() => assertReadOnlySelectSql("SELECT 1; DELETE FROM t")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("SELECT 1; DELETE FROM t")).toThrow(
+      "Statement contains a forbidden keyword",
+    );
+  });
+
+  test("rejects SELECT followed by a DROP keyword", () => {
+    expect(() => assertReadOnlySelectSql("SELECT 1; DROP TABLE t")).toThrow(SqlGuardError);
+    expect(() => assertReadOnlySelectSql("SELECT 1; DROP TABLE t")).toThrow(
+      "Statement contains a forbidden keyword",
+    );
+  });
+
+  test("rejects WITH … SELECT that also contains DELETE", () => {
+    expect(() => assertReadOnlySelectSql("WITH x AS (SELECT 1) DELETE FROM t")).toThrow(
+      SqlGuardError,
+    );
+    expect(() => assertReadOnlySelectSql("WITH x AS (SELECT 1) DELETE FROM t")).toThrow(
+      "Statement contains a forbidden keyword",
+    );
+  });
+
+  test("rejects SELECT followed by an INSERT keyword", () => {
+    expect(() => assertReadOnlySelectSql("SELECT id FROM t; INSERT INTO t VALUES (99)")).toThrow(
+      SqlGuardError,
+    );
+    expect(() => assertReadOnlySelectSql("SELECT id FROM t; INSERT INTO t VALUES (99)")).toThrow(
+      "Statement contains a forbidden keyword",
+    );
+  });
+
+  // WITH … SELECT that is fully allowed (no forbidden keywords, no disallowed PRAGMA)
+  test("permits WITH … SELECT (CTE)", () => {
+    expect(() =>
+      assertReadOnlySelectSql("WITH cte AS (SELECT id FROM t) SELECT * FROM cte"),
+    ).not.toThrow();
+  });
+
+  // Disallowed PRAGMA error message check
+  test("rejects disallowed PRAGMA with its name in the message", () => {
+    expect(() => assertReadOnlySelectSql("SELECT 1; PRAGMA writable_schema")).toThrow(
+      "Disallowed PRAGMA in statement: writable_schema",
+    );
+  });
+
+  // Allowed PRAGMA set membership — both sides
+  test("permits all members of ALLOWED_PRAGMA", () => {
+    const allowedPragmas = [
+      "query_only",
+      "table_info",
+      "foreign_key_list",
+      "index_list",
+      "index_info",
+      "function_list",
+      "module_list",
+      "collation_list",
+      "database_list",
+      "compile_options",
+    ];
+    for (const pragma of allowedPragmas) {
+      expect(() => assertReadOnlySelectSql(`SELECT 1; PRAGMA ${pragma}`)).not.toThrow();
+    }
+  });
+});
+
 describe("query-guard wall-clock timeout (S5-F3)", () => {
   test("aborts an unbounded recursive CTE within the configured timeout", async () => {
     const dbPath = tempDbPath();
+    // Use a short timeout the timer reliably fires before the worker can either
+    // materialise the unbounded CTE or OOM-crash — keeps the timeout-reject branch
+    // deterministic (a long timeout races the timer against the worker crashing).
     const start = Date.now();
     await expect(
       runReadOnlySelect(
         dbPath,
         "WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM x) SELECT * FROM x",
-        { timeoutMs: 1500 },
+        { timeoutMs: 100 },
       ),
-    ).rejects.toThrow(/exceeded.*1500ms/);
+    ).rejects.toThrow(/exceeded.*100ms/);
     expect(Date.now() - start).toBeLessThan(8000);
   });
 
@@ -62,5 +189,48 @@ describe("query-guard wall-clock timeout (S5-F3)", () => {
       timeoutMs: 5000,
     });
     expect(rows).toEqual([{ name: "a" }, { name: "b" }, { name: "c" }]);
+  });
+});
+
+describe("runReadOnlySelect — worker round-trip (S5-F4)", () => {
+  // line 52: assertReadOnlySelectSql throws BEFORE spawning worker — rejects with SqlGuardError
+  test("rejects guard-invalid SQL before spawning a worker", async () => {
+    const dbPath = tempDbPath();
+    await expect(runReadOnlySelect(dbPath, "DROP TABLE t")).rejects.toThrow(SqlGuardError);
+    await expect(runReadOnlySelect(dbPath, "DROP TABLE t")).rejects.toThrow(
+      "Only SELECT (or WITH … SELECT) statements are allowed",
+    );
+  });
+
+  test("rejects guard-invalid empty SQL before spawning a worker", async () => {
+    const dbPath = tempDbPath();
+    await expect(runReadOnlySelect(dbPath, "   ")).rejects.toThrow(SqlGuardError);
+    await expect(runReadOnlySelect(dbPath, "   ")).rejects.toThrow("SQL statement is empty");
+  });
+
+  // line 69 FALSE arm: guard-valid SQL that causes a sqlite error at execution time.
+  // The worker receives it, sqlite throws (no such table), worker posts {ok:false, message:…},
+  // the onmessage handler takes the else branch and calls reject(new Error(msg.message)).
+  test("rejects when the worker returns ok:false (no such table)", async () => {
+    const dbPath = tempDbPath();
+    await expect(
+      runReadOnlySelect(dbPath, "SELECT * FROM does_not_exist", { timeoutMs: 5000 }),
+    ).rejects.toThrow(/does_not_exist|no such table/i);
+  });
+
+  test("rejects when the worker returns ok:false (column does not exist)", async () => {
+    const dbPath = tempDbPath();
+    await expect(
+      runReadOnlySelect(dbPath, "SELECT nonexistent_col FROM t", { timeoutMs: 5000 }),
+    ).rejects.toThrow(/nonexistent_col|no such column/i);
+  });
+
+  // Verify the resolve path returns an empty array when no rows match (rows ?? [] TRUE arm)
+  test("returns empty array when SELECT matches no rows", async () => {
+    const dbPath = tempDbPath();
+    const rows = await runReadOnlySelect(dbPath, "SELECT id FROM t WHERE id = 9999", {
+      timeoutMs: 5000,
+    });
+    expect(rows).toEqual([]);
   });
 });

--- a/packages/gateway/src/db/repair.test.ts
+++ b/packages/gateway/src/db/repair.test.ts
@@ -589,7 +589,7 @@ type FakeStmt = {
 /** Partial shape of bun:sqlite Database that repair.ts touches */
 type FakeRepairDb = {
   query: (sql: string) => FakeStmt;
-  run: (sql: string) => void;
+  run: (sql: string, ...rest: unknown[]) => void;
   transaction: (fn: () => void) => () => void;
 };
 
@@ -626,14 +626,16 @@ describe("repairIndex — catch false-arm: non-Error thrown from db.run", () => 
       query(sql: string): FakeStmt {
         return delegateRepairStmt(real, sql);
       },
-      run(sql: string): void {
+      run(sql: string, ...rest: unknown[]): void {
         // Intercept only the item_fts INSERT (both verify's integrity-check and
         // repair's rebuild).  All other .run() calls (PRAGMA foreign_keys, audit_log
-        // INSERT, etc.) are delegated to the real backing db.
+        // INSERT, etc.) are delegated to the real backing db — forwarding bound
+        // params so writeAuditEntry's parameterised INSERT actually executes.
         if (sql.includes("item_fts")) {
           throw nonError;
         }
-        real.run(sql);
+        const realRun = real.run.bind(real) as unknown as (s: string, ...r: unknown[]) => void;
+        realRun(sql, ...rest);
       },
       transaction(fn: () => void): () => void {
         return real.transaction(fn);
@@ -666,14 +668,16 @@ describe("repairIndex — catch false-arm: non-Error thrown from db.run", () => 
       query(sql: string): FakeStmt {
         return delegateRepairStmt(real, sql);
       },
-      run(sql: string): void {
+      run(sql: string, ...rest: unknown[]): void {
         // Intercept only the DELETE FROM sync_state write.  All other .run() calls
         // (PRAGMA foreign_keys = ON from checkForeignKeyIntegrity, audit_log
-        // INSERT from writeAuditEntry, etc.) are delegated to the real db.
+        // INSERT from writeAuditEntry, etc.) are delegated to the real db —
+        // forwarding bound params so the parameterised audit INSERT executes.
         if (sql.includes("DELETE FROM sync_state")) {
           throw nonError;
         }
-        real.run(sql);
+        const realRun = real.run.bind(real) as unknown as (s: string, ...r: unknown[]) => void;
+        realRun(sql, ...rest);
       },
       transaction(fn: () => void): () => void {
         return real.transaction(fn);

--- a/packages/gateway/src/db/repair.test.ts
+++ b/packages/gateway/src/db/repair.test.ts
@@ -1,0 +1,747 @@
+/**
+ * Branch-coverage tests for db/repair.ts (true-coverage program B4).
+ *
+ * Uses real in-memory SQLite + a minimal hand-rolled schema that satisfies
+ * every SQL query in repair.ts, without loading the full migration stack
+ * (which would pull in sqlite-vec). Where the full LocalIndex schema is
+ * needed to drive verifyIndex we import it; elsewhere we build tables inline.
+ *
+ * D-candidates (intentionally unreachable branches — see bottom of file).
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { formatRepairReport, repairIndex } from "./repair.ts";
+
+// ---------------------------------------------------------------------------
+// Minimal schema helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the minimal set of tables needed by verifyIndex (called from
+ * repairIndex) and by the repair functions themselves, WITHOUT loading
+ * sqlite-vec. vec_items_384 is created as a plain table so COUNT/DELETE work.
+ */
+function buildMinimalDb(): Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    -- Required by checkIntegrity (always first check in verifyIndex)
+    -- Nothing special needed — PRAGMA integrity_check works on any db.
+
+    -- _schema_migrations — required by checkSchemaVersion
+    CREATE TABLE IF NOT EXISTS _schema_migrations (
+      version     INTEGER PRIMARY KEY,
+      description TEXT NOT NULL,
+      applied_at  INTEGER NOT NULL
+    );
+
+    -- sync_state — required by checkOrphanedSyncTokens + repairOrphanedSyncTokens
+    CREATE TABLE IF NOT EXISTS sync_state (
+      connector_id    TEXT PRIMARY KEY,
+      last_sync_at    INTEGER,
+      next_sync_token TEXT
+    );
+
+    -- scheduler_state — required by checkOrphanedSyncTokens + repairVecOrphans cursor reset
+    CREATE TABLE IF NOT EXISTS scheduler_state (
+      service_id              TEXT PRIMARY KEY,
+      cursor                  TEXT,
+      interval_ms             INTEGER NOT NULL DEFAULT 60000,
+      last_sync_at            INTEGER,
+      next_sync_at            INTEGER,
+      status                  TEXT    NOT NULL DEFAULT 'ok',
+      error_msg               TEXT,
+      consecutive_failures    INTEGER NOT NULL DEFAULT 0,
+      paused                  INTEGER NOT NULL DEFAULT 0
+    );
+
+    -- audit_log — written by writeAuditEntry after repairs
+    CREATE TABLE IF NOT EXISTS audit_log (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      action_type TEXT NOT NULL,
+      hitl_status TEXT NOT NULL,
+      action_json TEXT NOT NULL,
+      timestamp   INTEGER NOT NULL
+    );
+
+    -- item_fts as a NON-fts5 table so the integrity-check INSERT throws
+    -- (used by the fts5_consistency fail path; recreated per-test as needed)
+
+    -- vec_items_384 as a PLAIN table (no sqlite-vec extension required)
+    CREATE TABLE IF NOT EXISTS vec_items_384 (
+      rowid INTEGER PRIMARY KEY
+    );
+
+    -- embedding_chunk — required by checkVecRowidAlignment
+    CREATE TABLE IF NOT EXISTS embedding_chunk (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_id     TEXT NOT NULL,
+      chunk_index INTEGER NOT NULL,
+      chunk_text  TEXT NOT NULL,
+      vec_rowid   INTEGER,
+      model       TEXT,
+      dims        INTEGER,
+      embedded_at INTEGER
+    );
+  `);
+  return db;
+}
+
+/**
+ * Stamp the _schema_migrations table so checkSchemaVersion is satisfied
+ * at the given version number.
+ */
+function stampVersion(db: Database, version: number): void {
+  db.run(
+    `INSERT OR REPLACE INTO _schema_migrations (version, description, applied_at) VALUES (?, 'test', 1)`,
+    [version],
+  );
+  db.exec(`PRAGMA user_version = ${String(version)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1 — clean index: no failures → outcomes: [], "clean" return
+// ---------------------------------------------------------------------------
+
+describe("repairIndex — clean index (no repairs needed)", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = buildMinimalDb();
+    stampVersion(db, 0);
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  test("returns empty outcomes array and a repairedAt timestamp", () => {
+    const before = Date.now();
+    const report = repairIndex(db, 0);
+    const after = Date.now();
+
+    expect(report.outcomes).toEqual([]);
+    expect(typeof report.repairedAt).toBe("string");
+    const ts = new Date(report.repairedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after + 100);
+  });
+
+  test("formatRepairReport on empty outcomes returns clean message", () => {
+    const report = repairIndex(db, 0);
+    const msg = formatRepairReport(report);
+    expect(msg).toBe("Nothing to repair — index is clean.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2 — vec_rowid_mismatch → repairVecOrphans
+// ---------------------------------------------------------------------------
+
+describe("repairIndex — vec_rowid_mismatch triggers repairVecOrphans", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = buildMinimalDb();
+    stampVersion(db, 0);
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  test("orphaned vec rows are deleted and scheduler cursor is reset", () => {
+    // Insert vec rows (orphans — no corresponding embedding_chunk)
+    db.run(`INSERT INTO vec_items_384 (rowid) VALUES (1)`);
+    db.run(`INSERT INTO vec_items_384 (rowid) VALUES (2)`);
+
+    // Add a scheduler row with a non-null cursor so we can verify it is reset
+    db.run(
+      `INSERT INTO scheduler_state (service_id, cursor, interval_ms, status) VALUES ('svc-a', 'tok123', 60000, 'ok')`,
+    );
+
+    // Precondition: embedding_chunk has 0 rows, vec_items_384 has 2 → mismatch
+    const vecCountBefore = (
+      db.query("SELECT COUNT(*) as c FROM vec_items_384").get() as { c: number }
+    ).c;
+    expect(vecCountBefore).toBe(2);
+
+    const report = repairIndex(db, 0);
+
+    expect(report.outcomes).toHaveLength(1);
+    const outcome = report.outcomes[0];
+    expect(outcome?.action).toBe("vec_orphan_delete");
+    expect(outcome?.status).toBe("applied");
+    expect(outcome?.detail).toContain("2 orphaned vec row(s)");
+    expect(outcome?.detail).toContain("reset all sync cursors");
+
+    // Vec rows must be gone
+    const vecCountAfter = (
+      db.query("SELECT COUNT(*) as c FROM vec_items_384").get() as { c: number }
+    ).c;
+    expect(vecCountAfter).toBe(0);
+
+    // Cursor must be reset to NULL
+    const row = db.query("SELECT cursor FROM scheduler_state WHERE service_id = 'svc-a'").get() as {
+      cursor: string | null;
+    };
+    expect(row?.cursor).toBeNull();
+  });
+
+  test("vec orphan repair returns applied with 1 deleted row (single orphan)", () => {
+    db.run(`INSERT INTO vec_items_384 (rowid) VALUES (99)`);
+
+    const report = repairIndex(db, 0);
+    expect(report.outcomes[0]?.status).toBe("applied");
+    expect(report.outcomes[0]?.detail).toContain("1 orphaned vec row(s)");
+  });
+
+  test("when all vec rows match embedding_chunk — no mismatch — repairVecOrphans skipped path (line 32)", () => {
+    // Insert matching pair: vec rowid 5, embedding_chunk.vec_rowid 5
+    db.run(`INSERT INTO vec_items_384 (rowid) VALUES (5)`);
+    db.run(
+      `INSERT INTO embedding_chunk (item_id, chunk_index, chunk_text, vec_rowid, model, dims, embedded_at)
+       VALUES ('item-x', 0, 'hello', 5, 'm', 384, 1)`,
+    );
+    // Both counts are 1 — verifyIndex reports ok, so repairVecOrphans never runs
+    const report = repairIndex(db, 0);
+    const vecOutcome = report.outcomes.find((o) => o.action === "vec_orphan_delete");
+    expect(vecOutcome).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3 — orphaned_sync_tokens → repairOrphanedSyncTokens
+// ---------------------------------------------------------------------------
+
+describe("repairIndex — orphaned_sync_tokens triggers repairOrphanedSyncTokens", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = buildMinimalDb();
+    stampVersion(db, 0);
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  test("orphaned sync_state rows are deleted and outcome is applied", () => {
+    // Insert a sync_state row whose connector_id has no matching scheduler_state row
+    db.run(
+      `INSERT INTO sync_state (connector_id, last_sync_at, next_sync_token)
+       VALUES ('orphan-connector', 1, 'tok')`,
+    );
+    // scheduler_state is empty → connector_id not in scheduler → verify FAILS
+
+    const before = (db.query("SELECT COUNT(*) as c FROM sync_state").get() as { c: number }).c;
+    expect(before).toBe(1);
+
+    const report = repairIndex(db, 0);
+
+    const outcome = report.outcomes.find((o) => o.action === "orphaned_sync_tokens_delete");
+    expect(outcome?.status).toBe("applied");
+    expect(outcome?.detail).toContain("1 orphaned token row(s)");
+
+    const after = (db.query("SELECT COUNT(*) as c FROM sync_state").get() as { c: number }).c;
+    expect(after).toBe(0);
+  });
+
+  test("multiple orphaned tokens are all deleted", () => {
+    db.run(`INSERT INTO sync_state (connector_id) VALUES ('ghost-1')`);
+    db.run(`INSERT INTO sync_state (connector_id) VALUES ('ghost-2')`);
+
+    const report = repairIndex(db, 0);
+    const outcome = report.outcomes.find((o) => o.action === "orphaned_sync_tokens_delete");
+    expect(outcome?.status).toBe("applied");
+    expect(outcome?.detail).toContain("2 orphaned token row(s)");
+  });
+
+  test("non-orphaned token (connector_id in scheduler_state) is NOT deleted", () => {
+    // Register the service in scheduler_state first
+    db.run(
+      `INSERT INTO scheduler_state (service_id, interval_ms, status) VALUES ('registered-svc', 60000, 'ok')`,
+    );
+    // Add a sync_state row pointing to the registered service — not orphaned
+    db.run(`INSERT INTO sync_state (connector_id) VALUES ('registered-svc')`);
+
+    const report = repairIndex(db, 0);
+    // No orphan check should fail — repair should not run
+    const outcome = report.outcomes.find((o) => o.action === "orphaned_sync_tokens_delete");
+    expect(outcome).toBeUndefined();
+    // Row must still exist
+    const row = db.query("SELECT COUNT(*) as c FROM sync_state").get() as { c: number };
+    expect(row.c).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 4 — foreign_key_integrity → repairForeignKeys (the I9 path)
+// ---------------------------------------------------------------------------
+
+describe("repairIndex — foreign_key_integrity triggers repairForeignKeys (I9 escapeIdentifier)", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = buildMinimalDb();
+    stampVersion(db, 0);
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  test("FK-violating child row is deleted; escapeIdentifier path exercised with real table name", () => {
+    // Create parent + child tables with a FK relationship
+    db.exec(`
+      CREATE TABLE _fk_parent (id TEXT PRIMARY KEY);
+      CREATE TABLE _fk_child (
+        id        TEXT PRIMARY KEY,
+        parent_id TEXT NOT NULL REFERENCES _fk_parent(id)
+      );
+    `);
+
+    // Insert orphan child row with FK enforcement OFF (simulate broken state)
+    db.run("PRAGMA foreign_keys = OFF");
+    db.run(`INSERT INTO _fk_child (id, parent_id) VALUES ('c1', 'nonexistent')`);
+    db.run("PRAGMA foreign_keys = ON");
+
+    const childCountBefore = (
+      db.query("SELECT COUNT(*) as c FROM _fk_child").get() as { c: number }
+    ).c;
+    expect(childCountBefore).toBe(1);
+
+    const report = repairIndex(db, 0);
+
+    const outcome = report.outcomes.find((o) => o.action === "foreign_key_cascade_delete");
+    expect(outcome?.status).toBe("applied");
+    expect(outcome?.detail).toContain("1 row(s) with FK violations");
+
+    // The offending row must be gone
+    const childCountAfter = (db.query("SELECT COUNT(*) as c FROM _fk_child").get() as { c: number })
+      .c;
+    expect(childCountAfter).toBe(0);
+  });
+
+  test("multiple FK violations across one table are all deleted in batch", () => {
+    db.exec(`
+      CREATE TABLE _fk_parent2 (id TEXT PRIMARY KEY);
+      CREATE TABLE _fk_child2 (
+        id        TEXT PRIMARY KEY,
+        parent_id TEXT NOT NULL REFERENCES _fk_parent2(id)
+      );
+    `);
+
+    db.run("PRAGMA foreign_keys = OFF");
+    db.run(`INSERT INTO _fk_child2 (id, parent_id) VALUES ('a', 'ghost1')`);
+    db.run(`INSERT INTO _fk_child2 (id, parent_id) VALUES ('b', 'ghost2')`);
+    db.run("PRAGMA foreign_keys = ON");
+
+    const report = repairIndex(db, 0);
+    const outcome = report.outcomes.find((o) => o.action === "foreign_key_cascade_delete");
+    expect(outcome?.status).toBe("applied");
+    expect(outcome?.detail).toContain("2 row(s) with FK violations");
+
+    const remaining = (db.query("SELECT COUNT(*) as c FROM _fk_child2").get() as { c: number }).c;
+    expect(remaining).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 5 — catch arms (lines 62/76/102/165 true-Error branch)
+// Trigger by making verify report a FAIL, then dropping the table the repair
+// needs so the repair SQL throws.
+// ---------------------------------------------------------------------------
+
+describe("repairIndex — catch arms produce error outcomes", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = buildMinimalDb();
+    stampVersion(db, 0);
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  test("repairVecOrphans catch arm — vec_items_384 is WITHOUT ROWID so rowid SELECT throws (line 62)", () => {
+    // WITHOUT ROWID tables have no implicit rowid column.
+    // verifyIndex's checkVecRowidAlignment does COUNT(*) (works fine) →
+    // reports mismatch when counts differ.
+    // repairVecOrphans then does SELECT v.rowid ... which throws on a WITHOUT
+    // ROWID table → catch arm fires.
+    db.run("DROP TABLE vec_items_384");
+    db.exec(`
+      CREATE TABLE vec_items_384 (
+        vec_id INTEGER NOT NULL,
+        PRIMARY KEY (vec_id)
+      ) WITHOUT ROWID
+    `);
+    // Insert a row (COUNT=1) with embedding_chunk empty (COUNT=0) → mismatch
+    db.run("INSERT INTO vec_items_384 (vec_id) VALUES (1)");
+
+    const report = repairIndex(db, 0);
+    const outcome = report.outcomes.find((o) => o.action === "vec_orphan_delete");
+    expect(outcome?.status).toBe("error");
+    expect(typeof outcome?.detail).toBe("string");
+    expect((outcome?.detail ?? "").length).toBeGreaterThan(0);
+  });
+
+  test("repairFts5 catch arm — item_fts is a plain table so special INSERT throws (line 76)", () => {
+    // verifyIndex's checkFts5Consistency checks tableExists then does
+    //   INSERT INTO item_fts(item_fts) VALUES('integrity-check')
+    // which throws on a non-fts5 table → fts5_consistency = fail.
+    // repairFts5 then does
+    //   INSERT INTO item_fts(item_fts) VALUES('rebuild')
+    // which also throws on the same plain table → catch arm fires.
+    // Keep item_fts as a plain table for BOTH verify and repair calls.
+    db.exec("CREATE TABLE item_fts (other TEXT)");
+
+    const report = repairIndex(db, 0);
+    const outcome = report.outcomes.find((o) => o.action === "fts5_rebuild");
+    expect(outcome?.status).toBe("error");
+    expect(typeof outcome?.detail).toBe("string");
+    expect((outcome?.detail ?? "").length).toBeGreaterThan(0);
+  });
+
+  test("repairOrphanedSyncTokens catch arm — sync_state lacks connector_id column (line 102)", () => {
+    // Replace sync_state with a table lacking the connector_id column.
+    // verifyIndex's checkOrphanedSyncTokens queries connector_id → throws →
+    // orphaned_sync_tokens = fail.
+    // repairOrphanedSyncTokens then DELETEs WHERE connector_id NOT IN ... →
+    // also throws (no such column) → catch arm fires.
+    db.run("DROP TABLE sync_state");
+    db.exec("CREATE TABLE sync_state (bad_col TEXT PRIMARY KEY)");
+
+    const report = repairIndex(db, 0);
+    const outcome = report.outcomes.find((o) => o.action === "orphaned_sync_tokens_delete");
+    expect(outcome?.status).toBe("error");
+    expect(typeof outcome?.detail).toBe("string");
+    expect((outcome?.detail ?? "").length).toBeGreaterThan(0);
+  });
+
+  test("repairForeignKeys catch arm — DELETE blocked by BEFORE trigger that raises (line 165)", () => {
+    // Create parent + child tables with a FK, insert an orphan child (FK off),
+    // then add a BEFORE DELETE trigger that raises an error so the repair
+    // DELETE throws inside the transaction → catch arm fires.
+    db.exec(`
+      CREATE TABLE _fk_pb (id TEXT PRIMARY KEY);
+      CREATE TABLE _fk_cb (
+        id        TEXT PRIMARY KEY,
+        parent_id TEXT NOT NULL REFERENCES _fk_pb(id)
+      );
+    `);
+    db.run("PRAGMA foreign_keys = OFF");
+    db.run(`INSERT INTO _fk_cb (id, parent_id) VALUES ('x', 'ghost')`);
+    db.run("PRAGMA foreign_keys = ON");
+
+    // Add a trigger that unconditionally raises so repair's DELETE throws
+    db.exec(`
+      CREATE TRIGGER _fk_cb_block_delete
+      BEFORE DELETE ON _fk_cb
+      BEGIN
+        SELECT RAISE(ABORT, 'delete blocked by test trigger');
+      END
+    `);
+
+    const report = repairIndex(db, 0);
+    const outcome = report.outcomes.find((o) => o.action === "foreign_key_cascade_delete");
+    expect(outcome?.status).toBe("error");
+    expect(typeof outcome?.detail).toBe("string");
+    expect((outcome?.detail ?? "").length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 6 — formatRepairReport: all status tags + detail lines
+// ---------------------------------------------------------------------------
+
+describe("formatRepairReport", () => {
+  test("returns clean message for empty outcomes", () => {
+    const msg = formatRepairReport({ outcomes: [], repairedAt: "2026-06-11T00:00:00.000Z" });
+    expect(msg).toBe("Nothing to repair — index is clean.");
+  });
+
+  test("applied tag is rendered", () => {
+    const msg = formatRepairReport({
+      outcomes: [
+        {
+          action: "vec_orphan_delete",
+          status: "applied",
+          detail: "deleted 3 orphaned vec row(s); reset all sync cursors",
+        },
+      ],
+      repairedAt: "2026-06-11T00:00:00.000Z",
+    });
+    expect(msg).toContain("[applied]");
+    expect(msg).toContain("vec_orphan_delete");
+    expect(msg).toContain("deleted 3");
+    expect(msg).toContain("Repaired at: 2026-06-11T00:00:00.000Z");
+  });
+
+  test("skipped tag is rendered", () => {
+    const msg = formatRepairReport({
+      outcomes: [
+        { action: "vec_orphan_delete", status: "skipped", detail: "no orphaned vec rows" },
+      ],
+      repairedAt: "2026-06-11T00:00:00.000Z",
+    });
+    expect(msg).toContain("[skipped]");
+  });
+
+  test("error tag is rendered", () => {
+    const msg = formatRepairReport({
+      outcomes: [{ action: "fts5_rebuild", status: "error", detail: "no such table: item_fts" }],
+      repairedAt: "2026-06-11T00:00:00.000Z",
+    });
+    expect(msg).toContain("[ error ]");
+    expect(msg).toContain("fts5_rebuild");
+    expect(msg).toContain("no such table");
+  });
+
+  test("mixed outcomes render all three tags", () => {
+    const msg = formatRepairReport({
+      outcomes: [
+        { action: "fts5_rebuild", status: "applied", detail: "item_fts rebuilt" },
+        { action: "vec_orphan_delete", status: "skipped", detail: "no orphaned vec rows" },
+        { action: "orphaned_sync_tokens_delete", status: "error", detail: "boom" },
+      ],
+      repairedAt: "2026-06-11T12:00:00.000Z",
+    });
+    expect(msg).toContain("[applied]");
+    expect(msg).toContain("[skipped]");
+    expect(msg).toContain("[ error ]");
+    expect(msg).toContain("Repaired at: 2026-06-11T12:00:00.000Z");
+  });
+
+  test("outcome with no detail omits the colon-suffix", () => {
+    const msg = formatRepairReport({
+      outcomes: [{ action: "fts5_rebuild", status: "applied" }],
+      repairedAt: "2026-06-11T00:00:00.000Z",
+    });
+    // Should not contain a stray ": " at end of action name
+    expect(msg).not.toContain("fts5_rebuild:");
+    expect(msg).toContain("fts5_rebuild");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 7 — audit_log entry is written after a repair
+// ---------------------------------------------------------------------------
+
+describe("repairIndex — audit_log entry written", () => {
+  test("audit_log receives a db.repair entry after repairs run", () => {
+    const db = buildMinimalDb();
+    stampVersion(db, 0);
+
+    // Create an orphaned sync token to force at least one repair
+    db.run(`INSERT INTO sync_state (connector_id) VALUES ('audit-test-ghost')`);
+
+    const before = (db.query("SELECT COUNT(*) as c FROM audit_log").get() as { c: number }).c;
+
+    repairIndex(db, 0);
+
+    const after = (db.query("SELECT COUNT(*) as c FROM audit_log").get() as { c: number }).c;
+    expect(after).toBe(before + 1);
+
+    const row = db.query("SELECT action_type FROM audit_log ORDER BY id DESC LIMIT 1").get() as {
+      action_type: string;
+    };
+    expect(row?.action_type).toBe("db.repair");
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 8 — catch false-arms (lines 76 / 102): err instanceof Error FALSE branch
+// Trigger by making verify produce a FAIL, then using a selective delegating
+// proxy whose .run() throws a NON-Error only for the targeted SQL fragment,
+// delegating all other .run() calls to a real backing db.
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a bun:sqlite Statement returned by db.query() */
+type FakeStmt = {
+  all: (...args: unknown[]) => unknown[];
+  get: (...args: unknown[]) => unknown;
+};
+
+/** Partial shape of bun:sqlite Database that repair.ts touches */
+type FakeRepairDb = {
+  query: (sql: string) => FakeStmt;
+  run: (sql: string) => void;
+  transaction: (fn: () => void) => () => void;
+};
+
+/** Delegate a real bun:sqlite statement, forwarding variadic params. */
+function delegateRepairStmt(real: Database, sql: string): FakeStmt {
+  return {
+    all(...args: unknown[]) {
+      const stmt = real.query(sql);
+      return (
+        args.length > 0 ? stmt.all(...(args as Parameters<typeof stmt.all>)) : stmt.all()
+      ) as unknown[];
+    },
+    get(...args: unknown[]) {
+      const stmt = real.query(sql);
+      return (
+        args.length > 0 ? stmt.get(...(args as Parameters<typeof stmt.get>)) : stmt.get()
+      ) as unknown;
+    },
+  };
+}
+
+describe("repairIndex — catch false-arm: non-Error thrown from db.run", () => {
+  test("repairFts5 false-arm (line 76): non-Error detail === String(thrown)", () => {
+    // Real backing db: item_fts exists (as a plain table) so tableExists returns
+    // true and checkFts5Consistency proceeds to the INSERT.  All other tables are
+    // present so the remaining verify checks don't blow up.
+    const real = buildMinimalDb();
+    stampVersion(real, 0);
+    real.exec("CREATE TABLE item_fts (other TEXT)");
+
+    const nonError: unknown = "fts5 rebuild blew up";
+
+    const fake: FakeRepairDb = {
+      query(sql: string): FakeStmt {
+        return delegateRepairStmt(real, sql);
+      },
+      run(sql: string): void {
+        // Intercept only the item_fts INSERT (both verify's integrity-check and
+        // repair's rebuild).  All other .run() calls (PRAGMA foreign_keys, audit_log
+        // INSERT, etc.) are delegated to the real backing db.
+        if (sql.includes("item_fts")) {
+          throw nonError;
+        }
+        real.run(sql);
+      },
+      transaction(fn: () => void): () => void {
+        return real.transaction(fn);
+      },
+    };
+
+    const report = repairIndex(fake as unknown as Database, 0);
+    const outcome = report.outcomes.find((o) => o.action === "fts5_rebuild");
+    expect(outcome?.status).toBe("error");
+    // String(nonError) === "fts5 rebuild blew up" — proves the FALSE arm executed
+    expect(outcome?.detail).toBe(String(nonError));
+
+    real.close();
+  });
+
+  test("repairOrphanedSyncTokens false-arm (line 102): non-Error detail === String(thrown)", () => {
+    // Real backing db: sync_state has an orphaned row (connector_id not in
+    // scheduler_state) so checkOrphanedSyncTokens returns fail.
+    const real = buildMinimalDb();
+    stampVersion(real, 0);
+    real.run(
+      `INSERT INTO sync_state (connector_id, last_sync_at, next_sync_token)
+       VALUES ('orphan-ghost', 1, 'tok')`,
+    );
+    // scheduler_state is empty → connector_id not found → verify FAILS
+
+    const nonError: unknown = "sync delete blew up";
+
+    const fake: FakeRepairDb = {
+      query(sql: string): FakeStmt {
+        return delegateRepairStmt(real, sql);
+      },
+      run(sql: string): void {
+        // Intercept only the DELETE FROM sync_state write.  All other .run() calls
+        // (PRAGMA foreign_keys = ON from checkForeignKeyIntegrity, audit_log
+        // INSERT from writeAuditEntry, etc.) are delegated to the real db.
+        if (sql.includes("DELETE FROM sync_state")) {
+          throw nonError;
+        }
+        real.run(sql);
+      },
+      transaction(fn: () => void): () => void {
+        return real.transaction(fn);
+      },
+    };
+
+    const report = repairIndex(fake as unknown as Database, 0);
+    const outcome = report.outcomes.find((o) => o.action === "orphaned_sync_tokens_delete");
+    expect(outcome?.status).toBe("error");
+    // String(nonError) === "sync delete blew up" — proves the FALSE arm executed
+    expect(outcome?.detail).toBe(String(nonError));
+
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-candidates (NOT tested — intentionally unreachable or race-only branches)
+// ---------------------------------------------------------------------------
+//
+// line 32 (repairVecOrphans):
+//   `if (orphans.length === 0) return skipped`
+//   This branch is ONLY reachable if verifyIndex said vec_rowid_mismatch=FAIL
+//   (meaning vec count ≠ chunk count) but the subsequent SELECT for orphaned
+//   vec rows returns 0. That requires vec rows to disappear between the two
+//   SQL queries — a pure race / TOCTOU. D-candidate: not fabricated.
+//
+// line 89 (repairOrphanedSyncTokens):
+//   `(result as {changes}).changes ?? 0` — RIGHT arm (`?? 0`)
+//   `dbRun` always returns a SQLite statement result which always has a
+//   `.changes` field (never undefined). The `?? 0` is a defensive fallback
+//   added for robustness. D-candidate: defensive-only.
+//
+// line 90 (repairOrphanedSyncTokens):
+//   `if (deleted === 0) return skipped`
+//   Repair only runs when verify said orphaned_sync_tokens=FAIL (there are
+//   orphans), so the DELETE must remove ≥1 row. deleted===0 can only occur
+//   if the orphan is cleaned up between verify and repair — a race.
+//   D-candidate: race-only.
+//
+// line 123 (repairForeignKeys):
+//   `if (violations.length === 0) return skipped`
+//   Same race pattern: repair only runs when verify said foreign_key_integrity
+//   =FAIL, so PRAGMA foreign_key_check must have returned violations. They
+//   could only be gone between verify and repair due to a concurrent write.
+//   D-candidate: race-only.
+//
+// line 139 (repairForeignKeys — I9 guard):
+//   `if (isUnsafeSqlIdentifier(table)) continue`
+//   PRAGMA foreign_key_check returns table names from SQLite's own catalog —
+//   these are always valid SQL identifiers (non-empty, no NUL). This guard is
+//   an intentional I9 DEFENSE-IN-DEPTH against any future code path that might
+//   construct a synthetic violation. It MUST NOT be removed or weakened.
+//   D-candidate: unreachable via real SQLite; do not fabricate a fake FK-check.
+//
+// line 151 (repairForeignKeys):
+//   `(res as {changes}).changes ?? 0` — RIGHT arm (`?? 0`)
+//   Same pattern as line 89: dbRun's return value always carries `.changes`.
+//   D-candidate: defensive-only.
+//
+// lines 76 / 102 — `err instanceof Error` FALSE arm:
+//   Covered by Suite 8 via a selective delegating proxy that throws a non-Error
+//   string only for the targeted SQL fragment.
+//
+// lines 62 / 165 — `err instanceof Error` FALSE arm:
+//   SQLite (bun:sqlite) always throws real Error instances; a non-Error throw
+//   from the driver is not observable in practice. Covered by Suite 5 tests
+//   for the TRUE arm (normal Error). The FALSE arm (`String(err)`) would require
+//   a non-Error value thrown by a db.query() call inside a transaction, which is
+//   not interceptable without mock.module (prohibited). D-candidate for the
+//   false arm only.

--- a/packages/gateway/src/db/snapshot.test.ts
+++ b/packages/gateway/src/db/snapshot.test.ts
@@ -1,0 +1,378 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_SNAPSHOT_CONFIG,
+  formatSnapshotList,
+  listSnapshots,
+  previewRestore,
+  pruneSnapshots,
+  restoreSnapshot,
+  type SnapshotEntry,
+  startSnapshotScheduler,
+  takeSnapshot,
+} from "./snapshot.ts";
+
+// Helper: create a minimal in-memory DB with an `item` table
+function makeDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE item (id INTEGER PRIMARY KEY)");
+  return db;
+}
+
+// Helper: create a real snapshot and return its path
+function createSnapshot(db: Database, dataDir: string): string {
+  return takeSnapshot(db, dataDir);
+}
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "nimbus-snap-"));
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+// ─── takeSnapshot + listSnapshots (happy path) ───────────────────────────────
+
+describe("takeSnapshot + listSnapshots — happy path", () => {
+  test("takeSnapshot produces a .db.gz file that listSnapshots discovers", () => {
+    const db = makeDb();
+    const gzPath = createSnapshot(db, dataDir);
+    db.close();
+
+    expect(gzPath).toMatch(/nimbus-\d+\.db\.gz$/);
+
+    const entries = listSnapshots(dataDir);
+    expect(entries).toHaveLength(1);
+    const first = entries[0];
+    expect(first).toBeDefined();
+    expect(first!.path).toBe(gzPath);
+    expect(first!.compressedSizeBytes).toBeGreaterThan(0);
+    expect(first!.timestampMs).toBeGreaterThan(0);
+  });
+
+  test("listSnapshots returns entries sorted newest-first", () => {
+    const db = makeDb();
+    // Write two fake snapshot files with known timestamps
+    const snapshotsDir = join(dataDir, "snapshots");
+    mkdirSync(snapshotsDir, { recursive: true });
+
+    const t1 = 1_700_000_000_000;
+    const t2 = 1_700_000_001_000;
+    // Bun.gzipSync needs actual bytes — use a real compressed copy
+    const rawDb = new Database(":memory:");
+    rawDb.exec("CREATE TABLE item (id INTEGER)");
+    const tmpSnap = join(dataDir, "tmp-for-gz.db");
+    rawDb.run(`VACUUM INTO ?`, [tmpSnap]);
+    rawDb.close();
+    const rawBytes = readFileSync(tmpSnap);
+    const gz = Bun.gzipSync(rawBytes);
+    rmSync(tmpSnap);
+
+    writeFileSync(join(snapshotsDir, `nimbus-${String(t1)}.db.gz`), gz);
+    writeFileSync(join(snapshotsDir, `nimbus-${String(t2)}.db.gz`), gz);
+    db.close();
+
+    const entries = listSnapshots(dataDir);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.timestampMs).toBeGreaterThanOrEqual(entries[1]!.timestampMs);
+  });
+});
+
+// ─── listSnapshots: non-existent dir → [] ────────────────────────────────────
+
+describe("listSnapshots — non-existent dir", () => {
+  test("returns empty array when snapshots dir does not exist", () => {
+    const absent = join(dataDir, "no-such-dir");
+    const entries = listSnapshots(absent);
+    expect(entries).toEqual([]);
+  });
+});
+
+// ─── listSnapshots line 103: NaN timestamp → skipped (TRUE arm) ──────────────
+
+describe("listSnapshots — line 103 TRUE arm: NaN timestamp skipped", () => {
+  test("file named nimbus-NOTANUMBER.db.gz is skipped", () => {
+    const snapshotsDir = join(dataDir, "snapshots");
+    mkdirSync(snapshotsDir, { recursive: true });
+
+    // Write a junk file whose timestamp portion is not numeric
+    writeFileSync(join(snapshotsDir, "nimbus-NOTANUMBER.db.gz"), "junk");
+
+    const db = makeDb();
+    const gzPath = createSnapshot(db, dataDir);
+    db.close();
+
+    const entries = listSnapshots(dataDir);
+    // The real snapshot should be present; the junk file should be absent
+    const names = entries.map((e) => e.filename);
+    expect(names.some((n) => n.includes("NOTANUMBER"))).toBe(false);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries.some((e) => e.path === gzPath)).toBe(true);
+  });
+
+  test("file named nimbus-.db.gz (empty digits) is skipped", () => {
+    const snapshotsDir = join(dataDir, "snapshots");
+    mkdirSync(snapshotsDir, { recursive: true });
+    // parseInt("") → NaN
+    writeFileSync(join(snapshotsDir, "nimbus-.db.gz"), "junk");
+
+    const entries = listSnapshots(dataDir);
+    expect(entries).toHaveLength(0);
+  });
+});
+
+// ─── previewRestore — happy path ─────────────────────────────────────────────
+
+describe("previewRestore — happy path", () => {
+  test("returns snapshotItemCount matching what was in the snapshot db", () => {
+    const db = makeDb();
+    db.run("INSERT INTO item (id) VALUES (1), (2), (3)");
+    const gzPath = createSnapshot(db, dataDir);
+
+    const preview = previewRestore(db, gzPath);
+    expect(preview.snapshotItemCount).toBe(3);
+    expect(preview.currentItemCount).toBe(3);
+    expect(preview.snapshotTimestampMs).toBeGreaterThan(0);
+    db.close();
+  });
+});
+
+// ─── previewRestore lines 156/160: regex doesn't match → snapshotTimestampMs=0
+
+describe("previewRestore — line 156 TRUE arm: non-matching filename", () => {
+  test("snapshotPath with no matching nimbus-<digits>.db.gz pattern yields snapshotTimestampMs=0", () => {
+    // Create a real snapshot and copy to a weird name so gunzip still works
+    const db = makeDb();
+    const gzPath = createSnapshot(db, dataDir);
+    db.close();
+
+    // Copy the valid gz bytes to a path that doesn't match the regex
+    const gzBytes = readFileSync(gzPath);
+    const weirdPath = join(dataDir, "weird-name.gz");
+    writeFileSync(weirdPath, gzBytes);
+
+    const db2 = makeDb();
+    const preview = previewRestore(db2, weirdPath);
+    db2.close();
+
+    // tsStr becomes "0", parseInt("0")=0 which IS finite, so snapshotTimestampMs=0
+    expect(preview.snapshotTimestampMs).toBe(0);
+  });
+});
+
+// ─── previewRestore lines 142/150: `row?.c ?? 0` defensive arms ──────────────
+// These arms guard against the db.query().get() returning `undefined`.
+// With real SQLite, COUNT(*) always returns a row with a numeric c — these
+// are DEFENSIVE/UNREACHABLE with real sqlite. See D-candidates section below.
+
+// ─── previewRestore line 160 FALSE arm: Number.isFinite(tsMs) = false ────────
+// When the regex matches (snapshotTsMatch?.[1] is a digit string), parseInt
+// always returns a finite number (JS digits never overflow to NaN). The only
+// path to the FALSE arm is regex-no-match → tsStr="0" → parseInt("0")=0 which
+// IS finite. Thus the FALSE arm of line 160 is DEFENSIVE/UNREACHABLE with any
+// realistic input (see D-candidates).
+
+// ─── restoreSnapshot ─────────────────────────────────────────────────────────
+
+describe("restoreSnapshot", () => {
+  test("overwrites the target db file with snapshot contents", () => {
+    const db = makeDb();
+    db.run("INSERT INTO item (id) VALUES (42)");
+    const gzPath = createSnapshot(db, dataDir);
+    db.close();
+
+    const targetPath = join(dataDir, "restored.db");
+    restoreSnapshot(gzPath, targetPath);
+
+    const restored = new Database(targetPath, { readonly: true });
+    const row = restored.query("SELECT COUNT(*) as c FROM item").get() as { c: number };
+    expect(row.c).toBe(1);
+    restored.close();
+  });
+});
+
+// ─── pruneSnapshots ──────────────────────────────────────────────────────────
+
+describe("pruneSnapshots", () => {
+  test("deletes oldest snapshots beyond keepLast and returns deleted count", () => {
+    // Create 3 snapshots with distinct timestamps via fabricated files
+    const snapshotsDir = join(dataDir, "snapshots");
+    mkdirSync(snapshotsDir, { recursive: true });
+
+    // Build a minimal gz to put in each fabricated snapshot file
+    const rawDb = new Database(":memory:");
+    rawDb.exec("CREATE TABLE item (id INTEGER)");
+    const tmpPath = join(dataDir, "tmpraw.db");
+    rawDb.run(`VACUUM INTO ?`, [tmpPath]);
+    rawDb.close();
+    const rawBytes = readFileSync(tmpPath);
+    const gz = Bun.gzipSync(rawBytes);
+    rmSync(tmpPath);
+
+    const t1 = 1_700_000_001_000;
+    const t2 = 1_700_000_002_000;
+    const t3 = 1_700_000_003_000;
+    writeFileSync(join(snapshotsDir, `nimbus-${String(t1)}.db.gz`), gz);
+    writeFileSync(join(snapshotsDir, `nimbus-${String(t2)}.db.gz`), gz);
+    writeFileSync(join(snapshotsDir, `nimbus-${String(t3)}.db.gz`), gz);
+
+    const deleted = pruneSnapshots(dataDir, 2);
+    expect(deleted).toBe(1);
+
+    const remaining = listSnapshots(dataDir);
+    expect(remaining).toHaveLength(2);
+    // The remaining entries should be the two newest (t3, t2)
+    const remainTs = remaining.map((e) => e.timestampMs).sort((a, b) => b - a);
+    expect(remainTs[0]).toBe(t3);
+    expect(remainTs[1]).toBe(t2);
+  });
+
+  test("pruneSnapshots with keepLast >= total count deletes nothing", () => {
+    const db = makeDb();
+    createSnapshot(db, dataDir);
+    db.close();
+
+    const deleted = pruneSnapshots(dataDir, 10);
+    expect(deleted).toBe(0);
+    expect(listSnapshots(dataDir)).toHaveLength(1);
+  });
+
+  test("pruneSnapshots on non-existent dir returns 0", () => {
+    const absent = join(dataDir, "no-snapshots-here");
+    const deleted = pruneSnapshots(absent, 3);
+    expect(deleted).toBe(0);
+  });
+});
+
+// ─── startSnapshotScheduler ──────────────────────────────────────────────────
+
+describe("startSnapshotScheduler — enabled:false early return (line 200)", () => {
+  test("returns a no-op handle when config.enabled is false", () => {
+    const db = makeDb();
+    const config = { ...DEFAULT_SNAPSHOT_CONFIG, enabled: false };
+    const handle = startSnapshotScheduler(db, dataDir, config, false);
+
+    // stop() must not throw
+    expect(() => handle.stop()).not.toThrow();
+
+    // No snapshot should have been taken
+    expect(listSnapshots(dataDir)).toHaveLength(0);
+    db.close();
+  });
+});
+
+describe("startSnapshotScheduler — runNow:true creates a snapshot immediately", () => {
+  test("runNow=true takes a snapshot before returning the handle", () => {
+    const db = makeDb();
+    const config = { ...DEFAULT_SNAPSHOT_CONFIG, intervalMs: 999_999_999 };
+    const handle = startSnapshotScheduler(db, dataDir, config, true);
+
+    const entries = listSnapshots(dataDir);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+
+    handle.stop();
+    db.close();
+  });
+});
+
+describe("startSnapshotScheduler — enabled:true, runNow:false", () => {
+  test("returns a stoppable handle without immediately taking a snapshot", () => {
+    const db = makeDb();
+    const config = { ...DEFAULT_SNAPSHOT_CONFIG, intervalMs: 999_999_999 };
+    const handle = startSnapshotScheduler(db, dataDir, config, false);
+
+    // No snapshot yet (interval hasn't fired)
+    expect(listSnapshots(dataDir)).toHaveLength(0);
+    handle.stop();
+    db.close();
+  });
+});
+
+// ─── formatSnapshotList ───────────────────────────────────────────────────────
+
+describe("formatSnapshotList — empty list", () => {
+  test("returns 'No snapshots found.' for empty input", () => {
+    expect(formatSnapshotList([])).toBe("No snapshots found.");
+  });
+});
+
+describe("formatSnapshotList — humanBytes tiers (lines 229–232)", () => {
+  function entry(compressedSizeBytes: number): SnapshotEntry {
+    return {
+      path: join("snapshots", `nimbus-1700000000000.db.gz`),
+      filename: "nimbus-1700000000000.db.gz",
+      timestampMs: 1_700_000_000_000,
+      compressedSizeBytes,
+    };
+  }
+
+  test("< 1024 bytes → output contains 'B' (not KB/MB/GB)", () => {
+    const out = formatSnapshotList([entry(500)]);
+    expect(out).toContain(" B");
+    expect(out).not.toContain("KB");
+    expect(out).not.toContain("MB");
+    expect(out).not.toContain("GB");
+  });
+
+  test("1024–1048575 bytes → output contains 'KB'", () => {
+    const out = formatSnapshotList([entry(2048)]);
+    expect(out).toContain("KB");
+    expect(out).not.toContain("MB");
+    expect(out).not.toContain("GB");
+  });
+
+  test("1048576–1073741823 bytes → output contains 'MB'", () => {
+    const out = formatSnapshotList([entry(5 * 1024 * 1024)]);
+    expect(out).toContain("MB");
+    expect(out).not.toContain("GB");
+  });
+
+  test(">= 1073741824 bytes → output contains 'GB'", () => {
+    const out = formatSnapshotList([entry(3 * 1024 * 1024 * 1024)]);
+    expect(out).toContain("GB");
+  });
+
+  test("non-empty list includes header and separator row", () => {
+    const out = formatSnapshotList([entry(512)]);
+    expect(out).toContain("FILENAME");
+    expect(out).toContain("TIMESTAMP");
+    expect(out).toContain("SIZE");
+    expect(out).toContain("─");
+  });
+});
+
+// ─── DEFAULT_SNAPSHOT_CONFIG ──────────────────────────────────────────────────
+
+describe("DEFAULT_SNAPSHOT_CONFIG", () => {
+  test("has expected default values", () => {
+    expect(DEFAULT_SNAPSHOT_CONFIG.enabled).toBe(true);
+    expect(DEFAULT_SNAPSHOT_CONFIG.keepLast).toBe(7);
+    expect(DEFAULT_SNAPSHOT_CONFIG.intervalMs).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+/*
+ * D-CANDIDATES (DEFENSIVE / UNREACHABLE branches — NOT tested)
+ *
+ * line 142 — `row?.c ?? 0` (snapCount fallback in previewRestore):
+ *   BunDatabase.query("SELECT COUNT(*) as c …").get() always returns a row
+ *   object with a numeric `c` when the table exists. The `undefined` branch
+ *   is a TypeScript-safety cast artifact; no runtime path reaches it.
+ *
+ * line 150 — `row?.c ?? 0` (liveCount fallback in previewRestore):
+ *   Same reasoning as line 142 — COUNT(*) on a real SQLite table is never null.
+ *   The missing-table case is caught by the surrounding try/catch (liveCount
+ *   stays 0 from the `let` initialisation, not from `?? 0`).
+ *
+ * line 160 — `Number.isFinite(tsMs) ? tsMs : 0` FALSE arm (tsMs non-finite):
+ *   `tsStr` is either the regex-captured digit string (parseInt → always finite
+ *   for JS digit strings) or the literal "0" when the regex doesn't match
+ *   (parseInt("0") = 0, which is finite). There is no realistic input that
+ *   reaches this arm; it is a belt-and-suspenders guard.
+ */

--- a/packages/gateway/src/db/verify.test.ts
+++ b/packages/gateway/src/db/verify.test.ts
@@ -1,7 +1,8 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { LocalIndex } from "../index/local-index.ts";
-import { verifyIndex } from "./verify.ts";
+import type { VerifyFinding, VerifyResult } from "./verify.ts";
+import { formatVerifyResult, verifyIndex } from "./verify.ts";
 
 let db: Database;
 
@@ -143,5 +144,602 @@ describe("verifyIndex — catch-block coverage via broken queries", () => {
     expect(fts?.status).toBe("fail");
     expect(fts?.detail).toBeDefined();
     fresh.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal fake Database object for catch/defensive branches.
+// Only the methods that verify.ts actually calls are stubbed; everything else
+// delegates to a real in-memory SQLite so unrelated checks stay valid.
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a bun:sqlite Statement returned by db.query() */
+type FakeStmt = {
+  all: (...args: unknown[]) => unknown[];
+  get: (...args: unknown[]) => unknown;
+};
+
+/** Partial shape of bun:sqlite Database that verify.ts touches */
+type FakeDb = {
+  query: (sql: string) => FakeStmt;
+  run: (sql: string) => void;
+};
+
+/** Delegate a real bun:sqlite statement, forwarding variadic params. */
+function delegateStmt(real: Database, sql: string): FakeStmt {
+  return {
+    all(...args: unknown[]) {
+      const stmt = real.query(sql);
+      return (
+        args.length > 0 ? stmt.all(...(args as Parameters<typeof stmt.all>)) : stmt.all()
+      ) as unknown[];
+    },
+    get(...args: unknown[]) {
+      const stmt = real.query(sql);
+      return (
+        args.length > 0 ? stmt.get(...(args as Parameters<typeof stmt.get>)) : stmt.get()
+      ) as unknown;
+    },
+  };
+}
+
+/**
+ * Build a fake Database that delegates all calls to a real backing DB except
+ * for the one SQL fragment listed in `interceptSql`. For that fragment:
+ *   - if `throwOnQuery` is set, `.all()` / `.get()` on the returned statement throws it
+ *   - if `returnNullOnGet` is true, `.get()` returns null (for defensive ?? arms)
+ *   - if `throwOnRun` is set, `db.run()` throws it (for dbRun-routed writes)
+ */
+function makeFakeDb(
+  real: Database,
+  opts: {
+    interceptSql?: string;
+    throwOnQuery?: unknown;
+    returnNullOnGet?: boolean;
+    throwOnRun?: unknown;
+  } = {},
+): Database {
+  const fake: FakeDb = {
+    query(sql: string): FakeStmt {
+      const { interceptSql, throwOnQuery, returnNullOnGet } = opts;
+      const shouldIntercept = interceptSql !== undefined && sql.includes(interceptSql);
+      if (shouldIntercept && throwOnQuery !== undefined) {
+        const thrown = throwOnQuery;
+        return {
+          all() {
+            throw thrown;
+          },
+          get() {
+            throw thrown;
+          },
+        };
+      }
+      if (shouldIntercept && returnNullOnGet === true) {
+        return {
+          all(...args: unknown[]) {
+            return delegateStmt(real, sql).all(...args);
+          },
+          get() {
+            return null;
+          },
+        };
+      }
+      return delegateStmt(real, sql);
+    },
+    run(sql: string): void {
+      if (opts.throwOnRun !== undefined) {
+        throw opts.throwOnRun;
+      }
+      real.run(sql);
+    },
+  };
+  return fake as unknown as Database;
+}
+
+// ---------------------------------------------------------------------------
+// Line 22 FALSE arm: integrity_check returns non-"ok" row
+// ---------------------------------------------------------------------------
+describe("verifyIndex — integrity_check FAIL path", () => {
+  test("integrity_check returns non-ok detail lines → FAIL finding", () => {
+    // Use a real DB that has the full schema so other checks don't interfere,
+    // but override PRAGMA integrity_check to return a corruption row.
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        if (sql.includes("integrity_check")) {
+          return {
+            all() {
+              return [
+                { integrity_check: "*** in database main ***" },
+                { integrity_check: "row 5 missing from index item_fts" },
+              ] as unknown[];
+            },
+            get() {
+              return { integrity_check: "*** in database main ***" };
+            },
+          };
+        }
+        return delegateStmt(real, sql);
+      },
+      run(sql: string): void {
+        real.run(sql);
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, LocalIndex.SCHEMA_VERSION);
+    const ic = result.findings.find((f) => f.label === "integrity_check");
+    expect(ic?.status).toBe("fail");
+    expect(ic?.detail).toContain("row 5 missing");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lines 35 TRUE + FALSE: checkIntegrity catch — Error and non-Error throws
+// ---------------------------------------------------------------------------
+describe("verifyIndex — integrity_check catch branches", () => {
+  test("integrity_check catch TRUE arm: thrown Error → detail is err.message", () => {
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+    const thrownErr = new Error("integrity query exploded");
+    const fakeDb = makeFakeDb(real, {
+      interceptSql: "integrity_check",
+      throwOnQuery: thrownErr,
+    });
+    const result = verifyIndex(fakeDb, LocalIndex.SCHEMA_VERSION);
+    const ic = result.findings.find((f) => f.label === "integrity_check");
+    expect(ic?.status).toBe("fail");
+    expect(ic?.detail).toBe("integrity query exploded");
+    real.close();
+  });
+
+  test("integrity_check catch FALSE arm: thrown non-Error → detail is String(thrown)", () => {
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+    const nonError: unknown = "integrity_check_boom_string";
+    const fakeDb = makeFakeDb(real, {
+      interceptSql: "integrity_check",
+      throwOnQuery: nonError,
+    });
+    const result = verifyIndex(fakeDb, LocalIndex.SCHEMA_VERSION);
+    const ic = result.findings.find((f) => f.label === "integrity_check");
+    expect(ic?.status).toBe("fail");
+    expect(ic?.detail).toBe("integrity_check_boom_string");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Line 59 FALSE: checkFts5Consistency catch — non-Error throw from dbRun
+// (The TRUE arm / Error throw is already covered by the real-table test above;
+// this adds the non-Error arm.)
+// ---------------------------------------------------------------------------
+describe("verifyIndex — fts5_consistency catch non-Error arm", () => {
+  test("fts5 catch FALSE arm: db.run throws non-Error → detail is String(thrown)", () => {
+    // We need item_fts to EXIST (so the check doesn't skip) but db.run to throw
+    // a non-Error when the INSERT is attempted.
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+
+    const nonError: unknown = 42;
+
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        return delegateStmt(real, sql);
+      },
+      run(_sql: string): void {
+        throw nonError;
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, LocalIndex.SCHEMA_VERSION);
+    const fts = result.findings.find((f) => f.label === "fts5_consistency");
+    expect(fts?.status).toBe("fail");
+    expect(fts?.detail).toBe("42");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lines 81 + 82: vecRow?.c ?? 0 and chunkRow?.c ?? 0 defensive ?? arms
+// (both tables exist but .get() returns null/undefined — extremely defensive)
+// ---------------------------------------------------------------------------
+describe("verifyIndex — vec count defensive null arms", () => {
+  test("vecRow null → vecCount defaults to 0, chunkRow null → chunkCount defaults to 0 → ok", () => {
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+
+    // Ensure both tables exist in the real DB (skip if vec extension absent)
+    const hasVec =
+      real
+        .query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='vec_items_384'`)
+        .get() !== null;
+    const hasChunk =
+      real
+        .query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='embedding_chunk'`)
+        .get() !== null;
+
+    if (!hasVec || !hasChunk) {
+      real.close();
+      return; // vec extension not loaded — skip gracefully
+    }
+
+    // Build a fake that returns null for both COUNT queries
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        if (sql.includes("COUNT(*)") && sql.includes("vec_items_384")) {
+          return {
+            all() {
+              return [];
+            },
+            get() {
+              return null;
+            },
+          };
+        }
+        if (sql.includes("COUNT(*)") && sql.includes("embedding_chunk")) {
+          return {
+            all() {
+              return [];
+            },
+            get() {
+              return null;
+            },
+          };
+        }
+        return delegateStmt(real, sql);
+      },
+      run(sql: string): void {
+        real.run(sql);
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, LocalIndex.SCHEMA_VERSION);
+    const vec = result.findings.find((f) => f.label === "vec_rowid_mismatch");
+    // Both default to 0 → counts equal → ok
+    expect(vec?.status).toBe("ok");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lines 99 TRUE + FALSE: checkVecRowidAlignment catch — Error and non-Error
+// ---------------------------------------------------------------------------
+describe("verifyIndex — vec catch branches", () => {
+  test("vec catch TRUE arm: thrown Error → detail is err.message", () => {
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+
+    const hasVec =
+      real
+        .query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='vec_items_384'`)
+        .get() !== null;
+    const hasChunk =
+      real
+        .query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='embedding_chunk'`)
+        .get() !== null;
+
+    if (!hasVec || !hasChunk) {
+      real.close();
+      return;
+    }
+
+    const thrownErr = new Error("vec count exploded");
+    const fakeDb = makeFakeDb(real, {
+      interceptSql: "COUNT(*)",
+      throwOnQuery: thrownErr,
+    });
+
+    const result = verifyIndex(fakeDb, LocalIndex.SCHEMA_VERSION);
+    const vec = result.findings.find((f) => f.label === "vec_rowid_mismatch");
+    expect(vec?.status).toBe("fail");
+    expect(vec?.detail).toBe("vec count exploded");
+    real.close();
+  });
+
+  test("vec catch FALSE arm: thrown non-Error → detail is String(thrown)", () => {
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+
+    const hasVec =
+      real
+        .query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='vec_items_384'`)
+        .get() !== null;
+    const hasChunk =
+      real
+        .query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='embedding_chunk'`)
+        .get() !== null;
+
+    if (!hasVec || !hasChunk) {
+      real.close();
+      return;
+    }
+
+    const nonError: unknown = "vec_count_boom";
+    const fakeDb = makeFakeDb(real, {
+      interceptSql: "COUNT(*)",
+      throwOnQuery: nonError,
+    });
+
+    const result = verifyIndex(fakeDb, LocalIndex.SCHEMA_VERSION);
+    const vec = result.findings.find((f) => f.label === "vec_rowid_mismatch");
+    expect(vec?.status).toBe("fail");
+    expect(vec?.detail).toBe("vec_count_boom");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Line 133: row?.v ?? 0 right arm — MAX(version) over empty _schema_migrations
+// returns a row with v: null, so applied defaults to 0.
+// ---------------------------------------------------------------------------
+describe("verifyIndex — schema_version null MAX(version) arm", () => {
+  test("empty _schema_migrations → MAX(version) null → applied=0; expected=0 → ok", () => {
+    const fresh = new Database(":memory:");
+    // Create _schema_migrations without any rows so MAX(version) returns null
+    fresh.run(
+      "CREATE TABLE _schema_migrations (version INTEGER NOT NULL, applied_at TEXT NOT NULL)",
+    );
+    // PRAGMA user_version defaults to 0; expected=0 → both match → ok
+    const result = verifyIndex(fresh, 0);
+    const sv = result.findings.find((f) => f.label === "schema_version");
+    expect(sv?.status).toBe("ok");
+    fresh.close();
+  });
+
+  test("empty _schema_migrations → applied=0; expected=5 → fail with applied=0", () => {
+    const fresh = new Database(":memory:");
+    fresh.run(
+      "CREATE TABLE _schema_migrations (version INTEGER NOT NULL, applied_at TEXT NOT NULL)",
+    );
+    const result = verifyIndex(fresh, 5);
+    const sv = result.findings.find((f) => f.label === "schema_version");
+    expect(sv?.status).toBe("fail");
+    expect(sv?.detail).toContain("applied=0");
+    fresh.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Line 144: uvRow?.user_version ?? 0 right arm — fake db returns null for
+// PRAGMA user_version so uv defaults to 0.
+// ---------------------------------------------------------------------------
+describe("verifyIndex — schema_version uvRow null arm", () => {
+  test("uvRow null for PRAGMA user_version → uv defaults to 0", () => {
+    const real = new Database(":memory:");
+    // Create _schema_migrations with a version=5 row so applied=5 but uv→null→0
+    real.run(
+      "CREATE TABLE _schema_migrations (version INTEGER NOT NULL, applied_at TEXT NOT NULL)",
+    );
+    real.run("INSERT INTO _schema_migrations (version, applied_at) VALUES (5, '2024-01-01')");
+
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        if (sql.includes("user_version")) {
+          return {
+            all() {
+              return [];
+            },
+            get() {
+              return null; // triggers ?? 0 at line 147
+            },
+          };
+        }
+        return delegateStmt(real, sql);
+      },
+      run(sql: string): void {
+        real.run(sql);
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, 5);
+    const sv = result.findings.find((f) => f.label === "schema_version");
+    // applied=5 === expected=5 but uv=0 !== expected=5 → FAIL
+    expect(sv?.status).toBe("fail");
+    expect(sv?.detail).toContain("user_version=0");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Line 147 FALSE right operand: applied === expectedVersion but uv !== expectedVersion
+// Real & reachable: _schema_migrations has version=N but PRAGMA user_version = 0.
+// ---------------------------------------------------------------------------
+describe("verifyIndex — schema_version applied-ok but uv-mismatch", () => {
+  test("applied=N matches expected but user_version=0 → FAIL detail has user_version=0", () => {
+    const fresh = new Database(":memory:");
+    fresh.run(
+      "CREATE TABLE _schema_migrations (version INTEGER NOT NULL, applied_at TEXT NOT NULL)",
+    );
+    // Insert version=5 as applied (applied_at IS NOT NULL)
+    fresh.run("INSERT INTO _schema_migrations (version, applied_at) VALUES (5, '2024-01-01')");
+    // PRAGMA user_version stays at 0 (default) — we do NOT set it to 5
+
+    const result = verifyIndex(fresh, 5);
+    const sv = result.findings.find((f) => f.label === "schema_version");
+    expect(sv?.status).toBe("fail");
+    // applied=5 but uv=0 ≠ 5
+    expect(sv?.detail).toContain("user_version=0");
+    expect(sv?.detail).toContain("applied=5");
+    fresh.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Line 159: checkSchemaVersion outer catch — uvRow?.user_version ?? 0 right arm.
+// Triggered when _schema_migrations is absent (the catch fires) AND a fake db
+// returns null for PRAGMA user_version so the ?? 0 arm executes.
+// ---------------------------------------------------------------------------
+describe("verifyIndex — schema_version outer catch uvRow null arm", () => {
+  test("_schema_migrations missing AND uvRow null → uv defaults to 0 → expected=0 → ok", () => {
+    // No _schema_migrations table → query throws → catch fires.
+    // Inside catch, PRAGMA user_version returns null → ?? 0 → uv=0; expected=0 → ok.
+    const real = new Database(":memory:");
+    // real has no _schema_migrations — query will throw
+
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        if (sql.includes("user_version")) {
+          return {
+            all() {
+              return [];
+            },
+            get() {
+              return null; // triggers ?? 0 at line 159
+            },
+          };
+        }
+        return delegateStmt(real, sql);
+      },
+      run(sql: string): void {
+        real.run(sql);
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, 0);
+    const sv = result.findings.find((f) => f.label === "schema_version");
+    // uv=0 and expected=0 → ok
+    expect(sv?.status).toBe("ok");
+    real.close();
+  });
+
+  test("_schema_migrations missing AND uvRow null → uv defaults to 0 → expected=3 → fail", () => {
+    const real = new Database(":memory:");
+
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        if (sql.includes("user_version")) {
+          return {
+            all() {
+              return [];
+            },
+            get() {
+              return null;
+            },
+          };
+        }
+        return delegateStmt(real, sql);
+      },
+      run(sql: string): void {
+        real.run(sql);
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, 3);
+    const sv = result.findings.find((f) => f.label === "schema_version");
+    expect(sv?.status).toBe("fail");
+    expect(sv?.detail).toContain("_schema_migrations table missing");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lines 196 TRUE + FALSE: checkForeignKeyIntegrity catch — Error and non-Error.
+// db.run throws inside dbRun → dbRun rethrows → verify's catch fires.
+// ---------------------------------------------------------------------------
+describe("verifyIndex — fk catch branches", () => {
+  test("fk catch TRUE arm: db.run throws Error → detail is err.message", () => {
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+
+    const thrownErr = new Error("fk pragma exploded");
+
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        return delegateStmt(real, sql);
+      },
+      run(_sql: string): void {
+        throw thrownErr;
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, LocalIndex.SCHEMA_VERSION);
+    const fk = result.findings.find((f) => f.label === "foreign_key_integrity");
+    expect(fk?.status).toBe("fail");
+    expect(fk?.detail).toBe("fk pragma exploded");
+    real.close();
+  });
+
+  test("fk catch FALSE arm: db.run throws non-Error → detail is String(thrown)", () => {
+    const real = new Database(":memory:");
+    LocalIndex.ensureSchema(real);
+
+    const nonError: unknown = "fk_boom_string";
+
+    const fake: FakeDb = {
+      query(sql: string): FakeStmt {
+        return delegateStmt(real, sql);
+      },
+      run(_sql: string): void {
+        throw nonError;
+      },
+    };
+
+    const result = verifyIndex(fake as unknown as Database, LocalIndex.SCHEMA_VERSION);
+    const fk = result.findings.find((f) => f.label === "foreign_key_integrity");
+    expect(fk?.status).toBe("fail");
+    expect(fk?.detail).toBe("fk_boom_string");
+    real.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVerifyResult: [ok]/[FAIL] tags, detail undefined vs defined, exitCode
+// ---------------------------------------------------------------------------
+describe("formatVerifyResult", () => {
+  // verify.ts: tag = f.status === "ok" ? "[ok]  " : "[FAIL]", then ` ${f.label}`.
+  // So ok lines are "[ok]   <label>" (3 spaces) and fail lines are "[FAIL] <label>" (1 space).
+
+  test("clean result → all [ok] lines, exitCode 0", () => {
+    const result: VerifyResult = {
+      findings: [
+        { label: "integrity_check", status: "ok" },
+        { label: "fts5_consistency", status: "ok", detail: "item_fts not present, skipped" },
+      ],
+      clean: true,
+    };
+    const { output, exitCode } = formatVerifyResult(result);
+    expect(exitCode).toBe(0);
+    expect(output).toContain("[ok]   integrity_check");
+    expect(output).toContain("[ok]   fts5_consistency: item_fts not present, skipped");
+  });
+
+  test("result with a failure → [FAIL] line, exitCode 1", () => {
+    const result: VerifyResult = {
+      findings: [
+        { label: "integrity_check", status: "ok" },
+        {
+          label: "schema_version",
+          status: "fail",
+          detail: "applied=0, user_version=0, expected=5",
+        },
+      ],
+      clean: false,
+    };
+    const { output, exitCode } = formatVerifyResult(result);
+    expect(exitCode).toBe(1);
+    expect(output).toContain("[ok]   integrity_check");
+    expect(output).toContain("[FAIL] schema_version: applied=0");
+  });
+
+  test("finding with undefined detail → no colon appended", () => {
+    const finding: VerifyFinding = { label: "vec_rowid_mismatch", status: "ok" };
+    const result: VerifyResult = { findings: [finding], clean: true };
+    const { output } = formatVerifyResult(result);
+    // tag "[ok]  " + " " + label = "[ok]   vec_rowid_mismatch", no trailing colon
+    expect(output).toBe("[ok]   vec_rowid_mismatch");
+  });
+
+  test("finding with defined detail → colon+detail appended", () => {
+    const finding: VerifyFinding = {
+      label: "fts5_consistency",
+      status: "ok",
+      detail: "skipped",
+    };
+    const result: VerifyResult = { findings: [finding], clean: true };
+    const { output } = formatVerifyResult(result);
+    expect(output).toBe("[ok]   fts5_consistency: skipped");
   });
 });

--- a/packages/gateway/src/db/write.test.ts
+++ b/packages/gateway/src/db/write.test.ts
@@ -1,6 +1,14 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
-import { DiskFullError, dbExec, dbRun, dbStmtRun } from "./write.ts";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  DiskFullError,
+  dbExec,
+  dbRun,
+  dbStmtRun,
+  isDiskSpaceWarning,
+  onDiskFull,
+  setDiskSpaceWarning,
+} from "./write.ts";
 
 describe("dbRun", () => {
   test("returns Bun's RunResult shape on a normal INSERT", () => {
@@ -125,5 +133,344 @@ describe("dbStmtRun", () => {
     expect(caught).toBeInstanceOf(DiskFullError);
     stmt.finalize();
     db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDiskSpaceWarning / setDiskSpaceWarning / onDiskFull — unit tests
+// ---------------------------------------------------------------------------
+
+describe("isDiskSpaceWarning", () => {
+  afterEach(() => {
+    setDiskSpaceWarning(false);
+  });
+
+  test("returns false by default", () => {
+    // Reset first — prior suites (real SQLite FULL tests) may have left the flag set
+    setDiskSpaceWarning(false);
+    expect(isDiskSpaceWarning()).toBe(false);
+  });
+
+  test("returns true after setDiskSpaceWarning(true)", () => {
+    setDiskSpaceWarning(true);
+    expect(isDiskSpaceWarning()).toBe(true);
+  });
+
+  test("returns false after toggling back to false", () => {
+    setDiskSpaceWarning(true);
+    setDiskSpaceWarning(false);
+    expect(isDiskSpaceWarning()).toBe(false);
+  });
+});
+
+describe("setDiskSpaceWarning — listener notification", () => {
+  afterEach(() => {
+    setDiskSpaceWarning(false);
+  });
+
+  test("fires registered onDiskFull listeners when transitioning false→true", () => {
+    let fired = 0;
+    const unsub = onDiskFull(() => {
+      fired++;
+    });
+    setDiskSpaceWarning(true);
+    expect(fired).toBe(1);
+    unsub();
+  });
+
+  test("does NOT fire listeners when already true→true (no re-fire)", () => {
+    setDiskSpaceWarning(true);
+    let fired = 0;
+    const unsub = onDiskFull(() => {
+      fired++;
+    });
+    setDiskSpaceWarning(true);
+    expect(fired).toBe(0);
+    unsub();
+  });
+
+  test("does NOT fire listeners when transitioning true→false", () => {
+    setDiskSpaceWarning(true);
+    let fired = 0;
+    const unsub = onDiskFull(() => {
+      fired++;
+    });
+    setDiskSpaceWarning(false);
+    expect(fired).toBe(0);
+    unsub();
+  });
+
+  test("swallows a listener that throws — setDiskSpaceWarning does not throw", () => {
+    const unsub = onDiskFull(() => {
+      throw new Error("listener explosion");
+    });
+    expect(() => setDiskSpaceWarning(true)).not.toThrow();
+    unsub();
+  });
+
+  test("fires multiple listeners and swallows a throwing one without skipping later ones", () => {
+    const calls: string[] = [];
+    const unsub1 = onDiskFull(() => {
+      calls.push("before");
+    });
+    const unsub2 = onDiskFull(() => {
+      throw new Error("middle explodes");
+    });
+    const unsub3 = onDiskFull(() => {
+      calls.push("after");
+    });
+
+    expect(() => setDiskSpaceWarning(true)).not.toThrow();
+    expect(calls).toEqual(["before", "after"]);
+
+    unsub1();
+    unsub2();
+    unsub3();
+  });
+});
+
+describe("onDiskFull — unsubscribe", () => {
+  afterEach(() => {
+    setDiskSpaceWarning(false);
+  });
+
+  test("unsubscribed listener is not called on subsequent false→true transition", () => {
+    let fired = 0;
+    const unsub = onDiskFull(() => {
+      fired++;
+    });
+    unsub();
+    setDiskSpaceWarning(true);
+    expect(fired).toBe(0);
+  });
+
+  test("calling unsubscribe twice is a safe no-op", () => {
+    const unsub = onDiskFull(() => {
+      /* nothing */
+    });
+    unsub();
+    expect(() => unsub()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSqliteFull / handleWriteError — fake-db error-path coverage
+// ---------------------------------------------------------------------------
+
+describe("DiskFullError via fake db — numeric code paths", () => {
+  afterEach(() => {
+    setDiskSpaceWarning(false);
+  });
+
+  test("dbRun throws DiskFullError and sets warning when error.code === 13 (SQLITE_FULL low-byte)", () => {
+    const err: unknown = Object.assign(new Error("disk full"), { code: 13 });
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    expect(() => dbRun(fakeDb, "INSERT INTO t VALUES (1)")).toThrow(DiskFullError);
+    expect(isDiskSpaceWarning()).toBe(true);
+  });
+
+  test("dbRun DiskFullError carries the original error as cause", () => {
+    const original: unknown = Object.assign(new Error("disk full"), { code: 13 });
+    const fakeDb = {
+      run() {
+        throw original;
+      },
+      exec() {
+        throw original;
+      },
+    } as unknown as Database;
+    let caught: unknown;
+    try {
+      dbRun(fakeDb, "INSERT INTO t VALUES (1)");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(DiskFullError);
+    expect((caught as DiskFullError).cause).toBe(original);
+  });
+
+  test("dbRun throws DiskFullError for code with SQLITE_FULL in high bits (code & 0xff === 13)", () => {
+    // e.g. SQLITE_FULL | extended-error-code = 0x010D (269)
+    const err: unknown = Object.assign(new Error("disk full extended"), { code: 269 });
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    expect(() => dbRun(fakeDb, "INSERT INTO t VALUES (1)")).toThrow(DiskFullError);
+  });
+
+  test("dbExec throws DiskFullError and sets warning when error.code === 13", () => {
+    const err: unknown = Object.assign(new Error("disk full"), { code: 13 });
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    expect(() => dbExec(fakeDb, "INSERT INTO t VALUES (1)")).toThrow(DiskFullError);
+    expect(isDiskSpaceWarning()).toBe(true);
+  });
+
+  test("dbStmtRun throws DiskFullError and sets warning when error.code === 13", () => {
+    const err: unknown = Object.assign(new Error("disk full"), { code: 13 });
+    const fakeStmt: { run: () => unknown } = {
+      run() {
+        throw err;
+      },
+    };
+    expect(() => dbStmtRun(fakeStmt)).toThrow(DiskFullError);
+    expect(isDiskSpaceWarning()).toBe(true);
+  });
+});
+
+describe("DiskFullError via fake db — string code path", () => {
+  afterEach(() => {
+    setDiskSpaceWarning(false);
+  });
+
+  test("dbRun throws DiskFullError when error.code === 'SQLITE_FULL'", () => {
+    const err: unknown = Object.assign(new Error("disk full string"), { code: "SQLITE_FULL" });
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    expect(() => dbRun(fakeDb, "INSERT INTO t VALUES (1)")).toThrow(DiskFullError);
+    expect(isDiskSpaceWarning()).toBe(true);
+  });
+
+  test("dbExec throws DiskFullError when error.code === 'SQLITE_FULL'", () => {
+    const err: unknown = Object.assign(new Error("disk full string"), { code: "SQLITE_FULL" });
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    expect(() => dbExec(fakeDb, "INSERT INTO t VALUES (1)")).toThrow(DiskFullError);
+  });
+
+  test("non-SQLITE_FULL string code is rethrown verbatim by dbRun", () => {
+    const err: unknown = Object.assign(new Error("busy"), { code: "SQLITE_BUSY" });
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    let caught: unknown;
+    try {
+      dbRun(fakeDb, "INSERT INTO t VALUES (1)");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(err);
+    expect(caught).not.toBeInstanceOf(DiskFullError);
+  });
+});
+
+describe("isSqliteFull — non-object error paths", () => {
+  afterEach(() => {
+    setDiskSpaceWarning(false);
+  });
+
+  test("dbRun rethrows a thrown string (non-object) verbatim", () => {
+    const fakeDb = {
+      run() {
+        throw "raw string error";
+      },
+      exec() {
+        throw "raw string error";
+      },
+    } as unknown as Database;
+    let caught: unknown;
+    try {
+      dbRun(fakeDb, "INSERT INTO t VALUES (1)");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe("raw string error");
+    expect(isDiskSpaceWarning()).toBe(false);
+  });
+
+  test("dbRun rethrows null verbatim (null is not an object for isSqliteFull)", () => {
+    const fakeDb = {
+      run() {
+        throw null;
+      },
+      exec() {
+        throw null;
+      },
+    } as unknown as Database;
+    let caught: unknown;
+    try {
+      dbRun(fakeDb, "INSERT INTO t VALUES (1)");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeNull();
+    expect(isDiskSpaceWarning()).toBe(false);
+  });
+
+  test("dbRun rethrows a non-SQLITE_FULL numeric code verbatim", () => {
+    // code 5 = SQLITE_BUSY — should NOT trigger DiskFullError
+    const err: unknown = Object.assign(new Error("busy"), { code: 5 });
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    let caught: unknown;
+    try {
+      dbRun(fakeDb, "INSERT INTO t VALUES (1)");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(err);
+    expect(caught).not.toBeInstanceOf(DiskFullError);
+    expect(isDiskSpaceWarning()).toBe(false);
+  });
+
+  test("dbRun rethrows an object with no code property verbatim", () => {
+    const err: unknown = { message: "no code here" };
+    const fakeDb = {
+      run() {
+        throw err;
+      },
+      exec() {
+        throw err;
+      },
+    } as unknown as Database;
+    let caught: unknown;
+    try {
+      dbRun(fakeDb, "INSERT INTO t VALUES (1)");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(err);
+    expect(caught).not.toBeInstanceOf(DiskFullError);
   });
 });


### PR DESCRIPTION
## Sub-project B4 — gateway/db branch-coverage close-out

Raises all **9** below-floor `gateway/db` files to **≥80% branch** (≥80% line for `write.ts`) on Linux CI. Baseline drops **147→138** — a pure 9-file removal with **no untouched-file drift** (Docker-Linux reseed; diff is removals only).

### Files cleared

| File | Was (branch) | Note |
|---|---|---|
| `latency-ring-buffer.ts` | 78.13 | **clock DI seam** — `now: () => number = Date.now` on `flushLatencyBuffer` + `readLatencyPercentilesFromDb`; makes the retention-cutoff branches deterministic. This is the recurring timing-flaky file the program kept deferring — fixed for real (no more Docker-vs-CI drift). |
| `snapshot.ts` | 62.96 | real fs+sqlite: malformed filename skip, disabled scheduler, `humanBytes` tiers |
| `query-guard.ts` | 66.67 | real Worker round-trips + pure guard assertions (guard holds) |
| `repair.ts` | 66.67 | real index schema: vec/fts5/sync/FK repairs + non-Error catch arms via delegating proxy db; **I9 unsafe-identifier guard preserved** |
| `verify.ts` | 74.07 | real sqlite + type-safe delegating fakes for catch/`?? 0` arms |
| `audit-verify.ts` | 75.00 | pre-V33 column path, GENESIS fallback, tamper detection |
| `backup-manifest.ts` | 75.00 | missing-file mismatch |
| `metrics.ts` | 77.78 | real sqlite + fake-db for defensive raw-SQL-cast arms |
| `write.ts` | 76.19 (line) | I14 `DiskFullError` paths + disk-full listener notify/unsubscribe |

### Approach
- **TDD per file** (subagent-driven), real in-memory `bun:sqlite` + DI / type-safe fakes (cast through `unknown`). **No `any`, no `mock.module`, no `biome-ignore`.**
- **Security-invariant files assert the guard HOLDS, never weakened:** `write.ts` (I14) — `DiskFullError` on `SQLITE_FULL`, rethrow otherwise; `repair.ts` (I9) — `escapeIdentifier`/bound-param, unsafe-identifier guard kept as a documented D-candidate; `query-guard.ts` — forbidden keywords throw, PRAGMA allowlist enforced.
- Genuinely-unreachable defensive arms (e.g. `?? 0` on COUNT results, the I9 guard) left per spec §5.2 — no fabricated paths, no ignore comments.

### Verification
- `bun test src/db/` — **246 pass, 0 fail**; `tsc --noEmit` clean.
- `security-invariants.test.ts` — 66/66; static `audit:invariants` — clean.
- Docker-Linux reseed → `coverage-floor: ok (138 baselined; 927 scanned)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Significantly expanded test coverage across database areas: audit chain, backup manifests, latency/metrics, query guards, repair, snapshots, verification, and write/disk-full behavior.

* **Refactor**
  * Improved test determinism and cleanup; made latency/retention timing injectable to enable reliable tests and pruning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->