### PR TITLE
test(coverage): B6 — gateway/connectors Google+MS 365 family to ≥80% branch (130→115)

### DIFF
--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-06-11T13:21:31.943Z",
+  "generated_at": "2026-06-11T14:39:34.500Z",
   "files": {
     "packages/cli/src/commands/audit.ts": {
       "min_line_pct": 80,
@@ -134,18 +134,6 @@
       "min_line_pct": 80,
       "min_branch_pct": 76.56
     },
-    "packages/gateway/src/connectors/_lib/gmail/api.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 58.97
-    },
-    "packages/gateway/src/connectors/_lib/gmail/cursor.ts": {
-      "min_line_pct": 78.57,
-      "min_branch_pct": 76
-    },
-    "packages/gateway/src/connectors/_lib/gmail/history.ts": {
-      "min_line_pct": 68.52,
-      "min_branch_pct": 47.22
-    },
     "packages/gateway/src/connectors/_lib/http.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 76.92
@@ -157,14 +145,6 @@
     "packages/gateway/src/connectors/_lib/rate-limit-observer.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 77.78
-    },
-    "packages/gateway/src/connectors/_lib/teams/api.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 66.67
-    },
-    "packages/gateway/src/connectors/_lib/teams/cursor.ts": {
-      "min_line_pct": 69.84,
-      "min_branch_pct": 74.36
     },
     "packages/gateway/src/connectors/athena-sync.ts": {
       "min_line_pct": 80,
@@ -242,26 +222,6 @@
       "min_line_pct": 80,
       "min_branch_pct": 66.67
     },
-    "packages/gateway/src/connectors/gmail-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 60.87
-    },
-    "packages/gateway/src/connectors/google-drive-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 78.38
-    },
-    "packages/gateway/src/connectors/google-meet-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 79.31
-    },
-    "packages/gateway/src/connectors/google-photos-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 64.44
-    },
-    "packages/gateway/src/connectors/google-sync-shared.ts": {
-      "min_line_pct": 76.32,
-      "min_branch_pct": 66.67
-    },
     "packages/gateway/src/connectors/great-expectations-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 63.29
@@ -273,10 +233,6 @@
     "packages/gateway/src/connectors/jira-sync.ts": {
       "min_line_pct": 75.19,
       "min_branch_pct": 52.76
-    },
-    "packages/gateway/src/connectors/json-unknown.ts": {
-      "min_line_pct": 66.67,
-      "min_branch_pct": 80
     },
     "packages/gateway/src/connectors/launchdarkly-sync.ts": {
       "min_line_pct": 80,
@@ -290,10 +246,6 @@
       "min_line_pct": 80,
       "min_branch_pct": 68.57
     },
-    "packages/gateway/src/connectors/microsoft-graph-sync-shared.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 67.57
-    },
     "packages/gateway/src/connectors/notion-sync.ts": {
       "min_line_pct": 78.46,
       "min_branch_pct": 58.16
@@ -306,17 +258,9 @@
       "min_line_pct": 80,
       "min_branch_pct": 79.63
     },
-    "packages/gateway/src/connectors/onedrive-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 73.68
-    },
     "packages/gateway/src/connectors/openapi-indexer-config.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 78.38
-    },
-    "packages/gateway/src/connectors/outlook-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 56.41
     },
     "packages/gateway/src/connectors/pagerduty-sync.ts": {
       "min_line_pct": 80,
@@ -389,10 +333,6 @@
     "packages/gateway/src/index/drift-hints.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 78.26
-    },
-    "packages/gateway/src/index/item-store.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 79.07
     },
     "packages/gateway/src/index/local-index.ts": {
       "min_line_pct": 80,

--- a/packages/gateway/src/connectors/_lib/gmail/api.test.ts
+++ b/packages/gateway/src/connectors/_lib/gmail/api.test.ts
@@ -1,0 +1,495 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { itemPrimaryKey } from "../../../index/item-store.ts";
+import {
+  createOAuthConnectorTestSetup,
+  registerGlobalFetchRestore,
+  requestUrlString,
+} from "../../../testing/bun-test-support.ts";
+import type { GmailMessageResource, MessagePayload } from "./api.ts";
+import {
+  extractErrorMessage,
+  fetchMessageMetadataOrNullOn404,
+  fetchProfile,
+  gmailFetchJson,
+  headerFrom,
+  listQueryForInitial,
+  parseHistoryList,
+  parseMessagesList,
+  upsertGmailMessage,
+} from "./api.ts";
+
+type FetchInput = string | URL | Request;
+
+// ---------------------------------------------------------------------------
+// listQueryForInitial — pure, no network
+// ---------------------------------------------------------------------------
+describe("listQueryForInitial", () => {
+  test("clamps days below 1 to 1", () => {
+    expect(listQueryForInitial(0)).toBe("newer_than:1d");
+    expect(listQueryForInitial(-5)).toBe("newer_than:1d");
+  });
+
+  test("clamps days above 365 to 365", () => {
+    expect(listQueryForInitial(400)).toBe("newer_than:365d");
+  });
+
+  test("floors fractional days", () => {
+    expect(listQueryForInitial(30.9)).toBe("newer_than:30d");
+  });
+
+  test("returns exact day string for valid input", () => {
+    expect(listQueryForInitial(7)).toBe("newer_than:7d");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractErrorMessage — pure, all branches
+// ---------------------------------------------------------------------------
+describe("extractErrorMessage", () => {
+  test("returns message for Error instances (L84 true branch)", () => {
+    expect(extractErrorMessage(new Error("oops"))).toBe("oops");
+  });
+
+  test("returns the string itself when e is a string (L87 true branch)", () => {
+    // Cast through unknown to satisfy no-any rule
+    const thrown: unknown = "something went wrong";
+    expect(extractErrorMessage(thrown)).toBe("something went wrong");
+  });
+
+  test("returns 'Request failed' for non-Error non-string (L84+L87 false branches)", () => {
+    const thrown: unknown = { code: 42 };
+    expect(extractErrorMessage(thrown)).toBe("Request failed");
+
+    const thrownNull: unknown = null;
+    expect(extractErrorMessage(thrownNull)).toBe("Request failed");
+
+    const thrownNum: unknown = 123;
+    expect(extractErrorMessage(thrownNum)).toBe("Request failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// headerFrom — pure, branch coverage
+// ---------------------------------------------------------------------------
+describe("headerFrom", () => {
+  test("returns null when payload is undefined (L127 true branch — !Array.isArray)", () => {
+    expect(headerFrom(undefined, "Subject")).toBeNull();
+  });
+
+  test("returns null when headers is absent from payload (L127 true branch)", () => {
+    const payload: MessagePayload = {};
+    expect(headerFrom(payload, "Subject")).toBeNull();
+  });
+
+  test("returns null when headers is not an array (L127 true branch)", () => {
+    // Force a non-array via unknown cast
+    const payload = { headers: "bad" } as unknown as MessagePayload;
+    expect(headerFrom(payload, "Subject")).toBeNull();
+  });
+
+  test("returns null when no matching header found (loop exhausted, L140 null)", () => {
+    const payload: MessagePayload = {
+      headers: [{ name: "From", value: "a@b.com" }],
+    };
+    expect(headerFrom(payload, "Subject")).toBeNull();
+  });
+
+  test("returns header value when found (case-insensitive)", () => {
+    const payload: MessagePayload = {
+      headers: [
+        { name: "SUBJECT", value: "Hello World" },
+        { name: "From", value: "a@b.com" },
+      ],
+    };
+    expect(headerFrom(payload, "subject")).toBe("Hello World");
+  });
+
+  test("skips headers where name or value is not a string", () => {
+    // h.name undefined, h.value undefined — should be skipped
+    const payload = {
+      headers: [
+        { name: undefined, value: undefined },
+        { name: "Subject", value: "Found" },
+      ],
+    } as unknown as MessagePayload;
+    expect(headerFrom(payload, "Subject")).toBe("Found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMessagesList / parseHistoryList — pure passthrough of asUnknownObjectRecord
+// ---------------------------------------------------------------------------
+describe("parseMessagesList", () => {
+  test("returns empty object for null input", () => {
+    expect(parseMessagesList(null)).toEqual({});
+  });
+
+  test("returns empty object for array input", () => {
+    expect(parseMessagesList([])).toEqual({});
+  });
+
+  test("returns parsed object with messages array", () => {
+    const input: unknown = { messages: [{ id: "m1" }], nextPageToken: "tok" };
+    const result = parseMessagesList(input);
+    expect(result.messages).toEqual([{ id: "m1" }]);
+    expect(result.nextPageToken).toBe("tok");
+  });
+});
+
+describe("parseHistoryList", () => {
+  test("returns empty object for null input", () => {
+    expect(parseHistoryList(null)).toEqual({});
+  });
+
+  test("returns object for valid history shape", () => {
+    const input: unknown = { history: [], historyId: "999" };
+    const result = parseHistoryList(input);
+    expect(result.historyId).toBe("999");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gmailFetchJson + fetchProfile — fetch override tests
+// ---------------------------------------------------------------------------
+describe("gmailFetchJson", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  test("returns json and bytes on 200", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const result = await gmailFetchJson(ctx, "tok", "https://gmail.googleapis.com/test");
+    expect((result.json as Record<string, unknown>)["ok"]).toBe(true);
+    expect(result.bytes).toBeGreaterThan(0);
+  });
+
+  test("throws on non-200 response (covers L101 indirectly via google-sync-shared)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(JSON.stringify({ error: { code: 500, message: "internal" } }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await expect(gmailFetchJson(ctx, "tok", "https://gmail.googleapis.com/test")).rejects.toThrow(
+      "Gmail sync failed: 500",
+    );
+  });
+});
+
+describe("fetchProfile", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  test("returns profile with emailAddress and historyId", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(JSON.stringify({ emailAddress: "user@example.com", historyId: "42" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const profile = await fetchProfile(ctx, "tok");
+    expect(profile.emailAddress).toBe("user@example.com");
+    expect(profile.historyId).toBe("42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchMessageMetadataOrNullOn404 — branch coverage (L101 both arms)
+// ---------------------------------------------------------------------------
+describe("fetchMessageMetadataOrNullOn404", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  test("returns null on 404 response (L101 true branch)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(
+        JSON.stringify({ error: { code: 404, message: "Requested entity was not found." } }),
+        { status: 404, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const result = await fetchMessageMetadataOrNullOn404(ctx, "tok", "msg-gone");
+    expect(result).toBeNull();
+  });
+
+  test("rethrows non-404 errors (L101 false branch — throw e)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(JSON.stringify({ error: { code: 403, message: "Forbidden" } }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await expect(fetchMessageMetadataOrNullOn404(ctx, "tok", "msg-forbidden")).rejects.toThrow(
+      "403",
+    );
+  });
+
+  test("returns resource on success", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("msg-ok")) {
+        return new Response(
+          JSON.stringify({
+            id: "msg-ok",
+            threadId: "th1",
+            snippet: "hello",
+            internalDate: "1700000000000",
+            payload: { headers: [{ name: "Subject", value: "Test" }] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await fetchMessageMetadataOrNullOn404(ctx, "tok", "msg-ok");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("msg-ok");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertGmailMessage — all uncovered branches (L145–L180)
+// ---------------------------------------------------------------------------
+describe("upsertGmailMessage", () => {
+  test("returns early when id is undefined (L145 true branch — id undefined)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m: GmailMessageResource = {};
+    upsertGmailMessage(ctx, m, Date.now());
+    // No row should be inserted
+    const row = db.query("SELECT id FROM item WHERE service = 'gmail'").get();
+    expect(row).toBeNull();
+  });
+
+  test("returns early when id is empty string (L145 true branch — id '')", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m: GmailMessageResource = { id: "" };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db.query("SELECT id FROM item WHERE service = 'gmail'").get();
+    expect(row).toBeNull();
+  });
+
+  test("uses (no subject) when Subject header absent (L148 ?? fallback)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m: GmailMessageResource = {
+      id: "m-nosubj",
+      payload: { headers: [] },
+      snippet: "snip",
+      internalDate: "1700000000000",
+    };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-nosubj")) as { title: string } | null;
+    expect(row?.title).toBe("(no subject)");
+  });
+
+  test("snippet set to '' when snippet is not a string (L148/L149 false branches)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    // snippet as number through unknown to satisfy no-any
+    const m = {
+      id: "m-badsnip",
+      snippet: 999,
+      internalDate: "1700000000000",
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    } as unknown as GmailMessageResource;
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT body_preview FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-badsnip")) as { body_preview: string | null } | null;
+    expect(row?.body_preview).toBe("");
+  });
+
+  test("snippet longer than 512 chars is sliced (L149 true branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const longSnippet = "x".repeat(600);
+    const m: GmailMessageResource = {
+      id: "m-longsnip",
+      snippet: longSnippet,
+      internalDate: "1700000000000",
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT body_preview FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-longsnip")) as { body_preview: string | null } | null;
+    expect(row?.body_preview?.length).toBe(512);
+  });
+
+  test("subject longer than 512 chars is sliced (L173 true branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const longSubject = "A".repeat(600);
+    const m: GmailMessageResource = {
+      id: "m-longsubj",
+      snippet: "snip",
+      internalDate: "1700000000000",
+      payload: { headers: [{ name: "Subject", value: longSubject }] },
+    };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-longsubj")) as { title: string } | null;
+    expect(row?.title.length).toBe(512);
+  });
+
+  test("uses now when internalDate is undefined (L150 true branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const now = 1_700_000_000_000;
+    const m: GmailMessageResource = {
+      id: "m-nodate",
+      snippet: "snip",
+      // internalDate intentionally omitted
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    };
+    upsertGmailMessage(ctx, m, now);
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-nodate")) as { modified_at: number } | null;
+    expect(row?.modified_at).toBe(now);
+  });
+
+  test("uses now when internalDate is non-numeric (L151 false branch — not finite)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const now = 1_700_000_000_000;
+    const m = {
+      id: "m-badinternaldate",
+      snippet: "snip",
+      internalDate: "not-a-number",
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    } as unknown as GmailMessageResource;
+    upsertGmailMessage(ctx, m, now);
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-badinternaldate")) as { modified_at: number } | null;
+    // Number("not-a-number") = NaN, not finite → fallback to now
+    expect(row?.modified_at).toBe(now);
+  });
+
+  test("threadId '' when threadId is not a string (L152 false branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m = {
+      id: "m-badthreadid",
+      snippet: "snip",
+      internalDate: "1700000000000",
+      // threadId as number → non-string
+      threadId: 99,
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    } as unknown as GmailMessageResource;
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT url FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-badthreadid")) as { url: string } | null;
+    // threadId === '' → URL uses message id
+    expect(row?.url).toContain("m-badthreadid");
+    expect(row?.url).not.toContain("99");
+  });
+
+  test("URL uses threadId when threadId is non-empty string (L165 false branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m: GmailMessageResource = {
+      id: "m-withthreadid",
+      threadId: "th-real",
+      snippet: "snip",
+      internalDate: "1700000000000",
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT url, metadata FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-withthreadid")) as {
+      url: string;
+      metadata: string | null;
+    } | null;
+    expect(row?.url).toContain("th-real");
+    // metadata threadId field is set (L180 false branch)
+    const meta = JSON.parse(row?.metadata ?? "{}") as Record<string, unknown>;
+    expect(meta["threadId"]).toBe("th-real");
+  });
+
+  test("metadata threadId is undefined when threadId is '' (L180 true branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m = {
+      id: "m-nothreadid",
+      // threadId will be coerced to '' via non-string
+      snippet: "snip",
+      internalDate: "1700000000000",
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    } as unknown as GmailMessageResource;
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT metadata FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-nothreadid")) as { metadata: string | null } | null;
+    const meta = JSON.parse(row?.metadata ?? "{}") as Record<string, unknown>;
+    // threadId === '' → undefined in metadata
+    expect(meta["threadId"]).toBeUndefined();
+  });
+
+  test("from email present → resolves authorId (L162 false branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m: GmailMessageResource = {
+      id: "m-withauthor",
+      threadId: "th-author",
+      snippet: "snip",
+      internalDate: "1700000000000",
+      payload: {
+        headers: [
+          { name: "Subject", value: "S" },
+          { name: "From", value: "Alice <alice@example.com>" },
+        ],
+      },
+    };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-withauthor")) as { author_id: string | null } | null;
+    // email parsed → author_id should be set (non-null)
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  test("from header absent → authorId is null (L162 true branch — email undefined)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m: GmailMessageResource = {
+      id: "m-noauthor",
+      snippet: "snip",
+      internalDate: "1700000000000",
+      payload: { headers: [{ name: "Subject", value: "S" }] },
+    };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-noauthor")) as { author_id: string | null } | null;
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("from header with displayName included in resolvePersonForSync (L153 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const m: GmailMessageResource = {
+      id: "m-displayname",
+      snippet: "snip",
+      internalDate: "1700000000000",
+      payload: {
+        headers: [
+          { name: "Subject", value: "S" },
+          // Name + email format triggers displayName code path in parseFromHeaderForPerson
+          { name: "From", value: "Bob Smith <bob@example.com>" },
+        ],
+      },
+    };
+    upsertGmailMessage(ctx, m, Date.now());
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "m-displayname")) as { author_id: string | null } | null;
+    expect(row?.author_id).not.toBeNull();
+  });
+});

--- a/packages/gateway/src/connectors/_lib/gmail/cursor.test.ts
+++ b/packages/gateway/src/connectors/_lib/gmail/cursor.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import { encodeNimbusJsonCursor } from "../../nimbus-json-cursor.ts";
+import {
+  decodeGmailSyncCursor,
+  encodeGmailSyncCursor,
+  GMAIL_CURSOR_PREFIX,
+  type GmailSyncCursorV1,
+} from "./cursor.ts";
+
+// Helper: encode an arbitrary object (not necessarily a valid cursor) with the
+// Gmail prefix so that decodeNimbusJsonCursorPayload succeeds and the
+// structural validation inside decodeGmailSyncCursor is exercised.
+function encodeRaw(payload: unknown): string {
+  return encodeNimbusJsonCursor(GMAIL_CURSOR_PREFIX, payload);
+}
+
+// ─── Round-trip: both phases ──────────────────────────────────────────────────
+
+describe("encodeGmailSyncCursor / decodeGmailSyncCursor — round-trips", () => {
+  test("list phase with string pageToken", () => {
+    const cursor: GmailSyncCursorV1 = {
+      v: 1,
+      phase: "list",
+      q: "newer_than:30d",
+      pageToken: "tok1",
+    };
+    const encoded = encodeGmailSyncCursor(cursor);
+    expect(encoded.startsWith(GMAIL_CURSOR_PREFIX)).toBe(true);
+    expect(decodeGmailSyncCursor(encoded)).toEqual(cursor);
+  });
+
+  test("list phase with null pageToken", () => {
+    const cursor: GmailSyncCursorV1 = {
+      v: 1,
+      phase: "list",
+      q: "newer_than:30d",
+      pageToken: null,
+    };
+    expect(decodeGmailSyncCursor(encodeGmailSyncCursor(cursor))).toEqual(cursor);
+  });
+
+  test("delta phase with string pageToken", () => {
+    const cursor: GmailSyncCursorV1 = {
+      v: 1,
+      phase: "delta",
+      startHistoryId: "42000",
+      pageToken: "hp2",
+    };
+    const encoded = encodeGmailSyncCursor(cursor);
+    expect(encoded.startsWith(GMAIL_CURSOR_PREFIX)).toBe(true);
+    expect(decodeGmailSyncCursor(encoded)).toEqual(cursor);
+  });
+
+  test("delta phase with null pageToken", () => {
+    const cursor: GmailSyncCursorV1 = {
+      v: 1,
+      phase: "delta",
+      startHistoryId: "42000",
+      pageToken: null,
+    };
+    expect(decodeGmailSyncCursor(encodeGmailSyncCursor(cursor))).toEqual(cursor);
+  });
+});
+
+// ─── Top-level decode guards ──────────────────────────────────────────────────
+
+describe("decodeGmailSyncCursor — top-level guards", () => {
+  test("wrong prefix → undefined", () => {
+    // decodeNimbusJsonCursorPayload returns undefined when prefix mismatches
+    expect(decodeGmailSyncCursor("nimbus-other:eyJ2IjoxfQ")).toBeUndefined();
+  });
+
+  test("bad base64 after correct prefix → undefined", () => {
+    expect(decodeGmailSyncCursor(`${GMAIL_CURSOR_PREFIX}!!!not-base64`)).toBeUndefined();
+  });
+
+  test("JSON is an array → undefined", () => {
+    // encodeNimbusJsonCursor encodes the array; decodeNimbusJsonCursorPayload
+    // returns it as-is; our guard (Array.isArray) rejects it.
+    expect(decodeGmailSyncCursor(encodeRaw([1, 2, 3]))).toBeUndefined();
+  });
+
+  test("JSON is null → undefined", () => {
+    expect(decodeGmailSyncCursor(encodeRaw(null))).toBeUndefined();
+  });
+
+  test("JSON is a string scalar → undefined", () => {
+    expect(decodeGmailSyncCursor(encodeRaw("hello"))).toBeUndefined();
+  });
+
+  // L48: r["v"] !== 1
+  test("v = 2 → undefined (wrong version)", () => {
+    expect(
+      decodeGmailSyncCursor(encodeRaw({ v: 2, phase: "list", q: "q", pageToken: null })),
+    ).toBeUndefined();
+  });
+
+  test("v missing → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(encodeRaw({ phase: "list", q: "q", pageToken: null })),
+    ).toBeUndefined();
+  });
+
+  test("v = 1 but unknown phase → undefined", () => {
+    expect(decodeGmailSyncCursor(encodeRaw({ v: 1, phase: "unknown", q: "q" }))).toBeUndefined();
+  });
+
+  test("v = 1 but phase missing → undefined", () => {
+    expect(decodeGmailSyncCursor(encodeRaw({ v: 1, q: "q" }))).toBeUndefined();
+  });
+});
+
+// ─── List phase structural guards ────────────────────────────────────────────
+
+describe("decodeGmailSyncCursor — list phase structural guards", () => {
+  // L16: typeof q !== "string"
+  test("q is missing → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(encodeRaw({ v: 1, phase: "list", pageToken: null })),
+    ).toBeUndefined();
+  });
+
+  test("q is a number → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(encodeRaw({ v: 1, phase: "list", q: 42, pageToken: null })),
+    ).toBeUndefined();
+  });
+
+  // L19: pageToken !== null && typeof pageToken !== "string"
+  test("pageToken is a number (non-null, non-string) → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(
+        encodeRaw({ v: 1, phase: "list", q: "newer_than:30d", pageToken: 999 }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("pageToken is an object → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(encodeRaw({ v: 1, phase: "list", q: "newer_than:30d", pageToken: {} })),
+    ).toBeUndefined();
+  });
+
+  test("pageToken is false → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(
+        encodeRaw({ v: 1, phase: "list", q: "newer_than:30d", pageToken: false }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── Delta phase structural guards ───────────────────────────────────────────
+
+describe("decodeGmailSyncCursor — delta phase structural guards", () => {
+  // L28: typeof startHistoryId !== "string"
+  test("startHistoryId missing → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(encodeRaw({ v: 1, phase: "delta", pageToken: null })),
+    ).toBeUndefined();
+  });
+
+  test("startHistoryId is a number → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(
+        encodeRaw({ v: 1, phase: "delta", startHistoryId: 100, pageToken: null }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L28: startHistoryId === ""
+  test("startHistoryId is empty string → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(
+        encodeRaw({ v: 1, phase: "delta", startHistoryId: "", pageToken: null }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L31: pageToken !== null && typeof pageToken !== "string"
+  test("delta pageToken is a number (non-null, non-string) → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(
+        encodeRaw({ v: 1, phase: "delta", startHistoryId: "100", pageToken: 0 }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("delta pageToken is true → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(
+        encodeRaw({ v: 1, phase: "delta", startHistoryId: "100", pageToken: true }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("delta pageToken is an array → undefined", () => {
+    expect(
+      decodeGmailSyncCursor(
+        encodeRaw({ v: 1, phase: "delta", startHistoryId: "100", pageToken: [] }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── GMAIL_CURSOR_PREFIX export ───────────────────────────────────────────────
+
+describe("GMAIL_CURSOR_PREFIX", () => {
+  test("has expected value", () => {
+    expect(GMAIL_CURSOR_PREFIX).toBe("nimbus-gml1:");
+  });
+
+  test("encoded cursor always starts with prefix", () => {
+    const cursor: GmailSyncCursorV1 = {
+      v: 1,
+      phase: "list",
+      q: "test",
+      pageToken: null,
+    };
+    expect(encodeGmailSyncCursor(cursor).startsWith(GMAIL_CURSOR_PREFIX)).toBe(true);
+  });
+});

--- a/packages/gateway/src/connectors/_lib/gmail/history.test.ts
+++ b/packages/gateway/src/connectors/_lib/gmail/history.test.ts
@@ -1,0 +1,488 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+import {
+  createOAuthConnectorTestSetup,
+  registerGlobalFetchRestore,
+  requestUrlString,
+} from "../../../testing/bun-test-support.ts";
+import {
+  applyGmailHistoryRecords,
+  fetchGmailHistoryOrReset,
+  resolveDeltaHistoryId,
+} from "./history.ts";
+
+type FetchInput = string | URL | Request;
+
+interface CapturedLog {
+  obj: unknown;
+  msg: string | undefined;
+}
+
+function capturingLogger(base: Logger): { logger: Logger; warns: CapturedLog[] } {
+  const warns: CapturedLog[] = [];
+  const logger = {
+    ...base,
+    warn: (o: unknown, msg?: string) => {
+      warns.push({ obj: o, msg });
+    },
+  } as unknown as Logger;
+  return { logger, warns };
+}
+
+describe("applyGmailHistoryRecords", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  // L79: hist.history is undefined → empty records loop, returns zero counts
+  test("no history property → returns zeros and empty hist", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const histJson: unknown = { historyId: "500" };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(0);
+    expect(result.itemsDeleted).toBe(0);
+    expect(result.hist.historyId).toBe("500");
+  });
+
+  // L83: messagesAdded undefined → treated as []
+  test("history record with no messagesAdded/messagesDeleted → zeros", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const histJson: unknown = {
+      history: [{ id: "1" }],
+      historyId: "501",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(0);
+    expect(result.itemsDeleted).toBe(0);
+  });
+
+  // L26: message entry where message is undefined → skipped (continue branch)
+  test("messagesAdded entry with undefined message → skipped", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesAdded: [
+            {}, // no message property → message === undefined
+          ],
+        },
+      ],
+      historyId: "502",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(0);
+  });
+
+  // L30: message.id is undefined → skipped
+  test("messagesAdded entry with message but no id → skipped", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesAdded: [
+            { message: { threadId: "t1" } }, // id missing
+          ],
+        },
+      ],
+      historyId: "503",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(0);
+  });
+
+  // L30: message.id is "" → skipped
+  test("messagesAdded entry with empty string id → skipped", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesAdded: [{ message: { id: "", threadId: "t1" } }],
+        },
+      ],
+      historyId: "504",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(0);
+  });
+
+  // L33/L35: message has payload with Subject → hasSubject=true → use m directly (no fetch)
+  test("messagesAdded entry with payload+Subject → upserted without fetch", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("should not be called", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesAdded: [
+            {
+              message: {
+                id: "msg1",
+                threadId: "th1",
+                snippet: "hello",
+                internalDate: "1700000000000",
+                labelIds: ["INBOX"],
+                payload: {
+                  headers: [
+                    { name: "Subject", value: "Test Subject" },
+                    { name: "From", value: "sender@example.com" },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+      historyId: "505",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(1);
+    expect(fetchCalled).toBe(false);
+  });
+
+  // L35 false branch: message has no payload → hasSubject=false → fetch is called
+  // Also covers L33's false path for hasSubject
+  test("messagesAdded entry without payload → fetches metadata", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages/msg2")) {
+        return new Response(
+          JSON.stringify({
+            id: "msg2",
+            threadId: "th2",
+            snippet: "fetched snippet",
+            internalDate: "1700000000000",
+            labelIds: ["INBOX"],
+            payload: {
+              headers: [
+                { name: "Subject", value: "Fetched Subject" },
+                { name: "From", value: "other@example.com" },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesAdded: [
+            {
+              message: {
+                id: "msg2",
+                threadId: "th2",
+                // no payload → hasSubject = false → fetch path
+              },
+            },
+          ],
+        },
+      ],
+      historyId: "506",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(1);
+  });
+
+  // L35 false branch + 404 fetch → warn + continue
+  test("messagesAdded fetch returns 404 → warns and skips", async () => {
+    const setup = await createOAuthConnectorTestSetup("google");
+    const { logger, warns } = capturingLogger(setup.ctx.logger);
+    const ctx = { ...setup.ctx, logger };
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages/gone1")) {
+        return new Response(JSON.stringify({ error: { code: 404, message: "Not Found" } }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesAdded: [{ message: { id: "gone1", threadId: "th1" } }],
+        },
+      ],
+      historyId: "507",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsUpserted).toBe(0);
+    const w = warns.find((entry) => {
+      const o = entry.obj as Record<string, unknown> | null;
+      return o !== null && o["messageId"] === "gone1" && o["stage"] === "delta";
+    });
+    expect(w).toBeDefined();
+  });
+
+  // L60: deleted entry where message.id is undefined → not counted (false branch of typeof check)
+  test("messagesDeleted entry with no message id → not counted", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesDeleted: [
+            {}, // no message at all → mid is undefined
+            { message: {} }, // message exists but no id
+            { message: { id: "" } }, // empty string id
+          ],
+        },
+      ],
+      historyId: "508",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsDeleted).toBe(0);
+  });
+
+  // L60 true branch: deleted entry with valid message.id → counted
+  test("messagesDeleted entry with valid id → counted", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const histJson: unknown = {
+      history: [
+        {
+          id: "1",
+          messagesDeleted: [{ message: { id: "del1" } }],
+        },
+      ],
+      historyId: "509",
+    };
+    const result = await applyGmailHistoryRecords(ctx, "tok", Date.now(), histJson);
+    expect(result.itemsDeleted).toBe(1);
+  });
+});
+
+describe("fetchGmailHistoryOrReset", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  // L97 true branch: pageToken is non-null non-empty → included in URL
+  test("pageToken provided → included in history URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (input: FetchInput) => {
+      capturedUrl = requestUrlString(input);
+      return new Response(JSON.stringify({ history: [], historyId: "200" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await fetchGmailHistoryOrReset(ctx, "tok", {
+      startHistoryId: "100",
+      pageToken: "myPageToken",
+    });
+    expect(result.kind).toBe("ok");
+    expect(capturedUrl).toContain("pageToken=myPageToken");
+  });
+
+  // L97 false branch (null): pageToken null → not included
+  test("pageToken null → not included in history URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (input: FetchInput) => {
+      capturedUrl = requestUrlString(input);
+      return new Response(JSON.stringify({ history: [], historyId: "201" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await fetchGmailHistoryOrReset(ctx, "tok", {
+      startHistoryId: "100",
+      pageToken: null,
+    });
+    expect(result.kind).toBe("ok");
+    expect(capturedUrl).not.toContain("pageToken=");
+  });
+
+  // L97 false branch (empty string): pageToken "" → not included
+  test("pageToken empty string → not included in history URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (input: FetchInput) => {
+      capturedUrl = requestUrlString(input);
+      return new Response(JSON.stringify({ history: [], historyId: "202" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await fetchGmailHistoryOrReset(ctx, "tok", {
+      startHistoryId: "100",
+      pageToken: "",
+    });
+    expect(result.kind).toBe("ok");
+    expect(capturedUrl).not.toContain("pageToken=");
+  });
+
+  // L107 true branch: fetch throws with "404" in message → returns { kind: "reset" }
+  test("gmailFetchJson throws 404 error → returns reset", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ error: { code: 404, message: "Not Found" } }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await fetchGmailHistoryOrReset(ctx, "tok", {
+      startHistoryId: "100",
+      pageToken: null,
+    });
+    expect(result.kind).toBe("reset");
+  });
+
+  // L107 false branch: fetch throws non-404 error → rethrows
+  test("gmailFetchJson throws non-404 error → rethrows", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({ error: { code: 500, message: "Internal Server Error" } }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    await expect(
+      fetchGmailHistoryOrReset(ctx, "tok", {
+        startHistoryId: "100",
+        pageToken: null,
+      }),
+    ).rejects.toThrow();
+  });
+
+  // L107 catch: non-Error thrown value with "404" in its string → reset
+  // (covers extractErrorMessage typeof e === "string" branch + includes("404"))
+  test("string error containing 404 → returns reset", async () => {
+    globalThis.fetch = (async () => {
+      throw "Gmail sync failed: 404 history expired" as unknown;
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await fetchGmailHistoryOrReset(ctx, "tok", {
+      startHistoryId: "100",
+      pageToken: null,
+    });
+    expect(result.kind).toBe("reset");
+  });
+
+  // L107 catch: non-Error thrown value NOT containing "404" → rethrows
+  test("string error without 404 → rethrows", async () => {
+    globalThis.fetch = (async () => {
+      throw "some transient failure" as unknown;
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    await expect(
+      fetchGmailHistoryOrReset(ctx, "tok", {
+        startHistoryId: "100",
+        pageToken: null,
+      }),
+    ).rejects.toBe("some transient failure");
+  });
+});
+
+describe("resolveDeltaHistoryId", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  // L123 true branch: candidate is a non-empty string → returned directly
+  test("valid candidate → returned without fetching profile", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await resolveDeltaHistoryId(ctx, "tok", "12345");
+    expect(result).toBe("12345");
+    expect(fetchCalled).toBe(false);
+  });
+
+  // L123 false branch: candidate undefined → fetches profile
+  test("candidate undefined → fetches profile historyId", async () => {
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(
+          JSON.stringify({ historyId: "99999", emailAddress: "user@example.com" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await resolveDeltaHistoryId(ctx, "tok", undefined);
+    expect(result).toBe("99999");
+  });
+
+  // L123 false branch: candidate "" → fetches profile
+  test("candidate empty string → fetches profile historyId", async () => {
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "88888" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const result = await resolveDeltaHistoryId(ctx, "tok", "");
+    expect(result).toBe("88888");
+  });
+
+  // L128 true branch: profile has no historyId → throws
+  test("profile missing historyId → throws", async () => {
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ emailAddress: "user@example.com" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    await expect(resolveDeltaHistoryId(ctx, "tok", undefined)).rejects.toThrow(
+      "Gmail sync failed: history response missing historyId",
+    );
+  });
+
+  // L128 true branch: profile historyId is empty string → throws
+  test("profile historyId empty string → throws", async () => {
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    await expect(resolveDeltaHistoryId(ctx, "tok", undefined)).rejects.toThrow(
+      "Gmail sync failed: history response missing historyId",
+    );
+  });
+});

--- a/packages/gateway/src/connectors/_lib/teams/api.test.ts
+++ b/packages/gateway/src/connectors/_lib/teams/api.test.ts
@@ -1,0 +1,559 @@
+import { describe, expect, test } from "bun:test";
+import { itemPrimaryKey } from "../../../index/item-store.ts";
+import { createOAuthConnectorTestSetup } from "../../../testing/bun-test-support.ts";
+import {
+  deltaKey,
+  flattenPairs,
+  type GraphTeamsMessage,
+  nextMessageCursorFromDeltaPage,
+  parseChannelsListPage,
+  parseTeamsListPage,
+  TEAMS_GRAPH_BASE,
+  TEAMS_PAGE_SIZE,
+  TEAMS_SERVICE_ID,
+  upsertChannelMessage,
+} from "./api.ts";
+import type { TeamsSyncCursorV1 } from "./cursor.ts";
+import { encodeTeamsSyncCursor } from "./cursor.ts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+describe("teams/api constants", () => {
+  test("TEAMS_SERVICE_ID is teams", () => {
+    expect(TEAMS_SERVICE_ID).toBe("teams");
+  });
+  test("TEAMS_GRAPH_BASE points to Graph v1.0", () => {
+    expect(TEAMS_GRAPH_BASE).toBe("https://graph.microsoft.com/v1.0");
+  });
+  test("TEAMS_PAGE_SIZE is a positive integer", () => {
+    expect(typeof TEAMS_PAGE_SIZE).toBe("number");
+    expect(TEAMS_PAGE_SIZE).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deltaKey
+// ---------------------------------------------------------------------------
+describe("deltaKey", () => {
+  test("joins teamId and channelId with |", () => {
+    expect(deltaKey("t1", "c1")).toBe("t1|c1");
+  });
+  test("works with empty strings", () => {
+    expect(deltaKey("", "")).toBe("|");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flattenPairs
+// ---------------------------------------------------------------------------
+describe("flattenPairs", () => {
+  test("empty input yields empty array", () => {
+    expect(flattenPairs({})).toEqual([]);
+  });
+
+  test("single team single channel", () => {
+    expect(flattenPairs({ t1: ["c1"] })).toEqual([{ teamId: "t1", channelId: "c1" }]);
+  });
+
+  test("multiple teams sorted lexicographically", () => {
+    const result = flattenPairs({ tb: ["c1"], ta: ["c2"] });
+    expect(result[0]?.teamId).toBe("ta");
+    expect(result[1]?.teamId).toBe("tb");
+  });
+
+  test("channels within team sorted lexicographically", () => {
+    const result = flattenPairs({ t1: ["cb", "ca"] });
+    expect(result[0]?.channelId).toBe("ca");
+    expect(result[1]?.channelId).toBe("cb");
+  });
+
+  test("team with no channels (undefined via ?? [])", () => {
+    // Use a type-safe cast via unknown to mimic a record with an undefined entry
+    const input = { t1: undefined } as unknown as Record<string, string[]>;
+    const result = flattenPairs(input);
+    expect(result).toEqual([]);
+  });
+
+  test("multiple teams multiple channels cross product", () => {
+    const result = flattenPairs({ ta: ["c1", "c2"], tb: ["c3"] });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ teamId: "ta", channelId: "c1" });
+    expect(result[1]).toEqual({ teamId: "ta", channelId: "c2" });
+    expect(result[2]).toEqual({ teamId: "tb", channelId: "c3" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTeamsListPage
+// ---------------------------------------------------------------------------
+describe("parseTeamsListPage", () => {
+  test("null input returns empty ids and null nextLink (L110 branch: not array)", () => {
+    const result = parseTeamsListPage(null);
+    expect(result.ids).toEqual([]);
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("non-object input (string) returns empty", () => {
+    const result = parseTeamsListPage("not-an-object");
+    expect(result.ids).toEqual([]);
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("empty object (no value key) returns empty", () => {
+    const result = parseTeamsListPage({});
+    expect(result.ids).toEqual([]);
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("value is not an array (L110 branch: else path)", () => {
+    const result = parseTeamsListPage({ value: "not-an-array" });
+    expect(result.ids).toEqual([]);
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("value array with valid id", () => {
+    const result = parseTeamsListPage({ value: [{ id: "t1" }] });
+    expect(result.ids).toEqual([{ id: "t1" }]);
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("value array: item with empty id is skipped (L114 branch)", () => {
+    const result = parseTeamsListPage({ value: [{ id: "" }, { id: "t2" }] });
+    expect(result.ids).toEqual([{ id: "t2" }]);
+  });
+
+  test("value array: item with non-string id is skipped (L114 branch: typeof !== string)", () => {
+    const result = parseTeamsListPage({ value: [{ id: 42 }, { id: "t3" }] });
+    expect(result.ids).toEqual([{ id: "t3" }]);
+  });
+
+  test("value array: item with no id field is skipped", () => {
+    const result = parseTeamsListPage({ value: [{ name: "foo" }, { id: "t4" }] });
+    expect(result.ids).toEqual([{ id: "t4" }]);
+  });
+
+  test("value array: null item treated as empty object — skipped (L113 branch)", () => {
+    const result = parseTeamsListPage({ value: [null, { id: "t5" }] });
+    expect(result.ids).toEqual([{ id: "t5" }]);
+  });
+
+  test("nextLink present and non-empty (L133 branch: string path)", () => {
+    const result = parseTeamsListPage({
+      value: [],
+      "@odata.nextLink": "https://graph.example.com/next",
+    });
+    expect(result.nextLink).toBe("https://graph.example.com/next");
+  });
+
+  test("nextLink empty string → null (L133 branch: empty string)", () => {
+    const result = parseTeamsListPage({ value: [], "@odata.nextLink": "" });
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("nextLink is a number → null (L133 branch: not string)", () => {
+    const result = parseTeamsListPage({ value: [], "@odata.nextLink": 999 });
+    expect(result.nextLink).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseChannelsListPage
+// ---------------------------------------------------------------------------
+describe("parseChannelsListPage", () => {
+  test("null input returns empty (L133-like branch)", () => {
+    const result = parseChannelsListPage(null);
+    expect(result.channelIds).toEqual([]);
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("value not array (L133 branch)", () => {
+    const result = parseChannelsListPage({ value: 42 });
+    expect(result.channelIds).toEqual([]);
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("archived channel excluded (L138 branch: archived === true)", () => {
+    const result = parseChannelsListPage({
+      value: [
+        { id: "c1", isArchived: true },
+        { id: "c2", isArchived: false },
+      ],
+    });
+    expect(result.channelIds).toEqual(["c2"]);
+  });
+
+  test("channel with empty id excluded (L138 branch: id === '')", () => {
+    const result = parseChannelsListPage({
+      value: [{ id: "", isArchived: false }, { id: "c3" }],
+    });
+    expect(result.channelIds).toEqual(["c3"]);
+  });
+
+  test("channel with non-string id excluded (L138 branch: typeof id !== string)", () => {
+    const result = parseChannelsListPage({
+      value: [{ id: 99 }, { id: "c4" }],
+    });
+    expect(result.channelIds).toEqual(["c4"]);
+  });
+
+  test("null item in value treated as empty object — excluded", () => {
+    const result = parseChannelsListPage({ value: [null, { id: "c5" }] });
+    expect(result.channelIds).toEqual(["c5"]);
+  });
+
+  test("nextLink non-empty string is returned (L146 branch)", () => {
+    const result = parseChannelsListPage({
+      value: [],
+      "@odata.nextLink": "https://next.link",
+    });
+    expect(result.nextLink).toBe("https://next.link");
+  });
+
+  test("nextLink empty string → null (L146 branch)", () => {
+    const result = parseChannelsListPage({ value: [], "@odata.nextLink": "" });
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("nextLink non-string → null", () => {
+    const result = parseChannelsListPage({ value: [], "@odata.nextLink": false });
+    expect(result.nextLink).toBeNull();
+  });
+
+  test("isArchived undefined is treated as not archived (L138: archived !== true)", () => {
+    const result = parseChannelsListPage({ value: [{ id: "c6" }] });
+    expect(result.channelIds).toEqual(["c6"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nextMessageCursorFromDeltaPage
+// ---------------------------------------------------------------------------
+function makeBaseState(overrides?: Partial<TeamsSyncCursorV1>): TeamsSyncCursorV1 {
+  return {
+    v: 1,
+    phase: "messages",
+    teams: [],
+    teamsNext: null,
+    channelTeamIdx: 0,
+    channelsByTeam: {},
+    chanNext: null,
+    pairs: [
+      { teamId: "t1", channelId: "c1" },
+      { teamId: "t1", channelId: "c2" },
+    ],
+    pairIdx: 0,
+    deltaByKey: {},
+    ...overrides,
+  };
+}
+
+describe("nextMessageCursorFromDeltaPage", () => {
+  test("nextLink present: stores nextLink, hasMore=true (L158 branch)", () => {
+    const state = makeBaseState();
+    const page = { "@odata.nextLink": "https://next.page" };
+    const encode = encodeTeamsSyncCursor;
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encode);
+    expect(result.hasMore).toBe(true);
+    expect(result.stored).not.toBeNull();
+  });
+
+  test("nextLink empty string: falls through to deltaLink check (L158 branch: else path)", () => {
+    const state = makeBaseState();
+    const page = {
+      "@odata.nextLink": "",
+      "@odata.deltaLink": "https://delta.link",
+    };
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
+    // deltaLink branch: pairIdx advances from 0 → 1 (< pairs.length=2), hasMore=true
+    expect(result.hasMore).toBe(true);
+    expect(result.stored).not.toBeNull();
+  });
+
+  test("deltaLink present, pairIdx still < pairs.length: hasMore=true (L165 branch)", () => {
+    const state = makeBaseState({ pairIdx: 0 });
+    const page = { "@odata.deltaLink": "https://delta.link" };
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test("deltaLink present, pairIdx reaches pairs.length: pairIdx resets to 0, hasMore=false (L168 branch)", () => {
+    const state = makeBaseState({ pairIdx: 1 }); // pairIdx+1 = 2 >= pairs.length (2)
+    const page = { "@odata.deltaLink": "https://delta.link" };
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("neither nextLink nor deltaLink: falls through to last branch (L179)", () => {
+    const state = makeBaseState({ pairIdx: 0 });
+    const page = {};
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
+    // pairIdx advances 0 → 1 < 2, hasMore=true
+    expect(result.hasMore).toBe(true);
+    expect(result.stored).not.toBeNull();
+  });
+
+  test("last branch, pairIdx reaches pairs.length: pairIdx resets, hasMore=false (L181 branch)", () => {
+    const state = makeBaseState({ pairIdx: 1 }); // pairIdx+1 = 2 >= 2
+    const page = {};
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("nextLink non-string number: falls through (L158: typeof !== string)", () => {
+    const state = makeBaseState();
+    const page = { "@odata.nextLink": 999 } as unknown as { "@odata.nextLink"?: string };
+    const result = nextMessageCursorFromDeltaPage(
+      page as Parameters<typeof nextMessageCursorFromDeltaPage>[0],
+      state,
+      "t1|c1",
+      encodeTeamsSyncCursor,
+    );
+    // No nextLink, no deltaLink → last branch, pairIdx 0→1 < 2, hasMore=true
+    expect(result.hasMore).toBe(true);
+  });
+
+  test("deltaLink empty string: falls through to last branch (L165 branch: empty string)", () => {
+    const state = makeBaseState({ pairIdx: 0 });
+    const page = { "@odata.deltaLink": "" };
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test("single pair state: deltaLink → pairIdx 0+1=1 >= 1, hasMore=false", () => {
+    const state = makeBaseState({
+      pairs: [{ teamId: "t1", channelId: "c1" }],
+      pairIdx: 0,
+    });
+    const page = { "@odata.deltaLink": "https://delta.link" };
+    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
+    expect(result.hasMore).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertChannelMessage
+// ---------------------------------------------------------------------------
+describe("upsertChannelMessage", () => {
+  test("missing id (undefined): returns without upsert (L49 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {};
+    upsertChannelMessage(ctx, "t1", "c1", m, Date.now());
+    const row = db.query("SELECT count(*) as n FROM item WHERE service = 'teams'").get() as {
+      n: number;
+    };
+    expect(row.n).toBe(0);
+  });
+
+  test("empty string id: returns without upsert (L49 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = { id: "" };
+    upsertChannelMessage(ctx, "t1", "c1", m, Date.now());
+    const row = db.query("SELECT count(*) as n FROM item WHERE service = 'teams'").get() as {
+      n: number;
+    };
+    expect(row.n).toBe(0);
+  });
+
+  test("body.content is a string: used as preview source (L53 branch: body defined, content string)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg1",
+      body: { content: "Hello world message", contentType: "text" },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT body_preview FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg1")) as { body_preview: string | null } | null;
+    expect(row).not.toBeNull();
+    expect(row?.body_preview).not.toBe("");
+  });
+
+  test("body undefined: content defaults to empty string (L53 branch: body undefined)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = { id: "msg2" };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT body_preview, title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg2")) as {
+      body_preview: string | null;
+      title: string;
+    } | null;
+    expect(row).not.toBeNull();
+    // No preview, no fromName → title is "(message)" (L63/L64 branch)
+    expect(row?.title).toBe("(message)");
+  });
+
+  test("displayName non-empty: fromName set (L57 branch: defined and non-empty)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg3",
+      from: { user: { displayName: "Alice" } },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg3")) as { title: string } | null;
+    expect(row).not.toBeNull();
+    // No body content, fromName=Alice → L66: "Message from Alice"
+    expect(row?.title).toBe("Message from Alice");
+  });
+
+  test("displayName empty string: fromName remains null (L57 branch: displayName === '')", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg4",
+      from: { user: { displayName: "" } },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg4")) as { title: string } | null;
+    // displayName is empty → fromName stays null → title is "(message)" (L63/L64)
+    expect(row?.title).toBe("(message)");
+  });
+
+  test("displayName undefined: fromName remains null (L57 branch: undefined)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg5",
+      from: { user: { id: "uid-5" } },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    // displayName undefined → fromName null; graphUserId "uid-5" is set → authorId resolved
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg5")) as { author_id: string | null } | null;
+    expect(row).not.toBeNull();
+    // graphUserId is non-empty → resolvePersonForSync called → non-null
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  test("preview non-empty: title derived from preview (L61 branch: trim !== '')", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg6",
+      body: { content: "This is the message body text for preview", contentType: "text" },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg6")) as { title: string } | null;
+    expect(row).not.toBeNull();
+    // preview.trim() !== '' → L62: shortIndexedMessageTitleFromPreview
+    expect(row?.title).not.toBe("(message)");
+    expect(row?.title.length).toBeGreaterThan(0);
+  });
+
+  test("title exceeding 512 chars is truncated (L69 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    // Generate a fromName long enough to push title > 512 (no body, from path L66: "Message from <name>")
+    const longName = "A".repeat(520);
+    const m: GraphTeamsMessage = {
+      id: "msg7",
+      from: { user: { displayName: longName } },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg7")) as { title: string } | null;
+    expect(row).not.toBeNull();
+    expect(row?.title.length).toBe(512);
+  });
+
+  test("graphUserId empty string: authorId is null (L75 branch: graphUserId === '')", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg8",
+      from: { user: { displayName: "Bob", id: "" } },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg8")) as { author_id: string | null } | null;
+    // graphUserId="" → authorId=null (L75 branch: else null)
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("graphUserId undefined: authorId is null (L75 branch: graphUserId undefined)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg9",
+      from: { user: { displayName: "Carol" } },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg9")) as { author_id: string | null } | null;
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("lastModifiedDateTime defined: used for modifiedAt (L78 branch: defined path)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const isoTs = "2024-01-15T10:00:00Z";
+    const m: GraphTeamsMessage = {
+      id: "msg10",
+      lastModifiedDateTime: isoTs,
+      body: { content: "body text" },
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 9_999_999);
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg10")) as { modified_at: number } | null;
+    expect(row).not.toBeNull();
+    // Should NOT be the fallback value
+    expect(row?.modified_at).not.toBe(9_999_999);
+  });
+
+  test("lastModifiedDateTime undefined, createdDateTime defined: used via ?? (L78 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg11",
+      createdDateTime: "2024-02-20T12:00:00Z",
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 8_888_888);
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg11")) as { modified_at: number } | null;
+    expect(row).not.toBeNull();
+    expect(row?.modified_at).not.toBe(8_888_888);
+  });
+
+  test("both undefined: modifiedAt falls back to now (L78 branch: both undefined)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const now = 7_777_777;
+    const m: GraphTeamsMessage = { id: "msg12" };
+    upsertChannelMessage(ctx, "t1", "c1", m, now);
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg12")) as { modified_at: number } | null;
+    expect(row?.modified_at).toBe(now);
+  });
+
+  test("from is undefined: no displayName, no graphUserId (L57/L75 branches, from=undefined)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = { id: "msg13", body: { content: "" } };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT title, author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg13")) as {
+      title: string;
+      author_id: string | null;
+    } | null;
+    expect(row?.title).toBe("(message)");
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("graphUserId defined and displayName null: displayName fallback to graphUserId (L78 in resolvePersonForSync)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const m: GraphTeamsMessage = {
+      id: "msg14",
+      from: { user: { id: "gid-14" } }, // displayName undefined → fromName=null → displayName fallback to graphUserId
+    };
+    upsertChannelMessage(ctx, "t1", "c1", m, 1_000_000);
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("teams", "t1:c1:msg14")) as { author_id: string | null } | null;
+    expect(row?.author_id).not.toBeNull();
+  });
+});

--- a/packages/gateway/src/connectors/_lib/teams/cursor.test.ts
+++ b/packages/gateway/src/connectors/_lib/teams/cursor.test.ts
@@ -1,0 +1,1050 @@
+import { describe, expect, test } from "bun:test";
+import { encodeNimbusJsonCursor } from "../../nimbus-json-cursor.ts";
+import {
+  decodeTeamsSyncCursor,
+  encodeTeamsSyncCursor,
+  initialCursor,
+  parseCursor,
+  TEAMS_CURSOR_PREFIX,
+  type TeamsSyncCursorV1,
+} from "./cursor.ts";
+
+// Helper: encode an arbitrary object (not necessarily a valid cursor) with the
+// Teams prefix so decodeNimbusJsonCursorPayload succeeds and structural
+// validation inside decodeTeamsSyncCursor / isTeamsCursorV1 is exercised.
+function encodeRaw(payload: unknown): string {
+  return encodeNimbusJsonCursor(TEAMS_CURSOR_PREFIX, payload);
+}
+
+// A valid complete cursor for round-trip testing.
+const validCursor: TeamsSyncCursorV1 = {
+  v: 1,
+  phase: "teams",
+  teams: [{ id: "team-1" }],
+  teamsNext: "next-tok",
+  channelTeamIdx: 2,
+  channelsByTeam: { "team-1": ["chan-a", "chan-b"] },
+  chanNext: "ch-tok",
+  pairs: [{ teamId: "team-1", channelId: "chan-a" }],
+  pairIdx: 0,
+  deltaByKey: { "team-1|chan-a": "2026-01-01T00:00:00Z", "team-1|chan-b": null },
+};
+
+// ─── TEAMS_CURSOR_PREFIX ──────────────────────────────────────────────────────
+
+describe("TEAMS_CURSOR_PREFIX", () => {
+  test("has expected value", () => {
+    expect(TEAMS_CURSOR_PREFIX).toBe("nimbus-tms1:");
+  });
+
+  test("encoded cursor always starts with prefix", () => {
+    expect(encodeTeamsSyncCursor(validCursor).startsWith(TEAMS_CURSOR_PREFIX)).toBe(true);
+  });
+});
+
+// ─── initialCursor defaults ───────────────────────────────────────────────────
+
+describe("initialCursor()", () => {
+  test("returns expected defaults", () => {
+    const c = initialCursor();
+    expect(c.v).toBe(1);
+    expect(c.phase).toBe("teams");
+    expect(c.teams).toEqual([]);
+    expect(c.teamsNext).toBeNull();
+    expect(c.channelTeamIdx).toBe(0);
+    expect(c.channelsByTeam).toEqual({});
+    expect(c.chanNext).toBeNull();
+    expect(c.pairs).toEqual([]);
+    expect(c.pairIdx).toBe(0);
+    expect(c.deltaByKey).toEqual({});
+  });
+
+  test("returns a fresh object each call", () => {
+    const a = initialCursor();
+    const b = initialCursor();
+    a.teams.push({ id: "x" });
+    expect(b.teams).toHaveLength(0);
+  });
+});
+
+// ─── parseCursor ─────────────────────────────────────────────────────────────
+
+describe("parseCursor()", () => {
+  test("null → initialCursor()", () => {
+    expect(parseCursor(null)).toEqual(initialCursor());
+  });
+
+  test("empty string → initialCursor()", () => {
+    expect(parseCursor("")).toEqual(initialCursor());
+  });
+
+  test("valid encoded cursor → decoded cursor (round-trip)", () => {
+    const encoded = encodeTeamsSyncCursor(validCursor);
+    expect(parseCursor(encoded)).toEqual(validCursor);
+  });
+
+  // L131: isTeamsCursorV1 returns false → falls back to initialCursor()
+  test("encoded but structurally invalid payload → initialCursor() fallback", () => {
+    const bad = encodeRaw({ v: 1, phase: "teams" /* missing required fields */ });
+    expect(parseCursor(bad)).toEqual(initialCursor());
+  });
+
+  test("wrong prefix → initialCursor() fallback", () => {
+    expect(parseCursor("nimbus-other:eyJ2IjoxfQ")).toEqual(initialCursor());
+  });
+});
+
+// ─── encodeTeamsSyncCursor / decodeTeamsSyncCursor round-trips ───────────────
+
+describe("encodeTeamsSyncCursor / decodeTeamsSyncCursor — round-trips", () => {
+  test("full valid cursor round-trips", () => {
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(validCursor))).toEqual(validCursor);
+  });
+
+  test("channels phase", () => {
+    const c: TeamsSyncCursorV1 = { ...initialCursor(), phase: "channels" };
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(c))).toEqual(c);
+  });
+
+  test("messages phase", () => {
+    const c: TeamsSyncCursorV1 = { ...initialCursor(), phase: "messages" };
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(c))).toEqual(c);
+  });
+
+  test("null teamsNext and chanNext survive round-trip", () => {
+    const c: TeamsSyncCursorV1 = { ...initialCursor(), teamsNext: null, chanNext: null };
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(c))).toEqual(c);
+  });
+
+  test("deltaByKey with null value survives round-trip", () => {
+    const c: TeamsSyncCursorV1 = {
+      ...initialCursor(),
+      deltaByKey: { k1: null, k2: "ts" },
+    };
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(c))).toEqual(c);
+  });
+
+  test("multiple pairs survive round-trip", () => {
+    const c: TeamsSyncCursorV1 = {
+      ...initialCursor(),
+      pairs: [
+        { teamId: "t1", channelId: "c1" },
+        { teamId: "t2", channelId: "c2" },
+      ],
+      pairIdx: 1,
+    };
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(c))).toEqual(c);
+  });
+});
+
+// ─── decodeTeamsSyncCursor — top-level shape guards (L78-L86) ────────────────
+
+describe("decodeTeamsSyncCursor — top-level shape guards", () => {
+  // L78: o is null
+  test("null payload → undefined", () => {
+    expect(decodeTeamsSyncCursor(encodeRaw(null))).toBeUndefined();
+  });
+
+  // L78: o is not an object (string)
+  test("string scalar payload → undefined", () => {
+    expect(decodeTeamsSyncCursor(encodeRaw("hello"))).toBeUndefined();
+  });
+
+  // L78: Array.isArray(o) → true
+  test("array payload → undefined", () => {
+    expect(decodeTeamsSyncCursor(encodeRaw([1, 2, 3]))).toBeUndefined();
+  });
+
+  // L82: r["v"] !== 1
+  test("v = 2 → undefined (wrong version)", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 2,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("v missing → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L86: phase invalid
+  test("unknown phase → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "unknown",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("phase missing → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // Bad prefix / bad base64
+  test("wrong prefix → undefined", () => {
+    expect(decodeTeamsSyncCursor("nimbus-other:eyJ2IjoxfQ")).toBeUndefined();
+  });
+
+  test("bad base64 after correct prefix → undefined", () => {
+    expect(decodeTeamsSyncCursor(`${TEAMS_CURSOR_PREFIX}!!!not-base64`)).toBeUndefined();
+  });
+});
+
+// ─── teamsCursorTeamsEntriesOk guards (L34, L38, L42) ────────────────────────
+
+describe("decodeTeamsSyncCursor — teams array guards", () => {
+  // L34: teams is not an array
+  test("teams is not an array → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: "not-array",
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("teams is null → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: null,
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L38: element is null
+  test("teams contains null entry → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [null],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L38: element is not an object (string)
+  test("teams contains string entry → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: ["team-string"],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L38: element is an array (Array.isArray check)
+  test("teams contains array entry → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [["nested"]],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L42: id is not a string
+  test("teams entry with non-string id → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [{ id: 42 }],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L42: id is empty string
+  test("teams entry with empty string id → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [{ id: "" }],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L42: id is missing
+  test("teams entry with missing id → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [{}],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── teamsNext guard (L93) ────────────────────────────────────────────────────
+
+describe("decodeTeamsSyncCursor — teamsNext guard", () => {
+  // L93: teamsNext !== null && typeof teamsNext !== "string"
+  test("teamsNext is a number → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: 123,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("teamsNext is false → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: false,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("teamsNext is an object → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: {},
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── channelTeamIdx guard (L97-L100) ─────────────────────────────────────────
+
+describe("decodeTeamsSyncCursor — channelTeamIdx guard", () => {
+  // L97: typeof channelTeamIdx !== "number"
+  test("channelTeamIdx is a string → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: "zero",
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L98: !Number.isInteger (float)
+  test("channelTeamIdx is a float → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 1.5,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L99: channelTeamIdx < 0
+  test("channelTeamIdx is negative → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: -1,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── channelsByTeam guard (L105-L110) ────────────────────────────────────────
+
+describe("decodeTeamsSyncCursor — channelsByTeam guard", () => {
+  // L105: channelsByTeam is null
+  test("channelsByTeam is null → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: null,
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L106: typeof channelsByTeam !== "object" (string)
+  test("channelsByTeam is a string → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: "not-an-object",
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L108: Array.isArray(channelsByTeam)
+  test("channelsByTeam is an array → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: ["chan-a"],
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── chanNext guard (L113) ────────────────────────────────────────────────────
+
+describe("decodeTeamsSyncCursor — chanNext guard", () => {
+  // L113: chanNext !== null && typeof chanNext !== "string"
+  test("chanNext is a number → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: 0,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("chanNext is true → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: true,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("chanNext is an array → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: [],
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── teamsCursorPairsEntriesOk guards (L50, L54, L58) ────────────────────────
+
+describe("decodeTeamsSyncCursor — pairs array guards", () => {
+  // L50: pairs is not an array
+  test("pairs is not an array → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: "not-array",
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("pairs is null → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: null,
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L54: pair entry is null
+  test("pairs contains null entry → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [null],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L54: pair entry is not an object (string)
+  test("pairs contains string entry → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: ["string-pair"],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L54: pair entry is an array
+  test("pairs contains array entry → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [["t1", "c1"]],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L58: teamId is not a string
+  test("pair entry with non-string teamId → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [{ teamId: 42, channelId: "c1" }],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L58: channelId is not a string
+  test("pair entry with non-string channelId → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [{ teamId: "t1", channelId: null }],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L58: both missing
+  test("pair entry missing both teamId and channelId → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [{}],
+          pairIdx: 0,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── pairIdx guard (L120) ─────────────────────────────────────────────────────
+
+describe("decodeTeamsSyncCursor — pairIdx guard", () => {
+  // L120: typeof pairIdx !== "number"
+  test("pairIdx is a string → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: "0",
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L120: !Number.isInteger (float)
+  test("pairIdx is a float → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0.5,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L120: pairIdx < 0
+  test("pairIdx is negative → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: -1,
+          deltaByKey: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+// ─── teamsCursorDeltaValuesOk guards (L66, L70) ───────────────────────────────
+
+describe("decodeTeamsSyncCursor — deltaByKey guards", () => {
+  // L66: deltaByKey is null
+  test("deltaByKey is null → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: null,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L66: typeof deltaByKey !== "object" (string)
+  test("deltaByKey is a string → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: "not-an-object",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L66: Array.isArray(deltaByKey)
+  test("deltaByKey is an array → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: ["delta-entry"],
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L70: value is not null and not a string (number)
+  test("deltaByKey value is a number → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: { key1: 42 },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L70: value is boolean
+  test("deltaByKey value is a boolean → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: { key1: true },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // L70: value is an object
+  test("deltaByKey value is an object → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          deltaByKey: { key1: {} },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // Valid: empty deltaByKey is accepted
+  test("empty deltaByKey → valid cursor", () => {
+    const c: TeamsSyncCursorV1 = { ...initialCursor(), deltaByKey: {} };
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(c))).toEqual(c);
+  });
+
+  // Valid: deltaByKey with mixed null/string values
+  test("deltaByKey with mixed null and string values → valid cursor", () => {
+    const c: TeamsSyncCursorV1 = {
+      ...initialCursor(),
+      deltaByKey: { a: "2026-01-01T00:00:00Z", b: null },
+    };
+    expect(decodeTeamsSyncCursor(encodeTeamsSyncCursor(c))).toEqual(c);
+  });
+});
+
+// ─── L143: decodeTeamsSyncCursor returns undefined on malformed ───────────────
+
+describe("decodeTeamsSyncCursor — undefined on malformed", () => {
+  test("partially valid object (missing deltaByKey) → undefined", () => {
+    expect(
+      decodeTeamsSyncCursor(
+        encodeRaw({
+          v: 1,
+          phase: "teams",
+          teams: [],
+          teamsNext: null,
+          channelTeamIdx: 0,
+          channelsByTeam: {},
+          chanNext: null,
+          pairs: [],
+          pairIdx: 0,
+          // deltaByKey omitted
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("numeric literal payload → undefined", () => {
+    expect(decodeTeamsSyncCursor(encodeRaw(42))).toBeUndefined();
+  });
+});

--- a/packages/gateway/src/connectors/gmail-sync.test.ts
+++ b/packages/gateway/src/connectors/gmail-sync.test.ts
@@ -263,4 +263,348 @@ describe("createGmailSyncable", () => {
     });
     expect(skipWarn).toBeDefined();
   });
+
+  // ── New tests for uncovered branches ────────────────────────────────────────
+
+  test("null cursor: empty messages list returns delta cursor with 0 upserts", async () => {
+    // Covers L64 fallback: data.messages is undefined → entries = []
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        // no "messages" key → parseMessagesList returns {} → entries = []
+        return new Response(JSON.stringify({ nextPageToken: "" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "500" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, null);
+    expect(result.itemsUpserted).toBe(0);
+    expect(result.hasMore).toBe(false);
+    const dec = decodeGmailSyncCursor(result.cursor ?? "");
+    expect(dec?.phase).toBe("delta");
+  });
+
+  test("list phase: message with undefined id is skipped", async () => {
+    // Covers L67 TRUE branch: mid === undefined → continue
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        return new Response(
+          JSON.stringify({
+            // entry with no id and one with empty id
+            messages: [{ threadId: "t1" }, { id: "", threadId: "t2" }],
+            nextPageToken: "",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "501" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, null);
+    // Both entries skipped (no id / empty id)
+    expect(result.itemsUpserted).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("list phase: meta.id missing is filled from list entry id; threadId fallback applied", async () => {
+    // Covers L82 (meta.id ?? mid fallback) and L83-L84 (threadId fallback when meta.threadId empty)
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        return new Response(
+          JSON.stringify({
+            messages: [{ id: "mX", threadId: "thX" }],
+            nextPageToken: "",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/gmail/v1/users/me/messages/mX")) {
+        // Return a resource WITHOUT id and WITHOUT threadId so both fallbacks fire
+        return new Response(
+          JSON.stringify({
+            // id intentionally omitted → meta.id will be undefined → fallback to "mX"
+            // threadId intentionally omitted → fallback to e.threadId "thX"
+            snippet: "meta-fallback",
+            internalDate: "1700000000000",
+            labelIds: ["INBOX"],
+            payload: {
+              headers: [
+                { name: "Subject", value: "Fallback Test" },
+                { name: "From", value: "x@y.com" },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "502" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, null);
+    expect(result.itemsUpserted).toBe(1);
+    // Verify the item was upserted using the filled-in id "mX"
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("gmail", "mX")) as { title: string } | null;
+    expect(row?.title).toBe("Fallback Test");
+  });
+
+  test("list phase: nextPageToken present → hasMore=true with list-phase cursor", async () => {
+    // Covers L94 TRUE branch: next token triggers hasMore=true
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        return new Response(
+          JSON.stringify({
+            messages: [],
+            nextPageToken: "page2token",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, null);
+    expect(result.hasMore).toBe(true);
+    const dec = decodeGmailSyncCursor(result.cursor ?? "");
+    expect(dec?.phase).toBe("list");
+    if (dec?.phase === "list") {
+      expect(dec.pageToken).toBe("page2token");
+    }
+  });
+
+  test("list phase: profile returns empty historyId → throws", async () => {
+    // Covers L106 TRUE branch: historyId missing → throws Error
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        return new Response(JSON.stringify({ nextPageToken: "" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        // historyId missing entirely
+        return new Response(JSON.stringify({ emailAddress: "test@example.com" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    await expect(syncable.sync(ctx, null)).rejects.toThrow(
+      "Gmail sync failed: profile missing historyId",
+    );
+  });
+
+  test("non-prefix cursor → reset to initial list sync", async () => {
+    // Covers L129 TRUE branch: cursor doesn't start with GMAIL_CURSOR_PREFIX
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+    let listCalled = false;
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        listCalled = true;
+        return new Response(JSON.stringify({ nextPageToken: "" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "503" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, "some-other-prefix:xyz");
+    expect(listCalled).toBe(true);
+    expect(result.hasMore).toBe(false);
+    const dec = decodeGmailSyncCursor(result.cursor ?? "");
+    expect(dec?.phase).toBe("delta");
+  });
+
+  test("corrupt cursor (valid prefix, invalid payload) → throws", async () => {
+    // Covers L135 TRUE branch: decodeGmailSyncCursor returns undefined → throw
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    // Build a string with the right prefix but garbage base64 body
+    const badCursor = "nimbus-gml1:!!!notbase64!!!";
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response("should not be called", { status: 500 });
+    }) as typeof fetch;
+
+    await expect(syncable.sync(ctx, badCursor)).rejects.toThrow("Gmail sync: corrupt cursor");
+  });
+
+  test("list-phase cursor with pageToken resumes from that pageToken", async () => {
+    // Covers L139 TRUE branch (decoded.phase === "list") and L140 (pageToken passed)
+    // Also covers L58 TRUE branch (pageToken is set → searchParams.set called)
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+    let capturedListUrl = "";
+
+    const cursor = encodeGmailSyncCursor({
+      v: 1,
+      phase: "list",
+      q: "newer_than:30d",
+      pageToken: "resumeToken",
+    });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        capturedListUrl = url;
+        return new Response(JSON.stringify({ messages: [], nextPageToken: "" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "504" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, cursor);
+    expect(result.hasMore).toBe(false);
+    // Verify the pageToken was forwarded in the messages list URL
+    expect(capturedListUrl).toContain("pageToken=resumeToken");
+    const dec = decodeGmailSyncCursor(result.cursor ?? "");
+    expect(dec?.phase).toBe("delta");
+  });
+
+  test("delta phase: history 404 (reset) → falls back to initial list sync", async () => {
+    // Covers L144 TRUE branch: fetched.kind === "reset"
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+    let listCalled = false;
+
+    const cursor = encodeGmailSyncCursor({
+      v: 1,
+      phase: "delta",
+      startHistoryId: "200",
+      pageToken: null,
+    });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/history")) {
+        // Return 404 → fetchGmailHistoryOrReset will return { kind: "reset" }
+        return new Response(
+          JSON.stringify({ error: { code: 404, message: "History not found" } }),
+          { status: 404, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/gmail/v1/users/me/messages?")) {
+        listCalled = true;
+        return new Response(JSON.stringify({ nextPageToken: "" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/gmail/v1/users/me/profile")) {
+        return new Response(JSON.stringify({ historyId: "505" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, cursor);
+    expect(listCalled).toBe(true);
+    expect(result.hasMore).toBe(false);
+    const dec = decodeGmailSyncCursor(result.cursor ?? "");
+    expect(dec?.phase).toBe("delta");
+    if (dec?.phase === "delta") {
+      expect(dec.startHistoryId).toBe("505");
+    }
+  });
+
+  test("delta phase: nextPageToken in history response → hasMore=true with delta cursor", async () => {
+    // Covers L155 TRUE branch: nextPage present → returns hasMore=true delta cursor
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGmailSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    const cursor = encodeGmailSyncCursor({
+      v: 1,
+      phase: "delta",
+      startHistoryId: "300",
+      pageToken: null,
+    });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/gmail/v1/users/me/history")) {
+        return new Response(
+          JSON.stringify({
+            history: [],
+            historyId: "301",
+            nextPageToken: "deltaPage2",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await syncable.sync(ctx, cursor);
+    expect(result.hasMore).toBe(true);
+    const dec = decodeGmailSyncCursor(result.cursor ?? "");
+    expect(dec?.phase).toBe("delta");
+    if (dec?.phase === "delta") {
+      expect(dec.pageToken).toBe("deltaPage2");
+      expect(dec.startHistoryId).toBe("300");
+    }
+  });
 });

--- a/packages/gateway/src/connectors/google-meet-sync.test.ts
+++ b/packages/gateway/src/connectors/google-meet-sync.test.ts
@@ -13,6 +13,7 @@ import {
   encodeGoogleMeetSyncCursor,
   type GoogleMeetSyncCursorV1,
 } from "./google-meet-sync.ts";
+import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 
 describe("Google Meet sync cursor codec", () => {
   test("round-trip", () => {
@@ -26,6 +27,35 @@ describe("Google Meet sync cursor codec", () => {
       decodeGoogleMeetSyncCursor,
       "nimbus-gmeet1:",
     );
+  });
+
+  // L35 branch: o == null (wrong prefix → decodeNimbusJsonCursorPayload returns undefined)
+  test("decodeGoogleMeetSyncCursor returns undefined for wrong prefix", () => {
+    expect(decodeGoogleMeetSyncCursor("nimbus-OTHER:abc")).toBeUndefined();
+  });
+
+  // L35 branch: typeof o !== "object" (payload decodes to a primitive, e.g. a JSON number)
+  test("decodeGoogleMeetSyncCursor returns undefined when payload is a primitive", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gmeet1:", 42);
+    expect(decodeGoogleMeetSyncCursor(raw)).toBeUndefined();
+  });
+
+  // L35 branch: Array.isArray(o) (payload decodes to an array)
+  test("decodeGoogleMeetSyncCursor returns undefined when payload is an array", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gmeet1:", [1, 2, 3]);
+    expect(decodeGoogleMeetSyncCursor(raw)).toBeUndefined();
+  });
+
+  // L39 branch: r["v"] !== 1 (object but wrong version)
+  test("decodeGoogleMeetSyncCursor returns undefined when v field is not 1", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gmeet1:", { v: 2, pageToken: null });
+    expect(decodeGoogleMeetSyncCursor(raw)).toBeUndefined();
+  });
+
+  // L43 branch: pageToken is not null and not a string (e.g. a number)
+  test("decodeGoogleMeetSyncCursor returns undefined when pageToken is not null/string", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gmeet1:", { v: 1, pageToken: 99 });
+    expect(decodeGoogleMeetSyncCursor(raw)).toBeUndefined();
   });
 });
 
@@ -94,6 +124,82 @@ describe("createGoogleMeetSyncable", () => {
     expect(r.itemsUpserted).toBe(1);
     expect(r.hasMore).toBe(false);
     expect(r.cursor).toBeNull();
+  });
+
+  // L85 branch: dec is undefined → dec?.pageToken is undefined → ?? null arm taken
+  // This happens when the cursor has the right prefix but an invalid payload
+  test("corrupt cursor (valid prefix, invalid payload) falls back to pageToken=null", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGoogleMeetSyncable({ ensureGoogleMcpRunning: async () => {} });
+    let capturedUrl = "";
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      capturedUrl = url;
+      return new Response(JSON.stringify({ conferenceRecords: [], nextPageToken: "" }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    // Encode a payload with the right prefix but v !== 1, so decodeGoogleMeetSyncCursor returns undefined
+    const badCursor = encodeNimbusJsonCursor("nimbus-gmeet1:", { v: 99, pageToken: "ignored" });
+    const r = await syncable.sync(ctx, badCursor);
+    // dec is undefined → pageToken falls back to null → no pageToken param in URL
+    expect(capturedUrl).not.toContain("pageToken=");
+    expect(r.hasMore).toBe(false);
+    expect(r.itemsUpserted).toBe(0);
+  });
+
+  // L90 branch: parsed.conferenceRecords is undefined → ?? [] arm taken (empty list)
+  test("response with no conferenceRecords key yields 0 upserts", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGoogleMeetSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("conferenceRecords")) {
+        // Omit the conferenceRecords key entirely
+        return new Response(JSON.stringify({ nextPageToken: "" }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.hasMore).toBe(false);
+    expect(r.cursor).toBeNull();
+  });
+
+  // L95 branch: mapped === null → continue (record with no name is skipped)
+  test("conference record without a name is skipped (mapped === null)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGoogleMeetSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("conferenceRecords")) {
+        return new Response(
+          JSON.stringify({
+            conferenceRecords: [
+              // Record without `name` → mapGoogleMeetRecordToItem returns null
+              { startTime: "2024-03-01T10:00:00Z", endTime: "2024-03-01T11:00:00Z" },
+              // Valid record that should be upserted
+              {
+                name: "conferenceRecords/c99",
+                startTime: "2024-03-01T10:00:00Z",
+                endTime: "2024-03-01T11:00:00Z",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    // The nameless record is skipped, only c99 is upserted
+    expect(r.itemsUpserted).toBe(1);
   });
 
   test("401 throws UnauthenticatedError with API message", async () => {

--- a/packages/gateway/src/connectors/google-photos-sync.test.ts
+++ b/packages/gateway/src/connectors/google-photos-sync.test.ts
@@ -13,6 +13,7 @@ import {
   encodeGooglePhotosSyncCursor,
   type GooglePhotosSyncCursorV1,
 } from "./google-photos-sync.ts";
+import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 
 describe("Google Photos sync cursor codec", () => {
   test("round-trip", () => {
@@ -26,6 +27,46 @@ describe("Google Photos sync cursor codec", () => {
       decodeGooglePhotosSyncCursor,
       "nimbus-gph1:",
     );
+  });
+
+  // L40 branch: null / non-object / array payloads
+  test("decode returns undefined for null payload", () => {
+    // encode a payload that is null — decodeNimbusJsonCursorPayload returns null
+    const raw = encodeNimbusJsonCursor("nimbus-gph1:", null);
+    expect(decodeGooglePhotosSyncCursor(raw)).toBeUndefined();
+  });
+
+  test("decode returns undefined for array payload", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gph1:", [1, 2, 3]);
+    expect(decodeGooglePhotosSyncCursor(raw)).toBeUndefined();
+  });
+
+  test("decode returns undefined for non-object primitive payload", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gph1:", 42);
+    expect(decodeGooglePhotosSyncCursor(raw)).toBeUndefined();
+  });
+
+  // L44 branch: v !== 1
+  test("decode returns undefined for wrong version", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gph1:", { v: 2, pageToken: null });
+    expect(decodeGooglePhotosSyncCursor(raw)).toBeUndefined();
+  });
+
+  // L48 branch: pageToken is not null and not string
+  test("decode returns undefined for numeric pageToken", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gph1:", { v: 1, pageToken: 99 });
+    expect(decodeGooglePhotosSyncCursor(raw)).toBeUndefined();
+  });
+
+  test("decode returns undefined for boolean pageToken", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-gph1:", { v: 1, pageToken: true });
+    expect(decodeGooglePhotosSyncCursor(raw)).toBeUndefined();
+  });
+
+  // prefix mismatch → still undefined (existing coverage via round-trip failure)
+  test("decode returns undefined for wrong prefix", () => {
+    const raw = encodeNimbusJsonCursor("nimbus-other:", { v: 1, pageToken: null });
+    expect(decodeGooglePhotosSyncCursor(raw)).toBeUndefined();
   });
 });
 
@@ -108,5 +149,300 @@ describe("createGooglePhotosSyncable", () => {
     }
     expect(caught).toBeInstanceOf(UnauthenticatedError);
     expect((caught as Error).message).toMatch(/Invalid Credentials/);
+  });
+
+  // L149: mediaItems absent → items defaults to []
+  test("response with no mediaItems field yields 0 upserted and no hasMore", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        // No mediaItems key at all
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.hasMore).toBe(false);
+    expect(r.cursor).toBeNull();
+  });
+
+  // L140: empty-string cursor behaves like null cursor (no pageToken in body)
+  test("empty-string cursor is treated as fresh sync (no pageToken in request)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    let capturedBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const raw = init?.body;
+      capturedBody = JSON.parse(typeof raw === "string" ? raw : "{}") as Record<string, unknown>;
+      return new Response(JSON.stringify({ mediaItems: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, "");
+    expect(capturedBody["pageToken"]).toBeUndefined();
+  });
+
+  // L109: non-null, non-empty pageToken is forwarded in the POST body
+  // L144: cursor with a real pageToken is decoded and forwarded
+  test("valid cursor with pageToken forwards it in the search request body", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+    const cursor = encodeGooglePhotosSyncCursor({ v: 1, pageToken: "tok-abc" });
+
+    let capturedBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const raw = init?.body;
+      capturedBody = JSON.parse(typeof raw === "string" ? raw : "{}") as Record<string, unknown>;
+      return new Response(JSON.stringify({ mediaItems: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, cursor);
+    expect(capturedBody["pageToken"]).toBe("tok-abc");
+  });
+
+  // L144: cursor with pageToken: null still starts fresh (no pageToken in body)
+  test("cursor with null pageToken does not include pageToken in search body", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+    const cursor = encodeGooglePhotosSyncCursor({ v: 1, pageToken: null });
+
+    let capturedBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const raw = init?.body;
+      capturedBody = JSON.parse(typeof raw === "string" ? raw : "{}") as Record<string, unknown>;
+      return new Response(JSON.stringify({ mediaItems: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, cursor);
+    expect(capturedBody["pageToken"]).toBeUndefined();
+  });
+
+  // L69: item with undefined id is silently skipped (no DB row written)
+  test("media item with no id is skipped — no DB row written", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        return new Response(
+          JSON.stringify({
+            mediaItems: [
+              { filename: "no-id.jpg" }, // id is absent
+              { id: "", filename: "empty-id.jpg" }, // id is empty string
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+    // Neither item should produce a DB row since both have missing/empty ids
+    const rows = db.query("SELECT id FROM item WHERE service = 'google_photos'").all();
+    expect(rows.length).toBe(0);
+  });
+
+  // L73: item with no filename falls back to "photo_<id>"
+  // L74: item with no productUrl → url is null
+  // L60: item with no mediaMetadata creationTime → fallback timestamp used
+  test("media item without filename or productUrl or creationTime uses sensible defaults", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        return new Response(
+          JSON.stringify({
+            mediaItems: [
+              {
+                id: "p-no-meta",
+                // no filename, no productUrl, no mediaMetadata
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+
+    const row = db
+      .query("SELECT title, url, service FROM item WHERE id = ?")
+      .get(itemPrimaryKey("google_photos", "p-no-meta")) as
+      | { title: string; url: string | null; service: string }
+      | undefined;
+    expect(row?.service).toBe("google_photos");
+    expect(row?.title).toBe("photo_p-no-meta");
+    expect(row?.url).toBeNull();
+  });
+
+  // L73 branch: filename is empty string → fallback to "photo_<id>"
+  test("media item with empty filename falls back to photo_<id>", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        return new Response(
+          JSON.stringify({
+            mediaItems: [{ id: "p-empty-fn", filename: "" }],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("google_photos", "p-empty-fn")) as { title: string } | undefined;
+    expect(row?.title).toBe("photo_p-empty-fn");
+  });
+
+  // L60 branch: creationTime is empty string → fallback timestamp
+  test("media item with empty creationTime uses fallback timestamp", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    const before = Date.now();
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        return new Response(
+          JSON.stringify({
+            mediaItems: [
+              {
+                id: "p-empty-ts",
+                mediaMetadata: { creationTime: "" },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+    const after = Date.now();
+
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("google_photos", "p-empty-ts")) as { modified_at: number } | undefined;
+    // Should be in the range of now (the fallback), not some fixed old date
+    expect(row?.modified_at).toBeGreaterThanOrEqual(before);
+    expect(row?.modified_at).toBeLessThanOrEqual(after);
+  });
+
+  // L64 branch: creationTime is an un-parseable string → fallback
+  test("media item with invalid creationTime string uses fallback timestamp", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    const before = Date.now();
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        return new Response(
+          JSON.stringify({
+            mediaItems: [
+              {
+                id: "p-bad-ts",
+                mediaMetadata: { creationTime: "not-a-date" },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+    const after = Date.now();
+
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("google_photos", "p-bad-ts")) as { modified_at: number } | undefined;
+    expect(row?.modified_at).toBeGreaterThanOrEqual(before);
+    expect(row?.modified_at).toBeLessThanOrEqual(after);
+  });
+
+  // L88: title longer than 512 chars is truncated
+  test("media item with filename > 512 chars is truncated to 512", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    const longFilename = "x".repeat(600) + ".jpg";
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        return new Response(
+          JSON.stringify({
+            mediaItems: [{ id: "p-long", filename: longFilename }],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("google_photos", "p-long")) as { title: string } | undefined;
+    expect(row?.title?.length).toBe(512);
+    expect(row?.title).toBe(longFilename.slice(0, 512));
+  });
+
+  // nextPageToken absent / empty → hasMore false, cursor null
+  test("response with no nextPageToken yields hasMore false and null cursor", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrlString(input);
+      if (url.includes("mediaItems:search")) {
+        return new Response(JSON.stringify({ mediaItems: [{ id: "p2", filename: "b.jpg" }] }), {
+          status: 200,
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.hasMore).toBe(false);
+    expect(r.cursor).toBeNull();
+  });
+
+  // Non-decodable cursor string → treated as null pageToken (fresh start)
+  test("malformed cursor string falls back to null pageToken", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const syncable = createGooglePhotosSyncable({ ensureGoogleMcpRunning: async () => {} });
+
+    let capturedBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const raw = init?.body;
+      capturedBody = JSON.parse(typeof raw === "string" ? raw : "{}") as Record<string, unknown>;
+      return new Response(JSON.stringify({ mediaItems: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    // A non-empty string with a valid prefix but invalid content decodes to undefined cursor
+    const badCursor = encodeNimbusJsonCursor("nimbus-gph1:", { v: 99, pageToken: "x" });
+    await syncable.sync(ctx, badCursor);
+    expect(capturedBody["pageToken"]).toBeUndefined();
   });
 });

--- a/packages/gateway/src/connectors/google-sync-shared.test.ts
+++ b/packages/gateway/src/connectors/google-sync-shared.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { UnauthenticatedError } from "../sync/types.ts";
+import {
+  createOAuthConnectorTestSetup,
+  registerGlobalFetchRestore,
+  requestUrlString,
+} from "../testing/bun-test-support.ts";
+import { fetchGoogleJson, formatGoogleHttpError } from "./google-sync-shared.ts";
+
+type FetchInput = string | URL | Request;
+
+// ---------------------------------------------------------------------------
+// formatGoogleHttpError — pure function; no network
+// ---------------------------------------------------------------------------
+
+describe("formatGoogleHttpError", () => {
+  describe("truncate helper (L6 branches)", () => {
+    test("body within 160 chars is NOT truncated", () => {
+      // Force the non-JSON (catch) path with a short body so truncate returns text as-is
+      const body = "A".repeat(160);
+      const result = formatGoogleHttpError(500, body, "TestService");
+      // body == 160 chars, oneLine == body, truncate(body, 160) → body (equal, NOT >, so no truncation)
+      expect(result).toBe(`TestService sync failed: 500 — ${body}`);
+    });
+
+    test("body exceeding 160 chars IS truncated with ellipsis", () => {
+      // 161 "A"s → truncated at 160
+      const body = "A".repeat(161);
+      const result = formatGoogleHttpError(500, body, "TestService");
+      const expectedSuffix = "A".repeat(160) + "…";
+      expect(result).toBe(`TestService sync failed: 500 — ${expectedSuffix}`);
+    });
+  });
+
+  describe("JSON parse failure (catch block, L16 branches)", () => {
+    test("empty body → returns base string only (L16 true branch)", () => {
+      // trimmed === "" after JSON.parse throws
+      const result = formatGoogleHttpError(400, "", "Gmail");
+      expect(result).toBe("Gmail sync failed: 400");
+    });
+
+    test("whitespace-only body → returns base string only (L16 true branch)", () => {
+      const result = formatGoogleHttpError(400, "   \n\t  ", "Gmail");
+      expect(result).toBe("Gmail sync failed: 400");
+    });
+
+    test("unparseable non-empty body → returns base + body text (L16 false branch)", () => {
+      const result = formatGoogleHttpError(503, "Service Unavailable", "Drive");
+      expect(result).toBe("Drive sync failed: 503 — Service Unavailable");
+    });
+
+    test("unparseable body collapses whitespace into single line", () => {
+      const result = formatGoogleHttpError(500, "line one\n  line two", "Sheets");
+      expect(result).toBe("Sheets sync failed: 500 — line one line two");
+    });
+
+    test("unparseable body exceeding 160 chars is truncated", () => {
+      const long = "X".repeat(161);
+      const result = formatGoogleHttpError(500, long, "Svc");
+      expect(result).toContain("…");
+      // Prefix + em dash, then 160 Xs + ellipsis
+      expect(result).toBe(`Svc sync failed: 500 — ${"X".repeat(160)}…`);
+    });
+  });
+
+  describe("JSON parse success — errObj branch (L24 branches)", () => {
+    test("parsed JSON has no 'error' key → returns base + trimmed body (L24 true branch, non-object errObj)", () => {
+      const body = JSON.stringify({ message: "no top-level error key" });
+      const result = formatGoogleHttpError(500, body, "Calendar");
+      // asUnknownObjectRecord(parsed)["error"] is undefined → condition is true
+      expect(result).toContain("Calendar sync failed: 500");
+      expect(result).toContain("no top-level error key");
+    });
+
+    test("errObj is a string (not object) → returns base + trimmed body (L24 true branch)", () => {
+      const body = JSON.stringify({ error: "string-error" });
+      const result = formatGoogleHttpError(400, body, "Sheets");
+      expect(result).toContain("Sheets sync failed: 400");
+      expect(result).toContain('"error":"string-error"');
+    });
+
+    test("errObj is null → returns base + trimmed body (L24 true branch, errObj === null)", () => {
+      const body = JSON.stringify({ error: null });
+      const result = formatGoogleHttpError(400, body, "Drive");
+      expect(result).toContain("Drive sync failed: 400");
+    });
+
+    test("errObj is an array → returns base + trimmed body (L24 true branch, Array.isArray)", () => {
+      const body = JSON.stringify({ error: [{ code: 400 }] });
+      const result = formatGoogleHttpError(400, body, "Gmail");
+      expect(result).toContain("Gmail sync failed: 400");
+    });
+
+    test("errObj is a number → returns base + trimmed body (L24 true branch)", () => {
+      const body = JSON.stringify({ error: 404 });
+      const result = formatGoogleHttpError(404, body, "Svc");
+      expect(result).toContain("Svc sync failed: 404");
+    });
+  });
+
+  describe("JSON parse success — oneLine empty guard (L26 branches)", () => {
+    test("parsed JSON with non-object errObj and whitespace-only trimmed body → returns base only (L26 true branch)", () => {
+      // When errObj is not an object, the code falls through to the oneLine == "" check.
+      // We need trimmed to be empty-looking AFTER replaceAll. But trimmed is derived from
+      // bodyText.trim(), so if bodyText is whitespace-only then JSON.parse would throw first.
+      // L26 is only reachable when JSON.parse SUCCEEDS but errObj is not an object-literal,
+      // and the original trimmed (pre-collapse) collapses to "". This means the JSON itself
+      // is a scalar or the body collapses to all-whitespace after JSON stringification — but
+      // JSON.parse of "" would throw. The only reachable path is a valid JSON whose trimmed
+      // body collapses to all-whitespace after replaceAll, which is impossible since the JSON
+      // text itself always has non-whitespace chars. L26 is a DEFENSIVELY-UNREACHABLE branch.
+      //
+      // However, we can test L26 false branch (the common reachable case) where oneLine != "":
+      const body = JSON.stringify({ error: "a string" });
+      const result = formatGoogleHttpError(400, body, "Svc");
+      // oneLine != "" → returns base + oneLine (L26 false)
+      expect(result).not.toBe("Svc sync failed: 400");
+    });
+  });
+
+  describe("JSON parse success — error object with message (L31 branches)", () => {
+    test("errObj is object with string message → returns base + message (L31 true branch)", () => {
+      const body = JSON.stringify({ error: { code: 403, message: "Quota exceeded" } });
+      const result = formatGoogleHttpError(403, body, "Drive");
+      expect(result).toBe("Drive sync failed: 403 — Quota exceeded");
+    });
+
+    test("errObj is object with whitespace-only message → returns base only (L31 false branch, msg.trim() empty)", () => {
+      const body = JSON.stringify({ error: { code: 500, message: "   " } });
+      const result = formatGoogleHttpError(500, body, "Svc");
+      expect(result).toBe("Svc sync failed: 500");
+    });
+
+    test("errObj is object with non-string message → returns base only (L31 false branch, typeof msg !== string)", () => {
+      const body = JSON.stringify({ error: { code: 500, message: 42 } });
+      const result = formatGoogleHttpError(500, body, "Svc");
+      expect(result).toBe("Svc sync failed: 500");
+    });
+
+    test("errObj is object with no message key → returns base only (L31 false branch, undefined)", () => {
+      const body = JSON.stringify({ error: { code: 404 } });
+      const result = formatGoogleHttpError(404, body, "Gmail");
+      expect(result).toBe("Gmail sync failed: 404");
+    });
+
+    test("errObj message longer than 240 chars is truncated", () => {
+      const longMsg = "M".repeat(241);
+      const body = JSON.stringify({ error: { message: longMsg } });
+      const result = formatGoogleHttpError(500, body, "Svc");
+      expect(result).toBe(`Svc sync failed: 500 — ${"M".repeat(240)}…`);
+    });
+
+    test("errObj message exactly 240 chars is NOT truncated", () => {
+      const exactMsg = "M".repeat(240);
+      const body = JSON.stringify({ error: { message: exactMsg } });
+      const result = formatGoogleHttpError(500, body, "Svc");
+      expect(result).toBe(`Svc sync failed: 500 — ${"M".repeat(240)}`);
+      expect(result).not.toContain("…");
+    });
+
+    test("message with internal whitespace is collapsed to single line", () => {
+      const body = JSON.stringify({ error: { message: "line one\n  line two" } });
+      const result = formatGoogleHttpError(400, body, "Svc");
+      expect(result).toBe("Svc sync failed: 400 — line one line two");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchGoogleJson — uses globalThis.fetch override
+// ---------------------------------------------------------------------------
+
+describe("fetchGoogleJson", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  test("success: returns parsed json and byte count", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const payload = { items: [1, 2, 3] };
+    const body = JSON.stringify(payload);
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const result = await fetchGoogleJson(ctx, "tok123", "https://api.example.com/data", "TestSvc");
+    expect(result.json).toEqual(payload);
+    expect(result.bytes).toBe(Buffer.byteLength(body, "utf8"));
+  });
+
+  test("success: merges extra headers from init with Authorization", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const capturedHeaders: Record<string, string> = {};
+
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      const url = requestUrlString(input);
+      void url;
+      if (init?.headers !== undefined) {
+        for (const [k, v] of new Headers(init.headers)) {
+          capturedHeaders[k.toLowerCase()] = v;
+        }
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    await fetchGoogleJson(ctx, "mytoken", "https://api.example.com/res", "Svc", {
+      headers: { "X-Custom": "yes" },
+    });
+
+    expect(capturedHeaders["authorization"]).toBe("Bearer mytoken");
+    expect(capturedHeaders["x-custom"]).toBe("yes");
+  });
+
+  test("success: no init headers branch — only Authorization set", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    const capturedHeaders: Record<string, string> = {};
+
+    globalThis.fetch = (async (_input: FetchInput, init?: RequestInit) => {
+      if (init?.headers !== undefined) {
+        for (const [k, v] of new Headers(init.headers)) {
+          capturedHeaders[k.toLowerCase()] = v;
+        }
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch;
+
+    // Pass no init at all → init?.headers is undefined → skip the header merge loop
+    await fetchGoogleJson(ctx, "tok", "https://example.com", "Svc");
+    expect(capturedHeaders["authorization"]).toBe("Bearer tok");
+    // No extra headers
+    expect(Object.keys(capturedHeaders).length).toBe(1);
+  });
+
+  test("non-OK, non-401 status → throws Error with formatted message", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(JSON.stringify({ error: { message: "Quota exceeded" } }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await expect(
+      fetchGoogleJson(ctx, "tok", "https://api.example.com/res", "Drive"),
+    ).rejects.toThrow("Drive sync failed: 403 — Quota exceeded");
+  });
+
+  test("401 status → throws UnauthenticatedError", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(JSON.stringify({ error: { message: "Invalid credentials" } }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    let thrown: unknown;
+    try {
+      await fetchGoogleJson(ctx, "tok", "https://api.example.com/res", "Gmail");
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(UnauthenticatedError);
+    expect((thrown as UnauthenticatedError).message).toContain("Gmail sync failed: 401");
+  });
+
+  test("non-OK with empty body → error message is base only", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response("", { status: 500 });
+    }) as typeof fetch;
+
+    await expect(
+      fetchGoogleJson(ctx, "tok", "https://api.example.com/res", "Sheets"),
+    ).rejects.toThrow("Sheets sync failed: 500");
+  });
+
+  test("OK status but invalid JSON body → throws invalid JSON error", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response("not-json{{{", { status: 200 });
+    }) as typeof fetch;
+
+    await expect(
+      fetchGoogleJson(ctx, "tok", "https://api.example.com/res", "Calendar"),
+    ).rejects.toThrow("Calendar sync failed: invalid JSON");
+  });
+
+  test("byte count uses utf8 encoding (multi-byte chars)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("google");
+    // "é" is 2 bytes in utf8, "€" is 3 bytes — verify bytes !== text.length
+    const body = JSON.stringify({ s: "éàü€" });
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(body, { status: 200 });
+    }) as typeof fetch;
+
+    const result = await fetchGoogleJson(ctx, "tok", "https://example.com", "Svc");
+    expect(result.bytes).toBe(Buffer.byteLength(body, "utf8"));
+    // multi-byte: bytes > body.length for unicode chars
+    expect(result.bytes).toBeGreaterThan(body.length);
+  });
+});

--- a/packages/gateway/src/connectors/microsoft-graph-sync-shared.test.ts
+++ b/packages/gateway/src/connectors/microsoft-graph-sync-shared.test.ts
@@ -1,0 +1,447 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createOAuthConnectorTestSetup,
+  registerGlobalFetchRestore,
+  requestUrlString,
+} from "../testing/bun-test-support.ts";
+import {
+  decodeMicrosoftGraphDeltaCursor,
+  encodeMicrosoftGraphDeltaCursor,
+  fetchMicrosoftGraphJson,
+  type MicrosoftGraphDeltaCursorV1,
+  modifiedMsFromIso,
+  nextCursorFromODataDeltaLinks,
+  type ODataDeltaPage,
+  parseODataDeltaPage,
+} from "./microsoft-graph-sync-shared.ts";
+
+const PREFIX = "nimbus-msgraph1:";
+
+// ── decodeMicrosoftGraphDeltaCursor ─────────────────────────────────────────
+
+describe("decodeMicrosoftGraphDeltaCursor", () => {
+  test("round-trip: nextUrl=string", () => {
+    const cursor: MicrosoftGraphDeltaCursorV1 = {
+      v: 1,
+      nextUrl: "https://graph.example.com/delta?$skiptoken=abc",
+    };
+    const enc = encodeMicrosoftGraphDeltaCursor(PREFIX, cursor);
+    expect(enc.startsWith(PREFIX)).toBe(true);
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toEqual(cursor);
+  });
+
+  test("round-trip: nextUrl=null", () => {
+    const cursor: MicrosoftGraphDeltaCursorV1 = { v: 1, nextUrl: null };
+    const enc = encodeMicrosoftGraphDeltaCursor(PREFIX, cursor);
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toEqual(cursor);
+  });
+
+  // L19 true branch: decodeNimbusJsonCursorPayload returns null (payload decodes to JSON null)
+  test("returns undefined when payload is JSON null (o === null)", () => {
+    // encodeNimbusJsonCursor with null payload → base64url of "null"
+    const enc = PREFIX + Buffer.from("null", "utf8").toString("base64url");
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
+  });
+
+  // L19 true branch: decodeNimbusJsonCursorPayload returns an array
+  test("returns undefined when payload is a JSON array (Array.isArray branch)", () => {
+    const enc = PREFIX + Buffer.from("[1,2,3]", "utf8").toString("base64url");
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
+  });
+
+  // L19 true branch: decodeNimbusJsonCursorPayload returns a non-object primitive
+  test("returns undefined when payload is a JSON string (typeof !== object)", () => {
+    const enc = PREFIX + Buffer.from('"hello"', "utf8").toString("base64url");
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
+  });
+
+  // L23 true branch: v !== 1
+  test("returns undefined when v !== 1", () => {
+    const enc =
+      PREFIX + Buffer.from(JSON.stringify({ v: 2, nextUrl: null }), "utf8").toString("base64url");
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
+  });
+
+  // L27 true branch: nextUrl is not null and not a string (e.g. a number)
+  test("returns undefined when nextUrl is a number (not null and not string)", () => {
+    const enc =
+      PREFIX + Buffer.from(JSON.stringify({ v: 1, nextUrl: 42 }), "utf8").toString("base64url");
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
+  });
+
+  // L27 true branch: nextUrl is a boolean
+  test("returns undefined when nextUrl is a boolean", () => {
+    const enc =
+      PREFIX + Buffer.from(JSON.stringify({ v: 1, nextUrl: true }), "utf8").toString("base64url");
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
+  });
+
+  // Wrong prefix → decodeNimbusJsonCursorPayload returns undefined → non-object
+  test("returns undefined for wrong prefix", () => {
+    const enc =
+      "wrong-prefix:" +
+      Buffer.from(JSON.stringify({ v: 1, nextUrl: null }), "utf8").toString("base64url");
+    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
+  });
+
+  // Invalid base64 payload
+  test("returns undefined for invalid base64 payload", () => {
+    expect(decodeMicrosoftGraphDeltaCursor(PREFIX + "!!!notbase64!!!", PREFIX)).toBeUndefined();
+  });
+});
+
+// ── parseODataDeltaPage ──────────────────────────────────────────────────────
+
+describe("parseODataDeltaPage", () => {
+  // All three fields present (positive case — covers the true branches)
+  test("extracts value, nextLink, and deltaLink when all present", () => {
+    const input: unknown = {
+      value: [{ id: "item1" }],
+      "@odata.nextLink": "https://graph.example.com/next",
+      "@odata.deltaLink": "https://graph.example.com/delta",
+    };
+    const page = parseODataDeltaPage(input);
+    expect(page.value).toEqual([{ id: "item1" }]);
+    expect(page["@odata.nextLink"]).toBe("https://graph.example.com/next");
+    expect(page["@odata.deltaLink"]).toBe("https://graph.example.com/delta");
+  });
+
+  // L45 false branch: value is not an array (is a string) → not set
+  test("omits value when value field is not an array", () => {
+    const input: unknown = {
+      value: "not-an-array",
+      "@odata.nextLink": "https://graph.example.com/next",
+    };
+    const page = parseODataDeltaPage(input);
+    expect(page.value).toBeUndefined();
+    expect(page["@odata.nextLink"]).toBe("https://graph.example.com/next");
+  });
+
+  // L45 false branch: value is null → not set
+  test("omits value when value field is null", () => {
+    const input: unknown = { value: null };
+    const page = parseODataDeltaPage(input);
+    expect(page.value).toBeUndefined();
+  });
+
+  // L48 false branch: nextLink is not a string → not set
+  test("omits nextLink when it is a number", () => {
+    const input: unknown = {
+      value: [],
+      "@odata.nextLink": 999,
+    };
+    const page = parseODataDeltaPage(input);
+    expect(page["@odata.nextLink"]).toBeUndefined();
+    expect(page.value).toEqual([]);
+  });
+
+  // L51 false branch: deltaLink is not a string → not set
+  test("omits deltaLink when it is absent", () => {
+    const input: unknown = {
+      value: [1, 2],
+      "@odata.nextLink": "https://graph.example.com/next",
+    };
+    const page = parseODataDeltaPage(input);
+    expect(page["@odata.deltaLink"]).toBeUndefined();
+  });
+
+  // All three false branches: empty object input
+  test("returns empty ODataDeltaPage for empty object input", () => {
+    const page = parseODataDeltaPage({});
+    expect(page.value).toBeUndefined();
+    expect(page["@odata.nextLink"]).toBeUndefined();
+    expect(page["@odata.deltaLink"]).toBeUndefined();
+  });
+
+  // Non-object input (json-unknown maps it to {})
+  test("returns empty ODataDeltaPage for non-object input (null)", () => {
+    const page = parseODataDeltaPage(null);
+    expect(page.value).toBeUndefined();
+  });
+
+  // Non-object input: array
+  test("returns empty ODataDeltaPage for array input", () => {
+    const page = parseODataDeltaPage([{ value: [1] }]);
+    expect(page.value).toBeUndefined();
+  });
+});
+
+// ── modifiedMsFromIso ────────────────────────────────────────────────────────
+
+describe("modifiedMsFromIso", () => {
+  const FALLBACK = 1_700_000_000_000;
+
+  // L58 true branch: iso is undefined
+  test("returns fallback when iso is undefined", () => {
+    expect(modifiedMsFromIso(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  // L58 true branch: iso is empty string
+  test("returns fallback when iso is empty string", () => {
+    expect(modifiedMsFromIso("", FALLBACK)).toBe(FALLBACK);
+  });
+
+  // L62 false branch: iso is unparseable → NaN → not finite → fallback
+  test("returns fallback when iso is not a valid date string", () => {
+    expect(modifiedMsFromIso("not-a-date", FALLBACK)).toBe(FALLBACK);
+  });
+
+  // L62 false branch: iso looks like date but is completely invalid
+  test("returns fallback when iso is garbage", () => {
+    expect(modifiedMsFromIso("ZZZZ-ZZ-ZZ", FALLBACK)).toBe(FALLBACK);
+  });
+
+  // Happy path: valid ISO string (use a date clearly different from FALLBACK)
+  test("returns parsed ms for a valid ISO 8601 string", () => {
+    const iso = "2024-03-15T10:00:00.000Z";
+    const expected = Date.parse(iso); // 1710496800000 — distinct from FALLBACK
+    expect(modifiedMsFromIso(iso, FALLBACK)).toBe(expected);
+    expect(expected).not.toBe(FALLBACK); // sanity: chosen date ≠ fallback
+  });
+});
+
+// ── nextCursorFromODataDeltaLinks ────────────────────────────────────────────
+
+describe("nextCursorFromODataDeltaLinks", () => {
+  const encode = (c: MicrosoftGraphDeltaCursorV1): string =>
+    encodeMicrosoftGraphDeltaCursor(PREFIX, c);
+
+  // L71 true branch: nextLink present and non-empty → hasMore=true
+  test("uses nextLink when present → hasMore=true", () => {
+    const page: ODataDeltaPage = {
+      "@odata.nextLink": "https://graph.example.com/next?$skiptoken=tok",
+    };
+    const result = nextCursorFromODataDeltaLinks(page, encode);
+    expect(result.hasMore).toBe(true);
+    expect(result.stored).not.toBeNull();
+    const dec = decodeMicrosoftGraphDeltaCursor(result.stored ?? "", PREFIX);
+    expect(dec?.nextUrl).toBe("https://graph.example.com/next?$skiptoken=tok");
+  });
+
+  // L74 true branch: deltaLink present (no nextLink) → hasMore=false
+  test("uses deltaLink when nextLink absent → hasMore=false", () => {
+    const page: ODataDeltaPage = {
+      "@odata.deltaLink": "https://graph.example.com/delta?$deltatoken=dtok",
+    };
+    const result = nextCursorFromODataDeltaLinks(page, encode);
+    expect(result.hasMore).toBe(false);
+    expect(result.stored).not.toBeNull();
+    const dec = decodeMicrosoftGraphDeltaCursor(result.stored ?? "", PREFIX);
+    expect(dec?.nextUrl).toBe("https://graph.example.com/delta?$deltatoken=dtok");
+  });
+
+  // L71 false + L74 false: neither link present → stored=null, hasMore=false
+  test("returns stored=null and hasMore=false when neither link present", () => {
+    const page: ODataDeltaPage = {};
+    const result = nextCursorFromODataDeltaLinks(page, encode);
+    expect(result.stored).toBeNull();
+    expect(result.hasMore).toBe(false);
+  });
+
+  // L71 false branch via empty-string nextLink: empty string is falsy branch
+  test("skips empty-string nextLink and falls through to deltaLink", () => {
+    const page: ODataDeltaPage = {
+      "@odata.nextLink": "",
+      "@odata.deltaLink": "https://graph.example.com/delta?$deltatoken=d2",
+    };
+    const result = nextCursorFromODataDeltaLinks(page, encode);
+    expect(result.hasMore).toBe(false);
+    const dec = decodeMicrosoftGraphDeltaCursor(result.stored ?? "", PREFIX);
+    expect(dec?.nextUrl).toBe("https://graph.example.com/delta?$deltatoken=d2");
+  });
+
+  // L74 false via empty deltaLink: both empty → null/false
+  test("returns stored=null when both links are empty strings", () => {
+    const page: ODataDeltaPage = {
+      "@odata.nextLink": "",
+      "@odata.deltaLink": "",
+    };
+    const result = nextCursorFromODataDeltaLinks(page, encode);
+    expect(result.stored).toBeNull();
+    expect(result.hasMore).toBe(false);
+  });
+});
+
+// ── fetchMicrosoftGraphJson ──────────────────────────────────────────────────
+
+describe("fetchMicrosoftGraphJson", () => {
+  registerGlobalFetchRestore(afterEach);
+
+  type FetchInput = string | URL | Request;
+
+  test("success: returns parsed json and byte count", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const responseBody = JSON.stringify({ value: [{ id: "obj1" }] });
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(responseBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const result = await fetchMicrosoftGraphJson(
+      ctx,
+      "access-token-123",
+      null,
+      "https://graph.microsoft.com/v1.0/me/messages/delta",
+      "Messages",
+    );
+
+    expect(result.json).toEqual({ value: [{ id: "obj1" }] });
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(result.bytes).toBe(Buffer.byteLength(responseBody, "utf8"));
+  });
+
+  test("success: uses nextUrl when non-null and non-empty", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    let capturedUrl = "";
+    const nextUrl = "https://graph.microsoft.com/v1.0/me/messages/delta?$skiptoken=tok2";
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      capturedUrl = requestUrlString(input);
+      return new Response(JSON.stringify({ value: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await fetchMicrosoftGraphJson(
+      ctx,
+      "tok",
+      nextUrl,
+      "https://graph.microsoft.com/v1.0/me/messages/delta",
+      "Messages",
+    );
+
+    expect(capturedUrl).toBe(nextUrl);
+  });
+
+  test("success: uses initialUrl when nextUrl is null", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    let capturedUrl = "";
+    const initialUrl = "https://graph.microsoft.com/v1.0/me/messages/delta";
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      capturedUrl = requestUrlString(input);
+      return new Response(JSON.stringify({ value: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await fetchMicrosoftGraphJson(ctx, "tok", null, initialUrl, "Messages");
+
+    expect(capturedUrl).toBe(initialUrl);
+  });
+
+  test("success: uses initialUrl when nextUrl is empty string", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    let capturedUrl = "";
+    const initialUrl = "https://graph.microsoft.com/v1.0/me/messages/delta";
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      capturedUrl = requestUrlString(input);
+      return new Response(JSON.stringify({ value: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await fetchMicrosoftGraphJson(ctx, "tok", "", initialUrl, "Messages");
+
+    expect(capturedUrl).toBe(initialUrl);
+  });
+
+  // L94 true branch: !res.ok → throws with errorLabel in message
+  test("throws when response is non-OK (4xx)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response(JSON.stringify({ error: { code: "Unauthorized" } }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await expect(
+      fetchMicrosoftGraphJson(
+        ctx,
+        "bad-token",
+        null,
+        "https://graph.microsoft.com/v1.0/me/messages/delta",
+        "Messages",
+      ),
+    ).rejects.toThrow("Messages sync failed: 401");
+  });
+
+  // L94 true branch: non-OK 500
+  test("throws when response is non-OK (5xx)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response("Internal Server Error", {
+        status: 500,
+      });
+    }) as typeof fetch;
+
+    await expect(
+      fetchMicrosoftGraphJson(
+        ctx,
+        "tok",
+        null,
+        "https://graph.microsoft.com/v1.0/me/events/delta",
+        "Events",
+      ),
+    ).rejects.toThrow("Events sync failed: 500");
+  });
+
+  // Invalid JSON path (status 200 but body is not JSON)
+  // D-candidate: the JSON.parse catch branch at ~L100-L101 is reachable
+  test("throws when response body is not valid JSON", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+
+    globalThis.fetch = (async (_input: FetchInput) => {
+      return new Response("not json at all {{{", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }) as typeof fetch;
+
+    await expect(
+      fetchMicrosoftGraphJson(
+        ctx,
+        "tok",
+        null,
+        "https://graph.microsoft.com/v1.0/me/messages/delta",
+        "Messages",
+      ),
+    ).rejects.toThrow("Messages sync failed: invalid JSON");
+  });
+
+  // Authorization header is set correctly
+  test("sends Authorization Bearer header", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    let capturedAuthHeader = "";
+    const token = "super-secret-token-xyz";
+
+    globalThis.fetch = (async (_input: FetchInput, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      capturedAuthHeader = headers?.["Authorization"] ?? "";
+      return new Response(JSON.stringify({ value: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await fetchMicrosoftGraphJson(
+      ctx,
+      token,
+      null,
+      "https://graph.microsoft.com/v1.0/me/messages/delta",
+      "Messages",
+    );
+
+    expect(capturedAuthHeader).toBe(`Bearer ${token}`);
+  });
+});

--- a/packages/gateway/src/connectors/onedrive-sync.test.ts
+++ b/packages/gateway/src/connectors/onedrive-sync.test.ts
@@ -13,6 +13,8 @@ import {
   type OneDriveSyncCursorV1,
 } from "./onedrive-sync.ts";
 
+type FetchInput = string | URL | Request;
+
 describe("OneDrive sync cursor codec", () => {
   test("round-trip", () => {
     const samples: OneDriveSyncCursorV1[] = [
@@ -73,6 +75,361 @@ describe("createOneDriveSyncable", () => {
     expect(row?.type).toBe("file");
     expect(row?.external_id).toBe("f1");
     expect(row?.author_id).not.toBeNull();
+  });
+
+  test("folder item: sets type=folder, url=null when webUrl missing", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [
+              {
+                id: "folder1",
+                folder: {},
+                // no name → fallback to item_folder1
+                // no webUrl → url=null
+                lastModifiedDateTime: "2024-05-01T00:00:00Z",
+              },
+            ],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+
+    const row = db
+      .query("SELECT type, url FROM item WHERE id = ?")
+      .get(itemPrimaryKey("onedrive", "folder1")) as
+      | { type: string; url: string | null }
+      | undefined;
+    expect(row?.type).toBe("folder");
+    expect(row?.url).toBeNull();
+  });
+
+  test("item with no id is skipped — no DB row written (L66 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [
+              { name: "orphan.txt" }, // no id
+              { id: "", name: "empty-id.txt" }, // empty id → guard also fires
+            ],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+    // upsertDriveItem is called but returns early for both items, so no rows in DB
+    const count = db.query("SELECT COUNT(*) as c FROM item WHERE service = ?").get("onedrive") as {
+      c: number;
+    };
+    expect(count.c).toBe(0);
+  });
+
+  test("title fallback to item_<id> when name is missing (L69 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [
+              { id: "nname1" }, // no name field
+              { id: "nname2", name: "" }, // empty name
+            ],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row1 = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("onedrive", "nname1")) as { title: string } | undefined;
+    expect(row1?.title).toBe("item_nname1");
+
+    const row2 = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("onedrive", "nname2")) as { title: string } | undefined;
+    expect(row2?.title).toBe("item_nname2");
+  });
+
+  test("title is truncated to 512 chars when name exceeds 512 (L102 branch)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+    const longName = "a".repeat(600);
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "longname1", name: longName }],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("onedrive", "longname1")) as { title: string } | undefined;
+    expect(row?.title?.length).toBe(512);
+  });
+
+  test("file mimeType is undefined when file field is array (L77 branch)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [
+              { id: "arr1", name: "arr.bin", file: [] }, // array → mimeType=undefined
+              { id: "nf1", name: "nofile.bin" }, // no file field → mimeType=undefined
+            ],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(2);
+  });
+
+  test("authorId is null when lastModifiedBy has no usable email (L93 displayName fallback and null path)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [
+              {
+                id: "noauth1",
+                name: "file.txt",
+                // no lastModifiedBy → authorId = null
+              },
+              {
+                id: "noauth2",
+                name: "file2.txt",
+                lastModifiedBy: {
+                  user: { displayName: "No Email User" }, // no email/mail/userPrincipalName
+                },
+              },
+              {
+                id: "noauth3",
+                name: "file3.txt",
+                lastModifiedBy: {
+                  user: {
+                    // displayName is empty → fallback to email as displayName
+                    displayName: "",
+                    mail: "noname@example.com",
+                  },
+                },
+              },
+            ],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(3);
+
+    const row1 = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("onedrive", "noauth1")) as { author_id: string | null } | undefined;
+    expect(row1?.author_id).toBeNull();
+
+    const row2 = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("onedrive", "noauth2")) as { author_id: string | null } | undefined;
+    expect(row2?.author_id).toBeNull();
+
+    // noauth3 has a valid email so author_id should be set
+    const row3 = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("onedrive", "noauth3")) as { author_id: string | null } | undefined;
+    expect(row3?.author_id).not.toBeNull();
+  });
+
+  test("invalid cursor is treated as initial fetch (L131 branch)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    let capturedUrl = "";
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      capturedUrl = url;
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    // Pass a cursor that has the wrong prefix (decode returns undefined)
+    const r = await syncable.sync(ctx, "nimbus-wrong-prefix:garbage");
+    // Should succeed and fall back to the initial URL
+    expect(r.itemsUpserted).toBe(0);
+    expect(capturedUrl).toContain("/drive/root/delta");
+  });
+
+  test("empty value array when page has no value field (L142 branch)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            // no value field at all
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=x",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.itemsDeleted).toBe(0);
+  });
+
+  test("pagination: nextLink sets hasMore=true, uses nextLink on second call (L129/nextLink branch)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("token=page2")) {
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "p2", name: "page2.txt", file: {} }],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=done",
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/drive/root/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "p1", name: "page1.txt", file: {} }],
+            "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=page2",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r1 = await syncable.sync(ctx, null);
+    expect(r1.itemsUpserted).toBe(1);
+    expect(r1.hasMore).toBe(true);
+    expect(r1.cursor).not.toBeNull();
+
+    // second page: resume with the cursor
+    const r2 = await syncable.sync(ctx, r1.cursor ?? "");
+    expect(r2.itemsUpserted).toBe(1);
+    expect(r2.hasMore).toBe(false);
+  });
+
+  test("deleted.state='deleted' arm removes item with id (L155-L156 branches)", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOneDriveSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    let call = 0;
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (!url.includes("/drive/root/delta") && !url.includes("graph.example")) {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      call += 1;
+      if (call === 1) {
+        // seed the item
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "del1", name: "soon-gone.txt", file: {} }],
+            "@odata.deltaLink": "https://graph.example/delta",
+          }),
+          { status: 200 },
+        );
+      }
+      // second call: mark as deleted via deleted.state
+      return new Response(
+        JSON.stringify({
+          value: [
+            { id: "del1", deleted: { state: "deleted" } },
+            // item with no id in deleted branch → skipped
+            { deleted: { state: "deleted" } },
+          ],
+          "@odata.deltaLink": "https://graph.example/delta2",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+    const afterInsert = db
+      .query("SELECT COUNT(*) as c FROM item WHERE service = ?")
+      .get("onedrive") as { c: number };
+    expect(afterInsert.c).toBe(1);
+
+    const r2 = await syncable.sync(
+      ctx,
+      encodeOneDriveSyncCursor({ v: 1, nextUrl: "https://graph.example/delta" }),
+    );
+    expect(r2.itemsDeleted).toBe(1);
+    const afterDelete = db
+      .query("SELECT COUNT(*) as c FROM item WHERE service = ?")
+      .get("onedrive") as { c: number };
+    expect(afterDelete.c).toBe(0);
   });
 
   test("deletes when @removed present", async () => {

--- a/packages/gateway/src/connectors/outlook-sync.test.ts
+++ b/packages/gateway/src/connectors/outlook-sync.test.ts
@@ -13,6 +13,19 @@ import {
   type OutlookSyncCursorV1,
 } from "./outlook-sync.ts";
 
+type FetchInput = string | URL | Request;
+
+/** Builds a minimal Graph delta response with a deltaLink (no more pages). */
+function deltaResponse(messages: unknown[]): Response {
+  return new Response(
+    JSON.stringify({
+      value: messages,
+      "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/messages/delta?token=end",
+    }),
+    { status: 200 },
+  );
+}
+
 describe("Outlook sync cursor codec", () => {
   test("round-trip", () => {
     const samples: OutlookSyncCursorV1[] = [
@@ -31,11 +44,12 @@ describe("Outlook sync cursor codec", () => {
 describe("createOutlookSyncable", () => {
   registerGlobalFetchRestore(afterEach);
 
+  // ── existing smoke test ───────────────────────────────────────────────────
   test("indexes messages from delta page", async () => {
     const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
     const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
 
-    globalThis.fetch = (async (input: string | URL | Request) => {
+    globalThis.fetch = (async (input: FetchInput) => {
       const url = requestUrlString(input);
       if (url.includes("/messages/delta")) {
         return new Response(
@@ -72,5 +86,529 @@ describe("createOutlookSyncable", () => {
     expect(row?.service).toBe("outlook");
     expect(row?.type).toBe("email");
     expect(row?.author_id).not.toBeNull();
+  });
+
+  // ── L43: message with undefined id is skipped (id === undefined) ──────────
+  // The upserted counter is incremented for every non-removed entry even when
+  // upsertMessage returns early; verify via DB that no row was written for it.
+  test("skips message with undefined id — no DB row written", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([
+          { subject: "No id here", bodyPreview: "body" }, // no id field → upsertMessage returns early
+          {
+            id: "valid1",
+            subject: "Valid",
+            bodyPreview: "ok",
+            lastModifiedDateTime: "2024-05-01T10:00:00Z",
+          },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    // valid1 must be in the DB
+    const validRow = db
+      .query("SELECT id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "valid1")) as { id: string } | null;
+    expect(validRow).not.toBeNull();
+
+    // No row should exist for the no-id message (no externalId to key on)
+    const allRows = db.query("SELECT id FROM item").all() as { id: string }[];
+    expect(allRows.length).toBe(1);
+  });
+
+  // ── L43: message with empty-string id is skipped (id === "") ─────────────
+  test("skips message with empty-string id — no DB row written", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([
+          { id: "", subject: "Empty id" }, // id === "" → upsertMessage returns early
+          { id: "valid2", subject: "Valid" },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    // Only valid2 should be in the DB
+    const allRows = db.query("SELECT id FROM item").all() as { id: string }[];
+    expect(allRows.length).toBe(1);
+    expect(allRows[0]?.id).toBe(itemPrimaryKey("outlook", "valid2"));
+  });
+
+  // ── L46: missing subject → "(no subject)" ────────────────────────────────
+  test("falls back to (no subject) when subject is missing", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "nosub", lastModifiedDateTime: "2024-05-01T10:00:00Z" }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "nosub")) as { title: string } | undefined;
+    expect(row?.title).toBe("(no subject)");
+  });
+
+  // ── L46: empty-string subject → "(no subject)" ───────────────────────────
+  test("falls back to (no subject) when subject is empty string", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "empsub", subject: "" }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "empsub")) as { title: string } | undefined;
+    expect(row?.title).toBe("(no subject)");
+  });
+
+  // ── L47: missing bodyPreview → empty string in db ────────────────────────
+  test("stores empty preview when bodyPreview is absent", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "nobody", subject: "Test" }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT body_preview FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "nobody")) as { body_preview: string | null } | undefined;
+    expect(row?.body_preview ?? "").toBe("");
+  });
+
+  // ── L48: missing webLink → null url ──────────────────────────────────────
+  test("stores null url when webLink is absent", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "nolink", subject: "No link" }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT url FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "nolink")) as { url: string | null } | undefined;
+    expect(row?.url).toBeNull();
+  });
+
+  // ── L49: lastModifiedDateTime missing → fall back to receivedDateTime ────
+  test("uses receivedDateTime when lastModifiedDateTime is absent", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([
+          { id: "recv1", subject: "Received only", receivedDateTime: "2024-03-01T08:00:00Z" },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT modified_at FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "recv1")) as { modified_at: number } | undefined;
+    // 2024-03-01T08:00:00Z → 1709280000000
+    expect(row?.modified_at).toBe(Date.parse("2024-03-01T08:00:00Z"));
+  });
+
+  // ── L53: missing from address → null authorId ────────────────────────────
+  test("stores null authorId when from address is absent", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "nofrom", subject: "No from" }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "nofrom")) as { author_id: string | null } | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // ── L53: empty-string from address → null authorId ───────────────────────
+  test("stores null authorId when from address is empty string", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([
+          { id: "emptyfrom", subject: "Empty addr", from: { emailAddress: { address: "" } } },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "emptyfrom")) as { author_id: string | null } | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // ── L56: address present but name missing → addr used as displayName ─────
+  test("uses email address as displayName when name is absent", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([
+          {
+            id: "noname",
+            subject: "No name",
+            from: { emailAddress: { address: "noname@example.com" } }, // name omitted
+          },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "noname")) as { author_id: string | null } | undefined;
+    expect(row?.author_id).not.toBeNull(); // person resolved using addr as name
+  });
+
+  // ── L56: address present but name is empty string → addr used as displayName
+  test("uses email address as displayName when name is empty string", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([
+          {
+            id: "emptyname",
+            subject: "Empty name",
+            from: { emailAddress: { address: "emptyname@example.com", name: "" } },
+          },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+
+    const row = db
+      .query("SELECT author_id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "emptyname")) as { author_id: string | null } | undefined;
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  // ── L64: very long subject gets truncated to 512 chars ───────────────────
+  test("truncates subject longer than 512 chars", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+    const longSubject = "A".repeat(600);
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "longsubj", subject: longSubject }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    const row = db
+      .query("SELECT title FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "longsubj")) as { title: string } | undefined;
+    expect(row?.title?.length).toBe(512);
+    expect(row?.title).toBe("A".repeat(512));
+  });
+
+  // ── L93: null cursor → no delta decode, uses initial URL ─────────────────
+  test("null cursor triggers initial sync URL (not nextUrl)", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    const capturedUrls: string[] = [];
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      capturedUrls.push(url);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, null);
+
+    // Should have hit the initial /me/messages/delta URL
+    expect(capturedUrls.some((u) => u.includes("/me/messages/delta?$top="))).toBe(true);
+  });
+
+  // ── L93: empty-string cursor → treated same as null (no decode) ──────────
+  test("empty-string cursor triggers initial sync URL", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    const capturedUrls: string[] = [];
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      capturedUrls.push(url);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, "");
+
+    expect(capturedUrls.some((u) => u.includes("/me/messages/delta?$top="))).toBe(true);
+  });
+
+  // ── L95: valid cursor with a nextUrl → uses that URL as the page URL ─────
+  test("valid cursor uses stored nextUrl for continuation", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+    const nextUrl = "https://graph.microsoft.com/v1.0/me/messages/delta?$skiptoken=continuation123";
+    const cursor = encodeOutlookSyncCursor({ v: 1, nextUrl });
+
+    const capturedUrls: string[] = [];
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      capturedUrls.push(url);
+      return deltaResponse([]);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, cursor);
+
+    expect(capturedUrls.some((u) => u.includes("continuation123"))).toBe(true);
+  });
+
+  // ── L95: cursor with invalid prefix → dec undefined → nextUrl falls to null
+  test("cursor with wrong prefix is ignored, falls back to initial URL", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+    // Wrong prefix — decodeOutlookSyncCursor returns undefined
+    const badCursor = "nimbus-OTHER:abc123";
+
+    const capturedUrls: string[] = [];
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      capturedUrls.push(url);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, badCursor);
+
+    // Should fall back to the initial ?$top= URL, not the bad cursor
+    expect(capturedUrls.some((u) => u.includes("/me/messages/delta?$top="))).toBe(true);
+  });
+
+  // ── L106: empty value array → 0 upserted ─────────────────────────────────
+  test("returns 0 upserted when value array is empty", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([]); // empty value
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.itemsDeleted).toBe(0);
+  });
+
+  // ── L106: response without value key → 0 upserted ────────────────────────
+  test("returns 0 upserted when value key is absent from response", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        // No value key at all
+        return new Response(
+          JSON.stringify({
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/messages/delta?token=end",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+  });
+
+  // ── L112/L114: removed message with valid id → deleted, not upserted ─────
+  test("deletes message marked with @removed", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    // First upsert the message so it exists in the db
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "todelete", subject: "Will be deleted" }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r1 = await syncable.sync(ctx, null);
+    expect(r1.itemsUpserted).toBe(1);
+
+    // Now send the same id as removed
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([{ id: "todelete", "@removed": { reason: "deleted" } }]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r2 = await syncable.sync(ctx, null);
+    expect(r2.itemsDeleted).toBe(1);
+    expect(r2.itemsUpserted).toBe(0);
+
+    const row = db
+      .query("SELECT id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("outlook", "todelete")) as { id: string } | null;
+    expect(row).toBeNull();
+  });
+
+  // ── L114: @removed entry with undefined id → delete branch NOT taken ────────
+  // removed=true but id=undefined: the `if (removed && id !== undefined && id !== "")`
+  // guard is false, so deleteItemByServiceExternal is NOT called (itemsDeleted stays 0).
+  test("@removed entry with undefined id does not trigger delete", async () => {
+    const { db, ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return deltaResponse([
+          { "@removed": { reason: "deleted" } }, // no id: remove-guard fails, no delete
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    // No delete should have fired
+    expect(r.itemsDeleted).toBe(0);
+    // No rows should be in the DB (upsertMessage returns early for undefined id)
+    const allRows = db.query("SELECT id FROM item").all() as { id: string }[];
+    expect(allRows.length).toBe(0);
+  });
+
+  // ── pagination: nextLink present → hasMore = true, cursor stored ──────────
+  test("returns hasMore=true and stores nextLink cursor when nextLink present", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+    const nextLink = "https://graph.microsoft.com/v1.0/me/messages/delta?$skiptoken=page2";
+
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      if (url.includes("/messages/delta")) {
+        return new Response(
+          JSON.stringify({
+            value: [{ id: "pg1msg", subject: "Page 1" }],
+            "@odata.nextLink": nextLink,
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const r = await syncable.sync(ctx, null);
+    expect(r.hasMore).toBe(true);
+    expect(r.itemsUpserted).toBe(1);
+
+    const dec = decodeOutlookSyncCursor(r.cursor ?? "");
+    expect(dec?.nextUrl).toBe(nextLink);
+  });
+
+  // ── cursor with null nextUrl → dec.nextUrl is null → fallback to initial ─
+  test("cursor with null nextUrl falls back to initial URL", async () => {
+    const { ctx } = await createOAuthConnectorTestSetup("microsoft");
+    const syncable = createOutlookSyncable({ ensureMicrosoftMcpRunning: async () => {} });
+    const cursor = encodeOutlookSyncCursor({ v: 1, nextUrl: null });
+
+    const capturedUrls: string[] = [];
+    globalThis.fetch = (async (input: FetchInput) => {
+      const url = requestUrlString(input);
+      capturedUrls.push(url);
+      return deltaResponse([]);
+    }) as typeof fetch;
+
+    await syncable.sync(ctx, cursor);
+
+    // null nextUrl means no continuation, should use the default initial URL
+    expect(capturedUrls.some((u) => u.includes("/me/messages/delta?$top="))).toBe(true);
   });
 });

--- a/packages/gateway/test/unit/connectors/google-drive-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/google-drive-sync.test.ts
@@ -439,3 +439,376 @@ describe("google-drive-sync — phase machine: delta", () => {
     expect(fixture.fetchMock.calls).toHaveLength(0);
   });
 });
+
+// ─── Additional branch-coverage tests (B6) ──────────────────────────────────
+
+describe("google-drive-sync — cursor decode extra branches (L79, L109)", () => {
+  test("init_list cursor with listToken as a number → throws 'corrupt cursor' (L79 non-null non-string branch)", async () => {
+    // L79: listToken !== null && typeof listToken !== "string" → return undefined → corrupt cursor
+    await expect(
+      createGoogleDriveSyncable(ENSURE_MCP).sync(
+        fixture.createSyncContext(),
+        encodeCursor({ v: 1, phase: "init_list", t0: "abc", listToken: 42 }),
+      ),
+    ).rejects.toThrow(/corrupt cursor/);
+  });
+
+  test("cursor with v=2 → throws 'corrupt cursor' (L109 v !== 1 branch)", async () => {
+    // L109: r["v"] !== 1 → return undefined → corrupt cursor
+    await expect(
+      createGoogleDriveSyncable(ENSURE_MCP).sync(
+        fixture.createSyncContext(),
+        encodeCursor({ v: 2, phase: "init_list", t0: "abc", listToken: null }),
+      ),
+    ).rejects.toThrow(/corrupt cursor/);
+  });
+
+  test("init_list cursor with null listToken → passes through as null listToken (L459)", async () => {
+    // L459: v1.listToken ?? undefined → listToken is null → undefined passed to listFilesPage (no pageToken param)
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, { files: [] });
+    const cur = encodeCursor({ v: 1, phase: "init_list", t0: "tokA", listToken: null });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur);
+    expect(res.hasMore).toBe(true);
+    const filesCalls = fixture.fetchMock.calls.filter((c) => c.url.startsWith(FILES_LIST_PREFIX));
+    expect(filesCalls).toHaveLength(1);
+    // null listToken → no pageToken param in URL
+    expect(filesCalls[0]?.url).not.toContain("pageToken=");
+  });
+});
+
+describe("google-drive-sync — owner/email resolution branches (L133-L149)", () => {
+  test("file with empty owners array → no author_id (L133 owners.length === 0)", async () => {
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "f1", name: "file.txt", owners: [] }],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ author_id: unknown }, []>(
+        "SELECT author_id FROM item WHERE service = 'google_drive' AND external_id = 'f1'",
+      )
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("file with owner missing emailAddress → no author_id (L141/L144 email === undefined)", async () => {
+    // emailAddress absent → email = undefined → L144 return null
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "f2", name: "file.txt", owners: [{ displayName: "Alice" }] }],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ author_id: unknown }, []>(
+        "SELECT author_id FROM item WHERE service = 'google_drive' AND external_id = 'f2'",
+      )
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("file with owner empty emailAddress → no author_id (L141 emailAddress === '' branch)", async () => {
+    // emailAddress is "" → treated as undefined → email = undefined → null returned
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "f3", name: "file.txt", owners: [{ emailAddress: "", displayName: "Bob" }] }],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ author_id: unknown }, []>(
+        "SELECT author_id FROM item WHERE service = 'google_drive' AND external_id = 'f3'",
+      )
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("file with owner email only (no displayName) → ownerName falls back to email (L143/L149)", async () => {
+    // displayName absent → ownerName = undefined → L149 ownerName ?? email = email used as displayName
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "f4", name: "file.txt", owners: [{ emailAddress: "owner@example.com" }] }],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ author_id: unknown }, []>(
+        "SELECT author_id FROM item WHERE service = 'google_drive' AND external_id = 'f4'",
+      )
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  test("file with owner email + displayName → both fields used (L143 truthy branch, L149 ownerName used)", async () => {
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [
+        {
+          id: "f5",
+          name: "file.txt",
+          owners: [{ emailAddress: "owner@example.com", displayName: "Owner Person" }],
+        },
+      ],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ author_id: unknown }, []>(
+        "SELECT author_id FROM item WHERE service = 'google_drive' AND external_id = 'f5'",
+      )
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.author_id).not.toBeNull();
+  });
+});
+
+describe("google-drive-sync — upsertDriveFile field branches (L159, L163, L165-L169)", () => {
+  test("trashed file via changes.list file.trashed (not removed=true) → delete (L207)", async () => {
+    // L207: file.trashed === true in applyChange → deleteItemByServiceExternal
+    fixture.db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url, canonical_url, modified_at, author_id, metadata, synced_at, pinned)
+       VALUES (?, 'google_drive', 'file', 'trashed-via-file', 'x', 'x', null, null, 1, null, '{}', 1, 0)`,
+      [itemPrimaryKey("google_drive", "trashed-via-file")],
+    );
+    fixture.fetchMock.respond("GET", CHANGES_LIST_RE, {
+      changes: [{ file: { id: "trashed-via-file", name: "x.txt", trashed: true } }],
+      newStartPageToken: "next-tok",
+    });
+    const cur = encodeCursor({ v: 1, phase: "drain", changePage: "tokX" });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur);
+    expect(res.itemsDeleted).toBe(1);
+    const row = fixture.db
+      .query("SELECT id FROM item WHERE id = ?")
+      .get(itemPrimaryKey("google_drive", "trashed-via-file"));
+    expect(row).toBeNull();
+  });
+
+  test("change with no file and removed=false → skip (L200 file === undefined)", async () => {
+    // L200: file === undefined → return "skip"
+    fixture.fetchMock.respond("GET", CHANGES_LIST_RE, {
+      changes: [{ removed: false }],
+      newStartPageToken: "next-tok",
+    });
+    const cur = encodeCursor({ v: 1, phase: "drain", changePage: "tokY" });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur);
+    expect(res.itemsDeleted).toBe(0);
+    expect(res.itemsUpserted).toBe(0);
+  });
+
+  test("change file with empty id → skip (L204 id === '')", async () => {
+    // L204: id === "" → return "skip"
+    fixture.fetchMock.respond("GET", CHANGES_LIST_RE, {
+      changes: [{ file: { id: "", name: "x.txt" } }],
+      newStartPageToken: "next-tok",
+    });
+    const cur = encodeCursor({ v: 1, phase: "drain", changePage: "tokZ" });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur);
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.itemsDeleted).toBe(0);
+  });
+
+  test("change file with missing id → skip (L204 id === undefined)", async () => {
+    // L204: id === undefined → return "skip"
+    fixture.fetchMock.respond("GET", CHANGES_LIST_RE, {
+      changes: [{ file: { name: "x.txt" } }],
+      newStartPageToken: "next-tok",
+    });
+    const cur = encodeCursor({ v: 1, phase: "drain", changePage: "tokW" });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur);
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.itemsDeleted).toBe(0);
+  });
+
+  test("trashed file in files.list is skipped during init_list (L416 trashed guard)", async () => {
+    // L416 init_list loop guards `f.trashed !== true`, so a trashed file in files.list is never indexed.
+    // (upsertDriveFile's own L159 trashed arm is unreachable from this path — applyChange L207 short-circuits
+    //  trashed changes before calling upsertDriveFile — so it is a D-candidate, not covered here.)
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [
+        { id: "trashed-init", name: "deleted.txt", trashed: true },
+        { id: "live-init", name: "live.txt" },
+      ],
+    });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    // trashed file skipped → only live-init upserted
+    expect(res.itemsUpserted).toBe(1);
+    const row = fixture.db
+      .query(
+        "SELECT external_id FROM item WHERE service = 'google_drive' AND external_id = 'trashed-init'",
+      )
+      .get();
+    expect(row).toBeNull();
+  });
+
+  test("file missing mimeType → defaults to '' (not folder) (L163)", async () => {
+    // L163: f.mimeType ?? "" → "" → isFolder = false
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "no-mime", name: "file-no-mime.txt" }],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ type: string }, []>(
+        "SELECT type FROM item WHERE service = 'google_drive' AND external_id = 'no-mime'",
+      )
+      .get();
+    expect(row?.type).toBe("file");
+  });
+
+  test("file missing modifiedTime → uses now as modifiedAt (L165)", async () => {
+    // L165: f.modifiedTime === undefined → now used directly
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "no-modtime", name: "no-modtime.txt" }],
+    });
+    const before = Date.now();
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const after = Date.now();
+    const row = fixture.db
+      .query<{ modified_at: number }, []>(
+        "SELECT modified_at FROM item WHERE service = 'google_drive' AND external_id = 'no-modtime'",
+      )
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.modified_at).toBeGreaterThanOrEqual(before);
+    expect(row?.modified_at).toBeLessThanOrEqual(after);
+  });
+
+  test("file with invalid modifiedTime string → falls back to now (L166 !Number.isFinite)", async () => {
+    // L166: Number.isFinite(modifiedMs) = false (NaN from Date.parse("not-a-date")) → safeModified = now
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "bad-date", name: "bad-date.txt", modifiedTime: "not-a-date" }],
+    });
+    const before = Date.now();
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const after = Date.now();
+    const row = fixture.db
+      .query<{ modified_at: number }, []>(
+        "SELECT modified_at FROM item WHERE service = 'google_drive' AND external_id = 'bad-date'",
+      )
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.modified_at).toBeGreaterThanOrEqual(before);
+    expect(row?.modified_at).toBeLessThanOrEqual(after);
+  });
+
+  test("file with description set → description used as bodyPreview (L168 desc !== '' branch)", async () => {
+    // L168: desc === "" ? name : desc → desc path
+    const desc = "This is my file description";
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "with-desc", name: "file.txt", description: desc }],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ body_preview: string }, []>(
+        "SELECT body_preview FROM item WHERE service = 'google_drive' AND external_id = 'with-desc'",
+      )
+      .get();
+    expect(row?.body_preview).toBe(desc);
+  });
+
+  test("file with description > 512 chars → bodyPreview truncated to 512 (L169)", async () => {
+    // L169: previewBase.length > 512 → slice(0, 512)
+    const longDesc = "x".repeat(600);
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [{ id: "long-desc", name: "file.txt", description: longDesc }],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ body_preview: string }, []>(
+        "SELECT body_preview FROM item WHERE service = 'google_drive' AND external_id = 'long-desc'",
+      )
+      .get();
+    expect(row?.body_preview).toHaveLength(512);
+  });
+
+  test("file webViewLink set → url and canonicalUrl populated", async () => {
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "t0" });
+    fixture.fetchMock.respond("GET", FILES_LIST_RE, {
+      files: [
+        {
+          id: "with-link",
+          name: "file.txt",
+          webViewLink: "https://drive.google.com/file/d/123/view",
+        },
+      ],
+    });
+    await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
+    const row = fixture.db
+      .query<{ url: string }, []>(
+        "SELECT url FROM item WHERE service = 'google_drive' AND external_id = 'with-link'",
+      )
+      .get();
+    expect(row?.url).toBe("https://drive.google.com/file/d/123/view");
+  });
+});
+
+describe("google-drive-sync — getStartPageToken missing token (L247)", () => {
+  test("startPageToken response missing token field → throws (L247)", async () => {
+    // L247: typeof t !== "string" || t === "" → throw "missing startPageToken"
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, {});
+    await expect(
+      createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null),
+    ).rejects.toThrow(/missing startPageToken/);
+  });
+
+  test("startPageToken response has empty string token → throws (L247 t === '')", async () => {
+    fixture.fetchMock.respond("GET", START_TOKEN_RE, { startPageToken: "" });
+    await expect(
+      createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null),
+    ).rejects.toThrow(/missing startPageToken/);
+  });
+});
+
+describe("google-drive-sync — runDriveChangePage nextPageToken branch (L316)", () => {
+  test("delta page with nextPageToken → hasMore=true with new delta cursor (L316)", async () => {
+    // L316: next !== undefined && next !== "" → return hasMore=true with buildNextCursor(next)
+    // (delta phase, different from drain to get independent test for L316 delta path)
+    fixture.fetchMock.respond("GET", CHANGES_LIST_RE, {
+      changes: [],
+      nextPageToken: "more-changes",
+    });
+    const cur = encodeCursor({ v: 1, phase: "delta", pageToken: "tok1", deltaPage: 0 });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur);
+    expect(res.hasMore).toBe(true);
+    if (res.cursor === null) {
+      throw new Error("cursor null");
+    }
+    const decoded = JSON.parse(
+      Buffer.from(res.cursor.slice(CURSOR_PREFIX.length), "base64url").toString("utf8"),
+    );
+    // buildNextCursor for delta: { v:1, phase:"delta", pageToken: next, deltaPage: currentDeltaPage }
+    expect(decoded.phase).toBe("delta");
+    expect(decoded.pageToken).toBe("more-changes");
+    expect(decoded.deltaPage).toBe(1);
+  });
+
+  test("delta page finalizes with newStartPageToken (L316 else branch) → hasMore=false", async () => {
+    fixture.fetchMock.respond("GET", CHANGES_LIST_RE, {
+      changes: [],
+      newStartPageToken: "final-tok",
+    });
+    const cur = encodeCursor({ v: 1, phase: "delta", pageToken: "tok2" });
+    const res = await createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur);
+    expect(res.hasMore).toBe(false);
+    if (res.cursor === null) {
+      throw new Error("cursor null");
+    }
+    const decoded = JSON.parse(
+      Buffer.from(res.cursor.slice(CURSOR_PREFIX.length), "base64url").toString("utf8"),
+    );
+    expect(decoded).toEqual({ v: 1, phase: "delta", pageToken: "final-tok" });
+  });
+
+  test("delta page missing newStartPageToken → throws (delta missingNewTokenMessage)", async () => {
+    fixture.fetchMock.respond("GET", CHANGES_LIST_RE, { changes: [] });
+    const cur = encodeCursor({ v: 1, phase: "delta", pageToken: "tok3" });
+    await expect(
+      createGoogleDriveSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), cur),
+    ).rejects.toThrow(/missing newStartPageToken/);
+  });
+});


### PR DESCRIPTION
## What

True Coverage Program — **sub-project B6** (first `gateway/connectors` family slice). Raises **13 below-floor connector source files** in the **Google + Microsoft 365 personal-cloud family** to ≥80% branch coverage by **adding tests only** — no production source changes.

Baseline `docs/structure-audit/coverage-baseline.json`: **130 → 115** (15 files removed, 0 added, 0 watermark churn on retained files — a pure-removal reseed).

## Files targeted (all dropped from the baseline)

| Area | Files |
|---|---|
| Gmail `_lib` | `_lib/gmail/history.ts`, `_lib/gmail/api.ts`, `_lib/gmail/cursor.ts` |
| Google sync | `gmail-sync.ts`, `google-photos-sync.ts`, `google-drive-sync.ts`, `google-meet-sync.ts`, `google-sync-shared.ts` |
| Microsoft 365 | `outlook-sync.ts`, `onedrive-sync.ts`, `microsoft-graph-sync-shared.ts`, `_lib/teams/api.ts`, `_lib/teams/cursor.ts` |

Plus **2 incidental** sibling files cleared by these tests (CI reproduces): `connectors/json-unknown.ts` (shared JSON cursor helper) and `index/item-store.ts` (exercised by the upsert tests).

## How

- TDD per file (one fresh subagent each, two parallel waves), mapping each uncovered `BRDA` from the latest main CI `coverage-lcov-merged` artifact.
- Tests assert **behavior** — DB rows (real in-memory SQLite via `createOAuthConnectorTestSetup`), returned cursors/values, thrown error text, captured warnings — using `globalThis.fetch` fakes. **No `any`, no `mock.module`, no `biome-ignore`, no network.**
- Defensively-unreachable branches left per spec §5.2 (no fabricated paths, no `istanbul-ignore`); recorded as D-candidates.
- Baseline reseeded from a Docker `oven/bun:latest` (Linux-authoritative) full instrumented run; all 13 targets verified in the removed set.

## Verification

- `bunx tsc --noEmit` clean (gateway).
- `bun test src/connectors test/unit/connectors` → 2655 pass / 0 fail.
- `bun run audit:coverage-floor` → `ok (115 baselined; 927 scanned)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for Gmail, Teams, Google Meet, Google Photos, Google Drive, OneDrive, and Outlook sync connectors.
  * Added comprehensive test suites validating connector API behavior, cursor encoding/decoding, error handling, and data parsing.

* **Chores**
  * Updated coverage baseline entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->