### PR TITLE
ci(release): grant checks:write to the test-suite caller job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     permissions:
       contents: read
+      # Required by _test-suite.yml: the integration / e2e-gateway / e2e-cli
+      # jobs declare `checks: write` for their dorny/test-reporter step. A
+      # called workflow's jobs cannot request a permission the caller withholds,
+      # so this must be granted here (matches the ci.yml callers).
+      checks: write
       id-token: write
 
   build-gateway:


### PR DESCRIPTION
## Problem

The `release.yml` workflow failed validation:

> Error calling workflow '…/_test-suite.yml'. The nested job 'integration' is requesting 'checks: write', but is only allowed 'checks: none'. … the nested job 'e2e-gateway' is requesting 'checks: write', but is only allowed 'checks: none'.

## Root cause

The reusable `_test-suite.yml` has `integration`, `e2e-gateway`, and `e2e-cli` jobs that each declare `checks: write` (needed for their `dorny/test-reporter` step). GitHub forbids a *called* workflow's jobs from requesting a permission the *caller* withholds.

The `ci.yml` callers already grant `checks: write` (lines 144–148 and 370–373), but the `release.yml` `test` caller job granted only `contents: read` + `id-token: write`, so `checks` defaulted to `none` and the run failed before any job started.

## Fix

Add `checks: write` to the `test` caller job in `release.yml`, matching the established `ci.yml` pattern. One-line permission grant; no behavioral change to the test suite itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to ensure test reporting functionality operates correctly in the release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->