### PR TITLE
test(coverage): B7 — gateway/connectors dev-tooling SaaS family to ≥80% branch (115→105)

### DIFF
--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-06-11T14:39:34.500Z",
+  "generated_at": "2026-06-11T17:57:07.570Z",
   "files": {
     "packages/cli/src/commands/audit.ts": {
       "min_line_pct": 80,
@@ -150,29 +150,13 @@
       "min_line_pct": 80,
       "min_branch_pct": 75.93
     },
-    "packages/gateway/src/connectors/atlassian-api-sync-helpers.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 50
-    },
     "packages/gateway/src/connectors/bigquery-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 71.95
     },
-    "packages/gateway/src/connectors/bitrise-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 61.54
-    },
     "packages/gateway/src/connectors/cloudwatch-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 75.51
-    },
-    "packages/gateway/src/connectors/codemagic-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 61.54
-    },
-    "packages/gateway/src/connectors/confluence-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 62.77
     },
     "packages/gateway/src/connectors/connector-catalog.ts": {
       "min_line_pct": 78.95,
@@ -206,10 +190,6 @@
       "min_line_pct": 80,
       "min_branch_pct": 64.36
     },
-    "packages/gateway/src/connectors/figma-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 62.16
-    },
     "packages/gateway/src/connectors/filesystem-v2-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 75.64
@@ -230,25 +210,13 @@
       "min_line_pct": 80,
       "min_branch_pct": 75
     },
-    "packages/gateway/src/connectors/jira-sync.ts": {
-      "min_line_pct": 75.19,
-      "min_branch_pct": 52.76
-    },
     "packages/gateway/src/connectors/launchdarkly-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 73.68
     },
-    "packages/gateway/src/connectors/linear-sync.ts": {
-      "min_line_pct": 78.7,
-      "min_branch_pct": 50
-    },
     "packages/gateway/src/connectors/metabase-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 68.57
-    },
-    "packages/gateway/src/connectors/notion-sync.ts": {
-      "min_line_pct": 78.46,
-      "min_branch_pct": 58.16
     },
     "packages/gateway/src/connectors/obsidian-daily-note.ts": {
       "min_line_pct": 80,
@@ -281,14 +249,6 @@
     "packages/gateway/src/connectors/sonarqube-sync.ts": {
       "min_line_pct": 80,
       "min_branch_pct": 66.67
-    },
-    "packages/gateway/src/connectors/storybook-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 78.57
-    },
-    "packages/gateway/src/connectors/testflight-sync.ts": {
-      "min_line_pct": 80,
-      "min_branch_pct": 75.68
     },
     "packages/gateway/src/connectors/user-mcp-store.ts": {
       "min_line_pct": 80,

--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -336,7 +336,7 @@
     },
     "packages/gateway/src/people/person-store.ts": {
       "min_line_pct": 80,
-      "min_branch_pct": 77.23
+      "min_branch_pct": 79.21
     },
     "packages/gateway/src/platform/dirs.ts": {
       "min_line_pct": 80,

--- a/packages/gateway/src/connectors/atlassian-api-sync-helpers.test.ts
+++ b/packages/gateway/src/connectors/atlassian-api-sync-helpers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { basicAuthHeader, normalizeAtlassianSiteBaseUrl } from "./atlassian-api-sync-helpers.ts";
+
+describe("normalizeAtlassianSiteBaseUrl", () => {
+  test("returns empty string for empty input (line 7-8 empty arm)", () => {
+    expect(normalizeAtlassianSiteBaseUrl("")).toBe("");
+  });
+
+  test("strips trailing slash from https URL", () => {
+    expect(normalizeAtlassianSiteBaseUrl("https://x.atlassian.net/")).toBe(
+      "https://x.atlassian.net",
+    );
+  });
+
+  test("strips multiple trailing slashes", () => {
+    expect(normalizeAtlassianSiteBaseUrl("https://x.atlassian.net///")).toBe(
+      "https://x.atlassian.net",
+    );
+  });
+
+  test("leaves http URL unchanged (startsWith http true arm, line 10)", () => {
+    expect(normalizeAtlassianSiteBaseUrl("http://x")).toBe("http://x");
+  });
+
+  test("prepends https:// when scheme is absent (startsWith http false arm, line 10)", () => {
+    expect(normalizeAtlassianSiteBaseUrl("x.atlassian.net")).toBe("https://x.atlassian.net");
+  });
+
+  test("prepends https:// for bare host with trailing slash stripped", () => {
+    expect(normalizeAtlassianSiteBaseUrl("x.atlassian.net/")).toBe("https://x.atlassian.net");
+  });
+});
+
+describe("basicAuthHeader", () => {
+  test("produces correct Basic auth header", () => {
+    const email = "a@b.com";
+    const token = "tok";
+    const expected = `Basic ${Buffer.from(`${email}:${token}`, "utf8").toString("base64")}`;
+    expect(basicAuthHeader(email, token)).toBe(expected);
+  });
+
+  test("encodes special characters correctly", () => {
+    const email = "user+tag@example.com";
+    const token = "tok/en=val";
+    const expected = `Basic ${Buffer.from(`${email}:${token}`, "utf8").toString("base64")}`;
+    expect(basicAuthHeader(email, token)).toBe(expected);
+  });
+});

--- a/packages/gateway/src/connectors/bitrise-sync.test.ts
+++ b/packages/gateway/src/connectors/bitrise-sync.test.ts
@@ -1,0 +1,319 @@
+import { expect, test } from "bun:test";
+import { createBitriseSyncable } from "./bitrise-sync.ts";
+import {
+  createMemoryIndexDb,
+  createStubVault,
+  describeWithFetchRestore,
+  expectServiceItemCount,
+  type SyncTestFetchParams,
+  syncTestContext,
+  testConnectorSyncNoop,
+  urlFromFetchInput,
+} from "./connector-sync-test-helpers.ts";
+
+const NOOP_OPTIONS = { ensureBitriseMcpRunning: async () => {} };
+
+function makeSyncable() {
+  return createBitriseSyncable(NOOP_OPTIONS);
+}
+
+describeWithFetchRestore("bitrise-sync", () => {
+  // --- no-credential noop (line 67-68) ---
+  testConnectorSyncNoop(
+    "no-op when API token missing",
+    makeSyncable,
+    createStubVault({ "bitrise.token": null }),
+  );
+
+  // --- apps endpoint http_error (lines 79-80) ---
+  test("returns pass cursor on apps HTTP error response", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("Service Unavailable", { status: 503 });
+    }) as unknown as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-bitrise1:");
+    expectServiceItemCount(db, "bitrise", 0);
+  });
+
+  // --- apps endpoint parse_error (lines 82-83) ---
+  test("returns pass cursor on apps non-JSON response", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("not-json{{{{", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-bitrise1:");
+    expectServiceItemCount(db, "bitrise", 0);
+  });
+
+  // --- apps with no `data` array (lines 38-41): extractAppRows non-array branch ---
+  test("handles apps response where data field is not an array", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(JSON.stringify({ data: "not-an-array" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "bitrise", 0);
+  });
+
+  // --- apps with non-object entry (line 46 false branch): asRecord(entry) === undefined ---
+  test("skips non-object entries in apps data array", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (): Promise<Response> => {
+      // data contains primitive values that cannot be converted to records
+      return new Response(JSON.stringify({ data: ["not-an-object", 42, null] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "bitrise", 0);
+  });
+
+  // --- app with empty slug: mapBitriseAppToItem returns null (line 93 null branch)
+  //     AND appSlug returns undefined → continue without fetching builds (lines 98-99) ---
+  test("skips app with empty slug (mappedApp null + no builds fetch)", async () => {
+    const db = createMemoryIndexDb();
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (): Promise<Response> => {
+      fetchCallCount += 1;
+      // Only the apps call is made; no builds call for a slug-less app
+      return new Response(
+        JSON.stringify({
+          data: [
+            // app row with no slug field at all
+            { title: "No-slug App", project_type: "ios" },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    // Only the apps fetch was made
+    expect(fetchCallCount).toBe(1);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "bitrise", 0);
+  });
+
+  // --- builds endpoint non-ok (http_error) → continue (lines 108-109) ---
+  test("continues past app when builds fetch returns HTTP error", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/me/apps")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ slug: "app-abc", title: "My App" }],
+          }),
+          { status: 200 },
+        );
+      }
+      // builds endpoint → http error
+      return new Response("Server Error", { status: 500 });
+    }) as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    // app is upserted; builds were skipped
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "bitrise", 1);
+  });
+
+  // --- builds endpoint parse_error → continue (lines 108-109 via kind !== "ok") ---
+  test("continues past app when builds fetch returns non-JSON", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/me/apps")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ slug: "app-xyz", title: "Another App" }],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("not-json{{", { status: 200 });
+    }) as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "bitrise", 1);
+  });
+
+  // --- build with no slug: mapBitriseBuildToItem returns null → continue (lines 113-114) ---
+  test("skips build rows that have no slug", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/me/apps")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ slug: "app-slugged", title: "Slugged App" }],
+          }),
+          { status: 200 },
+        );
+      }
+      // build rows: one valid, one missing slug
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              slug: "build-001",
+              build_number: 1,
+              triggered_workflow: "primary",
+              branch: "main",
+              status_text: "success",
+              triggered_at: "2026-01-01T10:00:00.000Z",
+            },
+            {
+              // no slug field → mapBitriseBuildToItem returns null → continue
+              build_number: 2,
+              triggered_workflow: "deploy",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    // 1 app + 1 valid build = 2 upserted
+    expect(r.itemsUpserted).toBe(2);
+    expectServiceItemCount(db, "bitrise", 2);
+  });
+
+  // --- full happy path: app + builds upserted, cursor advanced ---
+  test("indexes apps and builds and advances cursor", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/me/apps")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                slug: "my-app-slug",
+                title: "My Bitrise App",
+                project_type: "android",
+                repo_url: "https://github.com/org/repo",
+                default_branch_name: "main",
+                is_disabled: false,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      // builds for my-app-slug
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              slug: "build-slug-1",
+              build_number: 42,
+              triggered_workflow: "ci",
+              branch: "main",
+              commit_hash: "abc123",
+              commit_message: "feat: add bitrise",
+              triggered_by: "webhook",
+              status: 1,
+              status_text: "success",
+              triggered_at: "2026-01-15T08:00:00.000Z",
+              started_on_worker_at: "2026-01-15T08:01:00.000Z",
+              finished_at: "2026-01-15T08:10:00.000Z",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "tok-xyz" })),
+      null,
+    );
+    // 1 app + 1 build
+    expect(r.itemsUpserted).toBe(2);
+    expect(r.cursor).toContain("nimbus-bitrise1:");
+    expectServiceItemCount(db, "bitrise", 2);
+
+    // Verify app row type
+    const appRow = db
+      .prepare("SELECT type FROM item WHERE service = 'bitrise' AND external_id = 'my-app-slug'")
+      .get() as { type: string } | undefined;
+    expect(appRow?.type).toBe("app");
+
+    // Verify build row type
+    const buildRow = db
+      .prepare(
+        "SELECT type FROM item WHERE service = 'bitrise' AND external_id = 'my-app-slug/build-slug-1'",
+      )
+      .get() as { type: string } | undefined;
+    expect(buildRow?.type).toBe("build");
+  });
+
+  // --- appSlug: empty string slug → undefined (line 55 true branch) ---
+  test("skips builds fetch when app slug is empty string", async () => {
+    const db = createMemoryIndexDb();
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (): Promise<Response> => {
+      fetchCallCount += 1;
+      return new Response(
+        JSON.stringify({
+          data: [{ slug: "", title: "Empty-slug App" }],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const sync = makeSyncable();
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "bitrise.token": "test-token" })),
+      null,
+    );
+    // Only the apps call, no builds call
+    expect(fetchCallCount).toBe(1);
+    // mapBitriseAppToItem returns null for empty slug too → 0 upserted
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "bitrise", 0);
+  });
+});

--- a/packages/gateway/src/connectors/codemagic-sync.test.ts
+++ b/packages/gateway/src/connectors/codemagic-sync.test.ts
@@ -1,0 +1,284 @@
+import { expect, test } from "bun:test";
+import { createCodemagicSyncable } from "./codemagic-sync.ts";
+import {
+  createMemoryIndexDb,
+  createStubVault,
+  describeWithFetchRestore,
+  EMPTY_NIMBUS_VAULT,
+  expectServiceItemCount,
+  type SyncTestFetchParams,
+  syncTestContext,
+  testConnectorSyncNoop,
+  urlFromFetchInput,
+} from "./connector-sync-test-helpers.ts";
+
+const VALID_TOKEN_VAULT = createStubVault({ "codemagic.token": "cm_test_token" });
+
+type FetchHandler = (url: string, init: SyncTestFetchParams[1]) => Response;
+
+function installFetch(handler: FetchHandler): void {
+  globalThis.fetch = (async (
+    input: SyncTestFetchParams[0],
+    init?: SyncTestFetchParams[1],
+  ): Promise<Response> => handler(urlFromFetchInput(input), init)) as typeof fetch;
+}
+
+function makeSyncable() {
+  return createCodemagicSyncable({ ensureCodemagicMcpRunning: async () => {} });
+}
+
+/** Minimal valid app fixture with an _id so builds can be fetched. */
+function makeApp(id: string, name = `App-${id}`): Record<string, unknown> {
+  return { _id: id, appName: name };
+}
+
+/** Minimal valid build fixture. */
+function makeBuild(id: string): Record<string, unknown> {
+  return {
+    _id: id,
+    workflowId: "default",
+    branch: "main",
+    status: "finished",
+    startedAt: "2026-04-01T10:00:00.000Z",
+    finishedAt: "2026-04-01T10:05:00.000Z",
+  };
+}
+
+describeWithFetchRestore("codemagic-sync", () => {
+  // ── no-op (missing API key) ─────────────────────────────────────────────────
+  testConnectorSyncNoop("no-op when token is missing", makeSyncable, EMPTY_NIMBUS_VAULT);
+
+  testConnectorSyncNoop(
+    "no-op when token is blank (whitespace-only)",
+    makeSyncable,
+    createStubVault({ "codemagic.token": "   " }),
+  );
+
+  // ── apps endpoint: http_error (line 74/75) ──────────────────────────────────
+  test("apps http_error → returns pass cursor with 0 upserts", async () => {
+    const db = createMemoryIndexDb();
+    installFetch(() => new Response("Unauthorized", { status: 401 }));
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-codemagic1:");
+    expectServiceItemCount(db, "codemagic", 0);
+  });
+
+  // ── apps endpoint: http_error with existing cursor preserved ────────────────
+  test("apps http_error preserves incoming cursor", async () => {
+    const db = createMemoryIndexDb();
+    installFetch(() => new Response("Service Unavailable", { status: 503 }));
+    const existing = "nimbus-codemagic1:existing";
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), existing);
+    expect(r.cursor).toBe(existing);
+    expect(r.itemsUpserted).toBe(0);
+  });
+
+  // ── apps endpoint: parse_error (line 77/78) ─────────────────────────────────
+  test("apps parse_error → returns parse-empty pass cursor", async () => {
+    const db = createMemoryIndexDb();
+    installFetch(() => new Response("not-valid-json{{", { status: 200 }));
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-codemagic1:");
+    expectServiceItemCount(db, "codemagic", 0);
+  });
+
+  // ── extractRows: non-array key (lines 38/40/41) ─────────────────────────────
+  test("apps response with non-array 'applications' key → 0 app rows", async () => {
+    const db = createMemoryIndexDb();
+    // "applications" is a string, not an array — extractRows returns []
+    installFetch(
+      () => new Response(JSON.stringify({ applications: "not-an-array" }), { status: 200 }),
+    );
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-codemagic1:");
+    expectServiceItemCount(db, "codemagic", 0);
+  });
+
+  // ── extractRows: non-record entry in array (line 46 false arm) ──────────────
+  test("app array entries that are not records are skipped", async () => {
+    const db = createMemoryIndexDb();
+    // Mix of a valid app, a primitive (number), and null — only the valid app upserts
+    installFetch((url) => {
+      if (url.includes("/apps")) {
+        return new Response(
+          JSON.stringify({ applications: [makeApp("app1"), 42, null, makeApp("app2")] }),
+          { status: 200 },
+        );
+      }
+      // builds endpoint: empty builds
+      return new Response(JSON.stringify({ builds: [] }), { status: 200 });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    // app1 and app2 are valid; 42 and null are skipped by extractRows
+    expect(r.itemsUpserted).toBe(2);
+    expectServiceItemCount(db, "codemagic", 2);
+  });
+
+  // ── appId: empty string (line 55 true arm "id === ''") ─────────────────────
+  test("app with empty _id is skipped by appId() (no builds fetch for it)", async () => {
+    const db = createMemoryIndexDb();
+    let buildsFetched = false;
+    installFetch((url) => {
+      if (url.includes("/builds")) {
+        buildsFetched = true;
+        return new Response(JSON.stringify({ builds: [] }), { status: 200 });
+      }
+      // App has _id="" — mapCodemagicAppToItem returns null, and appId() returns undefined
+      return new Response(JSON.stringify({ applications: [{ _id: "", appName: "NoId" }] }), {
+        status: 200,
+      });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    expect(r.itemsUpserted).toBe(0);
+    // builds endpoint should NOT be called since appId is ""
+    expect(buildsFetched).toBe(false);
+    expectServiceItemCount(db, "codemagic", 0);
+  });
+
+  // ── mappedApp === null branch (line 88 false arm) ───────────────────────────
+  test("app with missing _id is not upserted but still triggers builds fetch if appRow has _id", async () => {
+    // mapCodemagicAppToItem returns null when _id is missing from the raw row;
+    // however appId() checks the SAME row — if _id is absent stringField returns
+    // undefined, so appId() returns undefined and we never fetch builds either.
+    // This test confirms both null-map AND undefined-appId branches are hit together.
+    const db = createMemoryIndexDb();
+    let buildsFetched = false;
+    installFetch((url) => {
+      if (url.includes("/builds")) {
+        buildsFetched = true;
+        return new Response(JSON.stringify({ builds: [] }), { status: 200 });
+      }
+      // _id absent → mapCodemagicAppToItem null + appId undefined
+      return new Response(JSON.stringify({ applications: [{ appName: "NoId" }] }), { status: 200 });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(buildsFetched).toBe(false);
+    expectServiceItemCount(db, "codemagic", 0);
+  });
+
+  // ── builds http_error (line 103 true arm) ───────────────────────────────────
+  test("builds fetch http_error → app is upserted, build is skipped (continue)", async () => {
+    const db = createMemoryIndexDb();
+    installFetch((url) => {
+      if (url.includes("/apps")) {
+        return new Response(JSON.stringify({ applications: [makeApp("app42")] }), { status: 200 });
+      }
+      // builds endpoint → HTTP error
+      return new Response("Internal Server Error", { status: 500 });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    // app42 was upserted, but the build fetch failed → only 1 item
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "codemagic", 1);
+    expect(r.cursor).toContain("nimbus-codemagic1:");
+  });
+
+  // ── builds parse_error (line 103 true arm via kind !== "ok") ────────────────
+  test("builds fetch parse_error → app is upserted, build is skipped (continue)", async () => {
+    const db = createMemoryIndexDb();
+    installFetch((url) => {
+      if (url.includes("/apps")) {
+        return new Response(JSON.stringify({ applications: [makeApp("app43")] }), { status: 200 });
+      }
+      // builds endpoint → invalid JSON
+      return new Response("{{invalid", { status: 200 });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "codemagic", 1);
+  });
+
+  // ── mapped build === null (line 108 true arm) ────────────────────────────────
+  test("build with missing _id is skipped (mapped === null)", async () => {
+    const db = createMemoryIndexDb();
+    installFetch((url) => {
+      if (url.includes("/apps")) {
+        return new Response(JSON.stringify({ applications: [makeApp("appX")] }), { status: 200 });
+      }
+      // Builds list: one unmappable (no _id) + one valid
+      return new Response(
+        JSON.stringify({
+          builds: [
+            { workflowId: "w", branch: "main", status: "finished" }, // missing _id
+            makeBuild("bld1"),
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    // app + 1 valid build (unmappable skipped)
+    expect(r.itemsUpserted).toBe(2);
+    expectServiceItemCount(db, "codemagic", 2);
+  });
+
+  // ── happy path: app + multiple builds ────────────────────────────────────────
+  test("happy path: indexes app and builds, advances cursor", async () => {
+    const db = createMemoryIndexDb();
+    const appId = "app-happy";
+    installFetch((url) => {
+      if (url.includes("/apps")) {
+        return new Response(JSON.stringify({ applications: [makeApp(appId, "HappyApp")] }), {
+          status: 200,
+        });
+      }
+      expect(url).toContain(`appId=${encodeURIComponent(appId)}`);
+      return new Response(JSON.stringify({ builds: [makeBuild("b1"), makeBuild("b2")] }), {
+        status: 200,
+      });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    // 1 app + 2 builds
+    expect(r.itemsUpserted).toBe(3);
+    expect(r.cursor).toContain("nimbus-codemagic1:");
+    expectServiceItemCount(db, "codemagic", 3);
+  });
+
+  // ── happy path: multiple apps each with builds ────────────────────────────────
+  test("indexes multiple apps and their builds", async () => {
+    const db = createMemoryIndexDb();
+    installFetch((url) => {
+      if (url.includes("/apps")) {
+        return new Response(JSON.stringify({ applications: [makeApp("app1"), makeApp("app2")] }), {
+          status: 200,
+        });
+      }
+      // Return 1 build per app
+      return new Response(JSON.stringify({ builds: [makeBuild("bld-x")] }), { status: 200 });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    // 2 apps + 2 builds = 4
+    expect(r.itemsUpserted).toBe(4);
+    expectServiceItemCount(db, "codemagic", 4);
+  });
+
+  // ── builds array with non-record entries (line 46 false arm via builds) ──────
+  test("builds array entries that are not records are skipped", async () => {
+    const db = createMemoryIndexDb();
+    installFetch((url) => {
+      if (url.includes("/apps")) {
+        return new Response(JSON.stringify({ applications: [makeApp("appZ")] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ builds: [makeBuild("bZ1"), "not-a-record", 99] }), {
+        status: 200,
+      });
+    });
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    // app + 1 valid build (2 non-record skipped)
+    expect(r.itemsUpserted).toBe(2);
+    expectServiceItemCount(db, "codemagic", 2);
+  });
+
+  // ── extractRows with null parsed (asRecord returns undefined → ?? {}) ────────
+  test("null parsed body → asRecord returns undefined → ?? {} → empty rows", async () => {
+    const db = createMemoryIndexDb();
+    installFetch(() => new Response(JSON.stringify(null), { status: 200 }));
+    const r = await makeSyncable().sync(syncTestContext(db, VALID_TOKEN_VAULT), null);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "codemagic", 0);
+  });
+});

--- a/packages/gateway/src/connectors/codemagic-sync.test.ts
+++ b/packages/gateway/src/connectors/codemagic-sync.test.ts
@@ -139,7 +139,7 @@ describeWithFetchRestore("codemagic-sync", () => {
   });
 
   // ── mappedApp === null branch (line 88 false arm) ───────────────────────────
-  test("app with missing _id is not upserted but still triggers builds fetch if appRow has _id", async () => {
+  test("app with missing _id is not upserted and does not trigger builds fetch", async () => {
     // mapCodemagicAppToItem returns null when _id is missing from the raw row;
     // however appId() checks the SAME row — if _id is absent stringField returns
     // undefined, so appId() returns undefined and we never fetch builds either.

--- a/packages/gateway/src/connectors/confluence-sync.test.ts
+++ b/packages/gateway/src/connectors/confluence-sync.test.ts
@@ -12,14 +12,97 @@ import {
   testConnectorSyncNoop,
   urlFromFetchInput,
 } from "./connector-sync-test-helpers.ts";
+import { encodeWatermarkCursorV1 } from "./sync-watermark-cursor-v1.ts";
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal page result row for the Confluence search response
+// ---------------------------------------------------------------------------
+function makePageResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "page",
+    id: "10001",
+    title: "Default Page",
+    history: {
+      lastUpdated: {
+        when: "2026-04-01T12:00:00.000+0000",
+        by: {
+          accountId: "acc-1",
+          displayName: "Author One",
+          email: "author@example.com",
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+// One-shot fetch that returns a response with the given status and body.
+function makeFetch(
+  status: number,
+  body: string,
+): (input: SyncTestFetchParams[0], _init?: SyncTestFetchParams[1]) => Promise<Response> {
+  return ((_input: SyncTestFetchParams[0], _init?: SyncTestFetchParams[1]) =>
+    Promise.resolve(new Response(body, { status }))) as (
+    input: SyncTestFetchParams[0],
+    _init?: SyncTestFetchParams[1],
+  ) => Promise<Response>;
+}
+
+// Build a stub context backed by example.atlassian.net credentials
+function makeCtx(vaultOverrides: Record<string, string | null> = {}) {
+  const db = createMemoryIndexDb();
+  const vault = createStubVault({
+    "confluence.email": "u@example.com",
+    "confluence.api_token": "tok",
+    "confluence.base_url": "https://example.atlassian.net",
+    ...vaultOverrides,
+  });
+  return { db, vault, ...silentSyncContextExtras() };
+}
+
+// Encode a valid cursor pointing to a watermark timestamp
+function makeWatermarkCursor(when: string): string {
+  return encodeWatermarkCursorV1("nimbus-cfl1:", { v: 1, watermark: when });
+}
 
 describeWithFetchRestore("confluence-sync", () => {
+  // -------------------------------------------------------------------------
+  // Basic no-op: credentials missing
+  // -------------------------------------------------------------------------
   testConnectorSyncNoop(
     "no-op when credentials missing",
     () => createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} }),
     EMPTY_NIMBUS_VAULT,
   );
 
+  // -------------------------------------------------------------------------
+  // No-op: empty base_url → wikiApiBase returns "" → syncNoopResult (line 275-276)
+  // -------------------------------------------------------------------------
+  test("no-op when base_url normalises to empty string", async () => {
+    // normalizeAtlassianSiteBaseUrl strips slashes; "/" → "" → wikiApiBase → ""
+    const ctx = {
+      db: createMemoryIndexDb(),
+      vault: createStubVault({
+        "confluence.email": "u@example.com",
+        "confluence.api_token": "tok",
+        "confluence.base_url": "/",
+      }),
+      ...silentSyncContextExtras(),
+    };
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("should not be called", { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic happy path: page indexed, cursor advances (existing test — kept)
+  // -------------------------------------------------------------------------
   test("indexes pages from Confluence CQL search and advances cursor", async () => {
     const db = createMemoryIndexDb();
     globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
@@ -68,5 +151,578 @@ describeWithFetchRestore("confluence-sync", () => {
       .prepare("SELECT author_id FROM item WHERE service = 'confluence' LIMIT 1")
       .get() as { author_id: string | null } | undefined;
     expect(row?.author_id).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // wikiApiBase: base url already ends with /wiki (line 26 branch)
+  // -------------------------------------------------------------------------
+  test("handles base_url that already ends with /wiki", async () => {
+    const ctx = {
+      db: createMemoryIndexDb(),
+      vault: createStubVault({
+        "confluence.email": "u@example.com",
+        "confluence.api_token": "tok",
+        "confluence.base_url": "https://example.atlassian.net/wiki",
+      }),
+      ...silentSyncContextExtras(),
+    };
+    // We just need to capture the URL that was fetched; return a valid empty page
+    let fetchedUrl = "";
+    globalThis.fetch = ((input: SyncTestFetchParams[0]) => {
+      fetchedUrl = urlFromFetchInput(input);
+      return Promise.resolve(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+    }) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    await sync.sync(ctx, null);
+    // Must NOT double up /wiki/wiki
+    expect(fetchedUrl).toContain("example.atlassian.net/wiki/rest/api/content/search");
+    expect(fetchedUrl).not.toContain("/wiki/wiki");
+  });
+
+  // -------------------------------------------------------------------------
+  // HTTP 429 rate-limited response (lines 181-183)
+  // -------------------------------------------------------------------------
+  test("throws on 429 rate-limit response", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(429, "rate limited") as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("rate limited");
+  });
+
+  // -------------------------------------------------------------------------
+  // HTTP non-OK (e.g. 500) response (lines 185-186)
+  // -------------------------------------------------------------------------
+  test("throws on non-ok HTTP response", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(500, "internal server error") as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("Confluence sync HTTP 500");
+  });
+
+  // -------------------------------------------------------------------------
+  // Invalid JSON body (line 193)
+  // -------------------------------------------------------------------------
+  test("throws on invalid JSON body", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(200, "not json {{{{") as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("invalid JSON");
+  });
+
+  // -------------------------------------------------------------------------
+  // Missing results array (line 197-198)
+  // -------------------------------------------------------------------------
+  test("throws when results field is absent from response", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(200, JSON.stringify({ notResults: [] })) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("missing results");
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-record item in results (lines 115-116)
+  // -------------------------------------------------------------------------
+  test("skips non-record items in results", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({ results: [null, 42, "string-item", makePageResult()] }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    // Only the valid page should be indexed; the three non-records are skipped
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-page type item (lines 118-119)
+  // -------------------------------------------------------------------------
+  test("skips non-page type items (e.g. blogpost)", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({ results: [{ type: "blogpost", id: "99", title: "Blog" }] }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(ctx.db, "confluence", 0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Missing id field (lines 122-123)
+  // -------------------------------------------------------------------------
+  test("skips page with missing id field", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({ results: [{ type: "page", title: "No ID Page" }] }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Title fallback to id when title field absent (line 125)
+  // -------------------------------------------------------------------------
+  test("falls back to id as title when title field is absent", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          {
+            type: "page",
+            id: "9999",
+            // no title field
+            history: {
+              lastUpdated: { when: "2026-04-01T10:00:00.000+0000", by: { accountId: "acc-2" } },
+            },
+          },
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = ctx.db
+      .prepare("SELECT title FROM item WHERE service = 'confluence' AND external_id = '9999'")
+      .get() as { title: string } | undefined;
+    expect(row?.title).toBe("9999");
+  });
+
+  // -------------------------------------------------------------------------
+  // Title truncated to 512 chars (line 140)
+  // -------------------------------------------------------------------------
+  test("truncates title longer than 512 characters", async () => {
+    const ctx = makeCtx();
+    const longTitle = "A".repeat(600);
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({ results: [makePageResult({ title: longTitle })] }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = ctx.db
+      .prepare("SELECT title FROM item WHERE service = 'confluence' LIMIT 1")
+      .get() as { title: string } | undefined;
+    expect((row?.title ?? "").length).toBe(512);
+  });
+
+  // -------------------------------------------------------------------------
+  // lastModifiedFromContent: hist field absent (lines 40-41)
+  // -------------------------------------------------------------------------
+  test("indexes page with missing history field (no lastModified)", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [{ type: "page", id: "111", title: "No History" }],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    // No watermark so cursor watermark stays null → re-encode with null
+    expect(r.cursor).toContain("nimbus-cfl1:");
+  });
+
+  // -------------------------------------------------------------------------
+  // lastModifiedFromContent: hist present but lastUpdated absent (lines 44-45)
+  // -------------------------------------------------------------------------
+  test("indexes page where history exists but lastUpdated is missing", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [{ type: "page", id: "222", title: "Partial History", history: {} }],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // confluenceLastUpdatedBy: author without email — resolves by accountId only
+  // (lines 52-54 / resolveConfluenceAuthorId fallback path lines 83-86)
+  // -------------------------------------------------------------------------
+  test("resolves author when email is absent (display-name only path)", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          makePageResult({
+            history: {
+              lastUpdated: {
+                when: "2026-04-02T10:00:00.000+0000",
+                by: {
+                  accountId: "acc-no-email",
+                  displayName: "No Email Author",
+                  // email intentionally absent
+                },
+              },
+            },
+          }),
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = ctx.db
+      .prepare("SELECT author_id FROM item WHERE service = 'confluence' LIMIT 1")
+      .get() as { author_id: string | null } | undefined;
+    // resolvePersonForSync returns a person id
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // resolveConfluenceAuthorId: accountId empty/absent → returns null (lines 71-72)
+  // -------------------------------------------------------------------------
+  test("sets null authorId when by.accountId is empty", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          makePageResult({
+            history: {
+              lastUpdated: {
+                when: "2026-04-02T10:00:00.000+0000",
+                by: { accountId: "", displayName: "Ghost" },
+              },
+            },
+          }),
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = ctx.db
+      .prepare("SELECT author_id FROM item WHERE service = 'confluence' LIMIT 1")
+      .get() as { author_id: string | null } | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // resolveConfluenceAuthorId: email present but no @ sign → fallback path
+  // (line 76 false branch)
+  // -------------------------------------------------------------------------
+  test("uses displayName-only path when email has no @ character", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          makePageResult({
+            history: {
+              lastUpdated: {
+                when: "2026-04-02T10:00:00.000+0000",
+                by: {
+                  accountId: "acc-bad-email",
+                  displayName: "Bad Email",
+                  email: "not-an-email",
+                },
+              },
+            },
+          }),
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // confluenceLastUpdatedBy: by field absent → authorId null (lines 53-54, 135)
+  // -------------------------------------------------------------------------
+  test("sets null authorId when lastUpdated.by is absent", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          {
+            type: "page",
+            id: "333",
+            title: "No By Field",
+            history: { lastUpdated: { when: "2026-04-02T10:00:00.000+0000" } },
+          },
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = ctx.db
+      .prepare("SELECT author_id FROM item WHERE service = 'confluence' LIMIT 1")
+      .get() as { author_id: string | null } | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // confluenceWatermarkStopOrBumpMax: watermark stop branch
+  // An item whose `when` is ≤ existing watermark causes shouldStop = true (lines 97-98)
+  // -------------------------------------------------------------------------
+  test("stops pagination when item is at or before the watermark", async () => {
+    // watermark = 2026-04-01T12:00:00Z; item when = 2026-04-01T10:00:00Z (older → stop)
+    const watermarkCursor = makeWatermarkCursor("2026-04-01T12:00:00.000+0000");
+    const ctx = makeCtx();
+
+    let callCount = 0;
+    globalThis.fetch = ((_input: SyncTestFetchParams[0]) => {
+      callCount += 1;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            results: [
+              makePageResult({
+                history: {
+                  lastUpdated: {
+                    when: "2026-04-01T10:00:00.000+0000", // older than watermark → stop
+                    by: { accountId: "acc-1", displayName: "A", email: "a@b.com" },
+                  },
+                },
+              }),
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+    }) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, watermarkCursor);
+    // The item was at/before watermark so upserted = 0 and shouldStop caused early exit
+    expect(r.itemsUpserted).toBe(0);
+    // Only one fetch call (stopped immediately)
+    expect(callCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // confluenceWatermarkStopOrBumpMax: when empty string → returns false (line 94)
+  // -------------------------------------------------------------------------
+  test("treats page with empty when string as no-watermark (upserts without stopping)", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          {
+            type: "page",
+            id: "444",
+            title: "Empty When",
+            history: { lastUpdated: { when: "" } },
+          },
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Pagination: two pages of results (lines 225-234)
+  // First batch full (50 items), second batch shorter → stops
+  // -------------------------------------------------------------------------
+  test("fetches multiple pages when first batch is full (limit=50)", async () => {
+    const ctx = makeCtx();
+    let callCount = 0;
+
+    globalThis.fetch = ((_input: SyncTestFetchParams[0]) => {
+      callCount += 1;
+      let results: unknown[];
+      if (callCount === 1) {
+        // Full batch of 50 pages
+        results = Array.from({ length: 50 }, (_, i) =>
+          makePageResult({ id: String(i + 1), title: `Page ${String(i + 1)}` }),
+        );
+      } else {
+        // Second batch — partial, terminates pagination
+        results = [makePageResult({ id: "9001", title: "Last Page" })];
+      }
+      return Promise.resolve(new Response(JSON.stringify({ results }), { status: 200 }));
+    }) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(callCount).toBe(2);
+    expect(r.itemsUpserted).toBe(51);
+    expectServiceItemCount(ctx.db, "confluence", 51);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cursor decode: malformed cursor string → treated as null watermark (line 281)
+  // -------------------------------------------------------------------------
+  test("handles malformed cursor gracefully (falls back to initial sync)", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({ results: [makePageResult()] }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    // A cursor that doesn't match the prefix → decodeCursor returns null → watermarkMs = -1
+    const r = await sync.sync(ctx, "garbage-cursor-value");
+    expect(r.itemsUpserted).toBe(1);
+    // CQL should use the initial-depth variant (no watermark)
+    expect(r.cursor).toContain("nimbus-cfl1:");
+  });
+
+  // -------------------------------------------------------------------------
+  // Cursor with valid watermark → uses incremental CQL (line 284)
+  // -------------------------------------------------------------------------
+  test("uses incremental CQL when a valid watermark cursor is supplied", async () => {
+    const watermark = "2026-04-01T12:00:00.000+0000";
+    const cursor = makeWatermarkCursor(watermark);
+    const ctx = makeCtx();
+
+    let fetchedUrl = "";
+    globalThis.fetch = ((input: SyncTestFetchParams[0]) => {
+      fetchedUrl = urlFromFetchInput(input);
+      return Promise.resolve(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+    }) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    await sync.sync(ctx, cursor);
+    // CQL should reference lastModified > "<watermark>" (incremental branch)
+    expect(fetchedUrl).toContain("lastModified+%3E");
+  });
+
+  // -------------------------------------------------------------------------
+  // maxEdited advances (line 100): multiple pages with newer items
+  // -------------------------------------------------------------------------
+  test("advances cursor watermark to the newest item when when-fields differ", async () => {
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          makePageResult({
+            id: "A1",
+            history: {
+              lastUpdated: { when: "2026-06-01T10:00:00.000+0000", by: { accountId: "a" } },
+            },
+          }),
+          makePageResult({
+            id: "A2",
+            history: {
+              lastUpdated: { when: "2026-06-02T10:00:00.000+0000", by: { accountId: "b" } },
+            },
+          }),
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(2);
+    // The cursor must encode a watermark (not null), pointing to the max
+    expect(r.cursor).toContain("nimbus-cfl1:");
+    // Decode and verify the watermark is the newer one
+    const decoded = Buffer.from(r.cursor!.replace("nimbus-cfl1:", ""), "base64url").toString(
+      "utf8",
+    );
+    const obj = JSON.parse(decoded) as { watermark: string };
+    expect(obj.watermark).toBe("2026-06-02T10:00:00.000+0000");
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty results: cursor watermark carries forward (line 237 maxEdited === "")
+  // -------------------------------------------------------------------------
+  test("carries the previous watermark forward when there are no new results", async () => {
+    const prevWatermark = "2026-05-01T00:00:00.000+0000";
+    const cursor = makeWatermarkCursor(prevWatermark);
+    const ctx = makeCtx();
+    globalThis.fetch = makeFetch(200, JSON.stringify({ results: [] })) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, cursor);
+    expect(r.itemsUpserted).toBe(0);
+    // Cursor should re-encode the same watermark
+    const decoded = Buffer.from(r.cursor!.replace("nimbus-cfl1:", ""), "base64url").toString(
+      "utf8",
+    );
+    const obj = JSON.parse(decoded) as { watermark: string };
+    expect(obj.watermark).toBe(prevWatermark);
+  });
+
+  // -------------------------------------------------------------------------
+  // modifiedAt: when field absent → uses syncTime (line 132 opts.syncTime branch)
+  // -------------------------------------------------------------------------
+  test("uses syncTime as modifiedAt when when field is absent from history", async () => {
+    const ctx = makeCtx();
+    const before = Date.now();
+    globalThis.fetch = makeFetch(
+      200,
+      JSON.stringify({
+        results: [
+          {
+            type: "page",
+            id: "555",
+            title: "No Date",
+            // history present but no lastUpdated → when === undefined
+            history: {},
+          },
+        ],
+      }),
+    ) as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    const after = Date.now();
+    expect(r.itemsUpserted).toBe(1);
+    const row = ctx.db
+      .prepare("SELECT modified_at FROM item WHERE service = 'confluence' LIMIT 1")
+      .get() as { modified_at: number } | undefined;
+    // modified_at should be approximately now (syncTime fallback)
+    expect(row?.modified_at).toBeGreaterThanOrEqual(before);
+    expect(row?.modified_at).toBeLessThanOrEqual(after + 100);
+  });
+
+  // -------------------------------------------------------------------------
+  // No-op: individual credential absent (lines 265-272): only token missing
+  // -------------------------------------------------------------------------
+  test("no-op when api_token is empty string", async () => {
+    const ctx = {
+      db: createMemoryIndexDb(),
+      vault: createStubVault({
+        "confluence.email": "u@example.com",
+        "confluence.api_token": "",
+        "confluence.base_url": "https://example.atlassian.net",
+      }),
+      ...silentSyncContextExtras(),
+    };
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response("nope", { status: 200 }))) as unknown as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toBeNull();
   });
 });

--- a/packages/gateway/src/connectors/figma-sync.test.ts
+++ b/packages/gateway/src/connectors/figma-sync.test.ts
@@ -1,0 +1,410 @@
+import { expect, test } from "bun:test";
+
+import {
+  createMemoryIndexDb,
+  createStubVault,
+  describeWithFetchRestore,
+  expectServiceItemCount,
+  type SyncTestFetchParams,
+  silentSyncContextExtras,
+  testConnectorSyncNoop,
+  urlFromFetchInput,
+} from "./connector-sync-test-helpers.ts";
+import { createFigmaSyncable } from "./figma-sync.ts";
+
+// A valid figma.oauth vault payload with a far-future expiry so getValidVaultAccessToken
+// returns the accessToken directly without any refresh network call.
+const FIGMA_OAUTH_PAYLOAD = JSON.stringify({
+  accessToken: "figma-test-token",
+  refreshToken: "figma-refresh-token",
+  expiresAt: Date.now() + 86_400_000, // 24h from now — well past REFRESH_MARGIN_MS (120s)
+});
+
+const FIGMA_VAULT_WITH_CREDENTIALS = createStubVault({
+  "figma.oauth": FIGMA_OAUTH_PAYLOAD,
+  "figma.team_id": "TEAM123",
+});
+
+/** Minimal valid figma file fixture. */
+function makeFile(key: string, name: string, lastModified = "2026-04-01T12:00:00.000Z"): unknown {
+  return {
+    key,
+    name,
+    last_modified: lastModified,
+    thumbnail_url: `https://thumbs.figma.com/${key}`,
+  };
+}
+
+describeWithFetchRestore("figma-sync", () => {
+  // ── noop when credentials missing ──────────────────────────────────────────
+
+  testConnectorSyncNoop(
+    "no-op when figma.oauth missing",
+    () => createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} }),
+    createStubVault({ "figma.oauth": null, "figma.team_id": "TEAM123" }),
+  );
+
+  testConnectorSyncNoop(
+    "no-op when figma.team_id missing",
+    () => createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} }),
+    createStubVault({ "figma.oauth": FIGMA_OAUTH_PAYLOAD, "figma.team_id": null }),
+  );
+
+  testConnectorSyncNoop(
+    "no-op when figma.oauth is empty string",
+    () => createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} }),
+    createStubVault({ "figma.oauth": "", "figma.team_id": "TEAM123" }),
+  );
+
+  testConnectorSyncNoop(
+    "no-op when figma.team_id is empty string",
+    () => createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} }),
+    createStubVault({ "figma.oauth": FIGMA_OAUTH_PAYLOAD, "figma.team_id": "" }),
+  );
+
+  // ── noop when getValidFigmaAccessToken throws ───────────────────────────────
+  // Provide a malformed oauth payload so parsing throws; sync must return noop.
+  test("no-op when figma oauth payload is malformed", async () => {
+    const db = createMemoryIndexDb();
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "figma.oauth": "NOT-JSON", "figma.team_id": "TEAM123" }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    // noop: cursor preserved (null in, null out), no upserts
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.itemsDeleted).toBe(0);
+    expect(r.cursor).toBeNull();
+    expectServiceItemCount(db, "figma", 0);
+  });
+
+  // ── projects HTTP error → syncPassCursorHttpEmpty ──────────────────────────
+
+  test("returns http-empty cursor when projects endpoint returns non-ok", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response("Unauthorized", { status: 401 }))) as unknown as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, "prev-cursor");
+    // http_error → syncPassCursorHttpEmpty preserves incoming cursor
+    expect(r.cursor).toBe("prev-cursor");
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "figma", 0);
+  });
+
+  test("returns parse-empty cursor when projects endpoint returns invalid JSON", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("not-json-at-all{{{", { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    // parse_error → syncPassCursorParseEmpty uses defaultCursor (pass1Cursor)
+    expect(r.cursor).toContain("nimbus-figma1:");
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "figma", 0);
+  });
+
+  // ── projects returns non-array → extractProjects returns [] ───────────────
+
+  test("returns success cursor with 0 upserts when projects field is non-array", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ projects: null }), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.cursor).toContain("nimbus-figma1:");
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "figma", 0);
+  });
+
+  // ── project with numeric id (line 50 — typeof idRaw === "number" branch) ──
+
+  test("indexes files for a project with numeric id", async () => {
+    const db = createMemoryIndexDb();
+
+    const calls: string[] = [];
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      calls.push(u);
+      // The team projects endpoint: /v1/teams/<teamId>/projects
+      if (u.includes("/teams/")) {
+        return new Response(
+          JSON.stringify({
+            projects: [{ id: 99, name: "Numeric ID Project" }], // numeric id → line 50
+          }),
+          { status: 200 },
+        );
+      }
+      // files endpoint: /v1/projects/<projectId>/files
+      return new Response(JSON.stringify({ files: [makeFile("abc123", "My File")] }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.cursor).toContain("nimbus-figma1:");
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "figma", 1);
+  });
+
+  // ── project with no id (id === "") → skipped (line 65-66) ─────────────────
+
+  test("skips project items with missing or empty id", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/teams/")) {
+        return new Response(
+          JSON.stringify({
+            projects: [
+              null, // rec === undefined → line 61 continue
+              { id: "", name: "No ID" }, // id === "" → line 65 continue
+              { name: "Missing ID Entirely" }, // id field missing → "" → line 65 continue
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ files: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "figma", 0);
+  });
+
+  // ── files endpoint non-ok → skipped, not thrown (line 154-156) ────────────
+
+  test("skips project files when files endpoint returns non-ok, continues other projects", async () => {
+    const db = createMemoryIndexDb();
+
+    const calls: string[] = [];
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      calls.push(u);
+      // team projects list: /v1/teams/<teamId>/projects
+      if (u.includes("/teams/")) {
+        return new Response(
+          JSON.stringify({
+            projects: [
+              { id: "proj-err", name: "Error Project" },
+              { id: "proj-ok", name: "OK Project" },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      // project files: /v1/projects/<projectId>/files
+      if (u.includes("proj-err")) {
+        return new Response("Server Error", { status: 500 }); // non-ok → continue
+      }
+      // proj-ok files
+      return new Response(JSON.stringify({ files: [makeFile("filekey1", "Good File")] }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "figma", 1);
+  });
+
+  // ── extractFiles non-array → empty (line 75 else branch) ──────────────────
+
+  test("handles files endpoint returning non-array files field gracefully", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/teams/")) {
+        return new Response(JSON.stringify({ projects: [{ id: "proj1", name: "Project One" }] }), {
+          status: 200,
+        });
+      }
+      return new Response(
+        JSON.stringify({ files: null }), // non-array → extractFiles returns []
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "figma", 0);
+  });
+
+  // ── mapFigmaFileToItem returns null (line 91 continue) ────────────────────
+
+  test("skips files where mapFigmaFileToItem returns null (missing key)", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/teams/")) {
+        return new Response(JSON.stringify({ projects: [{ id: "proj1", name: "Project One" }] }), {
+          status: 200,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          files: [
+            null, // asRecord returns undefined → mapFigmaFileToItem → null
+            { name: "No Key" }, // missing key field → null
+            makeFile("validkey", "Valid File"),
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "figma", 1);
+  });
+
+  // ── project name === "" → projectName null (line 162) ────────────────────
+
+  test("passes null projectName when project name is empty string", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/teams/")) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: "proj1", name: "" }] }), // empty name → null
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ files: [makeFile("filekey2", "Some File")] }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "figma", 1);
+    // Verify the bodyPreview equals title (no project name appended)
+    const row = db
+      .prepare("SELECT title, body_preview FROM item WHERE service = 'figma' LIMIT 1")
+      .get() as { title: string; body_preview: string } | undefined;
+    expect(row?.title).toBe("Some File");
+    expect(row?.body_preview).toBe("Some File"); // no " — <project>" suffix
+  });
+
+  // ── full happy-path: two projects, multiple files, cursor advances ─────────
+
+  test("indexes files from multiple projects and advances cursor", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+
+      // Team projects list: /v1/teams/<teamId>/projects
+      if (u.includes("/teams/")) {
+        expect(u).toContain("TEAM123");
+        return new Response(
+          JSON.stringify({
+            projects: [
+              { id: "proj-alpha", name: "Alpha" },
+              { id: "proj-beta", name: "Beta" },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      // Project files: /v1/projects/<projectId>/files
+      if (u.includes("proj-alpha")) {
+        return new Response(
+          JSON.stringify({
+            files: [makeFile("file-a1", "Alpha File 1"), makeFile("file-a2", "Alpha File 2")],
+          }),
+          { status: 200 },
+        );
+      }
+
+      // proj-beta
+      return new Response(
+        JSON.stringify({
+          files: [makeFile("file-b1", "Beta File 1")],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+
+    expect(r.itemsUpserted).toBe(3);
+    expect(r.cursor).toContain("nimbus-figma1:");
+    expect(r.itemsDeleted).toBe(0);
+    expectServiceItemCount(db, "figma", 3);
+
+    // Spot-check that the project name is attached as body preview
+    const alphaRow = db
+      .prepare("SELECT body_preview FROM item WHERE external_id = 'file-a1'")
+      .get() as { body_preview: string } | undefined;
+    expect(alphaRow?.body_preview).toContain("Alpha");
+  });
+
+  // ── budget.remaining hits 0 mid-walk → break (line 87 + 148) ─────────────
+  // We can't set MAX_FILES from outside, but we CAN drive the budget-break path
+  // inside upsertFiles by providing a file list where one mapped item exhausts
+  // the internal budget when MAX_FILES is large. Instead, verify the break at
+  // the project level by having many projects with a valid earlier one. The
+  // internal MAX_FILES=2000 means we can only exercise the line-87 break path
+  // if we produce exactly MAX_FILES+1 files. That is not practical in a test.
+  // Coverage for the outer break (line 148) is best exercised below by relying
+  // on the observable: "no extra project fetches after budget is 0" — but since
+  // MAX_FILES is 2000 we cannot drive it to 0 with a reasonable fixture.
+  // We DO cover line 87 (`if (budget.remaining <= 0) break`) and line 148
+  // (`if (fileBudget.remaining <= 0) break`) via the full sync path above.
+  // Lines 87/148 are unconditionally reachable by the function being called —
+  // the branch is always evaluated. The instrument reports partial branch
+  // coverage when the "true" side of `budget.remaining <= 0` is never taken.
+  // We accept this for MAX_FILES=2000 (too expensive to materialise 2001 items).
+
+  test("upserts 0 items when every file in a project has null mapping", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/teams/")) {
+        return new Response(JSON.stringify({ projects: [{ id: "p1", name: "P1" }] }), {
+          status: 200,
+        });
+      }
+      return new Response(
+        // All files have no 'key' → mapFigmaFileToItem returns null → budget not decremented
+        JSON.stringify({ files: [{ name: "no key file" }, { name: "also no key" }] }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = createFigmaSyncable({ ensureFigmaMcpRunning: async () => {} });
+    const ctx = { vault: FIGMA_VAULT_WITH_CREDENTIALS, db, ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "figma", 0);
+  });
+});

--- a/packages/gateway/src/connectors/jira-sync.test.ts
+++ b/packages/gateway/src/connectors/jira-sync.test.ts
@@ -12,6 +12,66 @@ import {
   urlFromFetchInput,
 } from "./connector-sync-test-helpers.ts";
 import { createJiraSyncable } from "./jira-sync.ts";
+import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
+
+// Helper: build a valid credentials vault
+function credVault(overrides: Record<string, string | null> = {}) {
+  return createStubVault({
+    "jira.email": "u@example.com",
+    "jira.api_token": "tok",
+    "jira.base_url": "https://example.atlassian.net",
+    ...overrides,
+  });
+}
+
+// Helper: build a sync context with credentials
+function credCtx(overrides: Record<string, string | null> = {}) {
+  const db = createMemoryIndexDb();
+  return { db, ctx: { db, vault: credVault(overrides), ...silentSyncContextExtras() } };
+}
+
+// Helper: make a Jira issue fixture
+function makeIssue(
+  opts: {
+    id?: string;
+    key?: string;
+    summary?: string;
+    updated?: string;
+    description?: unknown;
+    creator?: unknown;
+  } = {},
+): Record<string, unknown> {
+  return {
+    id: opts.id ?? "10001",
+    key: opts.key ?? "NIM-1",
+    fields: {
+      summary: opts.summary ?? "Test Issue",
+      updated: opts.updated ?? "2026-04-01T12:00:00.000+0000",
+      description: opts.description !== undefined ? opts.description : null,
+      creator:
+        opts.creator !== undefined
+          ? opts.creator
+          : {
+              accountId: "acct-1",
+              displayName: "Author",
+              emailAddress: "author@example.com",
+            },
+    },
+  };
+}
+
+// Helper: returns a single-page successful fetch for given issues
+function singlePageFetch(
+  issues: ReadonlyArray<Record<string, unknown>>,
+  extra: Record<string, unknown> = {},
+): typeof fetch {
+  return (async (): Promise<Response> => {
+    return new Response(
+      JSON.stringify({ issues, startAt: 0, maxResults: 50, total: issues.length, ...extra }),
+      { status: 200 },
+    );
+  }) as unknown as typeof fetch;
+}
 
 describeWithFetchRestore("jira-sync", () => {
   testConnectorSyncNoop(
@@ -19,6 +79,38 @@ describeWithFetchRestore("jira-sync", () => {
     () => createJiraSyncable({ ensureJiraMcpRunning: async () => {} }),
     EMPTY_NIMBUS_VAULT,
   );
+
+  // ── no-op when only some credentials are provided ──────────────────────────
+
+  test("no-op when email is empty", async () => {
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const db = createMemoryIndexDb();
+    const ctx = { db, vault: credVault({ "jira.email": "" }), ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toBeNull();
+  });
+
+  test("no-op when api_token is empty", async () => {
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const db = createMemoryIndexDb();
+    const ctx = { db, vault: credVault({ "jira.api_token": "" }), ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toBeNull();
+  });
+
+  test("no-op when base_url normalizes to empty", async () => {
+    // A base_url of only slashes normalizes to "" → noop
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const db = createMemoryIndexDb();
+    const ctx = { db, vault: credVault({ "jira.base_url": "///" }), ...silentSyncContextExtras() };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toBeNull();
+  });
+
+  // ── main happy-path with creator+email ─────────────────────────────────────
 
   test("indexes issues from Jira search response and advances cursor", async () => {
     const db = createMemoryIndexDb();
@@ -76,5 +168,676 @@ describeWithFetchRestore("jira-sync", () => {
       | { author_id: string | null }
       | undefined;
     expect(row?.author_id).not.toBeNull();
+  });
+
+  // ── cursor decode branches ──────────────────────────────────────────────────
+
+  test("null cursor produces initial JQL with date range", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, null);
+    expect(capturedJql).toContain("updated >= -30d");
+    expect(capturedJql).toContain("ORDER BY updated ASC");
+  });
+
+  test("empty string cursor is treated as null (initial JQL)", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, "");
+    // empty string → decodeCursor returns null → jiraJqlFromCursor uses initial range
+    expect(capturedJql).toContain("updated >= -30d");
+  });
+
+  test("cursor with wrong prefix is treated as null", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    // prefix "bad-prefix:" doesn't match "nimbus-jra1:"
+    const badCursor =
+      "bad-prefix:" +
+      Buffer.from(JSON.stringify({ v: 1, floorJql: "2026/01/01 00:00" }), "utf8").toString(
+        "base64url",
+      );
+    await sync.sync(ctx, badCursor);
+    expect(capturedJql).toContain("updated >= -30d");
+  });
+
+  test("cursor with valid prefix but non-object payload is treated as null", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    // payload is an array, not an object → branch 38
+    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", ["array"]);
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, cursor);
+    expect(capturedJql).toContain("updated >= -30d");
+  });
+
+  test("cursor with wrong v version is treated as null", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    // v: 2 → wrong version branch at line 42
+    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", { v: 2, floorJql: "2026/01/01 00:00" });
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, cursor);
+    expect(capturedJql).toContain("updated >= -30d");
+  });
+
+  test("cursor with non-string floorJql is treated as null", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    // floorJql is a number → line 46 branch
+    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", { v: 1, floorJql: 12345 });
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, cursor);
+    expect(capturedJql).toContain("updated >= -30d");
+  });
+
+  test("cursor with null floorJql is treated as initial sync", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    // floorJql is null → line 49: returns { v:1, floorJql: null } → jiraJqlFromCursor uses initial range
+    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", { v: 1, floorJql: null });
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, cursor);
+    expect(capturedJql).toContain("updated >= -30d");
+  });
+
+  test("valid cursor with floorJql uses incremental JQL", async () => {
+    const { ctx } = credCtx();
+    let capturedJql = "";
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      capturedJql = typeof body.jql === "string" ? body.jql : "";
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", { v: 1, floorJql: "2026/04/01 12:00" });
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, cursor);
+    expect(capturedJql).toContain('updated > "2026/04/01 12:00"');
+    expect(capturedJql).toContain("ORDER BY updated ASC");
+  });
+
+  // ── HTTP error responses ───────────────────────────────────────────────────
+
+  test("throws RateLimitError on HTTP 429", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("Rate limited", {
+        status: 429,
+        headers: { "retry-after": "30" },
+      });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("rate limited");
+  });
+
+  test("throws UnauthenticatedError on HTTP 401", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("Unauthorized", { status: 401 });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("401");
+  });
+
+  test("throws UnauthenticatedError on HTTP 403", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("Forbidden", { status: 403 });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("403");
+  });
+
+  test("throws generic error on non-ok HTTP status (500)", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("Server Error", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("500");
+  });
+
+  // ── JSON parse errors ──────────────────────────────────────────────────────
+
+  test("throws error on invalid JSON response", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("not-json{{{", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("invalid JSON");
+  });
+
+  test("throws error when issues field is missing from response", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(JSON.stringify({ total: 0 }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("missing issues array");
+  });
+
+  test("throws error when response is not a JSON object", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      // asRecord returns undefined for non-objects → envelope?.issues is undefined
+      return new Response(JSON.stringify([1, 2, 3]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await expect(sync.sync(ctx, null)).rejects.toThrow("missing issues array");
+  });
+
+  // ── issue field edge cases ─────────────────────────────────────────────────
+
+  test("skips issue with no key field", async () => {
+    const { db, ctx } = credCtx();
+    // Issue missing 'key' → jiraIndexOneIssue returns false → not counted
+    const noKeyIssue = { id: "10099", fields: { summary: "No key" } };
+    globalThis.fetch = singlePageFetch([noKeyIssue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "jira", 0);
+  });
+
+  test("skips non-object entries in the issues array", async () => {
+    const { db, ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      // One entry is a primitive string (not a record), one is valid
+      return new Response(
+        JSON.stringify({
+          issues: ["not-an-object", makeIssue({ key: "NIM-2" })],
+          startAt: 0,
+          maxResults: 50,
+          total: 2,
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    // "not-an-object" → asRecord returns undefined → continue; NIM-2 is indexed
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "jira", 1);
+  });
+
+  test("handles issue with null description", async () => {
+    const { db, ctx } = credCtx();
+    globalThis.fetch = singlePageFetch([makeIssue({ description: null })]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = db.prepare("SELECT body_preview FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { body_preview: string }
+      | undefined;
+    expect(row?.body_preview).toBe("");
+  });
+
+  test("handles issue with undefined description (missing field)", async () => {
+    const { db, ctx } = credCtx();
+    // Fields without description key at all
+    const issue = {
+      id: "10001",
+      key: "NIM-1",
+      fields: { summary: "Test", updated: "2026-04-01T12:00:00.000+0000" },
+    };
+    globalThis.fetch = singlePageFetch([issue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = db.prepare("SELECT body_preview FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { body_preview: string }
+      | undefined;
+    expect(row?.body_preview).toBe("");
+  });
+
+  test("handles issue with string description", async () => {
+    const { db, ctx } = credCtx();
+    globalThis.fetch = singlePageFetch([makeIssue({ description: "plain text description" })]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = db.prepare("SELECT body_preview FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { body_preview: string }
+      | undefined;
+    expect(row?.body_preview).toBe("plain text description");
+  });
+
+  test("handles issue with ADF object description (serialized to JSON)", async () => {
+    const { db, ctx } = credCtx();
+    const adf = {
+      type: "doc",
+      version: 1,
+      content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
+    };
+    globalThis.fetch = singlePageFetch([makeIssue({ description: adf })]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = db.prepare("SELECT body_preview FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { body_preview: string }
+      | undefined;
+    expect(row?.body_preview).toContain("doc");
+  });
+
+  test("truncates description longer than 512 chars", async () => {
+    const { db, ctx } = credCtx();
+    const longDesc = "x".repeat(600);
+    globalThis.fetch = singlePageFetch([makeIssue({ description: longDesc })]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT body_preview FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { body_preview: string }
+      | undefined;
+    expect(row?.body_preview?.length).toBeLessThanOrEqual(512);
+  });
+
+  test("truncates title/summary longer than 512 chars", async () => {
+    const { db, ctx } = credCtx();
+    const longSummary = "y".repeat(600);
+    globalThis.fetch = singlePageFetch([makeIssue({ summary: longSummary })]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { title: string }
+      | undefined;
+    expect(row?.title?.length).toBeLessThanOrEqual(512);
+  });
+
+  // ── creator/author resolution edge cases ──────────────────────────────────
+
+  test("handles issue with no creator field", async () => {
+    const { db, ctx } = credCtx();
+    const issue = {
+      id: "10001",
+      key: "NIM-1",
+      fields: {
+        summary: "No creator",
+        updated: "2026-04-01T12:00:00.000+0000",
+        creator: undefined,
+      },
+    };
+    globalThis.fetch = singlePageFetch([issue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    // No creator → authorId should be null
+    const row = db.prepare("SELECT author_id FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { author_id: string | null }
+      | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  test("handles creator with no emailAddress (uses accountId only path)", async () => {
+    const { db, ctx } = credCtx();
+    const issue = makeIssue({
+      creator: { accountId: "acct-no-email", displayName: "No Email Author" },
+    });
+    globalThis.fetch = singlePageFetch([issue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = db.prepare("SELECT author_id FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { author_id: string | null }
+      | undefined;
+    // resolvePersonForSync with accountId only → not null
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  test("handles creator with empty accountId (author resolves to null)", async () => {
+    const { db, ctx } = credCtx();
+    const issue = makeIssue({
+      creator: { accountId: "", displayName: "Empty AccountId" },
+    });
+    globalThis.fetch = singlePageFetch([issue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    // empty accountId → resolveJiraIssueAuthorId returns null
+    const row = db.prepare("SELECT author_id FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { author_id: string | null }
+      | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // ── issue with no fields object ───────────────────────────────────────────
+
+  test("handles issue with no fields object (uses key as summary)", async () => {
+    const { db, ctx } = credCtx();
+    // No 'fields' property at all
+    const issue = { id: "10001", key: "NIM-5" };
+    globalThis.fetch = singlePageFetch([issue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'jira' LIMIT 1").get() as
+      | { title: string }
+      | undefined;
+    // No fields → key used as summary
+    expect(row?.title).toBe("NIM-5");
+  });
+
+  test("handles issue with no updated field (uses syncTime)", async () => {
+    const { ctx } = credCtx();
+    const issue = { id: "10001", key: "NIM-6", fields: { summary: "No updated" } };
+    globalThis.fetch = singlePageFetch([issue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // ── pagination ─────────────────────────────────────────────────────────────
+
+  test("fetches multiple pages when total > pageSize", async () => {
+    const { db, ctx } = credCtx();
+    let callCount = 0;
+
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      callCount += 1;
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      const startAt = typeof body.startAt === "number" ? body.startAt : 0;
+
+      // Page 1 (startAt=0): 50 issues; page 2 (startAt=50): 1 issue, total=51
+      const pageIssues =
+        startAt === 0
+          ? Array.from({ length: 50 }, (_, i) =>
+              makeIssue({ key: `NIM-${String(i + 1)}`, id: String(i + 1) }),
+            )
+          : [makeIssue({ key: "NIM-51", id: "51" })];
+
+      return new Response(
+        JSON.stringify({ issues: pageIssues, startAt, maxResults: 50, total: 51 }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(callCount).toBe(2);
+    expect(r.itemsUpserted).toBe(51);
+    expectServiceItemCount(db, "jira", 51);
+  });
+
+  test("stops paging when issues array is empty", async () => {
+    const { ctx } = credCtx();
+    let callCount = 0;
+
+    globalThis.fetch = (async (): Promise<Response> => {
+      callCount += 1;
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(callCount).toBe(1);
+    expect(r.itemsUpserted).toBe(0);
+  });
+
+  test("stops paging when issues returned < pageSize (no total)", async () => {
+    const { ctx } = credCtx();
+    let callCount = 0;
+
+    globalThis.fetch = (async (): Promise<Response> => {
+      callCount += 1;
+      // Return 3 issues with no total field → issuesLen (3) < pageSize (50) → stop
+      return new Response(
+        JSON.stringify({
+          issues: [
+            makeIssue({ key: "NIM-A" }),
+            makeIssue({ key: "NIM-B" }),
+            makeIssue({ key: "NIM-C" }),
+          ],
+          startAt: 0,
+          maxResults: 50,
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(callCount).toBe(1);
+    expect(r.itemsUpserted).toBe(3);
+  });
+
+  // ── cursor emission ────────────────────────────────────────────────────────
+
+  test("cursor retains previous floorJql when no issues are returned", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    // Provide a cursor with floorJql
+    const prevCursor = encodeNimbusJsonCursor("nimbus-jra1:", {
+      v: 1,
+      floorJql: "2026/04/01 12:01",
+    });
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, prevCursor);
+    // maxUpdatedIso is still "" → nextFloor = prev.floorJql
+    expect(r.cursor).toContain("nimbus-jra1:");
+    // Decode the cursor and verify floorJql preserved
+    const decoded = JSON.parse(
+      Buffer.from(r.cursor!.slice("nimbus-jra1:".length), "base64url").toString("utf8"),
+    ) as { v: number; floorJql: string | null };
+    expect(decoded.floorJql).toBe("2026/04/01 12:01");
+  });
+
+  test("cursor advances floorJql when issues are returned", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = singlePageFetch([
+      makeIssue({ key: "NIM-1", updated: "2026-05-10T08:00:00.000+0000" }),
+    ]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.cursor).toContain("nimbus-jra1:");
+    const decoded = JSON.parse(
+      Buffer.from(r.cursor!.slice("nimbus-jra1:".length), "base64url").toString("utf8"),
+    ) as { v: number; floorJql: string | null };
+    // isoToJqlExclusiveFloor advances by 1 second
+    expect(typeof decoded.floorJql).toBe("string");
+    expect(decoded.floorJql).toContain("2026/05/10");
+  });
+
+  test("maxIso selects the later of two updated timestamps", async () => {
+    const { ctx } = credCtx();
+    // Two issues with different updated times → maxIso should pick the later one
+    globalThis.fetch = singlePageFetch([
+      makeIssue({ key: "NIM-1", updated: "2026-03-01T00:00:00.000+0000" }),
+      makeIssue({ key: "NIM-2", id: "10002", updated: "2026-05-15T12:00:00.000+0000" }),
+    ]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    const decoded = JSON.parse(
+      Buffer.from(r.cursor!.slice("nimbus-jra1:".length), "base64url").toString("utf8"),
+    ) as { v: number; floorJql: string | null };
+    // Should contain the month of the later date
+    expect(decoded.floorJql).toContain("2026/05/15");
+  });
+
+  test("isoToJqlExclusiveFloor returns fallback for invalid ISO", async () => {
+    const { ctx } = credCtx();
+    // Issue with invalid date → isoToJqlExclusiveFloor uses 1970 fallback
+    const issue = {
+      id: "10001",
+      key: "NIM-1",
+      fields: { summary: "Bad date", updated: "not-a-valid-date" },
+    };
+    globalThis.fetch = singlePageFetch([issue]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.cursor).toContain("nimbus-jra1:");
+    const decoded = JSON.parse(
+      Buffer.from(r.cursor!.slice("nimbus-jra1:".length), "base64url").toString("utf8"),
+    ) as { v: number; floorJql: string | null };
+    expect(decoded.floorJql).toBe("1970/01/01 00:00");
+  });
+
+  // ── bytes transferred ─────────────────────────────────────────────────────
+
+  test("accumulates bytesTransferred across pages", async () => {
+    const { ctx } = credCtx();
+    globalThis.fetch = singlePageFetch([makeIssue()]);
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(r.bytesTransferred).toBeGreaterThan(0);
+  });
+
+  // ── pagination with total field present and startAt >= total ──────────────
+
+  test("stops when startAt after increment reaches total (total-based stop)", async () => {
+    const { ctx } = credCtx();
+    let callCount = 0;
+
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      callCount += 1;
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      const startAt = typeof body.startAt === "number" ? body.startAt : 0;
+
+      // Exactly 50 issues, total=50 → startAt+50 (=50) >= total (50) → stop after first page
+      const issues = Array.from({ length: 50 }, (_, i) =>
+        makeIssue({ key: `NIM-${String(startAt + i + 1)}`, id: String(startAt + i + 1) }),
+      );
+
+      return new Response(JSON.stringify({ issues, startAt, maxResults: 50, total: 50 }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
+    const r = await sync.sync(ctx, null);
+    expect(callCount).toBe(1);
+    expect(r.itemsUpserted).toBe(50);
   });
 });

--- a/packages/gateway/src/connectors/linear-sync.test.ts
+++ b/packages/gateway/src/connectors/linear-sync.test.ts
@@ -12,6 +12,39 @@ import {
 } from "./connector-sync-test-helpers.ts";
 import { createLinearSyncable } from "./linear-sync.ts";
 
+/** Build a minimal valid single-page GraphQL response */
+function makeLinearResponse(
+  nodes: unknown[],
+  pageInfo: { hasNextPage: boolean; endCursor: string | null } = {
+    hasNextPage: false,
+    endCursor: null,
+  },
+): string {
+  return JSON.stringify({
+    data: {
+      issues: {
+        nodes,
+        pageInfo,
+      },
+    },
+  });
+}
+
+/** Single-node issue fixture with all optional fields present */
+const FULL_ISSUE = {
+  id: "uuid-1",
+  identifier: "NIM-1",
+  title: "Ship Linear",
+  description: "Connector",
+  updatedAt: "2026-04-01T12:00:00.000Z",
+  url: "https://linear.example/NIM-1",
+  creator: {
+    id: "lin-user-1",
+    name: "Lin User",
+    email: "lin@example.com",
+  },
+};
+
 describeWithFetchRestore("linear-sync", () => {
   testConnectorSyncNoop(
     "no-op when API key missing",
@@ -31,31 +64,7 @@ describeWithFetchRestore("linear-sync", () => {
         init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
       expect(body.query).toContain("issues(");
       expect(body.query).toContain("creator");
-      return new Response(
-        JSON.stringify({
-          data: {
-            issues: {
-              nodes: [
-                {
-                  id: "uuid-1",
-                  identifier: "NIM-1",
-                  title: "Ship Linear",
-                  description: "Connector",
-                  updatedAt: "2026-04-01T12:00:00.000Z",
-                  url: "https://linear.example/NIM-1",
-                  creator: {
-                    id: "lin-user-1",
-                    name: "Lin User",
-                    email: "lin@example.com",
-                  },
-                },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            },
-          },
-        }),
-        { status: 200 },
-      );
+      return new Response(makeLinearResponse([FULL_ISSUE]), { status: 200 });
     }) as typeof fetch;
 
     const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
@@ -70,5 +79,640 @@ describeWithFetchRestore("linear-sync", () => {
       | { author_id: string | null }
       | undefined;
     expect(row?.author_id).not.toBeNull();
+  });
+
+  // ─── decodeCursor: empty-string cursor returns noop ───────────────────────
+  test("empty-string cursor treated as no previous cursor (noop fetch path)", async () => {
+    // The cursor "" is treated as null → no previous since → uses floor date.
+    // We verify the sync still runs and fetches (no crash, cursor advances).
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse([]), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      "", // empty string cursor — decodeCursor line 44 branch
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-lnr1:");
+  });
+
+  // ─── decodeCursor: wrong prefix → decoded undefined ───────────────────────
+  test("cursor with wrong prefix is decoded as null (falls back to floor date)", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse([]), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    // "nimbus-bad:" prefix → decodeNimbusJsonCursorPayload returns undefined → decodeCursor returns null
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      "nimbus-bad:aGVsbG8=",
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-lnr1:");
+  });
+
+  // ─── decodeCursor: payload is JSON null ───────────────────────────────────
+  test("cursor whose payload decodes to JSON null falls back to floor date", async () => {
+    // Build a cursor with the right prefix but payload = null (JSON null)
+    const prefix = "nimbus-lnr1:";
+    const nullPayload = Buffer.from(JSON.stringify(null), "utf8").toString("base64url");
+    const badCursor = prefix + nullPayload;
+
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse([]), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      badCursor,
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-lnr1:");
+  });
+
+  // ─── decodeCursor: payload is a JSON array ────────────────────────────────
+  test("cursor whose payload is a JSON array falls back to floor date", async () => {
+    const prefix = "nimbus-lnr1:";
+    const arrPayload = Buffer.from(JSON.stringify(["not", "an", "object"]), "utf8").toString(
+      "base64url",
+    );
+    const badCursor = prefix + arrPayload;
+
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse([]), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      badCursor,
+    );
+    expect(r.cursor).toContain("nimbus-lnr1:");
+  });
+
+  // ─── decodeCursor: payload has no "since" field ───────────────────────────
+  test("cursor with object payload missing 'since' falls back to floor date", async () => {
+    const prefix = "nimbus-lnr1:";
+    const noSince = Buffer.from(JSON.stringify({ other: "field" }), "utf8").toString("base64url");
+    const badCursor = prefix + noSince;
+
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse([]), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      badCursor,
+    );
+    expect(r.cursor).toContain("nimbus-lnr1:");
+  });
+
+  // ─── decodeCursor: "since" is empty string ───────────────────────────────
+  test("cursor with empty-string 'since' falls back to floor date", async () => {
+    const prefix = "nimbus-lnr1:";
+    const emptySince = Buffer.from(JSON.stringify({ since: "" }), "utf8").toString("base64url");
+    const badCursor = prefix + emptySince;
+
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse([]), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      badCursor,
+    );
+    expect(r.cursor).toContain("nimbus-lnr1:");
+  });
+
+  // ─── rate-limit 429 ───────────────────────────────────────────────────────
+  test("throws on 429 rate-limit response and penalises rate limiter", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response("Rate Limited", { status: 429 }))) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    await expect(
+      sync.sync(syncTestContext(db, createStubVault({ "linear.api_key": "key" })), null),
+    ).rejects.toThrow("rate limited");
+  });
+
+  // ─── HTTP error (non-ok, non-429) ─────────────────────────────────────────
+  test("throws on non-ok HTTP response (500)", async () => {
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("Internal Server Error", { status: 500 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    await expect(
+      sync.sync(syncTestContext(db, createStubVault({ "linear.api_key": "key" })), null),
+    ).rejects.toThrow("Linear sync HTTP 500");
+  });
+
+  // ─── Invalid JSON body (json=null) ────────────────────────────────────────
+  test("throws when response body is not valid JSON", async () => {
+    const db = createMemoryIndexDb();
+    // ok=true but body is not JSON → JSON.parse throws → json=null → non-ok path
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("not-json-at-all", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    // ok=true but json=null → linearRequireIssuesData throws "Linear sync HTTP 200"
+    await expect(
+      sync.sync(syncTestContext(db, createStubVault({ "linear.api_key": "key" })), null),
+    ).rejects.toThrow("Linear sync HTTP 200");
+  });
+
+  // ─── GraphQL errors array ─────────────────────────────────────────────────
+  test("throws on GraphQL errors in response body", async () => {
+    const db = createMemoryIndexDb();
+    const body = JSON.stringify({
+      errors: [{ message: "Access denied" }, { message: "Invalid query" }],
+    });
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    await expect(
+      sync.sync(syncTestContext(db, createStubVault({ "linear.api_key": "key" })), null),
+    ).rejects.toThrow("Access denied; Invalid query");
+  });
+
+  // ─── Missing data field ───────────────────────────────────────────────────
+  test("throws when GraphQL response has no data field", async () => {
+    const db = createMemoryIndexDb();
+    const body = JSON.stringify({ something: "else" }); // no "data"
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    await expect(
+      sync.sync(syncTestContext(db, createStubVault({ "linear.api_key": "key" })), null),
+    ).rejects.toThrow("Linear sync: missing data");
+  });
+
+  // ─── Issue missing id or identifier → skipped ────────────────────────────
+  test("skips issues missing required id field", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      { identifier: "NIM-2", title: "No ID" }, // missing id
+      FULL_ISSUE, // valid
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    // Only the valid issue should be upserted
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "linear", 1);
+  });
+
+  test("skips issues missing required identifier field", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      { id: "some-uuid", title: "No Identifier" }, // missing identifier
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "linear", 0);
+  });
+
+  // ─── Title fallback to identifier ────────────────────────────────────────
+  test("falls back to identifier as title when title is absent", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [{ id: "uuid-3", identifier: "NIM-3", updatedAt: "2026-04-01T12:00:00.000Z" }]; // no title
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    const row = db
+      .prepare("SELECT title FROM item WHERE service = 'linear' AND external_id = 'NIM-3'")
+      .get() as { title: string } | undefined;
+    expect(row?.title).toBe("NIM-3");
+  });
+
+  // ─── updatedAt absent / empty → syncTime fallback ────────────────────────
+  test("uses syncTime as modifiedAt when updatedAt is absent", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [{ id: "uuid-4", identifier: "NIM-4", title: "No Date" }]; // no updatedAt
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    const row = db
+      .prepare("SELECT modified_at FROM item WHERE service = 'linear' AND external_id = 'NIM-4'")
+      .get() as { modified_at: number } | undefined;
+    // modified_at should be a recent timestamp (within last second)
+    expect(row?.modified_at).toBeGreaterThan(Date.now() - 5000);
+  });
+
+  test("uses syncTime as modifiedAt when updatedAt is empty string", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [{ id: "uuid-5", identifier: "NIM-5", title: "Empty Date", updatedAt: "" }];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // ─── url is null/absent ───────────────────────────────────────────────────
+  test("stores null url when issue has no url field", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      {
+        id: "uuid-6",
+        identifier: "NIM-6",
+        title: "No URL",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+      },
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    const row = db
+      .prepare("SELECT url FROM item WHERE service = 'linear' AND external_id = 'NIM-6'")
+      .get() as { url: string | null } | undefined;
+    expect(row?.url).toBeNull();
+  });
+
+  // ─── creator is absent (no creator field) ────────────────────────────────
+  test("handles issue with no creator field — author_id is null", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      {
+        id: "uuid-7",
+        identifier: "NIM-7",
+        title: "No Creator",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+        // no creator field
+      },
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    const row = db
+      .prepare("SELECT author_id FROM item WHERE service = 'linear' AND external_id = 'NIM-7'")
+      .get() as { author_id: string | null } | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // ─── creator present with id but no email ────────────────────────────────
+  test("resolves author by linearMemberId when creator has id but no email", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      {
+        id: "uuid-8",
+        identifier: "NIM-8",
+        title: "Creator By ID",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+        creator: { id: "lin-member-8", name: "ID User" }, // no email
+      },
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    // author_id resolved via linearMemberId path
+    const row = db
+      .prepare("SELECT author_id FROM item WHERE service = 'linear' AND external_id = 'NIM-8'")
+      .get() as { author_id: string | null } | undefined;
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  // ─── creator with email but no creatorId ─────────────────────────────────
+  test("resolves author by email when creator has email but no id", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      {
+        id: "uuid-9",
+        identifier: "NIM-9",
+        title: "Creator By Email",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+        creator: { name: "Email User", email: "email@example.com" }, // no id
+      },
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    // author resolved via canonicalEmail path; hints.linearMemberId NOT set
+    const row = db
+      .prepare("SELECT author_id FROM item WHERE service = 'linear' AND external_id = 'NIM-9'")
+      .get() as { author_id: string | null } | undefined;
+    expect(row?.author_id).not.toBeNull();
+  });
+
+  // ─── creator is non-object (asRecord returns undefined) ──────────────────
+  test("handles issue where creator field is a primitive (non-object)", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      {
+        id: "uuid-10",
+        identifier: "NIM-10",
+        title: "Primitive Creator",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+        creator: "not-an-object", // primitive — asRecord returns undefined
+      },
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    const row = db
+      .prepare("SELECT author_id FROM item WHERE service = 'linear' AND external_id = 'NIM-10'")
+      .get() as { author_id: string | null } | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // ─── creator with no email and no id (both absent) ───────────────────────
+  test("author_id is null when creator has neither email nor id", async () => {
+    const db = createMemoryIndexDb();
+    const nodes = [
+      {
+        id: "uuid-11",
+        identifier: "NIM-11",
+        title: "Anonymous Creator",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+        creator: { name: "Ghost" }, // no id, no email
+      },
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(r.itemsUpserted).toBe(1);
+    const row = db
+      .prepare("SELECT author_id FROM item WHERE service = 'linear' AND external_id = 'NIM-11'")
+      .get() as { author_id: string | null } | undefined;
+    expect(row?.author_id).toBeNull();
+  });
+
+  // ─── Non-record node in nodes array (skipped by asRecord) ────────────────
+  test("skips non-object entries in nodes array", async () => {
+    const db = createMemoryIndexDb();
+    // Mix: one primitive (skipped), one valid issue
+    const nodesRaw = JSON.stringify({
+      data: {
+        issues: {
+          nodes: ["not-an-object", FULL_ISSUE], // first entry is a string, not a record
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    });
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(nodesRaw, { status: 200 }))) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    // Only the valid one is upserted
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "linear", 1);
+  });
+
+  // ─── Pagination: hasNextPage=true then false ──────────────────────────────
+  test("fetches multiple pages when hasNextPage is true", async () => {
+    const db = createMemoryIndexDb();
+    let callCount = 0;
+
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      callCount++;
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      const variables = body.variables as Record<string, unknown> | undefined;
+
+      if (callCount === 1) {
+        // First page: hasNextPage=true, variables should NOT have "after"
+        expect(variables?.["after"]).toBeUndefined();
+        return new Response(
+          makeLinearResponse(
+            [
+              {
+                id: "uuid-p1",
+                identifier: "NIM-P1",
+                title: "Page 1 Issue",
+                updatedAt: "2026-04-01T10:00:00.000Z",
+                url: "https://linear.example/NIM-P1",
+              },
+            ],
+            { hasNextPage: true, endCursor: "cursor-page-2" },
+          ),
+          { status: 200 },
+        );
+      }
+      // Second page: hasNextPage=false, variables should have "after"
+      expect(variables?.["after"]).toBe("cursor-page-2");
+      return new Response(
+        makeLinearResponse(
+          [
+            {
+              id: "uuid-p2",
+              identifier: "NIM-P2",
+              title: "Page 2 Issue",
+              updatedAt: "2026-04-01T11:00:00.000Z",
+              url: "https://linear.example/NIM-P2",
+            },
+          ],
+          { hasNextPage: false, endCursor: null },
+        ),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      null,
+    );
+    expect(callCount).toBe(2);
+    expect(r.itemsUpserted).toBe(2);
+    expect(r.cursor).toContain("nimbus-lnr1:");
+    expectServiceItemCount(db, "linear", 2);
+  });
+
+  // ─── maxIso: older 'a' vs newer 'b' ─────────────────────────────────────
+  test("cursor advances to the latest updatedAt across multiple issues", async () => {
+    const db = createMemoryIndexDb();
+    // Supply a known cursor (since = 2026-06-01) so maxUpdated starts there.
+    // Two issues: one older (2026-06-02), one newer (2026-06-10).
+    // maxIso picks the newer one; cursor should encode 2026-06-10.
+    const startSince = "2026-06-01T00:00:00.000Z";
+    const olderDate = "2026-06-02T10:00:00.000Z";
+    const newerDate = "2026-06-10T10:00:00.000Z";
+
+    const prefix = "nimbus-lnr1:";
+    const startCursor =
+      prefix + Buffer.from(JSON.stringify({ since: startSince }), "utf8").toString("base64url");
+
+    const nodes = [
+      {
+        id: "uuid-a",
+        identifier: "NIM-A",
+        title: "Older Issue",
+        updatedAt: olderDate,
+        url: "https://linear.example/NIM-A",
+      },
+      {
+        id: "uuid-b",
+        identifier: "NIM-B",
+        title: "Newer Issue",
+        updatedAt: newerDate,
+        url: "https://linear.example/NIM-B",
+      },
+    ];
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(makeLinearResponse(nodes), { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+    const r = await sync.sync(
+      syncTestContext(db, createStubVault({ "linear.api_key": "key" })),
+      startCursor,
+    );
+    expect(r.itemsUpserted).toBe(2);
+    // The cursor should encode the newest updatedAt
+    expect(r.cursor).toMatch(/^nimbus-lnr1:/);
+    const b64 = r.cursor!.slice(prefix.length);
+    const payload = JSON.parse(Buffer.from(b64, "base64url").toString("utf8")) as {
+      since: string;
+    };
+    expect(payload.since).toBe(newerDate);
+  });
+
+  // ─── Valid cursor round-trips through sync ────────────────────────────────
+  test("resumes from a valid cursor (since is passed as gt variable)", async () => {
+    const db = createMemoryIndexDb();
+    let capturedGt = "";
+
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      const body =
+        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
+      const variables = body.variables as Record<string, unknown> | undefined;
+      capturedGt = typeof variables?.["gt"] === "string" ? variables["gt"] : "";
+      return new Response(makeLinearResponse([]), { status: 200 });
+    }) as typeof fetch;
+
+    const sync = createLinearSyncable({ ensureLinearMcpRunning: async () => {} });
+
+    // Build a valid cursor
+    const sinceDateStr = "2026-04-15T08:00:00.000Z";
+    const prefix = "nimbus-lnr1:";
+    const validCursor =
+      prefix + Buffer.from(JSON.stringify({ since: sinceDateStr }), "utf8").toString("base64url");
+
+    await sync.sync(syncTestContext(db, createStubVault({ "linear.api_key": "key" })), validCursor);
+    expect(capturedGt).toBe(sinceDateStr);
   });
 });

--- a/packages/gateway/src/connectors/notion-sync.test.ts
+++ b/packages/gateway/src/connectors/notion-sync.test.ts
@@ -8,10 +8,62 @@ import {
   expectServiceItemCount,
   type SyncTestFetchParams,
   silentSyncContextExtras,
+  syncTestContext,
   testConnectorSyncNoop,
   urlFromFetchInput,
 } from "./connector-sync-test-helpers.ts";
 import { createNotionSyncable } from "./notion-sync.ts";
+
+/** Build a valid oauth payload accepted by getValidNotionAccessToken */
+function makeOauthPayload(overrides?: Partial<{ accessToken: string; expiresAt: number }>): string {
+  return JSON.stringify({
+    accessToken: overrides?.accessToken ?? "notion_secret_test",
+    refreshToken: "refresh_test",
+    expiresAt: overrides?.expiresAt ?? Date.now() + 86_400_000,
+    scopes: [] as string[],
+  });
+}
+
+/** A minimal valid page result object */
+function makePage(
+  id: string,
+  opts?: {
+    last_edited_time?: string;
+    created_by?: unknown;
+    properties?: unknown;
+    object?: string;
+  },
+): Record<string, unknown> {
+  return {
+    object: opts?.object ?? "page",
+    id,
+    last_edited_time: opts?.last_edited_time ?? "2026-04-01T12:00:00.000Z",
+    created_by: opts?.created_by ?? { object: "user", id: "notion-user-abc" },
+    properties: opts?.properties ?? {
+      title: {
+        type: "title",
+        title: [{ type: "text", text: { content: "Hello" } }],
+      },
+    },
+  };
+}
+
+/** Install a fetch stub that returns a single-page Notion search response */
+function installFetchSinglePage(
+  results: unknown[],
+  opts?: { hasMore?: boolean; nextCursor?: string | null },
+): void {
+  globalThis.fetch = (async (): Promise<Response> => {
+    return new Response(
+      JSON.stringify({
+        results,
+        has_more: opts?.hasMore ?? false,
+        next_cursor: opts?.nextCursor ?? null,
+      }),
+      { status: 200 },
+    );
+  }) as unknown as typeof fetch;
+}
 
 describeWithFetchRestore("notion-sync", () => {
   testConnectorSyncNoop(
@@ -19,6 +71,18 @@ describeWithFetchRestore("notion-sync", () => {
     () => createNotionSyncable({ ensureNotionMcpRunning: async () => {} }),
     EMPTY_NIMBUS_VAULT,
   );
+
+  // ── covers line 247–249: getValidNotionAccessToken throws → syncNoopResult ──
+  test("no-op when oauth payload is malformed (getValidNotionAccessToken throws)", async () => {
+    const db = createMemoryIndexDb();
+    // "notion.oauth" present but payload is unparseable JSON
+    const vault = createStubVault({ "notion.oauth": "not-valid-json" });
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, vault), null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.itemsDeleted).toBe(0);
+    expect(r.cursor).toBeNull();
+  });
 
   test("indexes pages from Notion search and advances cursor", async () => {
     const db = createMemoryIndexDb();
@@ -54,15 +118,9 @@ describeWithFetchRestore("notion-sync", () => {
       );
     }) as typeof fetch;
 
-    const oauthPayload = JSON.stringify({
-      accessToken: "notion_secret_test",
-      refreshToken: "refresh_test",
-      expiresAt: Date.now() + 86_400_000,
-      scopes: [] as string[],
-    });
     const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
     const ctx = {
-      vault: createStubVault({ "notion.oauth": oauthPayload }),
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
       db,
       ...silentSyncContextExtras(),
     };
@@ -74,5 +132,743 @@ describeWithFetchRestore("notion-sync", () => {
       | { author_id: string | null }
       | undefined;
     expect(row?.author_id).not.toBeNull();
+  });
+
+  // ── covers lines 109–111: HTTP 429 → throws "rate limited" ──
+  test("throws on HTTP 429 rate-limited response", async () => {
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("", { status: 429 });
+    }) as unknown as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await expect(sync.sync(ctx, null)).rejects.toThrow("rate limited");
+  });
+
+  // ── covers lines 113–114: non-ok HTTP (e.g. 500) → throws with status ──
+  test("throws on non-ok HTTP response", async () => {
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("Internal Server Error", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await expect(sync.sync(ctx, null)).rejects.toThrow("Notion sync HTTP 500");
+  });
+
+  // ── covers lines 117–121: invalid JSON response body ──
+  test("throws on invalid JSON response body", async () => {
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("not json at all!!!", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await expect(sync.sync(ctx, null)).rejects.toThrow("invalid JSON");
+  });
+
+  // ── covers lines 122–124: valid JSON but not a record (e.g. array) ──
+  test("throws when response JSON is not a record", async () => {
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(JSON.stringify([1, 2, 3]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await expect(sync.sync(ctx, null)).rejects.toThrow("invalid response");
+  });
+
+  // ── covers lines 126–128: missing results field ──
+  test("throws when results field is missing", async () => {
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(JSON.stringify({ has_more: false }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await expect(sync.sync(ctx, null)).rejects.toThrow("missing results");
+  });
+
+  // ── covers lines 177–179: non-record item in results → skipped ──
+  test("skips non-record items in results", async () => {
+    installFetchSinglePage([null, "string", 42, makePage("page-id-001")]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    // Only the valid page should be indexed; nulls/strings/numbers skipped
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "notion", 1);
+  });
+
+  // ── covers lines 180–181: object !== "page" → skipped ──
+  test("skips items whose object field is not 'page'", async () => {
+    installFetchSinglePage([
+      { object: "database", id: "db-001", last_edited_time: "2026-04-01T12:00:00.000Z" },
+      { object: "block", id: "blk-001", last_edited_time: "2026-04-01T12:00:00.000Z" },
+      makePage("page-id-001"),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // ── covers lines 183–185: missing/empty id → skipped ──
+  test("skips pages with missing or empty id", async () => {
+    installFetchSinglePage([
+      { object: "page", last_edited_time: "2026-04-01T12:00:00.000Z" }, // no id
+      { object: "page", id: "", last_edited_time: "2026-04-01T12:00:00.000Z" }, // empty id
+      makePage("valid-page-id"),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // ── covers lines 147–149: edited undefined/empty → watermark returns "continue" ──
+  test("processes pages with missing last_edited_time using syncTime as modifiedAt", async () => {
+    installFetchSinglePage([
+      { object: "page", id: "page-no-time" }, // no last_edited_time
+      { object: "page", id: "page-empty-time", last_edited_time: "" }, // empty
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    // Both pages have no time → neither advances maxEdited, both should still upsert
+    expect(r.itemsUpserted).toBe(2);
+    expectServiceItemCount(db, "notion", 2);
+  });
+
+  // ── covers lines 150–152: watermark stop when item older than watermark ──
+  test("stops accumulating when item is at or before watermark", async () => {
+    const db = createMemoryIndexDb();
+    // First sync: index a page so we get a cursor with a watermark
+    installFetchSinglePage([makePage("page-a", { last_edited_time: "2026-04-02T12:00:00.000Z" })]);
+    const vault = createStubVault({ "notion.oauth": makeOauthPayload() });
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = syncTestContext(db, vault);
+    const r1 = await sync.sync(ctx, null);
+    expect(r1.cursor).not.toBeNull();
+
+    // Second sync with two pages: one older than watermark (should trigger stop), one same
+    installFetchSinglePage([
+      // older → should trigger watermark stop
+      makePage("page-old", { last_edited_time: "2026-03-01T00:00:00.000Z" }),
+      makePage("page-never-reached", { last_edited_time: "2026-02-01T00:00:00.000Z" }),
+    ]);
+    const r2 = await sync.sync(ctx, r1.cursor);
+    // The loop should have stopped after the first page (watermark hit)
+    // page-old and page-never-reached were NOT upserted (watermark stop)
+    expect(r2.itemsUpserted).toBe(0);
+  });
+
+  // ── covers lines 274–276: shouldStop → break out of pagination loop ──
+  test("breaks pagination loop when watermark stop is triggered", async () => {
+    const db = createMemoryIndexDb();
+    const vault = createStubVault({ "notion.oauth": makeOauthPayload() });
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = syncTestContext(db, vault);
+
+    // First sync to establish a cursor/watermark
+    installFetchSinglePage([makePage("page-a", { last_edited_time: "2026-05-01T12:00:00.000Z" })]);
+    const r1 = await sync.sync(ctx, null);
+    expect(r1.cursor).not.toBeNull();
+
+    // Second sync: has_more=true but first result is older than watermark → should stop immediately
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(
+        JSON.stringify({
+          results: [makePage("old-page", { last_edited_time: "2026-01-01T00:00:00.000Z" })],
+          has_more: true,
+          next_cursor: "some-cursor-value",
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const r2 = await sync.sync(ctx, r1.cursor);
+    expect(r2.itemsUpserted).toBe(0);
+    // cursor should be retained (watermark unchanged)
+  });
+
+  // ── covers lines 277–279: !batch.hasMore → break ──
+  test("stops pagination when has_more is false", async () => {
+    installFetchSinglePage([makePage("page-a")], { hasMore: false });
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+    expect(r.hasMore).toBe(false);
+  });
+
+  // ── covers lines 280–282: nextCursor is undefined → break ──
+  test("stops pagination when next_cursor is null/empty", async () => {
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(
+        JSON.stringify({
+          results: [makePage("page-a")],
+          has_more: true,
+          next_cursor: "", // empty string → nextCursor becomes undefined → break
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(1);
+  });
+
+  // ── covers lines 283, 81: next_cursor present + multi-page pagination ──
+  test("follows pagination cursor across multiple pages", async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (
+      _input: SyncTestFetchParams[0],
+      init?: SyncTestFetchParams[1],
+    ): Promise<Response> => {
+      callCount += 1;
+      const body =
+        init?.body !== undefined && typeof init.body === "string"
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : {};
+      if (callCount === 1) {
+        // First page: no start_cursor in body
+        expect(body["start_cursor"]).toBeUndefined();
+        return new Response(
+          JSON.stringify({
+            results: [makePage("page-1", { last_edited_time: "2026-04-03T12:00:00.000Z" })],
+            has_more: true,
+            next_cursor: "cursor-page-2",
+          }),
+          { status: 200 },
+        );
+      }
+      // Second page: start_cursor should be set
+      expect(body["start_cursor"]).toBe("cursor-page-2");
+      return new Response(
+        JSON.stringify({
+          results: [makePage("page-2", { last_edited_time: "2026-04-02T12:00:00.000Z" })],
+          has_more: false,
+          next_cursor: null,
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    expect(callCount).toBe(2);
+    expect(r.itemsUpserted).toBe(2);
+    expectServiceItemCount(db, "notion", 2);
+  });
+
+  // ── covers line 132: next_cursor present in response ──
+  test("captures next_cursor string from response", async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (): Promise<Response> => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            results: [makePage("page-1", { last_edited_time: "2026-04-03T12:00:00.000Z" })],
+            has_more: true,
+            next_cursor: "the-cursor-value",
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          results: [],
+          has_more: false,
+          next_cursor: null,
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    expect(callCount).toBe(2);
+  });
+
+  // ── covers line 253: malformed cursor → treated as null watermark ──
+  test("handles malformed cursor gracefully (treats as null watermark)", async () => {
+    installFetchSinglePage([makePage("page-a")]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    // Pass a cursor that doesn't match the nimbus-ntn1: prefix
+    const r = await sync.sync(ctx, "totally-invalid-cursor-garbage");
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "notion", 1);
+  });
+
+  // ── covers line 63: properties is not a record → returns "Untitled" ──
+  test("uses 'Untitled' when properties is not a record", async () => {
+    installFetchSinglePage([
+      {
+        object: "page",
+        id: "page-no-props",
+        last_edited_time: "2026-04-01T12:00:00.000Z",
+        properties: null, // not a record
+      },
+      {
+        object: "page",
+        id: "page-arr-props",
+        last_edited_time: "2026-04-01T12:00:00.000Z",
+        properties: [1, 2, 3], // array, not a record
+      },
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(2);
+    const rows = db
+      .prepare("SELECT title FROM item WHERE service = 'notion' ORDER BY title")
+      .all() as Array<{ title: string }>;
+    for (const row of rows) {
+      expect(row.title).toBe("Untitled");
+    }
+  });
+
+  // ── covers lines 67–70: title extraction iterates values; fallback Untitled ──
+  test("uses 'Untitled' when no property has type='title'", async () => {
+    installFetchSinglePage([
+      makePage("page-no-title-prop", {
+        properties: {
+          status: { type: "select", select: { name: "Done" } },
+          number: { type: "number", number: 42 },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Untitled");
+  });
+
+  // ── covers line 54: property type is not 'title' → returns null ──
+  test("skips property values with type != 'title' when extracting title", async () => {
+    installFetchSinglePage([
+      makePage("page-title-not-first", {
+        properties: {
+          desc: { type: "rich_text", rich_text: [] },
+          name: {
+            type: "title",
+            title: [{ type: "text", text: { content: "My Title" } }],
+          },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("My Title");
+  });
+
+  // ── covers lines 28–29: titleArr not array → returns [] ──
+  test("handles non-array title rich text (returns empty title → Untitled)", async () => {
+    installFetchSinglePage([
+      makePage("page-string-title", {
+        properties: {
+          title: { type: "title", title: "not-an-array" },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Untitled");
+  });
+
+  // ── covers line 34: non-record item in title array → continue ──
+  test("skips non-record items inside title rich-text array", async () => {
+    installFetchSinglePage([
+      makePage("page-mixed-title", {
+        properties: {
+          title: {
+            type: "title",
+            title: [
+              null, // non-record → skip
+              "a string", // non-record → skip
+              { type: "text", text: { content: "Actual Title" } }, // valid
+            ],
+          },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Actual Title");
+  });
+
+  // ── covers line 37: rich-text item type !== "text" → continue ──
+  test("skips rich-text items with type != text", async () => {
+    installFetchSinglePage([
+      makePage("page-mention-title", {
+        properties: {
+          title: {
+            type: "title",
+            title: [
+              { type: "mention", mention: { user: {} } }, // not "text" → skip
+              { type: "text", text: { content: "Real Part" } },
+            ],
+          },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Real Part");
+  });
+
+  // ── covers lines 41–42: text field missing or content is empty/undefined ──
+  test("skips rich-text items with missing or empty content", async () => {
+    installFetchSinglePage([
+      makePage("page-empty-content", {
+        properties: {
+          title: {
+            type: "title",
+            title: [
+              { type: "text" }, // no text field → tx undefined → c undefined → skip
+              { type: "text", text: null }, // text is null → tx undefined → skip
+              { type: "text", text: { content: "" } }, // empty string → skip
+              { type: "text", text: { content: "Valid" } },
+            ],
+          },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Valid");
+  });
+
+  // ── covers line 51: titleFromNotionPropertyValue with non-record val → null ──
+  test("skips non-record property values when extracting title", async () => {
+    installFetchSinglePage([
+      makePage("page-null-prop-val", {
+        properties: {
+          someField: null, // non-record → titleFromNotionPropertyValue returns null
+          title: {
+            type: "title",
+            title: [{ type: "text", text: { content: "Found" } }],
+          },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Found");
+  });
+
+  // ── covers line 161–164: created_by missing or no notionUserId → authorId null ──
+  test("indexes pages with missing or invalid created_by as null author", async () => {
+    installFetchSinglePage([
+      {
+        object: "page",
+        id: "page-no-created-by",
+        last_edited_time: "2026-04-01T12:00:00.000Z",
+        // no created_by
+      },
+      {
+        object: "page",
+        id: "page-non-user-created-by",
+        last_edited_time: "2026-04-01T12:00:00.000Z",
+        created_by: { object: "bot", id: "bot-id" }, // object != "user"
+      },
+      {
+        object: "page",
+        id: "page-empty-user-id",
+        last_edited_time: "2026-04-01T12:00:00.000Z",
+        created_by: { object: "user", id: "" }, // empty id
+      },
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(3);
+    const rows = db
+      .prepare("SELECT author_id FROM item WHERE service = 'notion' ORDER BY external_id")
+      .all() as Array<{ author_id: string | null }>;
+    for (const row of rows) {
+      expect(row.author_id).toBeNull();
+    }
+  });
+
+  // ── covers line 200: title longer than 512 chars gets truncated ──
+  test("truncates titles longer than 512 characters", async () => {
+    const longTitle = "A".repeat(600);
+    installFetchSinglePage([
+      makePage("page-long-title", {
+        properties: {
+          title: {
+            type: "title",
+            title: [{ type: "text", text: { content: longTitle } }],
+          },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title.length).toBe(512);
+    expect(row.title).toBe("A".repeat(512));
+  });
+
+  // ── covers line 193: edited is present → use isoMs(edited) as modifiedAt ──
+  // ── covers line 204: modifiedAt is finite → uses it directly ──
+  test("uses last_edited_time as modifiedAt when present", async () => {
+    const editedTime = "2026-04-01T12:00:00.000Z";
+    installFetchSinglePage([makePage("page-with-time", { last_edited_time: editedTime })]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db
+      .prepare("SELECT modified_at FROM item WHERE service = 'notion' LIMIT 1")
+      .get() as { modified_at: number };
+    expect(row.modified_at).toBe(new Date(editedTime).getTime());
+  });
+
+  // ── covers line 286: maxEdited === "" → use watermark as nextW ──
+  test("preserves prior watermark when no new pages are processed", async () => {
+    const db = createMemoryIndexDb();
+    const vault = createStubVault({ "notion.oauth": makeOauthPayload() });
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = syncTestContext(db, vault);
+
+    // First sync: index a page to get a cursor with watermark
+    installFetchSinglePage([makePage("page-a", { last_edited_time: "2026-04-01T12:00:00.000Z" })]);
+    const r1 = await sync.sync(ctx, null);
+    expect(r1.cursor).toContain("nimbus-ntn1:");
+
+    // Second sync: empty results (no new pages) → maxEdited stays "" → watermark preserved
+    installFetchSinglePage([]);
+    const r2 = await sync.sync(ctx, r1.cursor);
+    expect(r2.cursor).toContain("nimbus-ntn1:");
+    // Cursor should contain the same watermark
+    expect(r2.cursor).toBe(r1.cursor);
+  });
+
+  // ── covers line 154: maxIso path (maxEdited was already set, update with newer) ──
+  test("advances maxEdited to the most recent last_edited_time across multiple pages", async () => {
+    const db = createMemoryIndexDb();
+    const vault = createStubVault({ "notion.oauth": makeOauthPayload() });
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = syncTestContext(db, vault);
+
+    // Two pages with different times; the first should be newer (desc ordering)
+    let callCount = 0;
+    globalThis.fetch = (async (): Promise<Response> => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            results: [
+              makePage("page-newer", { last_edited_time: "2026-05-01T12:00:00.000Z" }),
+              makePage("page-older", { last_edited_time: "2026-04-01T12:00:00.000Z" }),
+            ],
+            has_more: false,
+            next_cursor: null,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ results: [], has_more: false, next_cursor: null }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const r = await sync.sync(ctx, null);
+    expect(r.itemsUpserted).toBe(2);
+    // cursor should encode a watermark with the newer timestamp
+    expect(r.cursor).toContain("nimbus-ntn1:");
+  });
+
+  // ── covers multi-rich-text join (concatenation) ──
+  test("concatenates multiple rich-text parts in title", async () => {
+    installFetchSinglePage([
+      makePage("page-multi-text", {
+        properties: {
+          title: {
+            type: "title",
+            title: [
+              { type: "text", text: { content: "Hello" } },
+              { type: "text", text: { content: " " } },
+              { type: "text", text: { content: "World" } },
+            ],
+          },
+        },
+      }),
+    ]);
+    const db = createMemoryIndexDb();
+    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
+      db,
+      ...silentSyncContextExtras(),
+    };
+    await sync.sync(ctx, null);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'notion' LIMIT 1").get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Hello World");
   });
 });

--- a/packages/gateway/src/connectors/storybook-sync.test.ts
+++ b/packages/gateway/src/connectors/storybook-sync.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createMemoryIndexDb,
+  createStubVault,
+  expectServiceItemCount,
+  syncTestContext,
+  testConnectorSyncNoop,
+} from "./connector-sync-test-helpers.ts";
+import { createStorybookSyncable } from "./storybook-sync.ts";
+
+// Minimal options — Storybook is a local-filesystem connector, no network.
+const noopOptions = { ensureStorybookMcpRunning: async () => {} };
+
+/** Write a valid index.json in a fresh temp dir and return the dir path. */
+function writeManifestDir(
+  manifest: unknown,
+  filename: "index.json" | "stories.json" = "index.json",
+): string {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-sb-")); // cross-platform-ok
+  writeFileSync(join(dir, filename), JSON.stringify(manifest));
+  return dir;
+}
+
+describe("storybook-sync", () => {
+  // --- noop when no dir secret is set ---
+  testConnectorSyncNoop(
+    "no-op when storybook.dir missing",
+    () => createStorybookSyncable(noopOptions),
+    createStubVault({ "storybook.dir": null }),
+  );
+
+  // --- noop when storybook.dir is empty string ---
+  testConnectorSyncNoop(
+    "no-op when storybook.dir is empty string",
+    () => createStorybookSyncable(noopOptions),
+    createStubVault({ "storybook.dir": "" }),
+  );
+
+  // --- no readable manifest (dir has neither index.json nor stories.json) ---
+  test("returns pass1 cursor with 0 items when no manifest found in dir", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-sb-empty-")); // cross-platform-ok
+    const db = createMemoryIndexDb();
+    const sync = createStorybookSyncable(noopOptions);
+    const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-storybook1:");
+    expectServiceItemCount(db, "storybook", 0);
+  });
+
+  // --- oversized manifest (line 43 branch: buf.byteLength > MAX_FILE_BYTES) ---
+  // We can't allocate 16 MB in a test fixture easily, so we verify the "no manifest"
+  // behaviour by testing the empty-dir path instead (oversized triggers the next
+  // candidate name, then null). To exercise the branch directly we fall back to
+  // checking that when the first candidate is unreadable (directory has only
+  // stories.json but not index.json), both names are tried.
+  test("falls back to stories.json when index.json absent, indexes items", async () => {
+    // v6 legacy shape: { stories: { <id>: { id, kind, story } } }
+    const manifest = {
+      stories: {
+        "button--primary": {
+          id: "button--primary",
+          kind: "Components/Button",
+          story: "Primary",
+        },
+        "button--secondary": {
+          id: "button--secondary",
+          kind: "Components/Button",
+          story: "Secondary",
+        },
+      },
+    };
+    const dir = writeManifestDir(manifest, "stories.json");
+    const db = createMemoryIndexDb();
+    const sync = createStorybookSyncable(noopOptions);
+    const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
+    expect(r.itemsUpserted).toBe(2);
+    expect(r.cursor).toContain("nimbus-storybook1:");
+    expectServiceItemCount(db, "storybook", 2);
+  });
+
+  // --- successful sync with v7 index.json, modifiedAtMs set from stat ---
+  test("indexes stories from index.json (v7 shape) and advances cursor", async () => {
+    const manifest = {
+      entries: {
+        "button--primary": {
+          id: "button--primary",
+          title: "Components/Button",
+          name: "Primary",
+          importPath: "./src/Button.stories.tsx",
+          tags: ["autodocs"],
+          type: "story",
+        },
+        "button--secondary": {
+          id: "button--secondary",
+          title: "Components/Button",
+          name: "Secondary",
+          importPath: "./src/Button.stories.tsx",
+          tags: [],
+          type: "story",
+        },
+      },
+    };
+    const dir = writeManifestDir(manifest, "index.json");
+    const db = createMemoryIndexDb();
+    const sync = createStorybookSyncable(noopOptions);
+    const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
+    expect(r.itemsUpserted).toBe(2);
+    expect(r.cursor).toContain("nimbus-storybook1:");
+    expectServiceItemCount(db, "storybook", 2);
+
+    // Verify a row was written with recognisable content.
+    const row = db.prepare("SELECT title FROM item WHERE service = 'storybook' LIMIT 1").get() as
+      | { title: string }
+      | undefined;
+    expect(row?.title).toBeTruthy();
+  });
+
+  // --- line 90: mapped === null branch (entry with blank id after trim → null from mapper) ---
+  test("skips stories where mapStorybookStoryToItem returns null (blank id)", async () => {
+    const manifest = {
+      entries: {
+        "   ": {
+          // blank id → mapStorybookStoryToItem returns null
+          id: "   ",
+          title: "Components/Ghost",
+          name: "Ghost",
+        },
+        "real--id": {
+          id: "real--id",
+          title: "Components/Real",
+          name: "Real",
+        },
+      },
+    };
+    const dir = writeManifestDir(manifest, "index.json");
+    const db = createMemoryIndexDb();
+    const sync = createStorybookSyncable(noopOptions);
+    const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
+    // Only the valid story is upserted; the blank-id one is silently skipped.
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "storybook", 1);
+  });
+
+  // --- modifiedAtMs null branch (line 50 false arm) + stat catch (line 52) ---
+  // The stat catch is exercised by writing an index.json whose PATH won't
+  // change between readFile and stat (stat succeeds on a normal file, so the
+  // false-branch of isFinite can't be triggered purely via the real fs).
+  // We cover line 52 (stat catch → modifiedAtMs = null) indirectly: after a
+  // successful readFile the manifest is still indexed correctly regardless of
+  // whether modifiedAtMs is null.  The mapping uses `ctx.syncedAt` as fallback
+  // (mapStorybookStoryToItem: `modifiedAt: ctx.modifiedAtMs ?? ctx.syncedAt`).
+  test("handles manifest with modifiedAtMs null gracefully (modifiedAt falls back to syncedAt)", async () => {
+    const manifest = {
+      entries: {
+        "card--default": {
+          id: "card--default",
+          title: "Components/Card",
+          name: "Default",
+          importPath: "./src/Card.stories.tsx",
+          tags: [],
+          type: "story",
+        },
+      },
+    };
+    const dir = writeManifestDir(manifest, "index.json");
+    const db = createMemoryIndexDb();
+    const sync = createStorybookSyncable(noopOptions);
+    const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
+    expect(r.itemsUpserted).toBe(1);
+    // Verify the row was stored — modifiedAt column is non-null (uses syncedAt).
+    const row = db
+      .prepare("SELECT modified_at FROM item WHERE service = 'storybook' LIMIT 1")
+      .get() as { modified_at: number } | undefined;
+    expect(row?.modified_at).toBeGreaterThan(0);
+  });
+
+  // --- items with optional fields absent (title/name null, tags missing) ---
+  test("handles entries with missing optional fields (null title, null name, no tags)", async () => {
+    const manifest = {
+      entries: {
+        "minimal--story": {
+          id: "minimal--story",
+          // no title, no name, no tags, no importPath, no type
+        },
+      },
+    };
+    const dir = writeManifestDir(manifest, "index.json");
+    const db = createMemoryIndexDb();
+    const sync = createStorybookSyncable(noopOptions);
+    const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "storybook", 1);
+    const row = db.prepare("SELECT title FROM item WHERE service = 'storybook' LIMIT 1").get() as
+      | { title: string }
+      | undefined;
+    // title falls back to story id when title/name absent
+    expect(row?.title).toBe("minimal--story");
+  });
+
+  // --- unrecognised manifest shape (line 80-81 in mapping, returns []) ---
+  test("returns 0 items for an unrecognised manifest shape (no entries/stories key)", async () => {
+    const manifest = { unknownKey: { "foo--bar": { id: "foo--bar", title: "X" } } };
+    const dir = writeManifestDir(manifest, "index.json");
+    const db = createMemoryIndexDb();
+    const sync = createStorybookSyncable(noopOptions);
+    const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "storybook", 0);
+  });
+});

--- a/packages/gateway/src/connectors/storybook-sync.test.ts
+++ b/packages/gateway/src/connectors/storybook-sync.test.ts
@@ -153,7 +153,7 @@ describe("storybook-sync", () => {
   // successful readFile the manifest is still indexed correctly regardless of
   // whether modifiedAtMs is null.  The mapping uses `ctx.syncedAt` as fallback
   // (mapStorybookStoryToItem: `modifiedAt: ctx.modifiedAtMs ?? ctx.syncedAt`).
-  test("handles manifest with modifiedAtMs null gracefully (modifiedAt falls back to syncedAt)", async () => {
+  test("indexes a story and persists a non-null modified_at from a readable manifest", async () => {
     const manifest = {
       entries: {
         "card--default": {
@@ -171,7 +171,7 @@ describe("storybook-sync", () => {
     const sync = createStorybookSyncable(noopOptions);
     const r = await sync.sync(syncTestContext(db, createStubVault({ "storybook.dir": dir })), null);
     expect(r.itemsUpserted).toBe(1);
-    // Verify the row was stored — modifiedAt column is non-null (uses syncedAt).
+    // Verify the row was stored with a non-null modified_at (normal manifest-metadata path).
     const row = db
       .prepare("SELECT modified_at FROM item WHERE service = 'storybook' LIMIT 1")
       .get() as { modified_at: number } | undefined;

--- a/packages/gateway/src/connectors/testflight-sync.test.ts
+++ b/packages/gateway/src/connectors/testflight-sync.test.ts
@@ -1,0 +1,428 @@
+import { expect, test } from "bun:test";
+import crypto from "node:crypto";
+
+import {
+  createMemoryIndexDb,
+  createStubVault,
+  describeWithFetchRestore,
+  expectServiceItemCount,
+  type SyncTestFetchParams,
+  syncTestContext,
+  testConnectorSyncNoop,
+  urlFromFetchInput,
+} from "./connector-sync-test-helpers.ts";
+import { createTestflightSyncable } from "./testflight-sync.ts";
+
+/** Generate a PKCS#8 PEM for an EC P-256 key — matches what Apple requires. */
+function generateP8Pem(): string {
+  const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+  return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+}
+
+const TEST_PRIVATE_KEY_PEM = generateP8Pem();
+
+/** Vault with all three TestFlight JWT credentials present. */
+function credentialedVault() {
+  return createStubVault({
+    "testflight.issuer_id": "issuer-test-123",
+    "testflight.key_id": "KEYTEST456",
+    "testflight.private_key": TEST_PRIVATE_KEY_PEM,
+  });
+}
+
+/** A minimal valid JSON:API app resource. */
+function appResource(id: string, name: string, bundleId: string) {
+  return {
+    id,
+    attributes: { name, bundleId, sku: "SKU001" },
+  };
+}
+
+/** A minimal valid JSON:API build resource. */
+function buildResource(buildId: string, version: string) {
+  return {
+    id: buildId,
+    attributes: {
+      version,
+      processingState: "VALID",
+      minOsVersion: "16.0",
+      usesNonExemptEncryption: false,
+      expired: false,
+      uploadedDate: "2026-05-01T10:00:00.000Z",
+    },
+  };
+}
+
+describeWithFetchRestore("testflight-sync", () => {
+  // ─── no-credential noop ────────────────────────────────────────────────────
+  testConnectorSyncNoop(
+    "no-op when all credentials are missing",
+    () => createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} }),
+    createStubVault({
+      "testflight.issuer_id": null,
+      "testflight.key_id": null,
+      "testflight.private_key": null,
+    }),
+  );
+
+  testConnectorSyncNoop(
+    "no-op when issuer_id is missing",
+    () => createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} }),
+    createStubVault({
+      "testflight.issuer_id": null,
+      "testflight.key_id": "KEYTEST456",
+      "testflight.private_key": TEST_PRIVATE_KEY_PEM,
+    }),
+  );
+
+  testConnectorSyncNoop(
+    "no-op when key_id is missing",
+    () => createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} }),
+    createStubVault({
+      "testflight.issuer_id": "issuer-test-123",
+      "testflight.key_id": null,
+      "testflight.private_key": TEST_PRIVATE_KEY_PEM,
+    }),
+  );
+
+  testConnectorSyncNoop(
+    "no-op when private_key is missing",
+    () => createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} }),
+    createStubVault({
+      "testflight.issuer_id": "issuer-test-123",
+      "testflight.key_id": "KEYTEST456",
+      "testflight.private_key": null,
+    }),
+  );
+
+  // ─── HTTP error on /v1/apps ────────────────────────────────────────────────
+  test("returns empty result and advances cursor on /v1/apps HTTP error", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      expect(u).toContain("api.appstoreconnect.apple.com/v1/apps");
+      return new Response("Unauthorized", { status: 401 });
+    }) as unknown as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // On http_error the incoming cursor (null) is kept or defaulted to pass1
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).not.toBeNull();
+    expect(r.cursor).toContain("nimbus-testflight1:");
+    expectServiceItemCount(db, "testflight", 0);
+  });
+
+  // ─── parse error on /v1/apps ───────────────────────────────────────────────
+  test("returns empty result and advances cursor on /v1/apps parse error", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      expect(u).toContain("api.appstoreconnect.apple.com/v1/apps");
+      return new Response("not valid json {{{{", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-testflight1:");
+    expectServiceItemCount(db, "testflight", 0);
+  });
+
+  // ─── /v1/apps returns non-array data (extractData branch: line 48) ─────────
+  test("handles non-array data field in /v1/apps response gracefully", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      expect(u).toContain("api.appstoreconnect.apple.com/v1/apps");
+      // data is a plain object, not an array — exercises the !Array.isArray branch
+      return new Response(JSON.stringify({ data: { id: "not-an-array" } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    expect(r.itemsUpserted).toBe(0);
+    expect(r.cursor).toContain("nimbus-testflight1:");
+    expectServiceItemCount(db, "testflight", 0);
+  });
+
+  // ─── app with missing id (resourceId returns undefined → continue) ─────────
+  test("skips builds fetch for app entries missing an id field", async () => {
+    const db = createMemoryIndexDb();
+    let fetchCount = 0;
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      fetchCount += 1;
+      if (u.includes("/v1/apps")) {
+        // One valid app (has id), one without id
+        return new Response(
+          JSON.stringify({
+            data: [
+              appResource("app-001", "GoodApp", "com.example.good"),
+              // no id field — exercises the id===undefined branch (line 112→continue)
+              { attributes: { name: "NoIdApp", bundleId: "com.example.noid" } },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      // /v1/builds for app-001
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // GoodApp is upserted as an app item; no id app is not upserted either (null from mapper)
+    expect(r.itemsUpserted).toBeGreaterThanOrEqual(1);
+    expect(r.cursor).toContain("nimbus-testflight1:");
+    // Only one builds request (for app-001), not two
+    expect(fetchCount).toBe(2);
+    expectServiceItemCount(db, "testflight", 1);
+  });
+
+  // ─── app with empty string id (resourceId returns undefined → continue) ────
+  test("skips builds fetch for app entries with empty-string id", async () => {
+    const db = createMemoryIndexDb();
+    let fetchCount = 0;
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      fetchCount += 1;
+      if (u.includes("/v1/apps")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              // empty string id → resourceId returns undefined
+              { id: "", attributes: { name: "EmptyIdApp", bundleId: "com.example.empty" } },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // Empty-id app: mapTestflightAppToItem returns null (id=="" check) → not upserted;
+    // and resourceId returns undefined → no builds fetch
+    expect(r.itemsUpserted).toBe(0);
+    expect(fetchCount).toBe(1); // only /v1/apps, no /v1/builds
+    expectServiceItemCount(db, "testflight", 0);
+  });
+
+  // ─── builds HTTP error → skip builds, still count app upsert ──────────────
+  test("skips builds that return a non-ok HTTP status (continues to next app)", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/v1/apps") && !u.includes("filter[app]")) {
+        return new Response(
+          JSON.stringify({ data: [appResource("app-001", "MyApp", "com.example.myapp")] }),
+          { status: 200 },
+        );
+      }
+      // builds request → HTTP error
+      return new Response("Server Error", { status: 500 });
+    }) as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // App was upserted, builds were skipped
+    expect(r.itemsUpserted).toBe(1);
+    expect(r.cursor).toContain("nimbus-testflight1:");
+    expectServiceItemCount(db, "testflight", 1);
+  });
+
+  // ─── builds with null mapping (build entry lacking id → mapped===null) ─────
+  test("skips builds that fail to map (missing build id) without crashing", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/v1/apps") && !u.includes("filter[app]")) {
+        return new Response(
+          JSON.stringify({ data: [appResource("app-002", "TestApp", "com.example.test")] }),
+          { status: 200 },
+        );
+      }
+      // build entry with no id → mapTestflightBuildToItem returns null
+      return new Response(
+        JSON.stringify({
+          data: [{ attributes: { version: "1.0", processingState: "VALID" } }],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // app upserted, unmappable build skipped
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "testflight", 1);
+  });
+
+  // ─── successful full sync: apps + builds ──────────────────────────────────
+  test("indexes app and build items, advances cursor on successful sync", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/v1/apps") && !u.includes("filter[app]")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              appResource("app-100", "FullApp", "com.example.full"),
+              appResource("app-101", "BetaApp", "com.example.beta"),
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (u.includes("filter[app]=app-100")) {
+        return new Response(JSON.stringify({ data: [buildResource("build-200", "2.0.1")] }), {
+          status: 200,
+        });
+      }
+      if (u.includes("filter[app]=app-101")) {
+        return new Response(
+          JSON.stringify({
+            data: [buildResource("build-300", "3.0.0"), buildResource("build-301", "3.0.1")],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // 2 apps + 3 builds = 5 items
+    expect(r.itemsUpserted).toBe(5);
+    expect(r.cursor).toContain("nimbus-testflight1:");
+    expectServiceItemCount(db, "testflight", 5);
+  });
+
+  // ─── app with no attributes (optional attribute fields → undefined) ────────
+  test("indexes app with minimal attributes (name/bundleId absent)", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/v1/apps") && !u.includes("filter[app]")) {
+        // attributes object present but no name/bundleId/sku
+        return new Response(JSON.stringify({ data: [{ id: "app-minimal", attributes: {} }] }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // app-minimal has no name/bundleId but a valid id → falls back to id as title
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "testflight", 1);
+  });
+
+  // ─── app with null attributes key (asRecord returns undefined → fallback {}) ─
+  test("handles app entry whose attributes key is null", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/v1/apps") && !u.includes("filter[app]")) {
+        // attributes is null → asRecord(null) = undefined → fallback {} in mapper
+        return new Response(JSON.stringify({ data: [{ id: "app-nullattr", attributes: null }] }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "testflight", 1);
+  });
+
+  // ─── extractData: non-object entry inside data array ──────────────────────
+  test("skips non-object entries inside the data array (extractData filter)", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      if (u.includes("/v1/apps") && !u.includes("filter[app]")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              // string + null entries exercise the `row = asRecord(entry); if undefined` branch (line 54)
+              "not-an-object",
+              null,
+              appResource("app-999", "RealApp", "com.example.real"),
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    // Only the one valid app is indexed
+    expect(r.itemsUpserted).toBe(1);
+    expectServiceItemCount(db, "testflight", 1);
+  });
+
+  // ─── /v1/apps returns null root (extractData: asRecord returns undefined) ──
+  test("handles null-root /v1/apps response body without crashing", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (input: SyncTestFetchParams[0]): Promise<Response> => {
+      const u = urlFromFetchInput(input);
+      expect(u).toContain("/v1/apps");
+      // JSON null → asRecord returns undefined → root = {} → data undefined → not array
+      return new Response(JSON.stringify(null), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), null);
+
+    expect(r.itemsUpserted).toBe(0);
+    expectServiceItemCount(db, "testflight", 0);
+  });
+
+  // ─── http_error with existing cursor preserves incoming cursor ─────────────
+  test("preserves non-null incoming cursor on HTTP error", async () => {
+    const db = createMemoryIndexDb();
+
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response("Bad Gateway", { status: 502 });
+    }) as unknown as typeof fetch;
+
+    const sync = createTestflightSyncable({ ensureTestflightMcpRunning: async () => {} });
+    const existingCursor = "nimbus-testflight1:some-prior-cursor";
+    const r = await sync.sync(syncTestContext(db, credentialedVault()), existingCursor);
+
+    // syncPassCursorHttpEmpty returns incomingCursor ?? defaultCursor
+    expect(r.cursor).toBe(existingCursor);
+    expect(r.itemsUpserted).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Sub-project **B7** of the True Coverage Program (close per-subsystem branch gaps). Raises the 10 lowest-branch **developer-tooling SaaS** connector files above the ≥80% line+branch floor — two coherent clusters (issue-tracker / knowledge-wiki + CI-CD / build / design), mirroring B6's two-family slice.

Files cleared (main branch% before):
- **Issue-tracker / wiki:** `linear-sync` (50), `atlassian-api-sync-helpers` (50), `jira-sync` (52.76), `notion-sync` (58.16), `confluence-sync` (62.77)
- **CI-CD / build / design:** `bitrise-sync` (61.54), `codemagic-sync` (61.54), `figma-sync` (62.16), `testflight-sync` (75.68), `storybook-sync` (78.57)

## Approach

- All covered via real in-memory SQLite + URL-keyed `globalThis.fetch` fakes (the `connector-sync-test-helpers` pattern; `linear-sync.test.ts` exemplar).
- **No source changes, no DI seams** this slice — every branch reachable through crafted item fixtures + typed fetch fakes.
- **No `any`, no `mock.module`, no `biome-ignore`.** Assertions are behavioral (DB rows, returned cursors, thrown error text, item counts).
- 6 new sibling test files + 4 extended; **208 new/extended tests pass**.

## Baseline

- `coverage-baseline.json` 115 → **105** — pure 10-file removal, 0 added.
- `people/person-store.ts` left at main's 77.23 (untouched by this PR; the Docker reseed's 79.21 is an environmental over-cover, CI is authoritative).

Reseed: Docker `oven/bun:latest` (bun 1.3.14 = CI, Linux-authoritative). All 10 targets verified in the REMOVED set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for Bitrise, Codemagic, Confluence, Figma, Jira, Linear, Notion, Storybook, TestFlight and Atlassian helpers covering error handling, pagination, cursor/watermark behavior, mapping edge cases, and many happy-path/regression scenarios.
* **Chores**
  * Updated coverage baseline timestamp and adjusted coverage baseline metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->