### PR TITLE
test(cli/tui): fix Windows-only dumb-terminal spawn-timeout flake

### DIFF
--- a/packages/cli/src/tui/dumb-terminal.test.ts
+++ b/packages/cli/src/tui/dumb-terminal.test.ts
@@ -7,23 +7,36 @@ const CLI_ENTRY = join(REPO_ROOT, "packages", "cli", "src", "index.ts");
 
 const BUN_EXECUTABLE = process.execPath;
 
-function run(env: NodeJS.ProcessEnv = {}): { code: number; stdout: string; stderr: string } {
+function run(env: NodeJS.ProcessEnv = {}): {
+  code: number;
+  stdout: string;
+  stderr: string;
+  error: Error | undefined;
+} {
   const result = spawnSync(BUN_EXECUTABLE, ["run", CLI_ENTRY, "tui"], {
     env: { ...process.env, ...env },
     stdio: ["pipe", "pipe", "pipe"],
     encoding: "utf-8",
-    timeout: 5_000,
+    // A cold `bun run` of the CLI entry (transpile + module graph load) can exceed
+    // a few seconds on a loaded CI runner — notably Windows, where this was the
+    // first (cold) spawn in the file. A tight timeout killed the process before any
+    // output, surfacing as a confusing `combined.length === 0` failure. Give it
+    // generous headroom; each test runs a single spawn well within the suite timeout.
+    timeout: 30_000,
   });
   return {
     code: result.status ?? -1,
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",
+    error: result.error,
   };
 }
 
 describe("nimbus tui fallback behavior", () => {
   test("TERM=dumb prints fallback notice and does not attempt Ink render", () => {
-    const { stdout, stderr } = run({ TERM: "dumb" });
+    const { stdout, stderr, error } = run({ TERM: "dumb" });
+    // Surface a spawn timeout/error explicitly rather than as an opaque empty-output assertion.
+    expect(error).toBeUndefined();
     const combined = stdout + stderr;
     expect(combined.length).toBeGreaterThan(0);
     expect(combined).not.toContain("Sub-Tasks");


### PR DESCRIPTION
## What

Fixes the Windows-only CI flake in `packages/cli/src/tui/dumb-terminal.test.ts` that failed the `Unit + Coverage — windows-2025` job ([run 27365581708](https://github.com/nimbus-agent/Nimbus/actions/runs/27365581708/job/80864082335)):

```
(fail) nimbus tui fallback behavior > TERM=dumb prints fallback notice...
error: expect(received).toBeGreaterThan(expected)  Expected: > 0  Received: 0
  at packages/cli/src/tui/dumb-terminal.test.ts:28
```

## Root cause

That test is the **first** spawn in the file — a *cold* `bun run <cli-entry> tui` (transpile + module-graph load) — guarded by only a **5 s** `spawnSync` timeout. On a loaded Windows runner the cold start exceeded 5 s, the process was killed with **empty output**, so `combined.length` was `0`. The two later tests run *warm* (~520 ms) and don't assert length, so they passed — making this a Windows-only flake. Same class as the #541 Windows spawn-timeout fix.

## Fix

- Raise the `spawnSync` timeout 5 s → **30 s** (each test is a single spawn, well within the 60 s suite timeout).
- Assert `result.error` is `undefined` so a genuine spawn timeout surfaces as a clear failure instead of an opaque `Received: 0`.

## Verification

- `bun test packages/cli/src/tui/dumb-terminal.test.ts` → 3 pass / 0 fail
- `bunx biome check` on the file → clean
- `bun run typecheck` (full preflight) → pass

## Note — the Scorecard red is unrelated

The Scorecard job ([run 27365581725](https://github.com/nimbus-agent/Nimbus/actions/runs/27365581725)) failed only at result upload (`api.scorecard.dev` → context deadline exceeded) — a transient external-service outage; the analysis itself succeeded. No code change applies; it clears on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of CLI TUI test helper by increasing timeout threshold and enhancing error handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->