### PR TITLE
test(coverage): ★ flagship — pin executor.ts + tool-output-envelope.ts at 100% line+branch

### DIFF
--- a/docs/contributors/coverage.md
+++ b/docs/contributors/coverage.md
@@ -68,6 +68,12 @@ bun run audit:coverage-floor:update-baseline
 
 The script raises must-raise entries and drops must-remove entries in one pass.
 
+### `below_target` — a flagship 100% file slipped below its pinned ceiling
+
+A handful of security-core files are pinned at **100% line AND branch** via the `targets` section of `docs/structure-audit/coverage-baseline.json` (separate from the `files` debt map). These are the load-bearing invariant sites — e.g. `engine/executor.ts` (the HITL consent gate, I2/I3/I4) and `engine/tool-output-envelope.ts` (the LLM-facing `wrapToolOutput` envelope, I11). The gate flags `below_target` when such a file drops below its required pct on either axis.
+
+The fix is **never** to lower the target — add tests until the file is back at 100/100. For a genuinely-unreachable arm, prefer the [§5 unreachable-branch policy](../superpowers/specs/2026-06-07-true-coverage-program-design.md): a type-safe refactor that removes the dead branch (e.g. replace a provably-dead `?? fallback` with a typed helper), **not** `istanbul ignore` / `biome-ignore`. The `targets` section is hand-curated and is round-tripped untouched by `update-baseline` — a reseed can never silently relax a 100% ceiling. A target path must never also appear in `files` (the two carry contradictory intent; `parseBaseline` rejects it).
+
 ## OS-specific code
 
 The PR gate runs on Ubuntu only. Files with inline `process.platform === "win32"` branches will show the `win32` arm as uncovered.

--- a/docs/structure-audit/coverage-baseline.json
+++ b/docs/structure-audit/coverage-baseline.json
@@ -1,5 +1,15 @@
 {
   "version": 2,
-  "generated_at": "2026-06-12T17:50:11.182Z",
-  "files": {}
+  "generated_at": "2026-06-13T06:14:31.440Z",
+  "files": {},
+  "targets": {
+    "packages/gateway/src/engine/executor.ts": {
+      "min_line_pct": 100,
+      "min_branch_pct": 100
+    },
+    "packages/gateway/src/engine/tool-output-envelope.ts": {
+      "min_line_pct": 100,
+      "min_branch_pct": 100
+    }
+  }
 }

--- a/packages/gateway/src/engine/executor-delegation.test.ts
+++ b/packages/gateway/src/engine/executor-delegation.test.ts
@@ -73,6 +73,64 @@ describe("executor gate — delegation branch", () => {
     expect(localPrompted).toBe(true);
   });
 
+  it("delegation dep present but NO active delegate → falls back to the local owner prompt", async () => {
+    const db = db35();
+    const store = new DelegationStore(db); // empty: no delegation was ever created
+    let localPrompted = false;
+    const consent = {
+      requestApproval: async () => {
+        localPrompted = true;
+        return true;
+      },
+    };
+    const exec = new ToolExecutor(consent, audit, connectors, {
+      store,
+      isOperatorValid: () => true,
+      // requestRemote must never be reached: activeDelegateePeer() returns undefined first.
+      requestRemote: async (): Promise<RemoteApprovalOutcome> => {
+        throw new Error("requestRemote must not be called when there is no active delegate");
+      },
+    });
+    const r = await exec.gate({ type: "email.send", payload: {} });
+    expect(r).toBe("proceed");
+    expect(localPrompted).toBe(true);
+  });
+
+  it("honors a delegate's REJECTION (no local prompt; default reject reason; I20)", async () => {
+    const db = db35();
+    const store = new DelegationStore(db);
+    store.create({
+      delegatePeer: "peer:bob",
+      scopeKind: "action_type",
+      scopeValue: "email.send",
+      expiresAt: 9e15,
+      nowMs: 1,
+    });
+    let localPrompted = false;
+    const consent = {
+      requestApproval: async () => {
+        localPrompted = true;
+        return true; // would approve — must be bypassed by the delegate's deny
+      },
+    };
+    const remote = async (): Promise<RemoteApprovalOutcome> => ({
+      kind: "answered",
+      peerId: "peer:bob",
+      approved: false,
+    });
+    const exec = new ToolExecutor(consent, audit, connectors, {
+      store,
+      isOperatorValid: () => true,
+      requestRemote: remote,
+    });
+    const r = await exec.gate({ type: "email.send", payload: {} });
+    expect(r).not.toBe("proceed");
+    expect((r as { status: string; reason: string }).status).toBe("rejected");
+    // The delegate-rejection path never sets rejectReason explicitly — proves the default holds.
+    expect((r as { status: string; reason: string }).reason).toBe("User declined consent gate.");
+    expect(localPrompted).toBe(false);
+  });
+
   it("no delegation dep → always uses the local owner prompt (back-compat)", async () => {
     let localPrompted = false;
     const consent = {

--- a/packages/gateway/src/engine/executor-flagship.test.ts
+++ b/packages/gateway/src/engine/executor-flagship.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Flagship 100% coverage for engine/executor.ts (the HITL consent gate — invariants I2/I3/I4).
+ * Pairs with engine.test.ts / executor-delegation.test.ts / audit-payload-safety.test.ts; this
+ * file closes the last uncovered lines + branches (the HITL_REQUIRED facade methods, the
+ * redact value-shape arms, the serviceOf helper, and the agent-request sessionId audit stamp)
+ * so the file is pinned at 100% line+branch by the coverage-targets overlay.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { agentRequestContext } from "./agent-request-context.ts";
+import { redactPayloadForConsentDisplay, serviceOf } from "./executor.ts";
+import { HITL_REQUIRED, ToolExecutor } from "./index.ts";
+import type { AuditSink, ConnectorDispatcher, ConsentChannel } from "./types.ts";
+
+type AuditRecord = Parameters<AuditSink["recordAudit"]>[0];
+
+function approvingExecutor(auditCalls: AuditRecord[]): ToolExecutor {
+  const consent: ConsentChannel = { requestApproval: () => Promise.resolve(true) };
+  const audit: AuditSink = { recordAudit: (e) => auditCalls.push(e) };
+  const connectors: ConnectorDispatcher = { dispatch: () => Promise.resolve({ ok: true }) };
+  return new ToolExecutor(consent, audit, connectors);
+}
+
+describe("HITL_REQUIRED — frozen-set facade (full surface)", () => {
+  test("size reflects the backing set and matches the iterator length", () => {
+    expect(HITL_REQUIRED.size).toBeGreaterThan(80);
+    expect([...HITL_REQUIRED].length).toBe(HITL_REQUIRED.size);
+  });
+
+  test("entries() yields [value, value] pairs (Set semantics)", () => {
+    const entries = [...HITL_REQUIRED.entries()];
+    expect(entries.length).toBe(HITL_REQUIRED.size);
+    expect(entries).toContainEqual(["email.send", "email.send"]);
+  });
+
+  test("keys() and values() both enumerate the action types", () => {
+    const keys = [...HITL_REQUIRED.keys()];
+    const values = [...HITL_REQUIRED.values()];
+    expect(keys.length).toBe(HITL_REQUIRED.size);
+    expect(values.length).toBe(HITL_REQUIRED.size);
+    expect(keys).toContain("file.delete");
+    expect(values).toContain("file.delete");
+  });
+
+  test("forEach visits every entry, binds thisArg, and passes (value, value, set)", () => {
+    const collected: string[] = [];
+    const thisArg = { marker: "bound" };
+    const boundThis: unknown[] = [];
+    HITL_REQUIRED.forEach(function callback(this: unknown, value, value2, set) {
+      collected.push(value);
+      boundThis.push(this);
+      expect(value).toBe(value2); // Set.forEach passes the value twice
+      expect(set).toBe(HITL_REQUIRED);
+    }, thisArg);
+    expect(collected.length).toBe(HITL_REQUIRED.size);
+    expect(collected).toContain("vault.delete");
+    expect(boundThis.every((t) => t === thisArg)).toBe(true);
+  });
+});
+
+describe("redactPayloadForConsentDisplay — every value shape", () => {
+  test("returns null and primitives unchanged", () => {
+    expect(redactPayloadForConsentDisplay(null)).toBeNull();
+    expect(redactPayloadForConsentDisplay("plain")).toBe("plain");
+    expect(redactPayloadForConsentDisplay(42)).toBe(42);
+    expect(redactPayloadForConsentDisplay(true)).toBe(true);
+    expect(redactPayloadForConsentDisplay(undefined)).toBeUndefined();
+  });
+
+  test("recurses into arrays, redacting sensitive keys inside object elements", () => {
+    const out = redactPayloadForConsentDisplay([
+      { apiToken: "leak", safe: "ok" },
+      "scalar",
+      ["nested", { secret: "leak2" }],
+    ]) as unknown[];
+    expect(Array.isArray(out)).toBe(true);
+    expect(out[0]).toEqual({ apiToken: "[REDACTED]", safe: "ok" });
+    expect(out[1]).toBe("scalar");
+    expect((out[2] as unknown[])[1]).toEqual({ secret: "[REDACTED]" });
+  });
+});
+
+describe("serviceOf", () => {
+  test("returns the segment before the first dot", () => {
+    expect(serviceOf("email.send")).toBe("email");
+    expect(serviceOf("iac.terraform.apply")).toBe("iac");
+  });
+
+  test("returns the whole string when there is no dot", () => {
+    expect(serviceOf("filesystem")).toBe("filesystem");
+    expect(serviceOf("")).toBe("");
+  });
+
+  test('matches the legacy split(".")[0] semantics it replaced', () => {
+    for (const t of ["email.send", "a.b.c", "nodot", "", ".leading", "trailing."]) {
+      expect(serviceOf(t)).toBe(t.split(".")[0] ?? "");
+    }
+  });
+});
+
+describe("gate() — agent-request sessionId audit stamp", () => {
+  test("stamps the audit record with the active agent-request sessionId", async () => {
+    const auditCalls: AuditRecord[] = [];
+    const exec = approvingExecutor(auditCalls);
+    const result = await agentRequestContext.run({ sessionId: "session-xyz" }, () =>
+      exec.gate({ type: "file.delete", payload: { path: "/tmp/x" } }),
+    );
+    expect(result).toBe("proceed");
+    expect(auditCalls).toHaveLength(1);
+    expect(auditCalls[0]?.sessionId).toBe("session-xyz");
+  });
+
+  test("omits sessionId entirely when there is no agent-request context", async () => {
+    const auditCalls: AuditRecord[] = [];
+    const exec = approvingExecutor(auditCalls);
+    await exec.gate({ type: "filesystem.search" });
+    expect(auditCalls).toHaveLength(1);
+    expect(auditCalls[0]?.sessionId).toBeUndefined();
+    expect(Object.hasOwn(auditCalls[0] ?? {}, "sessionId")).toBe(false);
+  });
+});

--- a/packages/gateway/src/engine/executor.ts
+++ b/packages/gateway/src/engine/executor.ts
@@ -171,6 +171,18 @@ function auditPayload(
 }
 
 /**
+ * The connector/service prefix of an action type — the segment before the first ".", or the whole
+ * type when it has no dot (e.g. "email.send" → "email"). Used to match a service-scoped delegation.
+ * Exported so the no-dot arm is branch-coverable directly (the HITL gate only ever sees dotted
+ * action types). Equivalent to `action.type.split(".")[0] ?? ""` but without the unreachable
+ * nullish-coalesce arm (`String.prototype.split` always yields a string at index 0).
+ */
+export function serviceOf(actionType: string): string {
+  const dot = actionType.indexOf(".");
+  return dot === -1 ? actionType : actionType.slice(0, dot);
+}
+
+/**
  * Optional multi-user/delegated-HITL wiring (Slice 2). When present, the gate routes a HITL
  * action's approval to an active in-scope delegate before falling back to the local owner prompt.
  */
@@ -197,7 +209,7 @@ export class ToolExecutor {
   ): Promise<"approved" | "rejected" | "fallback"> {
     if (this.delegation === undefined) return "fallback";
     const del = this.delegation;
-    const service = action.type.split(".")[0] ?? "";
+    const service = serviceOf(action.type);
     const now = Date.now();
     if (del.store.activeDelegateePeer(action.type, service, now) === undefined) return "fallback";
     const outcome = await resolveDelegatedApproval({
@@ -228,14 +240,16 @@ export class ToolExecutor {
     const requiresHITL = HITL_REQUIRED.has(action.type);
 
     let hitlStatus: "approved" | "rejected" | "not_required";
-    let rejectReason: string | undefined;
+    // Reason for the rejected path. Defaults to the user-declined message (the only other
+    // rejection source — a consent disconnect — overwrites it below), so it is always a defined
+    // string by the time the rejected branch returns it (no nullish fallback needed).
+    let rejectReason = "User declined consent gate.";
     let auditExtras: { hitlRejectReason?: string } | undefined;
 
     try {
       if (requiresHITL) {
         const approved = await this.resolveHitlApproval(action);
         hitlStatus = approved ? "approved" : "rejected";
-        if (!approved) rejectReason = "User declined consent gate.";
       } else {
         hitlStatus = "not_required";
       }
@@ -259,7 +273,7 @@ export class ToolExecutor {
     });
 
     if (hitlStatus === "rejected") {
-      return { status: "rejected", reason: rejectReason ?? "User declined consent gate." };
+      return { status: "rejected", reason: rejectReason };
     }
     return "proceed";
   }

--- a/scripts/coverage-floor/baseline.test.ts
+++ b/scripts/coverage-floor/baseline.test.ts
@@ -61,6 +61,74 @@ describe("parseBaseline", () => {
     });
     expect(() => parseBaseline(json)).toThrow(/forward slashes/);
   });
+
+  test("parses a flagship `targets` section into the targets map", () => {
+    const json = JSON.stringify({
+      version: 2,
+      generated_at: "x",
+      files: {},
+      targets: {
+        "packages/gateway/src/engine/executor.ts": { min_line_pct: 100, min_branch_pct: 100 },
+      },
+    });
+    const got = parseBaseline(json);
+    expect(got.files.size).toBe(0);
+    expect(got.targets.get("packages/gateway/src/engine/executor.ts")).toEqual({
+      line: 100,
+      branch: 100,
+    });
+  });
+
+  test("defaults targets to an empty map when the section is absent (back-compat)", () => {
+    const json = JSON.stringify({ version: 2, generated_at: "x", files: {} });
+    expect(parseBaseline(json).targets.size).toBe(0);
+  });
+
+  test("a v1 baseline has no targets (empty map)", () => {
+    const json = JSON.stringify({
+      version: 1,
+      generated_at: "x",
+      files: { "a.ts": { min_coverage_pct: 70 } },
+    });
+    expect(parseBaseline(json).targets.size).toBe(0);
+  });
+
+  test("throws when a path is in BOTH files and targets (contradictory intent)", () => {
+    const json = JSON.stringify({
+      version: 2,
+      generated_at: "x",
+      files: {
+        "packages/gateway/src/engine/executor.ts": { min_line_pct: 78, min_branch_pct: 40 },
+      },
+      targets: {
+        "packages/gateway/src/engine/executor.ts": { min_line_pct: 100, min_branch_pct: 100 },
+      },
+    });
+    expect(() => parseBaseline(json)).toThrow(/both files and targets/);
+  });
+
+  test("validates target pct range and rejects backslash target paths", () => {
+    expect(() =>
+      parseBaseline(
+        JSON.stringify({
+          version: 2,
+          generated_at: "x",
+          files: {},
+          targets: { "a.ts": { min_line_pct: 100, min_branch_pct: 101 } },
+        }),
+      ),
+    ).toThrow(/min_branch_pct/);
+    expect(() =>
+      parseBaseline(
+        JSON.stringify({
+          version: 2,
+          generated_at: "x",
+          files: {},
+          targets: { "a\\b.ts": { min_line_pct: 100, min_branch_pct: 100 } },
+        }),
+      ),
+    ).toThrow(/forward slashes/);
+  });
 });
 
 describe("serializeBaseline", () => {
@@ -69,9 +137,31 @@ describe("serializeBaseline", () => {
       version: 2,
       generated_at: "2026-06-07T00:00:00Z",
       files: new Map([["packages/gateway/src/a.ts", { line: 78.6, branch: 40 }]]),
+      targets: new Map(),
     };
     const reparsed = parseBaseline(serializeBaseline(original));
     expect(reparsed.files.get("packages/gateway/src/a.ts")).toEqual({ line: 78.6, branch: 40 });
+  });
+
+  test("round-trips the targets section (a pinned 100% ceiling survives serialize→parse)", () => {
+    const original: Baseline = {
+      version: 2,
+      generated_at: "2026-06-13T00:00:00Z",
+      files: new Map(),
+      targets: new Map([
+        ["packages/gateway/src/engine/executor.ts", { line: 100, branch: 100 }],
+        ["packages/gateway/src/engine/tool-output-envelope.ts", { line: 100, branch: 100 }],
+      ]),
+    };
+    const reparsed = parseBaseline(serializeBaseline(original));
+    expect(reparsed.targets.get("packages/gateway/src/engine/executor.ts")).toEqual({
+      line: 100,
+      branch: 100,
+    });
+    expect(reparsed.targets.get("packages/gateway/src/engine/tool-output-envelope.ts")).toEqual({
+      line: 100,
+      branch: 100,
+    });
   });
 
   test("sorts entries alphabetically and ends with a single newline", () => {
@@ -82,6 +172,7 @@ describe("serializeBaseline", () => {
         ["z.ts", { line: 1, branch: 1 }],
         ["a.ts", { line: 2, branch: 2 }],
       ]),
+      targets: new Map(),
     });
     expect(text.indexOf("a.ts")).toBeLessThan(text.indexOf("z.ts"));
     expect(text.endsWith("\n")).toBe(true);
@@ -94,6 +185,7 @@ describe("computeBaselineDiff (dual-axis, file-level)", () => {
     version: 2,
     generated_at: "x",
     files: new Map([["a.ts", { line, branch }]]),
+    targets: new Map(),
   });
 
   test("no diff when both axes meet their stored floors and neither is fully clear", () => {

--- a/scripts/coverage-floor/baseline.ts
+++ b/scripts/coverage-floor/baseline.ts
@@ -6,7 +6,19 @@ export interface FileFloor {
 export interface Baseline {
   readonly version: 2;
   readonly generated_at: string;
+  /**
+   * Below-floor debt: files that have NOT yet cleared the 80% line+branch floor. The ratchet
+   * (`computeUpdatedBaseline`) grinds these up and drops each one once it clears both floors.
+   */
   readonly files: Map<string, FileFloor>;
+  /**
+   * Flagship 100% targets (hand-curated, NEVER auto-generated). A file listed here must meet its
+   * required pct on BOTH axes regardless of the global floor — `check.ts` flags `below_target`
+   * otherwise. The ratchet leaves this section untouched (`computeUpdatedBaseline` round-trips it
+   * verbatim), so a reseed can never silently lower a pinned 100% ceiling. Disjoint from `files`:
+   * a target is by definition above the debt floor and must never also be a ratchet entry.
+   */
+  readonly targets: Map<string, FileFloor>;
 }
 
 export interface BaselineDiff {
@@ -72,17 +84,71 @@ export function parseBaseline(text: string): Baseline {
       });
     }
   }
-  return { version: 2, generated_at: obj["generated_at"], files };
+  const targets = parseFloorMap(obj["targets"], "target", files);
+  return { version: 2, generated_at: obj["generated_at"], files, targets };
+}
+
+/**
+ * Parse the optional `targets` map (flagship 100% ceilings). Same `{min_line_pct, min_branch_pct}`
+ * shape as v2 `files`, but never has a v1 form. A target path must not also be a `files` entry —
+ * the two carry contradictory intent (debt-below-floor vs pinned-above-floor).
+ */
+function parseFloorMap(
+  raw: unknown,
+  label: string,
+  files: ReadonlyMap<string, FileFloor>,
+): Map<string, FileFloor> {
+  const out = new Map<string, FileFloor>();
+  if (raw === undefined) return out;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`baseline ${label}s must be an object`);
+  }
+  for (const [path, entry] of Object.entries(raw as Record<string, unknown>)) {
+    if (path.includes("\\")) {
+      throw new Error(
+        `baseline ${label} contains backslash separator: ${JSON.stringify(path)} — use forward slashes`,
+      );
+    }
+    if (files.has(path)) {
+      throw new Error(
+        `baseline path ${JSON.stringify(path)} is in both files and ${label}s — a ${label} is above the debt floor and must not also be a ratchet entry`,
+      );
+    }
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`baseline ${label} ${path}: must be an object`);
+    }
+    const e = entry as Record<string, unknown>;
+    out.set(path, {
+      line: assertPct(`${label}s.${path}.min_line_pct`, e["min_line_pct"]),
+      branch: assertPct(`${label}s.${path}.min_branch_pct`, e["min_branch_pct"]),
+    });
+  }
+  return out;
+}
+
+function serializeFloorMap(
+  m: ReadonlyMap<string, FileFloor>,
+): Record<string, { min_line_pct: number; min_branch_pct: number }> {
+  const sortedKeys = Array.from(m.keys()).sort((x, y) => (x > y ? 1 : -1));
+  const out: Record<string, { min_line_pct: number; min_branch_pct: number }> = {};
+  for (const k of sortedKeys) {
+    const v = m.get(k);
+    if (v !== undefined) out[k] = { min_line_pct: v.line, min_branch_pct: v.branch };
+  }
+  return out;
 }
 
 export function serializeBaseline(b: Baseline): string {
-  const sortedKeys = Array.from(b.files.keys()).sort((a, b) => (a > b ? 1 : -1));
-  const files: Record<string, { min_line_pct: number; min_branch_pct: number }> = {};
-  for (const k of sortedKeys) {
-    const v = b.files.get(k);
-    if (v !== undefined) files[k] = { min_line_pct: v.line, min_branch_pct: v.branch };
-  }
-  return `${JSON.stringify({ version: 2, generated_at: b.generated_at, files }, null, 2)}\n`;
+  return `${JSON.stringify(
+    {
+      version: 2,
+      generated_at: b.generated_at,
+      files: serializeFloorMap(b.files),
+      targets: serializeFloorMap(b.targets),
+    },
+    null,
+    2,
+  )}\n`;
 }
 
 export function computeBaselineDiff(

--- a/scripts/coverage-floor/check.test.ts
+++ b/scripts/coverage-floor/check.test.ts
@@ -4,7 +4,12 @@ import type { Baseline } from "./baseline.ts";
 import { computeUpdatedBaseline, evaluateCheck, lcovHasBranchData } from "./check.ts";
 import { parseLcov } from "./lcov-parse.ts";
 
-const emptyBaseline: Baseline = { version: 2, generated_at: "x", files: new Map() };
+const emptyBaseline: Baseline = {
+  version: 2,
+  generated_at: "x",
+  files: new Map(),
+  targets: new Map(),
+};
 
 describe("lcovHasBranchData (instrumentation canary)", () => {
   test("true when at least one file carries BRDA branch records", () => {
@@ -69,6 +74,7 @@ describe("evaluateCheck (dual-axis)", () => {
       version: 2,
       generated_at: "x",
       files: new Map([["packages/gateway/src/a.ts", { line: 78, branch: 40 }]]),
+      targets: new Map(),
     };
     const r = evaluateCheck({
       sourceFiles: ["packages/gateway/src/a.ts"],
@@ -90,10 +96,93 @@ describe("evaluateCheck (dual-axis)", () => {
   });
 });
 
+describe("evaluateCheck — flagship 100% targets overlay", () => {
+  const FLAGSHIP = "packages/gateway/src/engine/executor.ts";
+  const withTarget = (line: number, branch: number): Baseline => ({
+    version: 2,
+    generated_at: "x",
+    files: new Map(),
+    targets: new Map([[FLAGSHIP, { line, branch }]]),
+  });
+
+  test("passes when a targeted file meets its 100/100 ceiling", () => {
+    const r = evaluateCheck({
+      sourceFiles: [FLAGSHIP],
+      actualLine: new Map([[FLAGSHIP, 100]]),
+      actualBranch: new Map([[FLAGSHIP, 100]]),
+      baseline: withTarget(100, 100),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.violations).toEqual([]);
+  });
+
+  test("flags below_target on the line axis when a pinned file slips to 99", () => {
+    const r = evaluateCheck({
+      sourceFiles: [FLAGSHIP],
+      actualLine: new Map([[FLAGSHIP, 99]]),
+      actualBranch: new Map([[FLAGSHIP, 100]]),
+      baseline: withTarget(100, 100),
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.violations).toContainEqual({
+      kind: "below_target",
+      dimension: "line",
+      path: FLAGSHIP,
+      actual: 99,
+      required: 100,
+    });
+  });
+
+  test("flags below_target on the branch axis when a pinned file drops one branch", () => {
+    const r = evaluateCheck({
+      sourceFiles: [FLAGSHIP],
+      actualLine: new Map([[FLAGSHIP, 100]]),
+      actualBranch: new Map([[FLAGSHIP, 97.7]]),
+      baseline: withTarget(100, 100),
+    });
+    expect(r.violations).toContainEqual({
+      kind: "below_target",
+      dimension: "branch",
+      path: FLAGSHIP,
+      actual: 97.7,
+      required: 100,
+    });
+  });
+
+  test("fail-closed: a targeted file missing from the lcov reads as 0% line (below_target)", () => {
+    const r = evaluateCheck({
+      sourceFiles: [FLAGSHIP],
+      actualLine: new Map(),
+      actualBranch: new Map(),
+      baseline: withTarget(100, 100),
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.violations).toContainEqual({
+      kind: "below_target",
+      dimension: "line",
+      path: FLAGSHIP,
+      actual: 0,
+      required: 100,
+    });
+  });
+
+  test("a passing target sits ABOVE the floor pass — no below_floor, no must_* churn", () => {
+    // The same file clears the 80 floor AND its 100 target: exactly zero violations, proving the
+    // overlay is purely additive (it never double-reports or interferes with the ratchet).
+    const r = evaluateCheck({
+      sourceFiles: [FLAGSHIP],
+      actualLine: new Map([[FLAGSHIP, 100]]),
+      actualBranch: new Map([[FLAGSHIP, 100]]),
+      baseline: withTarget(100, 100),
+    });
+    expect(r.violations).toEqual([]);
+  });
+});
+
 describe("computeUpdatedBaseline (dual-axis)", () => {
   test("captures a sub-floor file at its actuals; satisfied axis pinned at the floor", () => {
     const next = computeUpdatedBaseline(
-      { version: 2, generated_at: "x", files: new Map() },
+      { version: 2, generated_at: "x", files: new Map(), targets: new Map() },
       new Map([["packages/gateway/src/a.ts", 90]]), // line satisfied
       new Map([["packages/gateway/src/a.ts", 55]]), // branch below floor
       ["packages/gateway/src/a.ts"],
@@ -108,6 +197,7 @@ describe("computeUpdatedBaseline (dual-axis)", () => {
         version: 2,
         generated_at: "x",
         files: new Map([["packages/gateway/src/a.ts", { line: 78, branch: 40 }]]),
+        targets: new Map(),
       },
       new Map([["packages/gateway/src/a.ts", 85]]),
       new Map([["packages/gateway/src/a.ts", 82]]),
@@ -123,6 +213,7 @@ describe("computeUpdatedBaseline (dual-axis)", () => {
         version: 2,
         generated_at: "x",
         files: new Map([["packages/gateway/src/a.ts", { line: 50, branch: 30 }]]),
+        targets: new Map(),
       },
       new Map([["packages/gateway/src/a.ts", 60]]),
       new Map([["packages/gateway/src/a.ts", 20]]), // dropped below stored — keep the higher watermark
@@ -130,5 +221,26 @@ describe("computeUpdatedBaseline (dual-axis)", () => {
       "now",
     );
     expect(next.files.get("packages/gateway/src/a.ts")).toEqual({ line: 60, branch: 30 });
+  });
+
+  test("round-trips the flagship targets section verbatim (a reseed never drops a 100% ceiling)", () => {
+    const targets = new Map([
+      ["packages/gateway/src/engine/executor.ts", { line: 100, branch: 100 }],
+    ]);
+    const next = computeUpdatedBaseline(
+      { version: 2, generated_at: "x", files: new Map(), targets },
+      // executor.ts clears both floors at 100/100, so the ratchet drops it from `files`...
+      new Map([["packages/gateway/src/engine/executor.ts", 100]]),
+      new Map([["packages/gateway/src/engine/executor.ts", 100]]),
+      ["packages/gateway/src/engine/executor.ts"],
+      "now",
+    );
+    expect(next.files.has("packages/gateway/src/engine/executor.ts")).toBe(false);
+    // ...but it stays pinned in `targets`, untouched.
+    expect(next.targets).toBe(targets);
+    expect(next.targets.get("packages/gateway/src/engine/executor.ts")).toEqual({
+      line: 100,
+      branch: 100,
+    });
   });
 });

--- a/scripts/coverage-floor/check.ts
+++ b/scripts/coverage-floor/check.ts
@@ -36,7 +36,14 @@ export type Violation =
       actual: number;
     }
   | { kind: "must_raise"; path: string }
-  | { kind: "must_remove"; path: string };
+  | { kind: "must_remove"; path: string }
+  | {
+      kind: "below_target";
+      dimension: "line" | "branch";
+      path: string;
+      actual: number;
+      required: number;
+    };
 
 export interface EvaluateResult {
   readonly exitCode: 0 | 1;
@@ -72,6 +79,30 @@ export function evaluateCheck(input: EvaluateInput): EvaluateResult {
   }
   for (const m of diff.mustRaise) violations.push({ kind: "must_raise", path: m.path });
   for (const m of diff.mustRemove) violations.push({ kind: "must_remove", path: m.path });
+  // Flagship 100% targets — a stricter, hand-curated ceiling above the global floor. Each listed
+  // file must meet its required line AND branch pct; a missing target file reads as 0% line
+  // (fail-closed). This is purely additive to the floor/ratchet pass above and is never relaxed by
+  // `update-baseline` (the targets section is round-tripped verbatim).
+  for (const [path, req] of input.baseline.targets) {
+    const line = input.actualLine.get(path) ?? 0;
+    const branch = input.actualBranch.get(path) ?? 100;
+    if (line < req.line)
+      violations.push({
+        kind: "below_target",
+        dimension: "line",
+        path,
+        actual: line,
+        required: req.line,
+      });
+    if (branch < req.branch)
+      violations.push({
+        kind: "below_target",
+        dimension: "branch",
+        path,
+        actual: branch,
+        required: req.branch,
+      });
+  }
   return { exitCode: violations.length === 0 ? 0 : 1, violations, diff };
 }
 
@@ -99,7 +130,9 @@ export function computeUpdatedBaseline(
     if (isExempt(path)) continue;
     consider(path);
   }
-  return { version: 2, generated_at: generatedAt, files: next };
+  // Round-trip the flagship 100% targets verbatim — the ratchet only manages below-floor debt and
+  // must never touch (or drop) a hand-curated 100% ceiling.
+  return { version: 2, generated_at: generatedAt, files: next, targets: baseline.targets };
 }
 
 export async function discoverSourceFiles(): Promise<string[]> {
@@ -186,6 +219,11 @@ function printViolations(violations: ReadonlyArray<Violation>): void {
           `::error file=${v.path}::coverage now clears both floors — remove the baseline entry: bun run audit:coverage-floor:update-baseline`,
         );
         break;
+      case "below_target":
+        console.error(
+          `::error file=${v.path}::${v.dimension} coverage ${v.actual}% < required ${v.required}% (flagship target — this security-core file is pinned at ${v.required}%; add tests, do NOT lower the target)`,
+        );
+        break;
     }
   }
 }
@@ -223,6 +261,7 @@ async function main(): Promise<void> {
         version: 2 as const,
         generated_at: new Date().toISOString(),
         files: new Map<string, { line: number; branch: number }>(),
+        targets: new Map<string, { line: number; branch: number }>(),
       } as Baseline);
   const sourceFiles = await discoverSourceFiles();
 


### PR DESCRIPTION
## ★ True Coverage flagship — security core → 100%

Sub-project B is complete (every non-flagship file clears the ≥80% line+branch floor; `coverage-baseline.json` `files` map is `{}`). This starts the flagship: drive the two **reserved** security-core files to **100% line AND branch** and lock them there with a stricter-than-floor gate.

| File | Invariants | Before | After |
|---|---|---|---|
| `engine/executor.ts` | I2 / I3 / I4 (HITL consent gate) | 56/63 line, 39/44 branch | **100/100** |
| `engine/tool-output-envelope.ts` | I11 (`wrapToolOutput`) | already 100/100 | **100/100** (pinned) |

### Enforcement mechanism — flagship 100% targets overlay

The ≥80 ratchet structurally **cannot** pin a file at 100 (`computeUpdatedBaseline` drops any file that clears both floors). So this adds a stricter, hand-curated ceiling (spec §9; resolves the §11 open question in favour of **extending `baseline.json`**):

- `baseline.json` gains a top-level **`targets`** map (`path → {min_line_pct, min_branch_pct}`), disjoint from `files`.
- `check.ts` emits a new **`below_target`** violation when a pinned file is below its required pct on **either** axis (fail-closed if the file is missing from the lcov).
- The ratchet **round-trips `targets` verbatim** — a reseed can never silently relax a 100% ceiling. `parseBaseline` rejects a path present in both `files` and `targets`.

This is purely additive to the floor/ratchet pass — no new CI gate (same `audit:coverage-floor` command, internally widened), so no preflight-manifest drift.

### Reaching 100 on executor.ts

New `executor-flagship.test.ts` covers the previously-uncovered surface: the `HITL_REQUIRED` frozen-set facade (`size`/`entries`/`keys`/`values`/`forEach` incl. `thisArg` binding), `redactPayloadForConsentDisplay` null/primitive/array arms, `serviceOf`, and the agent-request `sessionId` audit stamp. Plus two delegation-branch tests in `executor-delegation.test.ts` (no-active-delegate fallback; an honored delegate **rejection**).

**Two provably-dead branches** were removed via **zero-behaviour-change** refactors (per the §5 unreachable-branch policy — **not** `istanbul ignore` / `biome-ignore`):
- `action.type.split(".")[0] ?? ""` → exported `serviceOf()` helper. `split` always yields a string at `[0]`, so the `?? ""` arm was unreachable; the helper's no-dot arm is now branch-coverable directly (the HITL gate only ever sees dotted types).
- `gate()` `rejectReason` is **default-initialised** to `"User declined consent gate."`, dropping the unreachable `?? "…"` fallback (it is always a defined string when `hitlStatus === "rejected"`). The new delegate-rejection test asserts the default holds.

### Invariants preserved
69/69 `security-invariants.test.ts` + static `audit:invariants` green. The gate edits never touch `action.type`-only consumption (I3), `hitlStatus` assignment (I4), or the frozen backing set (I2); the envelope (I11) is unchanged.

### Verification (authoritative Docker/Linux istanbul lcov)
- `executor.ts` LF65/LH65, BRF40/BRH40 · `tool-output-envelope.ts` LF4/LH4, BRF2/BRH2 · `coverage-floor: ok`.
- **Negative E2E**: pinning a real sub-100 file (97.78% line / 96.55% branch) at 100 makes the real gate binary exit 1 with two `below_target` annotations; restoring → exit 0.
- 77 coverage-floor unit tests, 104 engine tests, gateway `tsc` + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "flagship targets" coverage enforcement for critical files, requiring sustained 100% line and branch coverage that cannot be reduced by baseline updates.

* **Documentation**
  * Added guidance on addressing coverage violations, including remediation through tests and type-safe refactors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->