### PR TITLE
fix(ci): unhang the Windows gateway cross-platform leg (was 30-min "cancelled")

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,10 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.filter.outputs.cross-platform-matrix) }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Backstop only — each test attempt has its own 10-min wall-clock cap (see the
+    # unit-tests step), so a hang fails fast via retry rather than burning this
+    # ceiling. Sized for setup + retried typecheck + 2 capped test attempts.
+    timeout-minutes: 25
     permissions:
       contents: read
 
@@ -287,13 +290,24 @@ jobs:
         #
         # Retry-once still tolerates a cold-start outlier and, unlike the
         # `_test-suite.yml` retry, PROPAGATES attempt 2's exit code so a real
-        # regression fails the job. The job-level `timeout-minutes: 30` bounds a
+        # regression fails the job. The job-level `timeout-minutes` bounds a
         # true hang; assertion failures fail in <1 s regardless of `--timeout`,
         # so this does not mask logic bugs.
+        #
+        # Each attempt is additionally wrapped in a 10-minute wall-clock timeout
+        # (`scripts/run-with-timeout.ts` — portable because GNU `timeout` is not on
+        # the macOS runner). `--timeout 60000` is PER-TEST and does not fire on a
+        # hung-at-exit `bun test` (a lingering timer keeps the process alive after
+        # all tests finish); without a whole-run cap such a hang spins until the
+        # job's `timeout-minutes` ceiling and surfaces as "The operation was
+        # canceled.". The wrapper kills the hang at 10 min (exit 124) so retry-once
+        # actually runs — recovering a transient hang in minutes instead of burning
+        # the full ceiling. 10 min is far above a healthy Windows run (~2-3 min), so
+        # it never false-kills a merely-slow run.
         run: |
           set +e
           for attempt in 1 2; do
-            bun test "packages/${{ matrix.pkg }}/src" --timeout 60000
+            bun scripts/run-with-timeout.ts 600 bun test "packages/${{ matrix.pkg }}/src" --timeout 60000
             code=$?
             if [ "$code" -eq 0 ]; then
               exit 0

--- a/packages/gateway/src/sync/rate-limiter.test.ts
+++ b/packages/gateway/src/sync/rate-limiter.test.ts
@@ -241,21 +241,27 @@ describe("ProviderRateLimiter – deterministic (clock-injected)", () => {
   test("wait-for-refill branch: a token deficit sleeps, then a later refill satisfies it", async () => {
     // Genuinely exercise the deficit → sleepMs → retry path in acquireUnderLock (the branch the
     // previous tests missed by pre-advancing the clock so refill succeeded on the first pass).
-    // The clock stays at `base` while tokens are short — forcing the wait branch — then jumps
-    // forward so a later loop iteration refills enough and returns. Flipping `advanced` only after
-    // a macrotask tick guarantees the acquire has already parked in its sleep, so the deficit
-    // branch is hit; if it ever isn't, the loop simply re-sleeps until `advanced`, so it always
-    // terminates AND always covers the wait path.
+    //
+    // The clock is driven off the nowFn READ COUNT, not an external flag flipped from a macrotask.
+    // The earlier flag-via-`await Bun.sleep(0)` version raced the acquire's internal `setTimeout`
+    // sleep and hung `bun test` indefinitely on Windows (passed on Linux/macOS) — the job then
+    // burned its full 30-minute ceiling and was reported "cancelled". Counting reads makes the
+    // clock jump deterministic and removes the real-timer race entirely.
+    //
+    // nowFn reads, in order (refill() takes `now` as a param — it does NOT call nowFn):
+    //   [0] constructor seeds the buckets
+    //   [1] acquire("github", 2) loop iteration 1 → drains both burst tokens
+    //   [2] acquire("github", 1) loop iteration 1 → 0 tokens, elapsed 0 → DEFICIT branch → sleepMs
+    //   [3] acquire("github", 1) loop iteration 2 → clock jumped → refill → resolve
     const base = 20_000_000;
-    let advanced = false;
-    const nowFn = () => (advanced ? base + 60_000 : base);
+    let reads = 0;
+    const nowFn = () => (reads++ >= 3 ? base + 60_000 : base);
     const quota = { requestsPerMinute: 600_000, burstSize: 2 };
     const limiter = new ProviderRateLimiter({ github: quota }, nowFn);
-    await limiter.acquire("github", 2); // drain both burst tokens
-    const waiting = limiter.acquire("github", 1); // 0 tokens → must wait for a refill
-    await Bun.sleep(0); // let the acquire reach its sleepMs (the deficit branch)
-    advanced = true; // next iteration sees the advanced clock → refill → resolve
-    await expect(waiting).resolves.toBeUndefined();
+    await limiter.acquire("github", 2); // drain both burst tokens (reads 0 + 1)
+    // 0 tokens → iteration 1 hits the deficit branch and sleeps; iteration 2 sees the advanced
+    // clock, refills to the burst cap, and resolves. No external flag, no macrotask race.
+    await expect(limiter.acquire("github", 1)).resolves.toBeUndefined();
   });
 });
 

--- a/scripts/run-with-timeout.ts
+++ b/scripts/run-with-timeout.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+// Portable wall-clock timeout for a child command, used by the cross-platform
+// CI test step. GNU coreutils `timeout` is NOT installed on the GitHub macOS
+// runner, so a shell `timeout` would break the macOS leg — Bun is guaranteed
+// present (it is the test runner), so we wrap with Bun.spawn instead.
+//
+// On timeout we SIGTERM the child, escalate to SIGKILL after a grace period,
+// and exit 124 (matching coreutils `timeout`) so the caller's retry loop treats
+// it as a failure rather than a pass. This converts a hung `bun test` (which
+// would otherwise burn the job's full `timeout-minutes` ceiling and surface as a
+// confusing "The operation was canceled.") into a fast, clearly-labelled failure
+// that retry-once can recover from when the hang is transient.
+//
+// Usage: bun scripts/run-with-timeout.ts <seconds> <command> [args...]
+
+import process from "node:process";
+
+const GRACE_MS = 10_000;
+const EXIT_TIMEOUT = 124;
+const EXIT_USAGE = 2;
+
+const [secondsRaw, cmd, ...args] = process.argv.slice(2);
+const seconds = Number(secondsRaw);
+
+if (!Number.isFinite(seconds) || seconds <= 0 || cmd === undefined) {
+  console.error("usage: run-with-timeout <seconds> <command> [args...]");
+  process.exit(EXIT_USAGE);
+}
+
+const child = Bun.spawn([cmd, ...args], {
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+let timedOut = false;
+const killTimer = setTimeout(() => {
+  timedOut = true;
+  child.kill("SIGTERM");
+  // If the child ignores SIGTERM, force-kill after a grace period.
+  setTimeout(() => child.kill("SIGKILL"), GRACE_MS);
+}, seconds * 1000);
+
+const code = await child.exited;
+clearTimeout(killTimer);
+
+if (timedOut) {
+  console.error(
+    `\n[run-with-timeout] '${cmd}' exceeded ${seconds}s — killed (exit ${EXIT_TIMEOUT})`,
+  );
+  process.exit(EXIT_TIMEOUT);
+}
+
+process.exit(code);


### PR DESCRIPTION
## Problem

The PR-quality **Cross-platform (gateway, windows-2025)** job ran ~25 min and was reported **"The operation was canceled."** ([example run](https://github.com/nimbus-agent/Nimbus/actions/runs/27461026112/job/81174784273)). It wasn't slow — one test **hung `bun test` on Windows**: output stopped at `08:09:24` right after the rate-limiter suite and never resumed until the job's `timeout-minutes: 30` killed it at `08:31:17` (a timeout-kill surfaces as "cancelled"). The same gateway suite finishes in **66s** on the macOS leg.

## Root cause

`packages/gateway/src/sync/rate-limiter.test.ts` → *"wait-for-refill branch"* relied on a real-timer race: an external `advanced` flag flipped from a `Bun.sleep(0)` macrotask, interleaving with the limiter's internal `setTimeout` sleep loop. Fine on Linux/macOS, hangs `bun test` indefinitely on Windows.

Reproduced locally on Windows (exit 124 every run); `test.skip` on that one test makes the file pass in **1.4s** and exit cleanly — proving it's the sole cause. This is a pre-existing `main` bug affecting **every** PR's Windows gateway leg; PR #590 just surfaced it.

## Fix

1. **`rate-limiter.test.ts`** — rewrite the test to drive the injected clock off the **nowFn read count** instead of a macrotask race. Same `deficit → sleepMs → refill` branch covered, now deterministic. **28/28 pass, clean exit, repeatable on Windows.**
2. **`scripts/run-with-timeout.ts`** (new) — portable Bun wall-clock timeout (GNU `timeout` is absent on the macOS runner). SIGTERM → SIGKILL → exit 124 on timeout.
3. **`ci.yml`** — wrap each cross-platform test attempt in a 10-min cap so a *future* hang fails fast and retry-once recovers (`--timeout 60000` is per-test and never fires on a hung-at-exit `bun test`); lower job `timeout-minutes` 30 → 25 as backstop.

## Verification

- `bun test packages/gateway/src/sync/rate-limiter.test.ts` — 28 pass / 0 fail, ~1.4s, exit 0, 3/3 consecutive Windows runs.
- `scripts/run-with-timeout.ts` — biome + tsc clean; exercised pass-through (0), timeout (124), non-zero passthrough (7).
- `ci.yml` — YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and determinism for rate limiting functionality with enhanced timing controls.

* **CI/Infrastructure**
  * Optimized job timeout configuration and refined test retry mechanisms to improve overall test stability and command execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->