### PR TITLE
fix(audit): close credential-redaction boundary escapes + property lock (True Coverage C1)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix-review.md
+++ b/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix-review.md
@@ -16,12 +16,16 @@ The implementation plan is highly detailed, follows a clear test-driven validati
 ## 2. Detailed Feedback & Suggestions
 
 ### 2.1. Bearer Token Generator Enhancement (Task 1 Step 1)
+
 - **Observation:** The `bearer` generator is currently defined as:
+
   ```typescript
   ["bearer", charsetArb(BEARER_BODY, 16).map((b) => `Bearer ${b}`)],
   ```
+
   This only generates Bearer tokens without trailing padding (`=`). However, the production regex has an optional `={0,2}` suffix.
 - **Suggestion:** Enhance the generator to produce tokens with 0, 1, or 2 trailing `=` signs to fully assert the boundary and pattern matching:
+
   ```typescript
   [
     "bearer",
@@ -33,12 +37,16 @@ The implementation plan is highly detailed, follows a clear test-driven validati
 ---
 
 ### 2.2. Character Class Escaping Safety (Task 1 Step 3)
+
 - **Observation:** In the production map's `bearer` regex:
+
   ```typescript
   ["bearer", /(?<![A-Za-z0-9])Bearer\s+[A-Za-z0-9_.\-+/]{16,}={0,2}(?![A-Za-z0-9_./+-])/g],
   ```
+
   The lookahead charset `(?![A-Za-z0-9_./+-])` puts the `-` at the very end to treat it as a literal.
 - **Suggestion:** To prevent parsing ambiguity or potential lint errors (e.g., Biome or TS warning about unescaped range delimiters), explicitly escape the hyphen in the lookahead as well:
+
   ```typescript
   (?![A-Za-z0-9_./+\-])
   ```
@@ -46,6 +54,7 @@ The implementation plan is highly detailed, follows a clear test-driven validati
 ---
 
 ### 2.3. Verification of Bearer `=` Lookahead Behavior
+
 - **Observation:** The lookahead `(?![A-Za-z0-9_./+-])` intentionally excludes `=`.
 - **Validation:** This is a correct design decision. If `=` were included in the lookahead charset (e.g. `(?![A-Za-z0-9_./+\-=])`), then a string containing an extra trailing equal sign (such as `Bearer 1234567890123456===`) would fail the lookahead at `==`, backtrack, fail at `=`, and fail the entire match—thereby leaking the credentials. Excluding `=` from the lookahead allows the regex to match and redact `Bearer 1234567890123456==` while leaving the trailing `=` unredacted.
 - **Action:** No code change is needed for this, but it serves as a confirmation of the correctness of the design.

--- a/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix-review.md
+++ b/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix-review.md
@@ -1,0 +1,57 @@
+# Review: True Coverage C1 — Audit-redaction boundary fix + property lock — Implementation Plan
+
+**Date:** 2026-06-13  
+**Reviewer:** AI Assistant (Antigravity)  
+**Status:** Review Completed  
+**Target Plan:** [`2026-06-13-true-coverage-C1-redaction-fix.md`](./2026-06-13-true-coverage-C1-redaction-fix.md)
+
+---
+
+## 1. Executive Summary
+
+The implementation plan is highly detailed, follows a clear test-driven validation cycle (ensuring tests fail before they pass), and provides exact copy-pasteable snippets. We have identified a few high-value adjustments to the property generators, regex formatting safety, and a subtle validation check for the Bearer token lookahead behavior.
+
+---
+
+## 2. Detailed Feedback & Suggestions
+
+### 2.1. Bearer Token Generator Enhancement (Task 1 Step 1)
+- **Observation:** The `bearer` generator is currently defined as:
+  ```typescript
+  ["bearer", charsetArb(BEARER_BODY, 16).map((b) => `Bearer ${b}`)],
+  ```
+  This only generates Bearer tokens without trailing padding (`=`). However, the production regex has an optional `={0,2}` suffix.
+- **Suggestion:** Enhance the generator to produce tokens with 0, 1, or 2 trailing `=` signs to fully assert the boundary and pattern matching:
+  ```typescript
+  [
+    "bearer",
+    fc.tuple(charsetArb(BEARER_BODY, 16), fc.constantFrom("", "=", "=="))
+      .map(([b, eq]) => `Bearer ${b}${eq}`),
+  ],
+  ```
+
+---
+
+### 2.2. Character Class Escaping Safety (Task 1 Step 3)
+- **Observation:** In the production map's `bearer` regex:
+  ```typescript
+  ["bearer", /(?<![A-Za-z0-9])Bearer\s+[A-Za-z0-9_.\-+/]{16,}={0,2}(?![A-Za-z0-9_./+-])/g],
+  ```
+  The lookahead charset `(?![A-Za-z0-9_./+-])` puts the `-` at the very end to treat it as a literal.
+- **Suggestion:** To prevent parsing ambiguity or potential lint errors (e.g., Biome or TS warning about unescaped range delimiters), explicitly escape the hyphen in the lookahead as well:
+  ```typescript
+  (?![A-Za-z0-9_./+\-])
+  ```
+
+---
+
+### 2.3. Verification of Bearer `=` Lookahead Behavior
+- **Observation:** The lookahead `(?![A-Za-z0-9_./+-])` intentionally excludes `=`.
+- **Validation:** This is a correct design decision. If `=` were included in the lookahead charset (e.g. `(?![A-Za-z0-9_./+\-=])`), then a string containing an extra trailing equal sign (such as `Bearer 1234567890123456===`) would fail the lookahead at `==`, backtrack, fail at `=`, and fail the entire match—thereby leaking the credentials. Excluding `=` from the lookahead allows the regex to match and redact `Bearer 1234567890123456==` while leaving the trailing `=` unredacted.
+- **Action:** No code change is needed for this, but it serves as a confirmation of the correctness of the design.
+
+---
+
+## 3. Conclusion
+
+With the minor improvements to the `bearer` generator and regex escaping, the implementation plan is fully optimized and ready to execute.

--- a/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix.md
+++ b/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix.md
@@ -101,7 +101,10 @@ const GENERATORS: ReadonlyMap<string, fc.Arbitrary<string>> = new Map([
       .tuple(fc.constantFrom("b", "o", "a", "p", "r"), fc.boolean(), charsetArb(ALNUM_D, 10))
       .map(([c, s, b]) => `xox${c}${s ? "s" : ""}-${b}`),
   ],
-  ["bearer", charsetArb(BEARER_BODY, 16).map((b) => `Bearer ${b}`)],
+  [
+    "bearer",
+    fc.tuple(charsetArb(BEARER_BODY, 16), fc.constantFrom("", "=", "==")).map(([b, eq]) => `Bearer ${b}${eq}`),
+  ],
   [
     "jwt",
     fc
@@ -210,7 +213,11 @@ export const SENSITIVE_VALUE_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
   ["openai", /(?<![A-Za-z0-9])sk-(?:proj-)?[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
   ["anthropic", /(?<![A-Za-z0-9])sk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
   ["slack", /(?<![A-Za-z0-9])xox[boapr]s?-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])/g],
-  ["bearer", /(?<![A-Za-z0-9])Bearer\s+[A-Za-z0-9_.\-+/]{16,}={0,2}(?![A-Za-z0-9_./+-])/g],
+  // Trailing lookahead EXCLUDES `=` on purpose: a token with 3+ trailing `=`
+  // (e.g. `Bearer <body>===`) would otherwise backtrack-fail and LEAK the whole
+  // credential. Excluding `=` lets `={0,2}` consume the padding and redact.
+  // (verified during plan review §2.3). Hyphen escaped for lint/consistency.
+  ["bearer", /(?<![A-Za-z0-9])Bearer\s+[A-Za-z0-9_.\-+/]{16,}={0,2}(?![A-Za-z0-9_./+\-])/g],
   ["jwt", /(?<![A-Za-z0-9])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?![A-Za-z0-9_-])/g],
   ["aws", /(?<![A-Za-z0-9])(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])/g],
 ]);
@@ -406,6 +413,22 @@ cross-platform leg is the chronic flake — rerun, don't chase. Fix and resolve 
 Sonar thread.
 
 ---
+
+## Review dispositions (2026-06-13)
+
+Addressing [the plan review](./2026-06-13-true-coverage-C1-redaction-fix-review.md):
+
+1. **§2.1 Bearer generator padding — ACCEPTED.** The `bearer` generator now emits 0/1/2 trailing
+   `=` (`fc.constantFrom("", "=", "==")`), exercising the production regex's `={0,2}` suffix.
+   Verified all padding lengths redact, including when an `=` separator follows.
+2. **§2.2 Escape the hyphen in the Bearer lookahead — ACCEPTED.** Changed `(?![A-Za-z0-9_./+-])`
+   → `(?![A-Za-z0-9_./+\-])`. Confirmed byte-identical behavior (trailing `-` was already literal);
+   the escape is for lint-safety + consistency with the body class `[A-Za-z0-9_.\-+/]`.
+3. **§2.3 `=` excluded from the Bearer lookahead — ACKNOWLEDGED, no change; now empirically
+   confirmed + documented in code.** Tested the rejected alternative (`=` *in* the lookahead): a
+   `Bearer <body>===` input **leaks the entire credential** (backtrack-fail), whereas the accepted
+   design redacts it. Added an inline comment at the pattern so a future editor doesn't "tidy" `=`
+   into the lookahead and silently re-open the leak.
 
 ## Self-review notes (author)
 

--- a/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix.md
+++ b/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix.md
@@ -33,16 +33,19 @@ source coverage only holds or rises).
 ## Task 1: Fix the boundary bug, locked by behavioral property tests
 
 **Files:**
+
 - Modify: `packages/gateway/src/audit/format-audit-payload.ts:1-49`
 - Test: `packages/gateway/src/audit/format-audit-payload.test.ts`
 
 - [ ] **Step 0: Confirm no security-invariant test pins these regex literals**
 
 Run:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
 grep -rn "SENSITIVE_VALUE_PATTERNS\|gh\[pousr\]\|redactAuditPayload" packages/gateway/src/security-invariants.test.ts || echo "NONE — safe"
 ```
+
 Expected: `NONE — safe` (the audit scrubber is a sibling of I11, not an invariant wiring site). If
 any hit appears, stop and reconcile with the spec §3.4 before proceeding.
 
@@ -171,10 +174,12 @@ describe("redactAuditPayload — property: ordinary prose is preserved", () => {
 - [ ] **Step 2: Run the new property tests against the LIVE (unfixed) module — verify they FAIL**
 
 Run:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
 bun test packages/gateway/src/audit/format-audit-payload.test.ts -t "property" 2>&1 | tail -25
 ```
+
 Expected: **FAIL.** fast-check finds and shrinks counterexamples — at minimum the `github_fine_grained`
 family (prefix never matched) and the `github_classic`/others with an `_` separator on a side
 (boundary escape). This proves the §3.1 blind spot on the real module before the fix.
@@ -236,19 +241,23 @@ Leave the rest of the file (`redact`, `formatAuditPayload`, `redactAuditPayload`
 - [ ] **Step 4: Run the full audit test file — verify ALL pass (new properties + existing 7)**
 
 Run:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
 bun test packages/gateway/src/audit/format-audit-payload.test.ts 2>&1 | tail -15
 ```
+
 Expected: **PASS** — all property tests green and the 7 pre-existing tests still green (the change
 only ever redacts more; the `"sketch a plan"` guard and the key-based redactions are unaffected).
 
 - [ ] **Step 5: Typecheck the changed package**
 
 Run:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/tc-C/packages/gateway && bun run typecheck 2>&1 | tail -15
 ```
+
 Expected: no errors in `audit/format-audit-payload.ts` or its test. (If `@nimbus-dev/client`
 false-fails, run `cd packages/client && bun run build` once, per the worktree gotcha.)
 
@@ -277,6 +286,7 @@ Prevents a future pattern being added to the production scrubber (or a generator
 counterpart — the property suite would otherwise silently stop covering it.
 
 **Files:**
+
 - Test: `packages/gateway/src/audit/format-audit-payload.test.ts`
 
 - [ ] **Step 1: Import the exported pattern map**
@@ -307,18 +317,22 @@ describe("redactAuditPayload — structural: every pattern has a generator", () 
 - [ ] **Step 3: Run the file — verify the guard passes**
 
 Run:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
 bun test packages/gateway/src/audit/format-audit-payload.test.ts 2>&1 | tail -12
 ```
+
 Expected: **PASS** — the 8 production keys match the 8 generator keys.
 
 - [ ] **Step 4: Prove the guard actually catches drift (temporary, do NOT commit)**
 
 Temporarily delete one generator entry (e.g. the `aws` line in `GENERATORS`) and re-run:
+
 ```bash
 bun test packages/gateway/src/audit/format-audit-payload.test.ts -t "1:1" 2>&1 | tail -8
 ```
+
 Expected: **FAIL** on the keyset mismatch. Then restore the deleted line and re-run to confirm
 green again. (This is a manual sanity check — leave the file restored.)
 
@@ -341,21 +355,25 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 - [ ] **Step 1: Confirm I11 / audit invariants still hold**
 
 Run:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
 bun test packages/gateway/src/security-invariants.test.ts 2>&1 | tail -8
 bun run audit:invariants 2>&1 | tail -8
 ```
+
 Expected: both **PASS** (no invariant references the scrubber regexes; this change is behavior-only).
 
 - [ ] **Step 2: Run the cheap static pre-flight + the audit subtree**
 
 Run:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
 bun run preflight:fast 2>&1 | tail -20
 bun test packages/gateway/src/audit 2>&1 | tail -10
 ```
+
 Expected: pre-flight static gates green; the whole `audit/` subtree green. (Biome may be skipped in
 the worktree via `!**/.claude` — if `preflight:fast` reports 0 lint files, validate with
 `bunx biome check packages/gateway/src/audit/format-audit-payload.ts packages/gateway/src/audit/format-audit-payload.test.ts`.)

--- a/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix.md
+++ b/docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix.md
@@ -1,0 +1,419 @@
+# True Coverage C1 — Audit-redaction boundary fix + property lock — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the credential-redaction blind spot in `audit/format-audit-payload.ts` (tokens adjacent to / containing `_`, and fine-grained `github_pat_` tokens, escape the `\b`-anchored scrubber) and lock it with fast-check property tests, including a structural guard against generator drift.
+
+**Architecture:** Replace each pattern's fragile `\b` anchors with an explicit leading `(?<![A-Za-z0-9])` and a trailing negative-lookahead **aligned to that pattern's own body charset**; split the GitHub family into two patterns (classic excludes `_`, fine-grained includes it) so a shared lookahead can't re-open the escape; export the patterns as a labeled `{name → RegExp}` map so a property test can prove 1:1 generator coverage. Pure regex + test change — no API/signature change, redaction only ever redacts *more*.
+
+**Tech Stack:** Bun 1.3.14 · TypeScript 6.x strict · `bun:test` · `fast-check@4.8.0` (already a `gateway` devDependency).
+
+**Spec:** [`docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md`](../specs/2026-06-13-true-coverage-C-depth-design.md) §3 (+ §10 review dispositions).
+
+**Worktree:** `C:\gitrep\Nimbus\.claude\worktrees\tc-C` · branch `dev/asafgolombek/true-coverage-C`. All paths below are repo-relative to that worktree.
+
+---
+
+## File structure
+
+- **Modify:** `packages/gateway/src/audit/format-audit-payload.ts` — convert the module-private
+  `SENSITIVE_VALUE_PATTERNS: ReadonlyArray<RegExp>` into an **exported** labeled
+  `ReadonlyMap<string, RegExp>` with the boundary-fixed regexes; iterate `.values()` in the scrubber.
+  (One file, ~50 lines; no caller changes — `redactAuditPayload`/`formatAuditPayload` signatures are
+  untouched.)
+- **Modify:** `packages/gateway/src/audit/format-audit-payload.test.ts` — keep the 7 existing tests;
+  add a `GENERATORS` map, a per-family positive property, a negative prose-preservation property
+  (Task 1), and the structural 1:1 drift guard (Task 2).
+
+No other files change. No migration, no coverage-baseline change (tests + a tightened regex; net
+source coverage only holds or rises).
+
+---
+
+## Task 1: Fix the boundary bug, locked by behavioral property tests
+
+**Files:**
+- Modify: `packages/gateway/src/audit/format-audit-payload.ts:1-49`
+- Test: `packages/gateway/src/audit/format-audit-payload.test.ts`
+
+- [ ] **Step 0: Confirm no security-invariant test pins these regex literals**
+
+Run:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+grep -rn "SENSITIVE_VALUE_PATTERNS\|gh\[pousr\]\|redactAuditPayload" packages/gateway/src/security-invariants.test.ts || echo "NONE — safe"
+```
+Expected: `NONE — safe` (the audit scrubber is a sibling of I11, not an invariant wiring site). If
+any hit appears, stop and reconcile with the spec §3.4 before proceeding.
+
+- [ ] **Step 1: Write the failing property tests (behavioral, via the public API)**
+
+Append to `packages/gateway/src/audit/format-audit-payload.test.ts`. Add the `fc` import at the top
+(next to the existing imports):
+
+```typescript
+import fc from "fast-check";
+```
+
+Then append this block at the end of the file (after the closing `});` of the existing
+`describe("redactAuditPayload (S2-F2)", …)`):
+
+```typescript
+// --- C1: property-based redaction lock (fast-check) ---
+
+const ALNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const ALNUM_US = `${ALNUM}_`; // alnum + underscore (fine-grained PAT body)
+const ALNUM_USD = `${ALNUM}_-`; // alnum + underscore + dash (sk- bodies)
+const ALNUM_D = `${ALNUM}-`; // alnum + dash (slack body)
+const ALNUM_UD = `${ALNUM}_-`; // alnum + underscore + dash (jwt segments)
+const UPPERNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"; // aws body
+const BEARER_BODY = `${ALNUM}_.+/-`; // bearer body charset
+
+/** A random string of `chars`, length in [min, max]. */
+function charsetArb(chars: string, min: number, max = min + 24): fc.Arbitrary<string> {
+  return fc
+    .array(fc.constantFrom(...chars.split("")), { minLength: min, maxLength: max })
+    .map((a) => a.join(""));
+}
+
+/**
+ * One generator per production SENSITIVE_VALUE_PATTERN family. Each yields a
+ * structurally valid token (correct prefix + random body of the correct charset
+ * and >= the minimum length). Keys MUST match the production map's keys — the
+ * structural guard in Task 2 enforces that 1:1.
+ */
+const GENERATORS: ReadonlyMap<string, fc.Arbitrary<string>> = new Map([
+  [
+    "github_classic",
+    fc
+      .tuple(fc.constantFrom("p", "o", "u", "s", "r"), charsetArb(ALNUM, 20))
+      .map(([c, b]) => `gh${c}_${b}`),
+  ],
+  ["github_fine_grained", charsetArb(ALNUM_US, 20).map((b) => `github_pat_${b}`)],
+  [
+    "openai",
+    fc.tuple(fc.boolean(), charsetArb(ALNUM_USD, 20)).map(([proj, b]) => `sk-${proj ? "proj-" : ""}${b}`),
+  ],
+  ["anthropic", charsetArb(ALNUM_USD, 20).map((b) => `sk-ant-${b}`)],
+  [
+    "slack",
+    fc
+      .tuple(fc.constantFrom("b", "o", "a", "p", "r"), fc.boolean(), charsetArb(ALNUM_D, 10))
+      .map(([c, s, b]) => `xox${c}${s ? "s" : ""}-${b}`),
+  ],
+  ["bearer", charsetArb(BEARER_BODY, 16).map((b) => `Bearer ${b}`)],
+  [
+    "jwt",
+    fc
+      .tuple(charsetArb(ALNUM_UD, 3), charsetArb(ALNUM_UD, 3), charsetArb(ALNUM_UD, 3))
+      .map(([a, b, c]) => `eyJ${a}.${b}.${c}`),
+  ],
+  ["aws", fc.tuple(fc.constantFrom("AKIA", "ASIA"), charsetArb(UPPERNUM, 16, 16)).map(([p, b]) => `${p}${b}`)],
+]);
+
+// Non-empty, non-alphanumeric separators — guarantee a token boundary on each
+// side. Includes "_" specifically to prove the underscore-adjacency fix.
+const SEP = fc.constantFrom(" ", "_", ":", "=", ",", "(", "[", "/", '"', "'", "\n", ".");
+// Clearly non-secret prose: lowercase letters + spaces only (cannot match any
+// pattern — every pattern needs a digit/dash/underscore/uppercase or a fixed prefix).
+const LOWORD = fc
+  .array(fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz".split("")), { minLength: 1, maxLength: 8 })
+  .map((a) => a.join(""));
+const PROSE = fc.array(LOWORD, { minLength: 1, maxLength: 6 }).map((a) => a.join(" "));
+const PROSE_OR_EMPTY = fc.oneof(fc.constant(""), PROSE);
+
+describe("redactAuditPayload — property: every token family is scrubbed anywhere", () => {
+  for (const [name, gen] of GENERATORS) {
+    test(`scrubs ${name} tokens regardless of surrounding noise`, () => {
+      fc.assert(
+        fc.property(
+          gen,
+          PROSE_OR_EMPTY,
+          SEP,
+          SEP,
+          PROSE_OR_EMPTY,
+          fc.boolean(),
+          (token, lead, s1, s2, trail, nest) => {
+            const embedded = `${lead}${s1}${token}${s2}${trail}`;
+            // Test both a bare-string payload and a value nested under a generic
+            // (non-sensitive) key — redaction must reach both.
+            const payload = nest ? { note: embedded } : embedded;
+            const out = redactAuditPayload(payload);
+            // The token (the secret material) must not survive...
+            expect(out.includes(token)).toBe(false);
+            // ...and a redaction marker must be present.
+            expect(out.includes("[REDACTED]")).toBe(true);
+          },
+        ),
+        { numRuns: 300 },
+      );
+    });
+  }
+});
+
+describe("redactAuditPayload — property: ordinary prose is preserved", () => {
+  test("never redacts lowercase-letter prose", () => {
+    fc.assert(
+      fc.property(PROSE, (prose) => {
+        const out = redactAuditPayload({ note: prose });
+        expect(out.includes(prose)).toBe(true);
+        expect(out.includes("[REDACTED]")).toBe(false);
+      }),
+      { numRuns: 300 },
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the new property tests against the LIVE (unfixed) module — verify they FAIL**
+
+Run:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+bun test packages/gateway/src/audit/format-audit-payload.test.ts -t "property" 2>&1 | tail -25
+```
+Expected: **FAIL.** fast-check finds and shrinks counterexamples — at minimum the `github_fine_grained`
+family (prefix never matched) and the `github_classic`/others with an `_` separator on a side
+(boundary escape). This proves the §3.1 blind spot on the real module before the fix.
+
+- [ ] **Step 3: Apply the boundary fix in the source module**
+
+Replace the top of `packages/gateway/src/audit/format-audit-payload.ts` (lines 1-21, the
+`DEFAULT_MAX_BYTES`/`SENSITIVE_KEY`/`SENSITIVE_VALUE_PATTERNS`/`redactSensitiveValueString` block)
+with:
+
+```typescript
+const DEFAULT_MAX_BYTES = 4096;
+
+const SENSITIVE_KEY = /(token|key|secret|password|credential|bearer|auth|^pat$)/i;
+
+/**
+ * Credential-shaped value patterns, keyed by a stable family name.
+ *
+ * Boundary design: JavaScript `\b` treats `_` as a word character, so a token
+ * adjacent to — or containing — `_` sits between two "word" chars, produces no
+ * boundary, and silently escapes redaction. Each pattern instead uses an
+ * explicit leading `(?<![A-Za-z0-9])` and a trailing negative lookahead aligned
+ * to that pattern's OWN body charset.
+ *
+ * The two GitHub prefixes are kept as separate patterns because their bodies
+ * differ (classic `gh[pousr]_` excludes `_`; fine-grained `github_pat_` includes
+ * it). A single shared trailing lookahead over a union would have to pick one
+ * charset, and an `_`-inclusive lookahead re-opens the `ghp_…_x` escape this
+ * scrubber fixes.
+ *
+ * Exported so the redaction property test can assert 1:1 generator coverage.
+ */
+export const SENSITIVE_VALUE_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
+  ["github_classic", /(?<![A-Za-z0-9])gh[pousr]_[A-Za-z0-9]{20,}(?![A-Za-z0-9])/g],
+  ["github_fine_grained", /(?<![A-Za-z0-9])github_pat_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])/g],
+  ["openai", /(?<![A-Za-z0-9])sk-(?:proj-)?[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
+  ["anthropic", /(?<![A-Za-z0-9])sk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
+  ["slack", /(?<![A-Za-z0-9])xox[boapr]s?-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])/g],
+  ["bearer", /(?<![A-Za-z0-9])Bearer\s+[A-Za-z0-9_.\-+/]{16,}={0,2}(?![A-Za-z0-9_./+-])/g],
+  ["jwt", /(?<![A-Za-z0-9])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?![A-Za-z0-9_-])/g],
+  ["aws", /(?<![A-Za-z0-9])(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])/g],
+]);
+
+function redactSensitiveValueString(s: string): string {
+  let out = s;
+  for (const pat of SENSITIVE_VALUE_PATTERNS.values()) {
+    out = out.replace(pat, "[REDACTED]");
+  }
+  return out;
+}
+```
+
+Leave the rest of the file (`redact`, `formatAuditPayload`, `redactAuditPayload`) unchanged.
+
+- [ ] **Step 4: Run the full audit test file — verify ALL pass (new properties + existing 7)**
+
+Run:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+bun test packages/gateway/src/audit/format-audit-payload.test.ts 2>&1 | tail -15
+```
+Expected: **PASS** — all property tests green and the 7 pre-existing tests still green (the change
+only ever redacts more; the `"sketch a plan"` guard and the key-based redactions are unaffected).
+
+- [ ] **Step 5: Typecheck the changed package**
+
+Run:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C/packages/gateway && bun run typecheck 2>&1 | tail -15
+```
+Expected: no errors in `audit/format-audit-payload.ts` or its test. (If `@nimbus-dev/client`
+false-fails, run `cd packages/client && bun run build` once, per the worktree gotcha.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+git add packages/gateway/src/audit/format-audit-payload.ts packages/gateway/src/audit/format-audit-payload.test.ts
+git commit -m "fix(audit): close credential-redaction boundary escapes (underscore-adjacent + github_pat_)
+
+The \\b-anchored scrubber treated _ as a word char, so gh/sk-/AKIA/JWT tokens
+adjacent to or containing _ — and all fine-grained github_pat_ tokens — escaped
+audit redaction. Replace \\b with explicit (?<![A-Za-z0-9]) + body-aligned
+trailing lookaheads; split the gh family into classic + fine-grained patterns.
+Locked with fast-check property tests over every token family embedded in
+adversarial noise (incl. underscore adjacency) + a prose-preservation property.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Structural 1:1 generator-drift guard
+
+Prevents a future pattern being added to the production scrubber (or a generator) without its
+counterpart — the property suite would otherwise silently stop covering it.
+
+**Files:**
+- Test: `packages/gateway/src/audit/format-audit-payload.test.ts`
+
+- [ ] **Step 1: Import the exported pattern map**
+
+Edit the top import of the test file to also pull in the patterns map:
+
+```typescript
+import { formatAuditPayload, redactAuditPayload, SENSITIVE_VALUE_PATTERNS } from "./format-audit-payload.ts";
+```
+
+- [ ] **Step 2: Add the structural guard test**
+
+Append at the end of `packages/gateway/src/audit/format-audit-payload.test.ts`:
+
+```typescript
+describe("redactAuditPayload — structural: every pattern has a generator", () => {
+  test("GENERATORS keys are 1:1 with SENSITIVE_VALUE_PATTERNS keys", () => {
+    const patternKeys = [...SENSITIVE_VALUE_PATTERNS.keys()].sort();
+    const generatorKeys = [...GENERATORS.keys()].sort();
+    // If this fails, a token family was added/removed in the production scrubber
+    // without updating GENERATORS (or vice-versa) — the property suite would stop
+    // fuzzing it. Fix by adding the matching generator/pattern.
+    expect(generatorKeys).toEqual(patternKeys);
+  });
+});
+```
+
+- [ ] **Step 3: Run the file — verify the guard passes**
+
+Run:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+bun test packages/gateway/src/audit/format-audit-payload.test.ts 2>&1 | tail -12
+```
+Expected: **PASS** — the 8 production keys match the 8 generator keys.
+
+- [ ] **Step 4: Prove the guard actually catches drift (temporary, do NOT commit)**
+
+Temporarily delete one generator entry (e.g. the `aws` line in `GENERATORS`) and re-run:
+```bash
+bun test packages/gateway/src/audit/format-audit-payload.test.ts -t "1:1" 2>&1 | tail -8
+```
+Expected: **FAIL** on the keyset mismatch. Then restore the deleted line and re-run to confirm
+green again. (This is a manual sanity check — leave the file restored.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+git add packages/gateway/src/audit/format-audit-payload.test.ts
+git commit -m "test(audit): structural 1:1 guard — every scrub pattern has a fast-check generator
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Validate, push, open PR
+
+**Files:** none (validation + git).
+
+- [ ] **Step 1: Confirm I11 / audit invariants still hold**
+
+Run:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+bun test packages/gateway/src/security-invariants.test.ts 2>&1 | tail -8
+bun run audit:invariants 2>&1 | tail -8
+```
+Expected: both **PASS** (no invariant references the scrubber regexes; this change is behavior-only).
+
+- [ ] **Step 2: Run the cheap static pre-flight + the audit subtree**
+
+Run:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+bun run preflight:fast 2>&1 | tail -20
+bun test packages/gateway/src/audit 2>&1 | tail -10
+```
+Expected: pre-flight static gates green; the whole `audit/` subtree green. (Biome may be skipped in
+the worktree via `!**/.claude` — if `preflight:fast` reports 0 lint files, validate with
+`bunx biome check packages/gateway/src/audit/format-audit-payload.ts packages/gateway/src/audit/format-audit-payload.test.ts`.)
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/tc-C
+git push -u origin dev/asafgolombek/true-coverage-C
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --base main --head dev/asafgolombek/true-coverage-C \
+  --title "fix(audit): close credential-redaction boundary escapes + property lock (True Coverage C1)" \
+  --body "$(cat <<'BODY'
+## What
+
+Sub-project **C1** of the True Coverage program (depth: property-based testing).
+
+Fixes an audit-redaction blind spot found by a fast-check spike: the `\b`-anchored
+credential scrubber in `audit/format-audit-payload.ts` treats `_` as a word char,
+so tokens **adjacent to or containing `_`** — and **all fine-grained `github_pat_`**
+tokens — escaped redaction (validated on the live module). The same latent class
+existed in the `sk-`/`xox`/`Bearer`/JWT/`AKIA` patterns.
+
+## How
+
+- Replace each pattern's `\b` anchors with explicit `(?<![A-Za-z0-9])` + a trailing
+  negative lookahead **aligned to that pattern's own body charset**.
+- Split the GitHub family into `github_classic` + `github_fine_grained` (different
+  body charsets; a shared union lookahead would re-open the escape — verified).
+- Export the patterns as a labeled `{name → RegExp}` map.
+
+## Tests
+
+- fast-check **positive** property: every token family, embedded in adversarial
+  noise (incl. `_` adjacency, nested under a generic key), is always scrubbed.
+- fast-check **negative** property: lowercase prose is never redacted.
+- **Structural 1:1 guard**: every production pattern has a generator (drift-proof).
+- The 7 pre-existing unit tests stay green; I11 / audit invariants unchanged.
+
+Spec: `docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md` §3.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 5: Watch CI to green**
+
+Authoritative gate: **PR quality — TS/Bun (ubuntu-24.04) / Unit + Coverage**. The windows-2025
+cross-platform leg is the chronic flake — rerun, don't chase. Fix and resolve every CodeRabbit +
+Sonar thread.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** §3.2 fix (Task 1 Step 3) ✓ · §3.3 positive/negative properties (Task 1 Step 1) ✓
+  · §3.3 structural 1:1 guard + labeled-map export (Task 1 Step 3 export + Task 2) ✓ · §3.4 invariant
+  confirm (Task 1 Step 0 + Task 3 Step 1) ✓ · §6 validation/push (Task 3) ✓.
+- **Type consistency:** `SENSITIVE_VALUE_PATTERNS` is a `ReadonlyMap<string, RegExp>` in source and
+  imported with that type in the test; `GENERATORS` is `ReadonlyMap<string, fc.Arbitrary<string>>`;
+  keys match (asserted by Task 2). `charsetArb(chars, min, max=min+24)` signature is used with 2 args
+  everywhere except `aws` (3 args, fixed length 16).
+- **No placeholders:** every code/command step is concrete and runnable.

--- a/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design-review.md
+++ b/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design-review.md
@@ -1,0 +1,60 @@
+# Review: True Coverage — Sub-project C: Depth (mutation + property-based testing)
+
+**Date:** 2026-06-13  
+**Reviewer:** AI Assistant (Antigravity)  
+**Status:** Review Completed  
+**Target Spec:** [`2026-06-13-true-coverage-C-depth-design.md`](./2026-06-13-true-coverage-C-depth-design.md)
+
+---
+
+## 1. Executive Summary
+
+The design for Sub-project C (Depth) is highly targeted, well-scoped, and directly addresses critical security risks (credential leakage via audit redaction blind spots) while introducing robust regression locking through property-based tests.
+
+We have reviewed the specification and identified a few minor areas of improvement, regex optimization, and safety nets to ensure seamless execution.
+
+---
+
+## 2. Detailed Feedback & Suggestions
+
+### 2.1. Regex Lookahead & Charset Alignment (Section 3.2)
+- **Observation:** In the proposed pattern for the GitHub PAT family:
+  ```
+  (?<![A-Za-z0-9])(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})(?![A-Za-z0-9])
+  ```
+  The body of `github_pat_` allows underscores (`_`), but the trailing negative lookahead is `(?![A-Za-z0-9])`. 
+- **Recommendation:** Align the trailing negative lookahead charset with the body charset of the pattern being matched. If a token body can contain `_`, the lookahead should ensure we don't match a partial token prefix before an underscore. Although greediness `{20,}` prevents premature stopping in most cases, using:
+  - `(?![A-Za-z0-9_])` for `github_pat_`
+  - `(?![A-Za-z0-9_-])` for `sk-`/`sk-ant-`/`xox`/`eyJ`
+  provides maximum robustness and mathematical correctness.
+
+- **Bearer Token Pattern:** The proposal to drop the fragile trailing `\b` after `={0,2}` is excellent since `=` is not a word character. However, to prevent matching a partial prefix of a longer base64-like string that ends with more than two `=` characters (or other non-boundary base64 characters), consider appending `(?![A-Za-z0-9_.\-+/])` or similar lookahead to assert a clean boundary.
+
+---
+
+### 2.2. Fast-Check Generator Completeness & Sync (Section 3.3)
+- **Observation:** As the codebase evolves, new token formats may be added to `SENSITIVE_VALUE_PATTERNS` in `format-audit-payload.ts`.
+- **Recommendation:** To prevent property-test drift (where a new pattern is added to the production scrubber but is forgotten in the property test generators):
+  1. Add a structural assertion in the test file that verifies the count of `SENSITIVE_VALUE_PATTERNS` matches the number of registered fast-check generators.
+  2. Or, construct a mapping of `pattern -> generator` to automatically ensure 1:1 coverage.
+
+---
+
+### 2.3. StrykerJS Performance & Configuration (Section 5)
+- **Observation:** Using the `command` runner fallback runs the command for each mutant. Even with Bun's sub-10ms startup, running the entire test suite on hundreds of mutants can lead to noticeable execution times.
+- **Recommendation:** 
+  1. Ensure the fallback `commandRunner.command` is tightly scoped to the target test suite (e.g., `bun test packages/gateway/src/audit/format-audit-payload.test.ts`) rather than `bun test` globally.
+  2. Add `coverageAnalysis: "perTest"` (supported by the experimental bun-runner) but fall back to `coverageAnalysis: "all"` or `"off"` for the command runner to guarantee correctness.
+
+---
+
+### 2.4. Cross-Runtime Compatibility (Stryker under Node)
+- **Observation:** StrykerJS core runs under Node.js (v20+ is present).
+- **Verification:** Ensure that the regexes using advanced lookbehinds and lookaheads function identically under both Bun (JSC) and Stryker's execution environment (Node/V8). 
+- **Status:** Lookbehinds (`(?<!...)`) and lookaheads (`(?!...)`) are fully standard in ES2018+ and are natively supported in all target runtimes (JSC/V8). No compatibility issues are expected.
+
+---
+
+## 3. Conclusion & Next Steps
+
+The design is approved for implementation with the above minor alignments. The next slice (C1) can proceed directly to the planning and implementation phase.

--- a/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design-review.md
+++ b/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design-review.md
@@ -18,11 +18,14 @@ We have reviewed the specification and identified a few minor areas of improveme
 ## 2. Detailed Feedback & Suggestions
 
 ### 2.1. Regex Lookahead & Charset Alignment (Section 3.2)
+
 - **Observation:** In the proposed pattern for the GitHub PAT family:
-  ```
+
+  ```text
   (?<![A-Za-z0-9])(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})(?![A-Za-z0-9])
   ```
-  The body of `github_pat_` allows underscores (`_`), but the trailing negative lookahead is `(?![A-Za-z0-9])`. 
+
+  The body of `github_pat_` allows underscores (`_`), but the trailing negative lookahead is `(?![A-Za-z0-9])`.
 - **Recommendation:** Align the trailing negative lookahead charset with the body charset of the pattern being matched. If a token body can contain `_`, the lookahead should ensure we don't match a partial token prefix before an underscore. Although greediness `{20,}` prevents premature stopping in most cases, using:
   - `(?![A-Za-z0-9_])` for `github_pat_`
   - `(?![A-Za-z0-9_-])` for `sk-`/`sk-ant-`/`xox`/`eyJ`
@@ -33,6 +36,7 @@ We have reviewed the specification and identified a few minor areas of improveme
 ---
 
 ### 2.2. Fast-Check Generator Completeness & Sync (Section 3.3)
+
 - **Observation:** As the codebase evolves, new token formats may be added to `SENSITIVE_VALUE_PATTERNS` in `format-audit-payload.ts`.
 - **Recommendation:** To prevent property-test drift (where a new pattern is added to the production scrubber but is forgotten in the property test generators):
   1. Add a structural assertion in the test file that verifies the count of `SENSITIVE_VALUE_PATTERNS` matches the number of registered fast-check generators.
@@ -41,16 +45,18 @@ We have reviewed the specification and identified a few minor areas of improveme
 ---
 
 ### 2.3. StrykerJS Performance & Configuration (Section 5)
+
 - **Observation:** Using the `command` runner fallback runs the command for each mutant. Even with Bun's sub-10ms startup, running the entire test suite on hundreds of mutants can lead to noticeable execution times.
-- **Recommendation:** 
+- **Recommendation:**
   1. Ensure the fallback `commandRunner.command` is tightly scoped to the target test suite (e.g., `bun test packages/gateway/src/audit/format-audit-payload.test.ts`) rather than `bun test` globally.
   2. Add `coverageAnalysis: "perTest"` (supported by the experimental bun-runner) but fall back to `coverageAnalysis: "all"` or `"off"` for the command runner to guarantee correctness.
 
 ---
 
 ### 2.4. Cross-Runtime Compatibility (Stryker under Node)
+
 - **Observation:** StrykerJS core runs under Node.js (v20+ is present).
-- **Verification:** Ensure that the regexes using advanced lookbehinds and lookaheads function identically under both Bun (JSC) and Stryker's execution environment (Node/V8). 
+- **Verification:** Ensure that the regexes using advanced lookbehinds and lookaheads function identically under both Bun (JSC) and Stryker's execution environment (Node/V8).
 - **Status:** Lookbehinds (`(?<!...)`) and lookaheads (`(?!...)`) are fully standard in ES2018+ and are natively supported in all target runtimes (JSC/V8). No compatibility issues are expected.
 
 ---

--- a/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
+++ b/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
@@ -73,11 +73,17 @@ boundary but **not** alphanumerics, and add the fine-grained PAT family:
 - **Leading boundary:** `(?<![A-Za-z0-9])` — the token must start a fresh alphanumeric run. `_`,
   spaces, quotes, and other punctuation before the prefix all qualify as a boundary (fixing the
   `x_ghp_…` escape), while `loghp_…` mid-word does not match (avoids nuking ordinary words).
-- **Trailing boundary:** `(?![<pattern charset>])` — not followed by another character of the
-  token's own charset (fixing the `ghp_…_x` and "longer than real" escapes).
-- **gh family** gains a `github_pat_[A-Za-z0-9_]{20,}` alternative (fine-grained PATs contain `_`):
+- **Trailing boundary:** `(?![<pattern body charset>])` — not followed by another character of the
+  token's **own body** charset (fixing the `ghp_…_x` and "longer than real" escapes). The lookahead
+  charset is **aligned to each pattern's body** (review §2.1), see the table below.
+- **gh family** gains fine-grained PAT support (`github_pat_…`, which legitimately contains `_`).
+  Because the two gh prefixes have **different body charsets** (classic `gh[pousr]_` excludes `_`,
+  fine-grained includes it), they are kept as **two separate patterns** rather than one union — a
+  shared trailing lookahead over a union forces a single charset, and `(?![A-Za-z0-9_])` on the
+  union reintroduces the `ghp_…_x` escape we are fixing (validated, see §3.2 note):
   ```
-  (?<![A-Za-z0-9])(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})(?![A-Za-z0-9])
+  (?<![A-Za-z0-9])gh[pousr]_[A-Za-z0-9]{20,}(?![A-Za-z0-9])        # classic — body excludes _
+  (?<![A-Za-z0-9])github_pat_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])     # fine-grained — body includes _
   ```
 - **Token cores stay specific** (prefix + minimum length + charset) so non-secret prose is
   preserved — in particular the existing guard test `"sketch a plan"` stays un-redacted (`sk-`
@@ -88,21 +94,25 @@ safer than leaking a live credential. The precise cores bound that over-redactio
 
 Per-pattern boundary corrections (applied uniformly):
 
-| Pattern | Trailing negative-lookahead charset |
-|---|---|
-| gh / github_pat | `[A-Za-z0-9]` |
-| `sk-` / `sk-ant-` | `[A-Za-z0-9_-]` |
-| `xox` | `[A-Za-z0-9-]` |
-| `Bearer …` | drop the fragile trailing `\b` after `={0,2}` |
-| JWT `eyJ…` | `[A-Za-z0-9_-]` |
-| `AKIA` / `ASIA` | `[A-Z0-9]` |
+| Pattern | Body charset | Trailing negative-lookahead (body-aligned) |
+|---|---|---|
+| `gh[pousr]_` (classic) | `[A-Za-z0-9]` | `(?![A-Za-z0-9])` |
+| `github_pat_` (fine-grained) | `[A-Za-z0-9_]` | `(?![A-Za-z0-9_])` |
+| `sk-` / `sk-ant-` | `[A-Za-z0-9_-]` | `(?![A-Za-z0-9_-])` |
+| `xox` | `[A-Za-z0-9-]` | `(?![A-Za-z0-9-])` |
+| `Bearer …` | `[A-Za-z0-9_.\-+/]…={0,2}` | `(?![A-Za-z0-9_./+-])` (replaces the fragile trailing `\b`; `=` is terminal padding, excluded) |
+| JWT `eyJ…` | `[A-Za-z0-9_-]` | `(?![A-Za-z0-9_-])` |
+| `AKIA` / `ASIA` | `[A-Z0-9]` | `(?![A-Z0-9])` |
 
 `SENSITIVE_KEY` (the key-name matcher) is unchanged — it is unaffected by the boundary bug.
 
-**Validated during design (2026-06-13):** the proposed regexes were run against all five §3.1
-escape cases *and* every existing-test sample — all escapes now redact (the token body never
-survives), all existing samples still redact, and the guard cases (`"sketch a plan"`, plain
-scalars) are preserved. Bun's JSC engine supports the lookbehind/lookahead, confirmed by running
+**Validated during design (2026-06-13):** the full body-aligned pattern set (gh split into two) was
+run against all five §3.1 escape cases, the fine-grained-PAT-followed-by-`_` case, a Bearer case,
+*and* every existing-test sample — all escapes now redact (the token body never survives), all
+existing samples still redact, and the guard cases (`"sketch a plan"`, plain sentences, plain
+scalars) are preserved. The naive "align lookahead to body **on the gh union**" form
+(`(?![A-Za-z0-9_])`) was also tested and confirmed to **reintroduce** the `ghp_…_x` escape — hence
+the two-pattern split. Bun's JSC engine supports the lookbehind/lookahead, confirmed by running
 them. So C1 carries no regex-feasibility risk into implementation.
 
 ### 3.3 Locking property test (fast-check)
@@ -118,6 +128,14 @@ Added to `format-audit-payload.test.ts` (the established home; `import fc from "
 - **Negative property — "ordinary prose is preserved."** Bounded generator of clearly-non-secret
   lowercase words (no token prefix) → asserts they survive verbatim. Keeps the over-redaction bias
   from degenerating into "redact everything."
+- **Structural 1:1 coverage guard (review §2.2) — prevents generator drift.** The token patterns
+  are exported from `format-audit-payload.ts` as a **labeled readonly map** (`{ name → RegExp }`)
+  rather than an anonymous array, and the test builds a parallel `{ name → fast-check generator }`
+  map. A structural test asserts the two key sets are **identical** — so adding a new pattern to the
+  production scrubber without adding its generator (or vice-versa) fails the suite immediately. The
+  positive property then iterates the generator map, guaranteeing every production pattern is fuzzed.
+  (Exporting the labeled map is the one source change beyond the regex fix; it does not alter
+  redaction behavior — the `redact()` loop iterates the map's values.)
 
 These properties are the regression lock: they fail today on the live module (the §3.1 escapes) and
 pass after §3.2.
@@ -163,6 +181,13 @@ Resolved from the §11 background research (2026-06-13):
   (`testRunner: "command"`, `commandRunner.command: "bun test <scope>"`, judged by exit code; it is
   built into core, no separate package). If the bun-runner misbehaves on our suite we lose only
   perTest-coverage *speed*, not the capability.
+- **Performance / coverage-analysis config (review §2.3):** scope `commandRunner.command` **tightly**
+  to the target test file(s) (e.g. `bun test packages/gateway/src/audit/format-audit-payload.test.ts`),
+  never a global `bun test` — the command runner reruns the whole scoped suite per mutant. Use
+  `coverageAnalysis: "perTest"` with the bun-runner (it supports per-test coverage to skip
+  irrelevant mutants), and fall back to `coverageAnalysis: "off"` for the command runner (which
+  cannot do per-test analysis) so correctness is never traded for speed. Detailed `stryker.conf`
+  values are finalized in the C3 plan.
 - **Dev-only, pinned exact** (no `^`); resolve the runner's exact current version via
   `npm view @hughescr/stryker-bun-runner` at C3 start and pin it. Run the dependency-safety
   pre-flight (`nimbus-commands` skill) before `bun add`.
@@ -200,7 +225,7 @@ FFI/boot/worker shells). D gets its own brainstorm → spec → plan.
 | Risk | Mitigation |
 |---|---|
 | C1 over-redaction nukes audit context | Keep precise token cores; the 7 existing unit tests + the bounded negative property pin the floor |
-| C1 misses a token family the property test doesn't model | Generators are built from the *actual* pattern charsets/lengths; add a family-coverage assertion that every `SENSITIVE_VALUE_PATTERN` has a generator |
+| C1 misses a token family the property test doesn't model | Generators are built from the *actual* pattern charsets/lengths; the §3.3 structural 1:1 guard (labeled pattern map ↔ generator map) fails if any pattern lacks a generator |
 | C3 experimental runner breaks | Pre-wired `command`-runner fallback; runner pinned exact + re-verified on any Bun bump; dev-only so a breakage never blocks CI |
 | C3 mutation runs are slow | Advisory-only + per-PR `git diff` scope + at-or-above-floor files only |
 | Stryker needs a Node runtime | Node v24 present; smoke-test `bunx stryker` first |
@@ -211,3 +236,31 @@ FFI/boot/worker shells). D gets its own brainstorm → spec → plan.
   (sandboxed research could not read the registry JSON directly).
 - Whether C2 surfaces a real bug in the envelope / key parsers (as the spike did for redaction) —
   handled in-slice if so.
+
+## 10. Review dispositions (2026-06-13)
+
+Addressing [the design review](./2026-06-13-true-coverage-C-depth-design-review.md):
+
+1. **§2.1 Regex lookahead / charset alignment — ACCEPTED, with a correction.** The principle
+   (align the trailing negative-lookahead to each pattern's *body* charset) is adopted across all
+   patterns (§3.2 table). **Correction:** applying it naively to the **gh union** — a single shared
+   `(?![A-Za-z0-9_])` over `(?:gh[pousr]_…|github_pat_…)` — **reintroduces the `ghp_…_x` escape this
+   PR fixes** (the classic body excludes `_`, so the shared `_`-inclusive lookahead refuses to end
+   the match before a trailing `_`). Validated empirically. Resolution: split the gh family into
+   **two patterns**, each with a body-aligned lookahead (`(?![A-Za-z0-9])` for classic,
+   `(?![A-Za-z0-9_])` for fine-grained). The Bearer pattern gets a body-aligned trailing boundary
+   `(?![A-Za-z0-9_./+-])` in place of the dropped `\b`. Full set re-validated against escapes +
+   existing samples + guards.
+2. **§2.2 Generator completeness / drift guard — ACCEPTED (promoted from a risk-table line to a
+   concrete requirement).** The patterns are exported as a **labeled `{name → RegExp}` map**; the
+   test builds a parallel `{name → generator}` map and a structural test asserts the key sets are
+   identical (1:1), so a new production pattern without a generator (or vice-versa) fails the suite
+   (§3.3). The positive property iterates the generator map.
+3. **§2.3 Stryker performance / config — ACCEPTED (folded into §5; detail deferred to the C3 plan).**
+   `commandRunner.command` is tightly scoped to the target test file (never global `bun test`);
+   `coverageAnalysis: "perTest"` with the bun-runner, `"off"` with the command-runner fallback.
+4. **§2.4 Cross-runtime regex compatibility — ACKNOWLEDGED, no action.** Lookbehind/lookahead are
+   ES2018-standard and supported in both JSC and V8. In practice the scrubber regex **only ever
+   executes under Bun/JSC**: the tests run via `bun test` even under Stryker (the bun-runner runs
+   Bun; the command-runner shells `bun test`), and Stryker core (Node/V8) only *orchestrates* — it
+   never evaluates the regex. So V8 parity is not even on the execution path.

--- a/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
+++ b/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
@@ -81,10 +81,12 @@ boundary but **not** alphanumerics, and add the fine-grained PAT family:
   fine-grained includes it), they are kept as **two separate patterns** rather than one union — a
   shared trailing lookahead over a union forces a single charset, and `(?![A-Za-z0-9_])` on the
   union reintroduces the `ghp_…_x` escape we are fixing (validated, see §3.2 note):
-  ```
+
+  ```text
   (?<![A-Za-z0-9])gh[pousr]_[A-Za-z0-9]{20,}(?![A-Za-z0-9])        # classic — body excludes _
   (?<![A-Za-z0-9])github_pat_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])     # fine-grained — body includes _
   ```
+
 - **Token cores stay specific** (prefix + minimum length + charset) so non-secret prose is
   preserved — in particular the existing guard test `"sketch a plan"` stays un-redacted (`sk-`
   still requires the hyphen).
@@ -173,7 +175,7 @@ Each test runs in the normal suite. Per-target findings get fixed in C2's plan.
 Resolved from the §11 background research (2026-06-13):
 
 - **Versions:** `@stryker-mutator/core@9.6.1` (current 9.x; Node ≥20 — satisfied, Node v24 present)
-  + `@hughescr/stryker-bun-runner` (requires Bun **≥1.3.7**; we run 1.3.14 — it depends on a
+  - `@hughescr/stryker-bun-runner` (requires Bun **≥1.3.7**; we run 1.3.14 — it depends on a
   *recent* Bun Inspector/TestReporter feature, so it tracks new Bun rather than being bit-rotted).
   The runner is a single-maintainer experimental community plugin outside the official
   `@stryker-mutator` org.

--- a/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
+++ b/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
@@ -100,7 +100,7 @@ Per-pattern boundary corrections (applied uniformly):
 | `github_pat_` (fine-grained) | `[A-Za-z0-9_]` | `(?![A-Za-z0-9_])` |
 | `sk-` / `sk-ant-` | `[A-Za-z0-9_-]` | `(?![A-Za-z0-9_-])` |
 | `xox` | `[A-Za-z0-9-]` | `(?![A-Za-z0-9-])` |
-| `Bearer …` | `[A-Za-z0-9_.\-+/]…={0,2}` | `(?![A-Za-z0-9_./+-])` (replaces the fragile trailing `\b`; `=` is terminal padding, excluded) |
+| `Bearer …` | `[A-Za-z0-9_.\-+/]…={0,2}` | `(?![A-Za-z0-9_./+\-])` (replaces the fragile trailing `\b`; `=` is **deliberately excluded** — including it makes `Bearer …===` backtrack-fail and **leak the whole credential**, verified) |
 | JWT `eyJ…` | `[A-Za-z0-9_-]` | `(?![A-Za-z0-9_-])` |
 | `AKIA` / `ASIA` | `[A-Z0-9]` | `(?![A-Z0-9])` |
 

--- a/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
+++ b/docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md
@@ -1,0 +1,213 @@
+# True Coverage — Sub-project C: Depth (mutation + property-based testing) — Design
+
+**Date:** 2026-06-13
+**Branch:** `dev/asafgolombek/true-coverage-C`
+**Status:** Design — awaiting review
+**Owner:** AsafGolombek
+**Umbrella spec:** [`2026-06-07-true-coverage-program-design.md`](./2026-06-07-true-coverage-program-design.md) (§7 sketches C; §9 the flagship targets overlay, now built; §11 the Stryker-runner open question, resolved here)
+
+## 1. Context
+
+The True Coverage program has shipped sub-projects **A** (the branch-coverage gate, PR #530), **B**
+(every non-flagship source file clears the ≥80% line+branch floor; `coverage-baseline.json` `files`
+map is `{}`, PRs #534–#587), and the **★ Flagship** (`executor.ts` + `tool-output-envelope.ts`
+pinned at 100% line+branch via the `targets` overlay, PR #589).
+
+Line and branch coverage are now saturated. The remaining *meaningful* gains are the two dimensions
+line/branch cannot measure (umbrella spec §1, dimensions 2 and 3):
+
+- **Mutation score** — proof the tests actually *fail* when the code breaks (assertion strength).
+- **Eliminated blind spots** — property-based tests that explore the *input space* a hand-picked
+  example set never reaches.
+
+This is **Sub-project C**. (The fourth dimension — shrinking the ~40 `exclusions.ts` entries — is
+**Sub-project D**, the program tail, specced separately when reached.)
+
+## 2. Decomposition (3 slices, 3 PRs)
+
+C is one sub-project delivered as three slices, each its own implementation plan and PR — mirroring
+how A shipped as tasks and B as slices B0…B14:
+
+| Slice | Delivers | New deps | CI impact |
+|---|---|---|---|
+| **C1** | The redaction security fix (an audit-redaction blind spot found by a fast-check spike) + its locking property test | none | none |
+| **C2** | The fast-check property suite on the pure security core (envelope / timing-safe-compare / key parsers) | none | none |
+| **C3** | StrykerJS mutation-testing harness (dev-only, advisory) | pinned dev-only | **none — never a CI gate in C3** |
+
+Only **C1 is fully detailed here** (it ships next). C2 and C3 are sketched at the design level and
+each get their own brainstorm-light → plan cycle when reached (the umbrella-spec convention for
+downstream slices).
+
+The **fast-check track (C1 + C2)** runs inside the normal `bun test` suite — `fast-check@4.8.0` is
+already a `gateway` devDependency (importable, verified), so there is nothing to install, no Docker,
+and no coverage-reseed machinery (we touch no source-coverage materially). The **Stryker track
+(C3)** is a separate dev-only harness, never part of the shipped surface.
+
+## 3. C1 — Redaction security fix + locking property test (detailed)
+
+### 3.1 Root cause (reproduced on the live module)
+
+`packages/gateway/src/audit/format-audit-payload.ts` scrubs credential-shaped substrings from audit
+payloads via `SENSITIVE_VALUE_PATTERNS`, each anchored with `\b`. JavaScript's `\b` treats `_` as a
+**word character**, so a token adjacent to — or containing — `_` sits between two word characters
+and produces no boundary, and the match silently fails. Reproduced against the live regexes:
+
+| Input | Result | Why |
+|---|---|---|
+| `ghp_<36 base62>` (alone) | ✅ redacted | works |
+| `ghp_<36>_x` (token followed by `_`) | ❌ **ESCAPED** | trailing `\b` fails — `_` is a word char, no boundary after the body |
+| `ghp_…_…` (underscore *inside* the run) | ❌ **ESCAPED** | body class `[A-Za-z0-9]` excludes `_`; the run truncates at `_`, then `\b` fails |
+| `github_pat_…` (fine-grained PAT) | ❌ **ESCAPED** | prefix not matched at all + the token legitimately contains `_` |
+| `x_ghp_<36>` (token preceded by `_`) | ❌ **ESCAPED** | leading `\b` fails — `_ghp` is word-word, no boundary |
+
+The defect is **not gh-specific**: the same `\b`/underscore (and trailing-extra-char) class is
+latent in the `sk-`, `sk-ant-`, `xox`, `Bearer`, JWT (`eyJ…`), and `AKIA`/`ASIA` patterns. A
+property test that fuzzes all token families would surface them, so C1 fixes the whole class at
+once.
+
+### 3.2 Fix — systemic boundary fix, over-redaction-biased, precise cores
+
+Replace the fragile `\b` anchors with explicit boundaries that treat `_` and other punctuation as a
+boundary but **not** alphanumerics, and add the fine-grained PAT family:
+
+- **Leading boundary:** `(?<![A-Za-z0-9])` — the token must start a fresh alphanumeric run. `_`,
+  spaces, quotes, and other punctuation before the prefix all qualify as a boundary (fixing the
+  `x_ghp_…` escape), while `loghp_…` mid-word does not match (avoids nuking ordinary words).
+- **Trailing boundary:** `(?![<pattern charset>])` — not followed by another character of the
+  token's own charset (fixing the `ghp_…_x` and "longer than real" escapes).
+- **gh family** gains a `github_pat_[A-Za-z0-9_]{20,}` alternative (fine-grained PATs contain `_`):
+  ```
+  (?<![A-Za-z0-9])(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})(?![A-Za-z0-9])
+  ```
+- **Token cores stay specific** (prefix + minimum length + charset) so non-secret prose is
+  preserved — in particular the existing guard test `"sketch a plan"` stays un-redacted (`sk-`
+  still requires the hyphen).
+
+The bias is deliberate: in an audit-redaction scrubber, over-redacting surrounding context is far
+safer than leaking a live credential. The precise cores bound that over-redaction.
+
+Per-pattern boundary corrections (applied uniformly):
+
+| Pattern | Trailing negative-lookahead charset |
+|---|---|
+| gh / github_pat | `[A-Za-z0-9]` |
+| `sk-` / `sk-ant-` | `[A-Za-z0-9_-]` |
+| `xox` | `[A-Za-z0-9-]` |
+| `Bearer …` | drop the fragile trailing `\b` after `={0,2}` |
+| JWT `eyJ…` | `[A-Za-z0-9_-]` |
+| `AKIA` / `ASIA` | `[A-Z0-9]` |
+
+`SENSITIVE_KEY` (the key-name matcher) is unchanged — it is unaffected by the boundary bug.
+
+**Validated during design (2026-06-13):** the proposed regexes were run against all five §3.1
+escape cases *and* every existing-test sample — all escapes now redact (the token body never
+survives), all existing samples still redact, and the guard cases (`"sketch a plan"`, plain
+scalars) are preserved. Bun's JSC engine supports the lookbehind/lookahead, confirmed by running
+them. So C1 carries no regex-feasibility risk into implementation.
+
+### 3.3 Locking property test (fast-check)
+
+Added to `format-audit-payload.test.ts` (the established home; `import fc from "fast-check"`):
+
+- **Positive property — "a valid-shaped token is always scrubbed, wherever it sits."** For each
+  token family, a generator builds a structurally valid token (correct prefix + random body of the
+  correct charset and ≥ the minimum length) embedded in random surrounding noise — including
+  adjacent `_`, leading/trailing punctuation, and nesting the value under an arbitrary generic
+  (non-sensitive) key. Assert the output contains **neither** the token's high-entropy body **nor**
+  the prefix-with-body, **and** contains `[REDACTED]`.
+- **Negative property — "ordinary prose is preserved."** Bounded generator of clearly-non-secret
+  lowercase words (no token prefix) → asserts they survive verbatim. Keeps the over-redaction bias
+  from degenerating into "redact everything."
+
+These properties are the regression lock: they fail today on the live module (the §3.1 escapes) and
+pass after §3.2.
+
+### 3.4 Invariant / blast-radius
+
+- This is the **audit-shipper redaction** path — a *sibling* defense to the I11 tool-output
+  envelope, **not** the I11 wiring site itself. Expectation: no `security-invariants.test.ts`
+  change. C1 will **confirm** that test asserts none of these exact regex literals before relying
+  on that expectation.
+- The 7 existing `format-audit-payload.test.ts` unit tests must stay green; since the change only
+  ever redacts *more*, they are expected to be unaffected.
+- Callers (`engine/agent.ts`, `engine/executor.ts`, `automation/workflow-runner.ts`) consume only
+  the redacted string — no signature change.
+
+## 4. C2 — fast-check property suite on the pure core (sketch)
+
+Characterization property tests beside each module (no source change expected; any bug found is
+fixed in-slice like C1). Targets, in priority order:
+
+- **`engine/tool-output-envelope.ts` escaping (I11):** for arbitrary tool-output strings — including
+  ones containing the envelope's own delimiter/sentinel sequences — the wrapped output cannot be
+  broken out of (no crafted content lets tool output masquerade as envelope structure).
+- **`util/timing-safe-compare.ts` oracle (I10):** property = **functional** equality with a naive
+  comparator over random equal / unequal / length-mismatched byte pairs. **Explicitly documented:**
+  fast-check verifies the *result*, **not** the constant-time guarantee — that stays a manual/review
+  invariant (umbrella spec §9 note).
+- **Vault / connector key parsers** (`CONNECTOR_VAULT_SECRET_KEYS` and the key parser/formatter):
+  parse∘format is identity on valid keys; malformed `unknown` input is rejected without throwing.
+
+Each test runs in the normal suite. Per-target findings get fixed in C2's plan.
+
+## 5. C3 — StrykerJS mutation testing (sketch)
+
+Resolved from the §11 background research (2026-06-13):
+
+- **Versions:** `@stryker-mutator/core@9.6.1` (current 9.x; Node ≥20 — satisfied, Node v24 present)
+  + `@hughescr/stryker-bun-runner` (requires Bun **≥1.3.7**; we run 1.3.14 — it depends on a
+  *recent* Bun Inspector/TestReporter feature, so it tracks new Bun rather than being bit-rotted).
+  The runner is a single-maintainer experimental community plugin outside the official
+  `@stryker-mutator` org.
+- **Adopt the bun-runner, but pre-wire the built-in `command` runner as a guaranteed fallback**
+  (`testRunner: "command"`, `commandRunner.command: "bun test <scope>"`, judged by exit code; it is
+  built into core, no separate package). If the bun-runner misbehaves on our suite we lose only
+  perTest-coverage *speed*, not the capability.
+- **Dev-only, pinned exact** (no `^`); resolve the runner's exact current version via
+  `npm view @hughescr/stryker-bun-runner` at C3 start and pin it. Run the dependency-safety
+  pre-flight (`nimbus-commands` skill) before `bun add`.
+- **Advisory-first:** `thresholds.break: null` — **never a CI gate in C3**. `mutate` scoped per-PR
+  via `git diff`, restricted to **at-or-above-floor files only**.
+- **Order:** security core (`executor.ts` + `tool-output-envelope.ts`, now 100% line+branch — the
+  ideal first substrate: any surviving mutant is a pure assertion-strength gap) → engine/HITL →
+  vault pure → query-gate → connector mappers.
+- **Per-subsystem mutation-score baseline** that ratchets up. Flipping `break` to a numeric floor
+  per subsystem is a *later* decision once baselines are stable (not C3).
+- **Up-front smoke test:** confirm `bunx stryker run` launches and produces a report on a tiny scope
+  before depending on the harness.
+
+## 6. Testing & verification
+
+- C1/C2 property tests run in the standard gateway `bun test` suite, exercised by `preflight:fast`
+  static gates + the suite. The authoritative CI gate is **PR quality — TS/Bun (ubuntu-24.04) /
+  Unit + Coverage**; the windows-2025 cross-platform red is the chronic flake (rerun, not a real
+  failure).
+- No Docker / coverage-reseed is needed for C1/C2 — they add tests (and, in C1, tighten a regex);
+  net source coverage only holds or increases, so the `coverage-baseline.json` `files` map stays
+  `{}` and the `targets` overlay is untouched.
+- Settled-tree `tsc --noEmit` + Biome before push (worktree skips Biome via `!**/.claude` — use the
+  temp-config trick or rely on CI's `biome ci`).
+- Fix every CodeRabbit + Sonar thread and resolve each.
+
+## 7. Sequencing
+
+C1 → merge → C2 → merge → C3 → merge → **Sub-project D** (shrink the ~40 `exclusions.ts` entries via
+DI-refactor à la #505 `imap-client`; clear residual debt; document genuinely-untestable
+FFI/boot/worker shells). D gets its own brainstorm → spec → plan.
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| C1 over-redaction nukes audit context | Keep precise token cores; the 7 existing unit tests + the bounded negative property pin the floor |
+| C1 misses a token family the property test doesn't model | Generators are built from the *actual* pattern charsets/lengths; add a family-coverage assertion that every `SENSITIVE_VALUE_PATTERN` has a generator |
+| C3 experimental runner breaks | Pre-wired `command`-runner fallback; runner pinned exact + re-verified on any Bun bump; dev-only so a breakage never blocks CI |
+| C3 mutation runs are slow | Advisory-only + per-PR `git diff` scope + at-or-above-floor files only |
+| Stryker needs a Node runtime | Node v24 present; smoke-test `bunx stryker` first |
+
+## 9. Open questions
+
+- Exact pinned version of `@hughescr/stryker-bun-runner` — resolve via `npm view` at C3 start
+  (sandboxed research could not read the registry JSON directly).
+- Whether C2 surfaces a real bug in the envelope / key parsers (as the spike did for redaction) —
+  handled in-slice if so.

--- a/packages/gateway/src/audit/format-audit-payload.test.ts
+++ b/packages/gateway/src/audit/format-audit-payload.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 
 import { formatAuditPayload, redactAuditPayload } from "./format-audit-payload.ts";
 
@@ -97,5 +98,122 @@ describe("redactAuditPayload (S2-F2)", () => {
   test("does not redact non-secret strings that merely contain the prefix `sk`", () => {
     const out = redactAuditPayload({ description: "sketch a plan" });
     expect(out.includes("sketch a plan")).toBe(true);
+  });
+});
+
+// --- C1: property-based redaction lock (fast-check) ---
+
+const ALNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const ALNUM_US = `${ALNUM}_`; // alnum + underscore (fine-grained PAT body)
+const ALNUM_USD = `${ALNUM}_-`; // alnum + underscore + dash (sk- bodies)
+const ALNUM_D = `${ALNUM}-`; // alnum + dash (slack body)
+const ALNUM_UD = `${ALNUM}_-`; // alnum + underscore + dash (jwt segments)
+const UPPERNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"; // aws body
+const BEARER_BODY = `${ALNUM}_.+/-`; // bearer body charset
+
+/** A random string of `chars`, length in [min, max]. */
+function charsetArb(chars: string, min: number, max = min + 24): fc.Arbitrary<string> {
+  return fc
+    .array(fc.constantFrom(...chars.split("")), { minLength: min, maxLength: max })
+    .map((a) => a.join(""));
+}
+
+/**
+ * One generator per production SENSITIVE_VALUE_PATTERN family. Each yields a
+ * structurally valid token (correct prefix + random body of the correct charset
+ * and >= the minimum length). Keys MUST match the production map's keys — the
+ * structural guard below enforces that 1:1.
+ */
+const GENERATORS: ReadonlyMap<string, fc.Arbitrary<string>> = new Map([
+  [
+    "github_classic",
+    fc
+      .tuple(fc.constantFrom("p", "o", "u", "s", "r"), charsetArb(ALNUM, 20))
+      .map(([c, b]) => `gh${c}_${b}`),
+  ],
+  ["github_fine_grained", charsetArb(ALNUM_US, 20).map((b) => `github_pat_${b}`)],
+  [
+    "openai",
+    fc
+      .tuple(fc.boolean(), charsetArb(ALNUM_USD, 20))
+      .map(([proj, b]) => `sk-${proj ? "proj-" : ""}${b}`),
+  ],
+  ["anthropic", charsetArb(ALNUM_USD, 20).map((b) => `sk-ant-${b}`)],
+  [
+    "slack",
+    fc
+      .tuple(fc.constantFrom("b", "o", "a", "p", "r"), fc.boolean(), charsetArb(ALNUM_D, 10))
+      .map(([c, s, b]) => `xox${c}${s ? "s" : ""}-${b}`),
+  ],
+  [
+    "bearer",
+    fc
+      .tuple(charsetArb(BEARER_BODY, 16), fc.constantFrom("", "=", "=="))
+      .map(([b, eq]) => `Bearer ${b}${eq}`),
+  ],
+  [
+    "jwt",
+    fc
+      .tuple(charsetArb(ALNUM_UD, 3), charsetArb(ALNUM_UD, 3), charsetArb(ALNUM_UD, 3))
+      .map(([a, b, c]) => `eyJ${a}.${b}.${c}`),
+  ],
+  [
+    "aws",
+    fc
+      .tuple(fc.constantFrom("AKIA", "ASIA"), charsetArb(UPPERNUM, 16, 16))
+      .map(([p, b]) => `${p}${b}`),
+  ],
+]);
+
+// Non-empty, non-alphanumeric separators — guarantee a token boundary on each
+// side. Includes "_" specifically to prove the underscore-adjacency fix.
+const SEP = fc.constantFrom(" ", "_", ":", "=", ",", "(", "[", "/", '"', "'", "\n", ".");
+// Clearly non-secret prose: lowercase letters + spaces only (cannot match any
+// pattern — every pattern needs a digit/dash/underscore/uppercase or a fixed prefix).
+const LOWORD = fc
+  .array(fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz".split("")), { minLength: 1, maxLength: 8 })
+  .map((a) => a.join(""));
+const PROSE = fc.array(LOWORD, { minLength: 1, maxLength: 6 }).map((a) => a.join(" "));
+const PROSE_OR_EMPTY = fc.oneof(fc.constant(""), PROSE);
+
+describe("redactAuditPayload — property: every token family is scrubbed anywhere", () => {
+  for (const [name, gen] of GENERATORS) {
+    test(`scrubs ${name} tokens regardless of surrounding noise`, () => {
+      fc.assert(
+        fc.property(
+          gen,
+          PROSE_OR_EMPTY,
+          SEP,
+          SEP,
+          PROSE_OR_EMPTY,
+          fc.boolean(),
+          (token, lead, s1, s2, trail, nest) => {
+            const embedded = `${lead}${s1}${token}${s2}${trail}`;
+            // Test both a bare-string payload and a value nested under a generic
+            // (non-sensitive) key — redaction must reach both.
+            const payload = nest ? { note: embedded } : embedded;
+            const out = redactAuditPayload(payload);
+            // The token (the secret material) must not survive...
+            expect(out.includes(token)).toBe(false);
+            // ...and a redaction marker must be present.
+            expect(out.includes("[REDACTED]")).toBe(true);
+          },
+        ),
+        { numRuns: 300 },
+      );
+    });
+  }
+});
+
+describe("redactAuditPayload — property: ordinary prose is preserved", () => {
+  test("never redacts lowercase-letter prose", () => {
+    fc.assert(
+      fc.property(PROSE, (prose) => {
+        const out = redactAuditPayload({ note: prose });
+        expect(out.includes(prose)).toBe(true);
+        expect(out.includes("[REDACTED]")).toBe(false);
+      }),
+      { numRuns: 300 },
+    );
   });
 });

--- a/packages/gateway/src/audit/format-audit-payload.test.ts
+++ b/packages/gateway/src/audit/format-audit-payload.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
 
-import { formatAuditPayload, redactAuditPayload } from "./format-audit-payload.ts";
+import {
+  formatAuditPayload,
+  redactAuditPayload,
+  SENSITIVE_VALUE_PATTERNS,
+} from "./format-audit-payload.ts";
 
 describe("formatAuditPayload", () => {
   test("returns JSON unchanged when under cap", () => {
@@ -215,5 +219,16 @@ describe("redactAuditPayload — property: ordinary prose is preserved", () => {
       }),
       { numRuns: 300 },
     );
+  });
+});
+
+describe("redactAuditPayload — structural: every pattern has a generator", () => {
+  test("GENERATORS keys are 1:1 with SENSITIVE_VALUE_PATTERNS keys", () => {
+    const patternKeys = [...SENSITIVE_VALUE_PATTERNS.keys()].sort();
+    const generatorKeys = [...GENERATORS.keys()].sort();
+    // If this fails, a token family was added/removed in the production scrubber
+    // without updating GENERATORS (or vice-versa) — the property suite would stop
+    // fuzzing it. Fix by adding the matching generator/pattern.
+    expect(generatorKeys).toEqual(patternKeys);
   });
 });

--- a/packages/gateway/src/audit/format-audit-payload.ts
+++ b/packages/gateway/src/audit/format-audit-payload.ts
@@ -2,19 +2,40 @@ const DEFAULT_MAX_BYTES = 4096;
 
 const SENSITIVE_KEY = /(token|key|secret|password|credential|bearer|auth|^pat$)/i;
 
-const SENSITIVE_VALUE_PATTERNS: ReadonlyArray<RegExp> = [
-  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,
-  /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/g,
-  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
-  /\bxox[boapr]s?-[A-Za-z0-9-]{10,}\b/g,
-  /\bBearer\s+[A-Za-z0-9_.\-+/]{16,}={0,2}\b/g,
-  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
-  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g,
-];
+/**
+ * Credential-shaped value patterns, keyed by a stable family name.
+ *
+ * Boundary design: JavaScript `\b` treats `_` as a word character, so a token
+ * adjacent to — or containing — `_` sits between two "word" chars, produces no
+ * boundary, and silently escapes redaction. Each pattern instead uses an
+ * explicit leading `(?<![A-Za-z0-9])` and a trailing negative lookahead aligned
+ * to that pattern's OWN body charset.
+ *
+ * The two GitHub prefixes are kept as separate patterns because their bodies
+ * differ (classic `gh[pousr]_` excludes `_`; fine-grained `github_pat_` includes
+ * it). A single shared trailing lookahead over a union would have to pick one
+ * charset, and an `_`-inclusive lookahead re-opens the `ghp_…_x` escape this
+ * scrubber fixes.
+ *
+ * Exported so the redaction property test can assert 1:1 generator coverage.
+ */
+export const SENSITIVE_VALUE_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
+  ["github_classic", /(?<![A-Za-z0-9])gh[pousr]_[A-Za-z0-9]{20,}(?![A-Za-z0-9])/g],
+  ["github_fine_grained", /(?<![A-Za-z0-9])github_pat_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])/g],
+  ["openai", /(?<![A-Za-z0-9])sk-(?:proj-)?[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
+  ["anthropic", /(?<![A-Za-z0-9])sk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
+  ["slack", /(?<![A-Za-z0-9])xox[boapr]s?-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])/g],
+  // Trailing lookahead EXCLUDES `=` on purpose: a token with 3+ trailing `=`
+  // (e.g. `Bearer <body>===`) would otherwise backtrack-fail and LEAK the whole
+  // credential. Excluding `=` lets `={0,2}` consume the padding and redact.
+  ["bearer", /(?<![A-Za-z0-9])Bearer\s+[A-Za-z0-9_.\-+/]{16,}={0,2}(?![A-Za-z0-9_./+-])/g],
+  ["jwt", /(?<![A-Za-z0-9])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?![A-Za-z0-9_-])/g],
+  ["aws", /(?<![A-Za-z0-9])(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])/g],
+]);
 
 function redactSensitiveValueString(s: string): string {
   let out = s;
-  for (const pat of SENSITIVE_VALUE_PATTERNS) {
+  for (const pat of SENSITIVE_VALUE_PATTERNS.values()) {
     out = out.replace(pat, "[REDACTED]");
   }
   return out;


### PR DESCRIPTION
## What

Sub-project **C1** of the True Coverage program (depth: property-based testing).

Fixes an audit-redaction blind spot found by a fast-check spike: the `\b`-anchored credential scrubber in `audit/format-audit-payload.ts` treats `_` as a word char, so tokens **adjacent to or containing `_`** — and **all fine-grained `github_pat_`** tokens — escaped redaction (validated on the live module). The same latent class existed in the `sk-`/`xox`/`Bearer`/JWT/`AKIA` patterns.

## How

- Replace each pattern's `\b` anchors with explicit `(?<![A-Za-z0-9])` + a trailing negative lookahead **aligned to that pattern's own body charset**.
- Split the GitHub family into `github_classic` + `github_fine_grained` (different body charsets; a shared union lookahead would re-open the escape — verified).
- Bearer lookahead **deliberately excludes `=`**: including it makes `Bearer …===` backtrack-fail and leak the whole credential (verified; documented inline).
- Export the patterns as a labeled `{name → RegExp}` map.

## Tests

- fast-check **positive** property: every token family, embedded in adversarial noise (incl. `_` adjacency, nested under a generic key, 0/1/2 `=` padding for Bearer), is always scrubbed.
- fast-check **negative** property: lowercase prose is never redacted.
- **Structural 1:1 guard**: every production pattern has a generator (drift-proof; verified it fails when a generator is dropped).
- The 9 pre-existing tests stay green; 75 security-invariant tests + static `audit:invariants` unchanged.

Spec: `docs/superpowers/specs/2026-06-13-true-coverage-C-depth-design.md` §3.
Plan: `docs/superpowers/plans/2026-06-13-true-coverage-C1-redaction-fix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential redaction so tokens adjacent to underscores, punctuation, or padding characters are reliably detected and scrubbed in audit output.

* **Tests**
  * Added property-based fuzz tests to ensure redaction holds across varied token shapes, noisy contexts, and nested payloads; verified non-secret prose remains unchanged.

* **Documentation**
  * Added implementation plans and design reviews describing the coverage, testing strategy, and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->