### PR TITLE
Fix two main-CI coverage-job flakes + document CI/release secrets

### DIFF
--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -1,0 +1,189 @@
+# CI / Release Secrets
+
+This page is the canonical inventory of every GitHub Actions secret the Nimbus
+workflows consume: what each one is for, which workflow reads it, whether it is
+required, and exactly how to mint and store it.
+
+All secrets live under **repo Settings → Secrets and variables → Actions**.
+Release/publish secrets are scoped to the **`release`** GitHub
+[deployment environment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment)
+(jobs that read them declare `environment: release`); add those under
+**Settings → Environments → release → Environment secrets**. Everything else is
+a plain repository secret.
+
+> **Token hygiene.** Fine-grained PATs expire (90 days by default). When a
+> release fails with `Bad credentials` from `softprops/action-gh-release`, the
+> `RELEASE_PAT` has expired or been revoked — rotate it (see below) and re-run
+> the failed job. Prefer the **shortest practical expiry** and the **narrowest
+> scope** for every token here; never grant org-wide or `repo`-classic scope
+> when a fine-grained per-repo grant works.
+
+---
+
+## Quick reference
+
+| Secret | Required for | Type | Used by |
+| --- | --- | --- | --- |
+| `RELEASE_PAT` | Publishing GitHub Releases | Fine-grained PAT — Contents: RW | `release.yml`, `release-please.yml` |
+| `RELEASE_PLEASE_PAT` | release-please PRs (optional) | Fine-grained PAT — Contents + PRs: RW | `release-please.yml` |
+| `GPG_SIGNING_SUBKEY` | Signing Linux artifacts + `SHA256SUMS` | ASCII-armored GPG private subkey | `release.yml` |
+| `GPG_PASSPHRASE` | Unlocking the GPG subkey | String | `release.yml` |
+| `UPDATER_SIGNING_KEY` | Signing the auto-updater manifest | Ed25519 private key | `release.yml` |
+| `WINDOWS_CERT_PFX_BASE64` | Windows code-signing the `.msi` | base64 of a `.pfx` | `release.yml` |
+| `WINDOWS_CERT_PASSWORD` | `.pfx` password | String | `release.yml` |
+| `APPLE_CERT_P12_BASE64` | macOS signing the `.pkg` | base64 of a `.p12` | `release.yml` |
+| `APPLE_CERT_PASSWORD` | `.p12` password | String | `release.yml` |
+| `APPLE_TEAM_ID` | macOS signing identity | Apple Team ID | `release.yml` |
+| `APPLE_DEVELOPER_ID_APP` | macOS app signing identity | Cert common-name | `release.yml` |
+| `APPLE_DEVELOPER_ID_INSTALLER` | macOS installer signing identity | Cert common-name | `release.yml` |
+| `APPLE_NOTARY_ID` | Apple notarization | Apple ID e-mail | `release.yml` |
+| `APPLE_NOTARY_PASSWORD` | Apple notarization | App-specific password | `release.yml` |
+| `PACKAGE_MANAGER_PAT` | Homebrew tap + Scoop bucket pushes | Fine-grained PAT — Contents: RW on the two channel repos | `publish-package-managers.yml` |
+| `WINGET_PAT` | winget submission PR | **Classic** PAT — `public_repo` scope | `publish-package-managers.yml` |
+| `VSCE_PAT` | VS Code Marketplace publish | Azure DevOps PAT — Marketplace (Manage) | `publish-vscode.yml` |
+| `OVSX_PAT` | Open VSX publish | Open VSX token | `publish-vscode.yml` |
+| `NPM_TOKEN` | Publishing `@nimbus-dev/sdk` + `@nimbus-dev/client` | npm automation token | `publish-sdk.yml`, `publish-client.yml` |
+| `SONAR_TOKEN` | SonarCloud quality gate (optional) | SonarCloud token | `ci.yml`, `_test-suite.yml`, `release.yml` |
+| `CODECOV_TOKEN` | Coverage upload (optional) | Codecov upload token | `_test-suite.yml` |
+| `SCORECARD_TOKEN` | OSSF Scorecard (optional) | Fine-grained PAT — read-only | `scorecard.yml` |
+| `NIMBUS_CHECKS_TOKEN` | Cross-workflow check runs (optional) | Fine-grained PAT — Checks: RW | `ci.yml`, `_test-suite.yml` |
+| `GITHUB_TOKEN` | — | **Automatic**, no action needed | all |
+
+`GITHUB_TOKEN` is injected by Actions automatically; it is never set by hand.
+Several optional secrets fall back to `github.token` when unset
+(`NIMBUS_CHECKS_TOKEN`, `RELEASE_PLEASE_PAT`) or simply skip their step
+(`SONAR_TOKEN`).
+
+---
+
+## Release & GitHub Release publishing (`release` environment)
+
+### `RELEASE_PAT` — **required to ship a release**
+
+Used by the `Create GitHub Release` step (`softprops/action-gh-release`) in
+`release.yml` and as the release-please fallback token. `GITHUB_TOKEN` is kept
+read-only in that job, so the Release API needs this PAT.
+
+Create it:
+
+1. <https://github.com/settings/personal-access-tokens/new> → **Fine-grained
+   token**.
+2. **Resource owner:** `nimbus-agent`. **Repository access:** *Only select
+   repositories* → `nimbus-agent/Nimbus`.
+3. **Repository permissions:** **Contents → Read and write**. (That alone is
+   enough to create releases and upload assets.)
+4. Set a short expiry, generate, copy the `github_pat_…` value.
+5. Store as the **`RELEASE_PAT`** environment secret under
+   **Settings → Environments → release**.
+
+> **Rotation:** when the release job logs
+> `⚠️ Unexpected error fetching GitHub release for tag …: HttpError: Bad
+> credentials`, regenerate this token and re-run the failed
+> `Publish GitHub Release` job. The git tag is created by release-please, so a
+> re-run after rotation publishes against the existing tag.
+
+### `RELEASE_PLEASE_PAT` — optional
+
+Lets release-please open its release PR with a PAT instead of `GITHUB_TOKEN`
+(so the PR can trigger downstream workflows). Fine-grained, `nimbus-agent/Nimbus`
+only, **Contents: RW + Pull requests: RW**. Falls back to `RELEASE_PAT`, then
+`github.token`, when unset.
+
+### `GPG_SIGNING_SUBKEY` + `GPG_PASSPHRASE` — required for Linux signing
+
+Signs the Linux installers and the aggregate `SHA256SUMS`. The public half lives
+at `docs/release/SIGNING-KEY.asc`; details in
+[`docs/release/signing-keys.md`](./release/signing-keys.md).
+
+- `GPG_SIGNING_SUBKEY`: the **ASCII-armored private subkey**, exported with
+  `gpg --armor --export-secret-subkeys <KEYID>!`. Paste the full
+  `-----BEGIN PGP PRIVATE KEY BLOCK-----` … block.
+- `GPG_PASSPHRASE`: the passphrase that unlocks that subkey.
+
+### `UPDATER_SIGNING_KEY` — required for the auto-updater
+
+Ed25519 private key used by `scripts/sign-ed25519.ts` to sign release artifacts
+and the update manifest the desktop/headless updater verifies. Generate with the
+repo's keygen helper and paste the private-key body.
+
+### Windows code-signing — `WINDOWS_CERT_PFX_BASE64`, `WINDOWS_CERT_PASSWORD`
+
+`WINDOWS_CERT_PFX_BASE64` is the code-signing certificate exported as a `.pfx`
+and base64-encoded (`base64 -w0 cert.pfx`); `WINDOWS_CERT_PASSWORD` is its
+export password. Consumed by `scripts/sign/sign-windows.ps1`.
+
+### macOS code-signing & notarization — `APPLE_*`
+
+Seven secrets feed the per-arch `.pkg` build/sign/notarize step:
+
+- `APPLE_CERT_P12_BASE64` — Developer ID certs exported as a `.p12`, base64-encoded.
+- `APPLE_CERT_PASSWORD` — the `.p12` export password.
+- `APPLE_TEAM_ID` — your 10-character Apple Developer Team ID.
+- `APPLE_DEVELOPER_ID_APP` — `Developer ID Application: … (TEAMID)` common name.
+- `APPLE_DEVELOPER_ID_INSTALLER` — `Developer ID Installer: … (TEAMID)` common name.
+- `APPLE_NOTARY_ID` — the Apple ID e-mail used for notarization.
+- `APPLE_NOTARY_PASSWORD` — an **app-specific password** for that Apple ID
+  (<https://appleid.apple.com> → Sign-In and Security → App-Specific Passwords).
+
+---
+
+## Package-manager channels (`publish-package-managers.yml`)
+
+### `PACKAGE_MANAGER_PAT` — Homebrew tap + Scoop bucket
+
+Pushes the updated formula/manifest to `nimbus-agent/homebrew-tap` and
+`nimbus-agent/scoop-bucket`. **Fine-grained** PAT, resource owner
+`nimbus-agent`, **both** channel repos selected, **Contents: Read and write**.
+
+### `WINGET_PAT` — winget submission
+
+`wingetcreate` must **fork** `microsoft/winget-pkgs`, push to the fork, and open
+a cross-repo PR — which a fine-grained PAT cannot do. This one must be a
+**classic** PAT with the **`public_repo`** scope
+(<https://github.com/settings/tokens/new>).
+
+---
+
+## VS Code extension (`publish-vscode.yml`, `release` environment)
+
+- `VSCE_PAT` — Azure DevOps Personal Access Token for the `nimbus-agent`
+  publisher with the **Marketplace → Manage** scope
+  (<https://dev.azure.com> → User settings → Personal access tokens).
+- `OVSX_PAT` — Open VSX Registry token for the `nimbus-agent` namespace
+  (<https://open-vsx.org/user-settings/tokens>).
+
+Neither touches the GitHub repo.
+
+---
+
+## npm packages (`publish-sdk.yml`, `publish-client.yml`)
+
+`NPM_TOKEN` publishes `@nimbus-dev/sdk` and `@nimbus-dev/client`. Create an
+**Automation** token at <https://www.npmjs.com/settings/~/tokens> for an account
+with publish rights on the `@nimbus-dev` scope.
+
+---
+
+## CI quality, coverage & supply-chain (mostly optional)
+
+- `SONAR_TOKEN` — SonarCloud analysis token. When unset the SonarQube step is
+  silently skipped. Generate under your SonarCloud account → Security.
+- `CODECOV_TOKEN` — Codecov upload token (<https://app.codecov.io> → repo
+  settings). Coverage still computes locally without it; only the upload needs it.
+- `SCORECARD_TOKEN` — read-only fine-grained PAT used by the OSSF Scorecard
+  workflow to read branch-protection metadata.
+- `NIMBUS_CHECKS_TOKEN` — optional fine-grained PAT with **Checks: Read and
+  write**, so one workflow can publish check runs attributed to another. Falls
+  back to `github.token` when unset.
+
+---
+
+## Verifying after a change
+
+After rotating or adding a secret, re-run the affected workflow from the Actions
+tab (**Re-run failed jobs** for a failed release). For the release path
+specifically, the `Require release PAT` / `Require PACKAGE_MANAGER_PAT` /
+`Require WINGET_PAT` guard steps fail fast with an actionable message when a
+required secret is missing, so a green guard step confirms the secret is at
+least present (it does not prove the token is unexpired — a valid-but-expired
+token still passes the guard and fails later at the API call).

--- a/docs/release/signing-keys.md
+++ b/docs/release/signing-keys.md
@@ -1,6 +1,6 @@
 # Signing Key Lifecycle
 
-Operational runbooks for the two signing keys Nimbus depends on: the **updater signing key** (Ed25519, gates auto-update) and the **release signing key** (GPG, signs release artifacts). The security *model* and reporting policy live in [`../SECURITY.md`](../SECURITY.md); this file is the maintainer-facing procedure for rotation and compromise response.
+Operational runbooks for the two signing keys Nimbus depends on: the **updater signing key** (Ed25519, gates auto-update) and the **release signing key** (GPG, signs release artifacts). The security *model* and reporting policy live in [`../SECURITY.md`](../SECURITY.md); this file is the maintainer-facing procedure for rotation and compromise response. The full inventory of every CI/release secret (PATs, signing certs, publish tokens) and how to mint each one is in [`../ci-secrets.md`](../ci-secrets.md).
 
 ---
 

--- a/packages/gateway/src/ipc/lan-server.test.ts
+++ b/packages/gateway/src/ipc/lan-server.test.ts
@@ -566,6 +566,10 @@ async function sendEncryptedPayload(
 
   return new Promise((resolve) => {
     let phase: "hello" | "rpc" = "hello";
+    // Reassemble length-prefixed frames: the server writes the 4-byte header and
+    // the payload as two separate socket.write() calls, which TCP may deliver split
+    // across data callbacks (or coalesced). Buffer bytes and only act on complete frames.
+    let buf = new Uint8Array(0);
     const conn = Bun.connect({
       hostname: "127.0.0.1",
       port: serverPort,
@@ -575,27 +579,38 @@ async function sendEncryptedPayload(
           socket.write(helloBytes);
         },
         data(socket, chunk) {
-          try {
-            if (chunk.length < 4) return;
-            const view = new DataView(chunk.buffer, chunk.byteOffset, chunk.byteLength);
-            const len = view.getUint32(0, false);
-            const body = chunk.slice(4, 4 + len);
-            const text = new TextDecoder().decode(body);
-            if (phase === "hello" && text.includes("hello_ok")) {
-              phase = "rpc";
-              socket.write(frameHeader);
-              socket.write(frame);
-            } else if (phase === "rpc") {
-              const plain = openBoxFrame(body, hostPubkey, clientKeypair.secretKey);
-              const parsed = JSON.parse(new TextDecoder().decode(plain)) as {
-                result?: unknown;
-                error?: { code: string; message: string };
-              };
-              resolve(parsed);
+          const merged = new Uint8Array(buf.length + chunk.length);
+          merged.set(buf, 0);
+          merged.set(chunk, buf.length);
+          buf = merged;
+          while (buf.length >= 4) {
+            const len = new DataView(buf.buffer, buf.byteOffset, buf.byteLength).getUint32(
+              0,
+              false,
+            );
+            if (buf.length < 4 + len) break; // wait for the rest of the frame
+            const body = buf.slice(4, 4 + len);
+            buf = buf.slice(4 + len);
+            if (phase === "hello") {
+              if (new TextDecoder().decode(body).includes("hello_ok")) {
+                phase = "rpc";
+                socket.write(frameHeader);
+                socket.write(frame);
+              }
+            } else {
+              try {
+                const plain = openBoxFrame(body, hostPubkey, clientKeypair.secretKey);
+                const parsed = JSON.parse(new TextDecoder().decode(plain)) as {
+                  result?: unknown;
+                  error?: { code: string; message: string };
+                };
+                resolve(parsed);
+              } catch {
+                resolve(null);
+              }
               socket.end();
+              return;
             }
-          } catch {
-            resolve(null);
           }
         },
         error() {

--- a/packages/gateway/test/integration/http/deployments-post-route.test.ts
+++ b/packages/gateway/test/integration/http/deployments-post-route.test.ts
@@ -233,7 +233,9 @@ describe("POST /v1/deployments (integration)", () => {
     expect(limited.headers.get("Retry-After")).not.toBeNull();
     const body = (await limited.json()) as { error?: string };
     expect(body.error).toBe("rate_limited");
-  });
+    // 61 sequential HTTP round-trips: slow on Windows CI runners (~5s), so the
+    // default 5000ms bun-test timeout is too tight. Allow generous headroom.
+  }, 30_000);
 
   test("401 writes a deployment.annotation_rejected audit row", async () => {
     handle = startServer();
@@ -297,5 +299,6 @@ describe("POST /v1/deployments (integration)", () => {
     };
     expect(parsed.result_code).toBe(429);
     expect(parsed.reason).toBe("rate_limited");
-  });
+    // 61 sequential HTTP round-trips: slow on Windows CI runners; see note above.
+  }, 30_000);
 });


### PR DESCRIPTION
## Why

Investigating two red coverage jobs on `main` CI (run [27469405399](https://github.com/nimbus-agent/Nimbus/actions/runs/27469405399)) plus a separate red v0.6.1 release job.

## What

### 1. LAN coverage (macOS) — `lan-server.test.ts:696` `Received: null`
The `sendEncryptedPayload` test helper assumed each TCP `data` callback delivered a complete `[4-byte header][payload]` frame. The server writes header and payload as two separate `socket.write()` calls, which TCP can split across callbacks; when the header arrived alone, `openBoxFrame` got an empty body, threw, and resolved `null`. Now buffers and reassembles length-prefixed frames, mirroring the production `lan-client` frame reader. **Production was never affected** — only the naive test helper.

### 2. Deployment coverage (Windows) — `429 …` tests timed out at 5000ms
Both "429" tests fire 61 sequential HTTP round-trips; on Windows runners this exceeds bun's default 5000ms per-test timeout (the sibling passed at 4934ms, right on the edge). Gave both a 30s timeout.

Both are **test-only** changes. Verified locally: LAN 15/15 (5× stable), deployment 12/12, biome + markdownlint clean.

### 3. v0.6.1 release job — NOT fixed here (no code fix possible)
The `Publish GitHub Release` job failed with `HttpError: Bad credentials` from `softprops/action-gh-release`. The `RELEASE_PAT` secret is **expired/revoked**. Fix = rotate the PAT and re-run the failed job. This PR adds **`docs/ci-secrets.md`** — a full inventory of every CI/release secret, what each is for, required vs optional, and how to mint each one (with the `RELEASE_PAT` rotation runbook called out explicitly). Backlinked from `docs/release/signing-keys.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GitHub Actions secrets inventory with operational guidance for CI/release workflows
  * Linked release documentation to centralized CI secrets reference

* **Tests**
  * Improved network communication robustness in encrypted message handling
  * Enhanced CI test reliability with adjusted timeout thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->