### PR TITLE
fix(ci): linux-repo publish verifies only the downloaded .deb/.rpm

### DIFF
--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -93,7 +93,11 @@ jobs:
             --distributions-out staging/apt/conf/distributions \
             --repo-file-out staging/nimbus.repo
           # Verify the downloaded artifacts match SHA256SUMS before publishing.
-          ( cd out && sha256sum -c <(grep -E 'nimbus-headless(_|-)' SHA256SUMS) )
+          # Match ONLY the two files we downloaded (the .deb + .rpm), anchored to
+          # end-of-line so the `.asc` lines are excluded: SHA256SUMS lists every
+          # release asset (.msi/.pkg/tarballs/AppImage/...), and a broad grep would
+          # make `sha256sum -c` fail on the assets this job never fetches.
+          ( cd out && sha256sum -c <(grep -E "(nimbus-headless_${VERSION}_amd64\.deb|nimbus-headless-${VERSION}-x86_64\.rpm)\$" SHA256SUMS) )
 
       - name: Import GPG signing key (ephemeral GNUPGHOME)
         env:


### PR DESCRIPTION
## Summary

The first live `publish-linux-repo` run (v0.6.1, run 27474486159) failed at **"Resolve + verify artifact checksums"**. The verify step ran:

```bash
( cd out && sha256sum -c <(grep -E 'nimbus-headless(_|-)' SHA256SUMS) )
```

…but that grep matches **every** `nimbus-headless*` asset in `SHA256SUMS` (`.msi`, `.pkg`, tarballs, AppImage, `.zip`, and all the `.asc` signatures — 14 lines), while the download step only fetches the `.deb` + `.rpm`. So `sha256sum -c` hit `No such file or directory` / `FAILED open or read` on every asset this job doesn't download, and exited non-zero.

**Fix:** match only the two files we actually downloaded, anchored to end-of-line (so `.asc` lines are excluded):

```bash
( cd out && sha256sum -c <(grep -E "(nimbus-headless_${VERSION}_amd64\.deb|nimbus-headless-${VERSION}-x86_64\.rpm)\$" SHA256SUMS) )
```

Verified against the real v0.6.1 `SHA256SUMS`: the broad grep returns 14 lines; the fixed grep returns exactly the `.deb` + `.rpm`.

Pure CI fix to the Slice 4 workflow (no source/test changes). The generator + the rest of the job were correct — only the verify grep was over-broad.

## Test plan
- [x] `yaml` parses (`jobs.publish-linux-repo`, 13 steps)
- [x] Fixed grep validated against v0.6.1 `SHA256SUMS` → exactly 2 lines (.deb + .rpm)
- [ ] Re-dispatch `publish-linux-repo` for v0.6.1 after merge → expect the apt/yum repo to publish to `nimbus-agent/linux-repo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined the automated release process to implement more targeted artifact checksum verification, ensuring validation occurs only for expected release packages and improving overall build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->