### PR TITLE
fix(ci): export GNUPGHOME in linux-repo publish so signing finds the key

### DIFF
--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -104,7 +104,11 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_SUBKEY }}
         run: |
           set -euo pipefail
-          GNUPGHOME="$(mktemp -d)"
+          # `export` so THIS step's `gpg --import` lands in the ephemeral home;
+          # GITHUB_ENV then propagates the same path to the later sign/export steps.
+          # (Without export, the import would use the default ~/.gnupg and the sign
+          # step — which reads GNUPGHOME from GITHUB_ENV — would find no secret key.)
+          export GNUPGHOME="$(mktemp -d)"
           chmod 700 "$GNUPGHOME"
           echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
           printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import


### PR DESCRIPTION
## Summary

Second issue surfaced by the live `publish-linux-repo` run (v0.6.1, run 27474687915): it got past the checksum verify (thanks to #603) and failed at **"Sign apt Release + yum repomd"** with:

```
gpg: no default secret key: No secret key
gpg: signing failed: No secret key
```

**Cause:** the import step did `GNUPGHOME="$(mktemp -d)"` … `echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"` … `gpg --import`. `$GITHUB_ENV` only affects **later** steps, and `GNUPGHOME` was never `export`ed in the import step — so `gpg --import` used the **default `~/.gnupg`** (log: "`/home/runner/.gnupg` created"), while the **sign** step (which reads `GNUPGHOME` from `$GITHUB_ENV`) looked in the empty `mktemp` home (`/tmp/tmp.…`) and found no secret key.

**Fix:** `export GNUPGHOME="$(mktemp -d)"` so the import lands in the ephemeral home, and `$GITHUB_ENV` propagates that same path to the sign/export-key steps.

Pure CI fix (one line + comment).

## Test plan
- [x] YAML parses (13 steps)
- [ ] Re-dispatch `publish-linux-repo` for v0.6.1 → expect signing + reprepro/createrepo + push to succeed and populate `nimbus-agent/linux-repo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This pull request contains no user-facing changes. It includes internal build process improvements to ensure consistent GPG key handling during package publishing.

* **Chores**
  * Improved CI/CD workflow reliability for package signing and export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->