### PR TITLE
perf(slo): widen S1 noise floor 200→300 ms to absorb cold-start jitter

### DIFF
--- a/docs/perf/slo.md
+++ b/docs/perf/slo.md
@@ -20,7 +20,7 @@ A bench fails when either:
 
 | Surface | Metric | Reference threshold | GHA threshold | Noise floor (rel %, abs) |
 |---|---|---|---|---|
-| S1 | p95_ms | **≤2 000 ms** | ≤10 000 ms | 25 %, 200 ms |
+| S1 | p95_ms | **≤2 000 ms** | ≤10 000 ms | 25 %, 300 ms |
 | S2-a | p95_ms | **≤30 ms** | ≤200 ms | 25 %, 5 ms |
 | S2-b | p95_ms | **≤80 ms** | ≤500 ms | 25 %, 10 ms |
 | S2-c | p95_ms | **≤300 ms** | n/a (reference only) | 25 %, 25 ms |

--- a/packages/gateway/src/perf/slo-thresholds.test.ts
+++ b/packages/gateway/src/perf/slo-thresholds.test.ts
@@ -75,7 +75,7 @@ describe("SLO_THRESHOLDS — schema invariants", () => {
       ghaMax: 10_000,
       gated: true,
       noiseFloorPct: 25,
-      noiseFloorAbs: 200,
+      noiseFloorAbs: 300,
       noiseFloorAbsUnit: "ms",
     } satisfies SloThreshold);
   });

--- a/packages/gateway/src/perf/slo-thresholds.ts
+++ b/packages/gateway/src/perf/slo-thresholds.ts
@@ -26,7 +26,14 @@ const NON_S8_THRESHOLDS: readonly SloThreshold[] = [
     ghaMax: 10_000,
     gated: true,
     noiseFloorPct: 25,
-    noiseFloorAbs: 200,
+    // S1 is the heaviest cold-start surface; on shared GHA macOS/Windows runners
+    // its p95 swings run-to-run between ~617 ms and ~841 ms (a ~224 ms / +36 %
+    // spawn-jitter envelope) with no code change. The 200 ms absolute floor was
+    // the binding constraint (200 / 617 ≈ 32 %, below that swing) and delta-failed
+    // a pure release commit. 300 ms lifts the effective floor to ~49 % (300 / 617):
+    // durable against the observed cold-start jitter while still catching a true
+    // ~1.5x regression (well under the 10 000 ms absolute ceiling above).
+    noiseFloorAbs: 300,
     noiseFloorAbsUnit: "ms",
   },
   {

--- a/packages/gateway/src/perf/threshold-comparator.test.ts
+++ b/packages/gateway/src/perf/threshold-comparator.test.ts
@@ -43,6 +43,18 @@ describe("compareAgainstHistory", () => {
     expect(s1?.status).toEqual({ kind: "absolute-fail", measured: 12_000, threshold: 10_000 });
   });
 
+  test("S1 cold-start jitter (617→841 ms, +36 %) sits inside the widened 300 ms floor → pass", () => {
+    // Regression guard for the run-27487164610 macOS delta-fail: a pure release
+    // commit swung S1 p95 from 616.87 to 840.81 ms. With noiseFloorAbs=300 the
+    // effective floor is 300/616.87 ≈ 48.6 %, above the +36.3 % swing. If the
+    // floor is ever re-tightened to 200 ms (32.4 %), this flips back to delta-fail.
+    const current = fakeLine("gha-macos", { S1: { samples_count: 301, p95_ms: 840.81 } });
+    const previous = fakeLine("gha-macos", { S1: { samples_count: 301, p95_ms: 616.87 } });
+    const out = compareAgainstHistory(current, previous, SLO_THRESHOLDS, "gha-macos");
+    const s1 = out.find((c) => c.surfaceId === "S1");
+    expect(s1?.status).toEqual({ kind: "pass" });
+  });
+
   test("delta-fail when delta > floorPct AND > floorAbs/previous*100", () => {
     const current = fakeLine("gha-ubuntu", { "S2-a": { samples_count: 500, p95_ms: 65 } });
     const previous = fakeLine("gha-ubuntu", { "S2-a": { samples_count: 500, p95_ms: 50 } });


### PR DESCRIPTION
## What

Widen the S1 perf surface's absolute noise floor **200 ms → 300 ms** so the post-merge `Performance Benchmarks` workflow stops delta-failing on cold-start runner variance.

## Why

On push to `main`, the macOS leg of run [27487164610](https://github.com/nimbus-agent/Nimbus/actions/runs/27487164610) delta-failed S1:

| Surface | Previous | Current | Δ | Status |
|---|---|---|---|---|
| S1 | 616.87 ms | 840.81 ms | **+36.3 %** | ⚠️ delta-fail (floor 32.4 %) |

The failing commit was `chore(main): release 0.6.2` — a **pure version bump with zero functional change** — so this is not a real regression. S1 is the heaviest cold-start surface and its p95 swings ~617↔841 ms run-to-run from spawn jitter on shared GHA macOS/Windows runners. The failure reproduced across re-runs, confirming the floor is genuinely too tight rather than a one-off blip.

The binding constraint was the **absolute** floor, not the percentage one:
`effectiveFloor = max(noiseFloorPct 25 %, noiseFloorAbs 200 / 616.87 = 32.4 %) = 32.4 %`, which the +36.3 % swing cleared.

## Change

Lift `noiseFloorAbs` to **300 ms** → effective floor `300 / 616.87 ≈ 48.6 %`: comfortably above the observed +36.3 % cold-start jitter, while still catching a true ~1.5x regression (the 10 000 ms absolute GHA ceiling is unchanged). Mirrors the existing **S11-b** floor-widening precedent documented in `slo-thresholds.ts`.

- `packages/gateway/src/perf/slo-thresholds.ts` — `noiseFloorAbs: 200 → 300` + rationale comment
- `packages/gateway/src/perf/slo-thresholds.test.ts` — update the pinned "S1 row matches spec § 3.2" assertion
- `docs/perf/slo.md` — update the §3.2 noise-floor column (`25 %, 200 ms → 300 ms`)
- `packages/gateway/src/perf/threshold-comparator.test.ts` — **new regression guard** asserting the exact 617→841 ms scenario now passes (flips back to `delta-fail` if the floor is ever re-tightened to 200 ms)

## Scope note

This only touches the S1 row. The **Windows** leg of the same run failed for an unrelated reason — a Bun v1.3.14 segfault on shutdown (`oh no: Bun has crashed. This indicates a bug in Bun, not your code.`), an upstream/infra flake out of scope here.

## Verification

`bun test packages/gateway/src/perf/` → **189 pass / 0 fail**; biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated S1 surface noise-floor threshold from 200 ms to 300 ms in performance SLO documentation.

* **Tests**
  * Updated performance threshold validation tests to reflect the new 300 ms S1 noise-floor value.
  * Added test case for S1 cold-start jitter scenario validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->