### PR TITLE
fix(ci): set --timeout 60000 on the integration test step

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -518,7 +518,7 @@ jobs:
         run: mkdir -p junit-reports
 
       - name: Integration tests
-        run: bun test packages/gateway/test/integration/ packages/cli/test/integration/ --reporter=junit --reporter-outfile=junit-reports/junit-integration.xml
+        run: bun test packages/gateway/test/integration/ packages/cli/test/integration/ --timeout 60000 --reporter=junit --reporter-outfile=junit-reports/junit-integration.xml
         env:
           CI: "true"
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "test:scripts": "bun test scripts",
     "kill-gateway": "bun scripts/kill-gateway.ts",
     "test:unit": "bun test packages/gateway/src packages/cli/src packages/sdk/src",
-    "test:integration": "bun test packages/gateway/test/integration/ packages/cli/test/integration/",
+    "test:integration": "bun test packages/gateway/test/integration/ packages/cli/test/integration/ --timeout 60000",
     "test:e2e:cli": "bun test packages/cli/test/e2e/",
     "test:e2e:gateway": "bun test packages/gateway/test/e2e/",
     "test:coverage": "bun test packages/gateway packages/cli packages/sdk --coverage",


### PR DESCRIPTION
## Problem

The push-to-main run [27489456889](https://github.com/nimbus-agent/Nimbus/actions/runs/27489456889/job/81251686754) failed on **Integration — windows-2025** only. Out of 358 integration tests, 355 passed, 2 skipped, and 1 was killed:

```
(fail) V27 migration — merged_as graph_relation_type > does not fail when applied to a DB already at V27 (idempotency) [8211.81ms]
  ^ this test timed out after 5000ms.
```

This is a Windows-only **wall-clock timeout**, not a logic failure. `migration-v27.test.ts`'s idempotency case runs the full 0→27 migration chain twice and needs ~8.2s on the slow `windows-2025` runner.

## Root cause

The Integration step in `_test-suite.yml` passed **no `--timeout`**, so Bun fell back to its bare **5000ms** default. The `[test] timeout = 30000` in `bunfig.toml` is **not** honored for `bun test <path>` invocations — the same gotcha PR #541 fixed for the cross-platform and unit steps, which already carry `--timeout 60000`. The integration step was missed.

## Fix

- `.github/workflows/_test-suite.yml` — add `--timeout 60000` to the Integration step, mirroring the cross-platform (line 205) and unit (line 260) steps.
- `package.json` — add the same to the local `test:integration` script so local runs match CI.

## Verification

Test passes locally with the proper timeout (logic is healthy; only the 5s wall clock killed it on the runner):

```
$ bun test packages/gateway/test/integration/index/migration-v27.test.ts --timeout 60000
 2 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test timeout configuration to 60 seconds to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->