### PR TITLE
fix(ci): harden Linux apt-get against flaky Microsoft repos + integration-test timeout

### DIFF
--- a/.github/actions/setup-rust-tauri/action.yml
+++ b/.github/actions/setup-rust-tauri/action.yml
@@ -16,6 +16,10 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        # The GHA ubuntu runner ships Microsoft apt repos (azure-cli + prod) that
+        # periodically 403 during key rotations and fail `apt-get update` wholesale.
+        # We don't need them here — drop them first. See scripts/linux/install-vault-deps.sh.
+        sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
         sudo apt-get update
         sudo apt-get install -y \
           libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \

--- a/.github/workflows/_perf.yml
+++ b/.github/workflows/_perf.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Linux — libsecret + D-Bus (gateway vault init)
         if: runner.os == 'Linux'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-tools gnome-keyring dbus
+        run: sudo bash scripts/linux/install-vault-deps.sh
 
       # macOS GHA marks downloaded native libs with `com.apple.quarantine`,
       # which blocks dlopen() of `sqlite-vec.dylib` from the bun:sqlite Workers

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Linux — libsecret + D-Bus (vault / PAL tests)
         if: runner.os == 'Linux'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-tools gnome-keyring dbus
+        run: sudo bash scripts/linux/install-vault-deps.sh
 
       - name: macOS — Strip quarantine from native SQLite extensions
         if: runner.os == 'macOS'
@@ -496,7 +496,7 @@ jobs:
       - name: Linux — libsecret + D-Bus (vault / PAL tests)
         if: runner.os == 'Linux'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-tools gnome-keyring dbus
+        run: sudo bash scripts/linux/install-vault-deps.sh
 
       - name: macOS — Strip quarantine from native SQLite extensions
         if: runner.os == 'macOS'
@@ -566,7 +566,7 @@ jobs:
       - name: Linux — libsecret + D-Bus (vault / PAL tests)
         if: runner.os == 'Linux'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-tools gnome-keyring dbus
+        run: sudo bash scripts/linux/install-vault-deps.sh
 
       - name: macOS — Strip quarantine from native SQLite extensions
         if: runner.os == 'macOS'
@@ -646,7 +646,7 @@ jobs:
       - name: Linux — libsecret + D-Bus (vault / PAL tests)
         if: runner.os == 'Linux'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-tools gnome-keyring dbus
+        run: sudo bash scripts/linux/install-vault-deps.sh
 
       - name: macOS — Strip quarantine from native SQLite extensions
         if: runner.os == 'macOS'
@@ -809,12 +809,16 @@ jobs:
       - name: Linux — libsecret + D-Bus (vault tests)
         if: runner.os == 'Linux' && matrix.gate.name == 'Vault'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-tools gnome-keyring dbus
+        run: sudo bash scripts/linux/install-vault-deps.sh
 
       - name: Linux — bubblewrap + libcap-dev + strace + cppcheck (sandbox tests)
         if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap libcap-dev strace cppcheck
+        run: |
+          # Drop the GHA runner's preinstalled Microsoft apt repos (azure-cli + prod);
+          # they periodically 403 and fail `apt-get update` wholesale. Not needed here.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+          sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap libcap-dev strace cppcheck
 
       - name: Build sandbox helper (Linux only, sandbox gate)
         if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
@@ -876,25 +880,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: latest
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-nimbus-ci
 
       - name: Setup Node 20
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       # Vault services must initialise before the spawned gateway can open its socket.
       # Without these the gateway crashes silently and the 15s socket-wait expires.
       - name: Linux — libsecret + D-Bus (vault tests)
         if: runner.os == 'Linux'
         shell: bash
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-tools gnome-keyring dbus
+        run: sudo bash scripts/linux/install-vault-deps.sh
 
       - name: macOS — Strip quarantine from native SQLite extensions
         if: runner.os == 'macOS'

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -518,7 +518,7 @@ jobs:
         run: mkdir -p junit-reports
 
       - name: Integration tests
-        run: bun test packages/gateway/test/integration/ packages/cli/test/integration/ --reporter=junit --reporter-outfile=junit-reports/junit-integration.xml
+        run: bun test packages/gateway/test/integration/ packages/cli/test/integration/ --timeout 60000 --reporter=junit --reporter-outfile=junit-reports/junit-integration.xml
         env:
           CI: "true"
 

--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install reprepro + createrepo_c
         run: |
           set -euo pipefail
+          # Drop the GHA runner's preinstalled Microsoft apt repos (azure-cli + prod);
+          # they periodically 403 and fail `apt-get update` wholesale. Not needed here.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends reprepro createrepo-c
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,6 +392,9 @@ jobs:
         shell: bash
         run: |
           set -e
+          # Drop the GHA runner's preinstalled Microsoft apt repos (azure-cli + prod);
+          # they periodically 403 and fail `apt-get update` wholesale. Not needed here.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libfuse2 file
           # Pin appimagetool; update hash when bumping the version.

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "test:scripts": "bun test scripts",
     "kill-gateway": "bun scripts/kill-gateway.ts",
     "test:unit": "bun test packages/gateway/src packages/cli/src packages/sdk/src",
-    "test:integration": "bun test packages/gateway/test/integration/ packages/cli/test/integration/",
+    "test:integration": "bun test packages/gateway/test/integration/ packages/cli/test/integration/ --timeout 60000",
     "test:e2e:cli": "bun test packages/cli/test/e2e/",
     "test:e2e:gateway": "bun test packages/gateway/test/e2e/",
     "test:coverage": "bun test packages/gateway packages/cli packages/sdk --coverage",

--- a/scripts/linux/install-vault-deps.sh
+++ b/scripts/linux/install-vault-deps.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Install the Linux vault / PAL test dependencies: libsecret-tools (secret-tool),
+# gnome-keyring (Secret Service provider), and dbus (session bus).
+#
+# Why this is a script and not an inline `apt-get` step:
+# The GitHub Actions ubuntu runner image ships preconfigured Microsoft apt repos
+# (packages.microsoft.com azure-cli + prod). During Microsoft signing-key rotations
+# those repos return `403 Forbidden` / "no longer signed", and because `apt-get update`
+# fails whole-hog when ANY configured repo can't be refreshed, our unrelated install
+# of three stock-Ubuntu packages goes red with it. We don't need those repos here, so
+# remove them before updating. See `_test-suite.yml` / `_perf.yml` callers.
+#
+# Privilege: does NOT call sudo itself — invoke with `sudo bash scripts/linux/install-vault-deps.sh`
+# on CI runners, or run directly when already root (e.g. inside a Docker container).
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# Drop the flaky/unneeded Microsoft repos so `apt-get update` only refreshes the
+# Ubuntu archive. `rm -f` is a no-op when the files are absent (non-GHA environments).
+rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+
+apt-get update -qq
+apt-get install -y -qq libsecret-tools gnome-keyring dbus


### PR DESCRIPTION
## What & why

CI's Linux legs intermittently go red on **unrelated** apt installs. The GHA ubuntu runner ships preconfigured Microsoft apt repos (`packages.microsoft.com` azure-cli + prod); during Microsoft signing-key rotations those repos return `403 Forbidden`, and `apt-get update` fails *wholesale* when any configured repo can't refresh — taking our stock-Ubuntu vault/sandbox dep installs down with it.

This branch also carries the original integration-test timeout fix that prompted it.

## Changes

**apt-get hardening**
- New `scripts/linux/install-vault-deps.sh`: drops the Microsoft/azure repos, then installs `libsecret-tools` + `gnome-keyring` + `dbus`. Replaces the 7 inline vault-dep apt steps across `_test-suite.yml` and `_perf.yml`.
- Same repo-drop added inline before the other Linux apt steps that install different packages (so no shared script): `setup-rust-tauri`, `publish-linux-repo.yml`, `release.yml`, and the **Sandbox** gate (`bubblewrap`/`libcap-dev`/`strace`/`cppcheck`).
- `rm -f` is a no-op when the files are absent, so it's safe in non-GHA/Docker environments.

**CI consistency**
- Converted the last manual `Setup Bun` + `bun install --frozen-lockfile` job in `_test-suite.yml` to the `setup-nimbus-ci` composite action (adds Bun cache + node_modules cache + lockfile verify). Every job now uses it.

**Integration-test timeout** (`097d2194`)
- `--timeout 60000` on the integration-test step + `test:integration` script — matches every other Bun test invocation in the repo (bunfig's `timeout = 30000` is not honored for `bun test <path>` invocations).

## Verification
- `bash -n scripts/linux/install-vault-deps.sh` ✅
- All 6 touched workflow/action YAML files parse cleanly ✅
- `reseed-docker.sh` left as-is — runs in `oven/bun:latest`, which has no Microsoft repos preinstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced build stability by fixing intermittent Linux dependency installation failures in CI pipelines
  * Extended integration test timeout to prevent tests from timing out prematurely

* **Chores**
  * Standardized Linux dependency installation process across CI workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->