### PR TITLE
fix(ci): guard gateway daily-log async destination against unhandled flush errors

### DIFF
--- a/packages/gateway/src/platform/gateway-log-file.test.ts
+++ b/packages/gateway/src/platform/gateway-log-file.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -266,6 +266,22 @@ describe("createGatewayPinoLogger", () => {
     } finally {
       restore();
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not throw when the log directory cannot be created (best-effort)", () => {
+    const restore = forceIsTty(false);
+    const base = mkdtempSync(join(tmpdir(), "nimbus-gw-baddir-"));
+    // Make a regular file, then use a path *under* it as the log dir: mkdirSync(recursive) fails
+    // with ENOTDIR because a path component is a file. The logger must swallow it and not throw.
+    const filePath = join(base, "not-a-dir");
+    writeFileSync(filePath, "x", "utf8");
+    const badLogDir = join(filePath, "logs");
+    try {
+      expect(() => createGatewayPinoLogger(badLogDir)).not.toThrow();
+    } finally {
+      restore();
+      rmSync(base, { recursive: true, force: true });
     }
   });
 

--- a/packages/gateway/src/platform/gateway-log-file.ts
+++ b/packages/gateway/src/platform/gateway-log-file.ts
@@ -132,9 +132,15 @@ export function createGatewayPinoLogger(logDir: string): Logger {
     hooks: { logMethod: pinoLogMethodHook },
   };
 
-  // Ensure the target directory exists before the async destination opens it; the daily log is
-  // best-effort, so a missing dir must never throw out of logger construction.
-  mkdirSync(logDir, { recursive: true });
+  // Ensure the target directory exists before the async destination opens it. The daily log is
+  // best-effort, so directory creation must never throw out of logger construction — mkdirSync can
+  // fail (EACCES/ENOSPC/EROFS); swallow it and let the destination's async `error` handler below
+  // absorb the subsequent open failure (mirrors emergencyGatewayLog's defensive try/catch).
+  try {
+    mkdirSync(logDir, { recursive: true });
+  } catch {
+    /* best-effort daily log — ignore directory-creation failures */
+  }
 
   const fileDest = pino.destination({ dest: logPath, sync: false });
   // `sync: false` opens and flushes on a later tick via a background SonicBoom stream. Without an

--- a/packages/gateway/src/platform/gateway-log-file.ts
+++ b/packages/gateway/src/platform/gateway-log-file.ts
@@ -132,7 +132,19 @@ export function createGatewayPinoLogger(logDir: string): Logger {
     hooks: { logMethod: pinoLogMethodHook },
   };
 
+  // Ensure the target directory exists before the async destination opens it; the daily log is
+  // best-effort, so a missing dir must never throw out of logger construction.
+  mkdirSync(logDir, { recursive: true });
+
   const fileDest = pino.destination({ dest: logPath, sync: false });
+  // `sync: false` opens and flushes on a later tick via a background SonicBoom stream. Without an
+  // `error` listener an async open/flush failure (e.g. the dir was removed after the logger was
+  // built, as happens for short-lived loggers in tests) becomes an unhandled `error` event that
+  // can crash the process or be mis-attributed to an unrelated in-flight test. The daily log is
+  // best-effort: swallow these async errors rather than let them escape.
+  fileDest.on("error", () => {
+    /* best-effort daily log — ignore async open/flush failures */
+  });
 
   if (process.stdout.isTTY === true) {
     return pino(


### PR DESCRIPTION
## What

Hardens `createGatewayPinoLogger` in `packages/gateway/src/platform/gateway-log-file.ts`:

- `mkdirSync(logDir, { recursive: true })` before constructing the destination, so a missing directory can never throw out of logger construction.
- Attaches a swallowing `error` listener to the `sync: false` SonicBoom destination. The daily log is best-effort, so async open/flush failures must not escape as unhandled `error` events.

## Why

The gateway daily-log uses `pino.destination({ sync: false })`, which opens and flushes via a background SonicBoom stream on a later tick. With no `error` listener, an async open/flush failure becomes an **unhandled `error` event** that can crash the process or be mis-attributed to an unrelated in-flight test.

This surfaced as a **macOS-only flake** on the cross-platform CI leg (observed on PR #614's release job, run 27494059073): a short-lived logger built in one test would async-open its log file *after* that test's temp dir had already been `rmSync`'d, emitting an `ENOENT` that failed the next test — `gateway-log-file.test.ts > createGatewayPinoLogger > appends JSON to daily log file when stdout is not a TTY`:

```
ENOENT: no such file or directory, open '/var/folders/.../T/nimbus-gw-log-level-.../gateway-2026-06-14.log'
  syscall: "open", errno: -2, code: "ENOENT"
(fail) ... appends JSON to daily log file when stdout is not a TTY [2.23ms]
```

The ~2ms failure time (well under the test's 5000ms poll deadline) confirms it was the unhandled async-stream error, not the poll helper timing out.

## Verification

- Scoped test green **5/5 runs** (was non-deterministic): `bun test packages/gateway/src/platform/gateway-log-file.test.ts` → 32 pass / 0 fail.
- Full `bun run preflight`: green on all gates. `audit:coverage-floor` failed only on the local **Windows** lcov (known Windows≠Linux skew); verified authoritatively on Docker-Linux (`oven/bun:latest`, bun 1.3.14) — **coverage-floor PASS**. The changed file is at **90.9% line / 88.5% branch** on Linux; the new `error`-handler arrow is covered by existing tests.
- `tsc --noEmit` (gateway): clean. `biome check`: clean.

## Notes

This does **not** itself unblock PR #614 (that's the release-please bot branch and just needs its flaky macOS job re-run); this is the durable repo-wide remedy so the flake stops recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging resilience to gracefully handle directory creation failures and async log-writing errors, preventing application crashes.
  * Logger now maintains best-effort logging even when filesystem issues occur.

* **Tests**
  * Added test coverage for logger error handling in edge-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->