### PR TITLE
fix(perf): gate S1 + S11-b latency on Linux only to stop main bench delta-flapping

### DIFF
--- a/packages/gateway/src/perf/slo-thresholds.test.ts
+++ b/packages/gateway/src/perf/slo-thresholds.test.ts
@@ -77,7 +77,17 @@ describe("SLO_THRESHOLDS — schema invariants", () => {
       noiseFloorPct: 25,
       noiseFloorAbs: 300,
       noiseFloorAbsUnit: "ms",
+      // Gated on Linux only: macOS/Windows cold-start spawn jitter is irreducible
+      // and was the dominant no-code-change delta-fail source on main. Mirrors S7.
+      linuxOnlyGate: true,
     } satisfies SloThreshold);
+  });
+
+  test("S1, S11-b carry linuxOnlyGate (latency spawn-jitter, gated on Linux only)", () => {
+    for (const id of ["S1", "S11-b"] as const) {
+      const row = SLO_THRESHOLDS.find((r) => r.surfaceId === id);
+      expect(row?.linuxOnlyGate).toBe(true);
+    }
   });
 
   test("S2-a row matches spec § 3.2 exactly", () => {

--- a/packages/gateway/src/perf/slo-thresholds.ts
+++ b/packages/gateway/src/perf/slo-thresholds.ts
@@ -28,13 +28,19 @@ const NON_S8_THRESHOLDS: readonly SloThreshold[] = [
     noiseFloorPct: 25,
     // S1 is the heaviest cold-start surface; on shared GHA macOS/Windows runners
     // its p95 swings run-to-run between ~617 ms and ~841 ms (a ~224 ms / +36 %
-    // spawn-jitter envelope) with no code change. The 200 ms absolute floor was
-    // the binding constraint (200 / 617 ≈ 32 %, below that swing) and delta-failed
-    // a pure release commit. 300 ms lifts the effective floor to ~49 % (300 / 617):
-    // durable against the observed cold-start jitter while still catching a true
-    // ~1.5x regression (well under the 10 000 ms absolute ceiling above).
+    // spawn-jitter envelope) with no code change. A fixed absolute floor cannot
+    // hold this: the floor-as-percentage shrinks as the baseline grows, and the
+    // Windows baseline is ~2x macOS (~1123 ms), so 300 ms = only ~26.7 % there —
+    // a +38 % no-code-change run (27498114264) delta-failed straight through it.
+    // The jitter is a property of the shared runner, not the code, so — exactly
+    // like the S7 memory surfaces — S1 is gated on Linux only (linuxOnlyGate).
+    // The 300 ms floor + 10 000 ms ceiling still apply on gha-ubuntu (low-jitter)
+    // and reference-m1air, where they catch a true ~1.5x regression. On macOS /
+    // Windows the delta is still computed and shown in the PR comment for humans,
+    // it just no longer gates the build.
     noiseFloorAbs: 300,
     noiseFloorAbsUnit: "ms",
+    linuxOnlyGate: true,
   },
   {
     surfaceId: "S2-a",
@@ -114,14 +120,17 @@ const NON_S8_THRESHOLDS: readonly SloThreshold[] = [
     // shared GHA runners that does NOT scale with the 50 ms local reference, so
     // ghaMax is a deliberately larger multiple than the ~5x siblings. The CI
     // p95 hovers near 600 ms on macOS/Windows and tipped a hard 600 ceiling at
-    // ~607 (a ~1% spawn-jitter flake). With this row's own 40% declared noise
-    // floor (600 x 1.4 ≈ 840), 900 sits just past the noise envelope: durable
-    // against re-flake while still catching a true >=2x spawn regression.
+    // ~607 (a ~1% spawn-jitter flake). Like S1, this spawn jitter is a runner
+    // property, not a code signal, so S11-b is gated on Linux only
+    // (linuxOnlyGate). The 900 ms ceiling + 40 % floor still apply on gha-ubuntu
+    // and reference-m1air to catch a true >=2x spawn regression; on macOS /
+    // Windows the delta is shown in the PR comment but no longer gates.
     ghaMax: 900,
     gated: true,
     noiseFloorPct: 40,
     noiseFloorAbs: 10,
     noiseFloorAbsUnit: "ms",
+    linuxOnlyGate: true,
   },
 
   {

--- a/packages/gateway/src/perf/threshold-comparator.test.ts
+++ b/packages/gateway/src/perf/threshold-comparator.test.ts
@@ -43,17 +43,36 @@ describe("compareAgainstHistory", () => {
     expect(s1?.status).toEqual({ kind: "absolute-fail", measured: 12_000, threshold: 10_000 });
   });
 
-  test("S1 cold-start jitter (617→841 ms, +36 %) sits inside the widened 300 ms floor → pass", () => {
-    // Regression guard for the run-27487164610 macOS delta-fail: a pure release
-    // commit swung S1 p95 from 616.87 to 840.81 ms. With noiseFloorAbs=300 the
-    // effective floor is 300/616.87 ≈ 48.6 %, above the +36.3 % swing. If the
-    // floor is ever re-tightened to 200 ms (32.4 %), this flips back to delta-fail.
-    const current = fakeLine("gha-macos", { S1: { samples_count: 301, p95_ms: 840.81 } });
-    const previous = fakeLine("gha-macos", { S1: { samples_count: 301, p95_ms: 616.87 } });
-    const out = compareAgainstHistory(current, previous, SLO_THRESHOLDS, "gha-macos");
+  test("S1 cold-start jitter (617→841 ms, +36 %) sits inside the widened 300 ms floor → pass (Linux)", () => {
+    // Regression guard for the run-27487164610 delta-fail: a pure release commit
+    // swung S1 p95 from 616.87 to 840.81 ms. With noiseFloorAbs=300 the effective
+    // floor is 300/616.87 ≈ 48.6 %, above the +36.3 % swing. If the floor is ever
+    // re-tightened to 200 ms (32.4 %), this flips back to delta-fail. Asserted on
+    // gha-ubuntu because S1 is now Linux-only-gated (see the macOS/Windows tests
+    // below) — Linux is the runner where the floor still does the gating work.
+    const current = fakeLine("gha-ubuntu", { S1: { samples_count: 301, p95_ms: 840.81 } });
+    const previous = fakeLine("gha-ubuntu", { S1: { samples_count: 301, p95_ms: 616.87 } });
+    const out = compareAgainstHistory(current, previous, SLO_THRESHOLDS, "gha-ubuntu");
     const s1 = out.find((c) => c.surfaceId === "S1");
     expect(s1?.status).toEqual({ kind: "pass" });
   });
+
+  // S1 + S11-b carry linuxOnlyGate: their shared-runner spawn jitter on macOS /
+  // Windows is irreducible and was the dominant source of no-code-change perf
+  // delta-fails on main (e.g. run-27498114264 S1 +38.1 % on windows-2025). The
+  // delta is still computed + surfaced in the PR comment; it just no longer gates
+  // the build off Linux. Mirrors the S7 memory-surface precedent above.
+  for (const surfaceId of ["S1", "S11-b"] as const) {
+    for (const runner of ["gha-macos", "gha-windows"] as const) {
+      test(`${surfaceId} on ${runner} resolves to skipped(linux-only-gate)`, () => {
+        const current = fakeLine(runner, { [surfaceId]: { samples_count: 301, p95_ms: 99_999 } });
+        const previous = fakeLine(runner, { [surfaceId]: { samples_count: 301, p95_ms: 600 } });
+        const out = compareAgainstHistory(current, previous, SLO_THRESHOLDS, runner);
+        const c = out.find((x) => x.surfaceId === surfaceId);
+        expect(c?.status).toEqual({ kind: "skipped", reason: "linux-only-gate" });
+      });
+    }
+  }
 
   test("delta-fail when delta > floorPct AND > floorAbs/previous*100", () => {
     const current = fakeLine("gha-ubuntu", { "S2-a": { samples_count: 500, p95_ms: 65 } });


### PR DESCRIPTION
## Problem

The **Performance Benchmarks** workflow failed **~37% of recent `main` runs** (11 of 30, the highest absolute failure count of any workflow). Every gating failure is a `delta-fail` on the **S1** (cold-start) or **S11** (warm-CLI) latency surfaces on the shared GHA **macOS/Windows** runners, with **no code change** — e.g. run [27498114264](https://github.com/nimbus-agent/Nimbus/actions/runs/27498114264) tripped at `S1 p95 +38.1%` (1123→1551 ms) on `windows-2025` while every other surface moved ≤9.4%.

Root cause: an **absolute noise floor can't hold shared-runner spawn jitter**. The floor-as-percentage shrinks as the baseline grows, and the Windows baseline (~1123 ms) is ~2x macOS, so the 300 ms S1 floor is only ~26.7% there — below the observed jitter envelope. The prior median-baseline fix stabilized the *baseline* side, but the *current* single run is still noisy on macOS/Windows.

## Fix

The jitter is a property of the runner, not the code. So — exactly like the **S7** memory surfaces already do (`linuxOnlyGate: true`) — gate **S1** and **S11-b** on **Linux only**:

- `gha-ubuntu` + `reference-m1air` still enforce the floor + absolute ceiling and catch a true ~1.5x / ≥2x regression.
- On macOS/Windows the delta is **still computed and shown in the PR comment** for humans — it just no longer fails the build.

This is the adversarially-verified option (it does **not** suppress real signal: PRs still surface macOS/Windows deltas informationally, and Linux still gates). Rejected alternatives during review: `|| true` (would neuter PR gating too), p95→p50 (loses tail-latency signal), runs 5→10 (2x cost, redundant with median baseline).

## Tests

- Update the S1 exact-row assertion + move the floor regression-guard to `gha-ubuntu` (the runner that still gates).
- Add explicit `skipped(linux-only-gate)` coverage for **S1 + S11-b** on **macOS and Windows**.
- Full perf suite green locally (214 pass), gateway `tsc --noEmit` clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance threshold gating configuration for S1 and S11-b surfaces to run exclusively on Linux environments.
  * Added validation tests to confirm macOS and Windows runners skip these performance gates as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->