### PR TITLE
fix(client): widen node-compat askStream streamId poll to STREAM_TIMEOUT_MS

### DIFF
--- a/packages/client/test/node-compat.test.ts
+++ b/packages/client/test/node-compat.test.ts
@@ -133,10 +133,16 @@ if (GATEWAY_BIN === undefined) {
       const client = await NimbusClient.open({ socketPath });
       const handle = client.askStream("hello");
       // streamId is resolved asynchronously by the underlying engine.askStream
-      // RPC. Poll briefly until it lands so we can assert we got one.
+      // RPC. Poll until it lands so we can assert we got one. The deadline is
+      // STREAM_TIMEOUT_MS (not a tighter ad-hoc value): on a cold macOS/Windows
+      // CI runner the very first askStream round-trip can exceed 5 s while the
+      // gateway finishes its one-time agent/runtime warm-up, which was producing
+      // a false "askStream should return a streamId" failure (later streaming
+      // tests passed against the now-warm gateway). The hard assertion below
+      // still fails fast if the streamId genuinely never arrives.
       const waitForStreamId = async (): Promise<string> => {
         const start = Date.now();
-        while (Date.now() - start < 5000) {
+        while (Date.now() - start < STREAM_TIMEOUT_MS) {
           if (handle.streamId !== "") return handle.streamId;
           await new Promise((r) => setTimeout(r, 50));
         }


### PR DESCRIPTION
## Problem

The `Client node-compat (windows-latest)` job failed on `main` ([run 27498114244](https://github.com/nimbus-agent/Nimbus/actions/runs/27498114244)):

```
not ok 1 - askStream returns a streamId and cancel terminates the iterator
  error: 'askStream should return a streamId' (ERR_ASSERTION)
  duration_ms: 14298
```

Test **#1** polled `handle.streamId` for a **hardcoded 5 s** before asserting it was non-empty. On a cold macOS/Windows CI runner the *first* `engine.askStream` round-trip can exceed 5 s while the gateway finishes its one-time agent/runtime warm-up. The tell: test **#3** ("cancel() mid-stream"), which also streams, **passed on the same run** against the now-warm gateway.

## Fix

Poll for the file's existing `STREAM_TIMEOUT_MS` (30 s) instead of the ad-hoc 5 s. This is the only adversarially-verified-safe option:

- The hard assertion still fails fast if the streamId genuinely never arrives.
- The downstream `withStreamTimeout` wrapper keeps the upper bound on a stuck iterator.
- So it removes the cold-start false-fail **without** weakening real hang detection.

Rejected alternatives during review: a `gateway.ping` warm-up (no such client method — won't compile) and reordering tests (each test spawns & kills its *own* gateway, so there's no warmth to inherit).

## Verification

- `packages/client` `tsc --noEmit` clean, biome clean.
- The node-compat suite runs cross-platform in CI (needs a built gateway binary + `node:test`); the timing fix is validated by the macOS/Windows legs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for stream handling to reduce false failures in continuous integration pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->