### PR TITLE
fix(perf): gate S11-a latency on Linux only (completes the spawn-jitter set)

### DIFF
--- a/packages/gateway/src/perf/slo-thresholds.test.ts
+++ b/packages/gateway/src/perf/slo-thresholds.test.ts
@@ -83,8 +83,8 @@ describe("SLO_THRESHOLDS — schema invariants", () => {
     } satisfies SloThreshold);
   });
 
-  test("S1, S11-b carry linuxOnlyGate (latency spawn-jitter, gated on Linux only)", () => {
-    for (const id of ["S1", "S11-b"] as const) {
+  test("S1, S11-a, S11-b carry linuxOnlyGate (latency spawn-jitter, gated on Linux only)", () => {
+    for (const id of ["S1", "S11-a", "S11-b"] as const) {
       const row = SLO_THRESHOLDS.find((r) => r.surfaceId === id);
       expect(row?.linuxOnlyGate).toBe(true);
     }

--- a/packages/gateway/src/perf/slo-thresholds.ts
+++ b/packages/gateway/src/perf/slo-thresholds.ts
@@ -109,8 +109,17 @@ const NON_S8_THRESHOLDS: readonly SloThreshold[] = [
     ghaMax: 1_500,
     gated: true,
     noiseFloorPct: 40,
+    // Sibling of S11-b: warm-CLI latency dominated by fixed process-spawn cost
+    // on shared GHA runners. Same irreducible jitter — a no-code-change release
+    // commit (#622) swung S11-a p95 +57.7 % on macos-15 (168.5 -> 265.8 ms),
+    // past the 40 % floor, after S1/S11-b were already Linux-only-gated. The
+    // jitter is a runner property, not a code signal, so gate on Linux only
+    // (linuxOnlyGate), like S1/S11-b/S7. The 1 500 ms ceiling + 40 % floor still
+    // apply on gha-ubuntu and reference-m1air to catch a true spawn regression;
+    // on macOS / Windows the delta is shown in the PR comment but no longer gates.
     noiseFloorAbs: 50,
     noiseFloorAbsUnit: "ms",
+    linuxOnlyGate: true,
   },
   {
     surfaceId: "S11-b",

--- a/packages/gateway/src/perf/threshold-comparator.test.ts
+++ b/packages/gateway/src/perf/threshold-comparator.test.ts
@@ -57,12 +57,13 @@ describe("compareAgainstHistory", () => {
     expect(s1?.status).toEqual({ kind: "pass" });
   });
 
-  // S1 + S11-b carry linuxOnlyGate: their shared-runner spawn jitter on macOS /
-  // Windows is irreducible and was the dominant source of no-code-change perf
-  // delta-fails on main (e.g. run-27498114264 S1 +38.1 % on windows-2025). The
-  // delta is still computed + surfaced in the PR comment; it just no longer gates
-  // the build off Linux. Mirrors the S7 memory-surface precedent above.
-  for (const surfaceId of ["S1", "S11-b"] as const) {
+  // S1 + S11-a + S11-b carry linuxOnlyGate: their shared-runner spawn jitter on
+  // macOS / Windows is irreducible and was the dominant source of no-code-change
+  // perf delta-fails on main (e.g. run-27498114264 S1 +38.1 % on windows-2025;
+  // S11-a +57.7 % on macos-15 on the #622 release commit). The delta is still
+  // computed + surfaced in the PR comment; it just no longer gates the build off
+  // Linux. Mirrors the S7 memory-surface precedent above.
+  for (const surfaceId of ["S1", "S11-a", "S11-b"] as const) {
     for (const runner of ["gha-macos", "gha-windows"] as const) {
       test(`${surfaceId} on ${runner} resolves to skipped(linux-only-gate)`, () => {
         const current = fakeLine(runner, { [surfaceId]: { samples_count: 301, p95_ms: 99_999 } });


### PR DESCRIPTION
## Problem

The first post-merge `main` Performance Benchmarks run after #623 ([run 27501081344](https://github.com/nimbus-agent/Nimbus/actions/runs/27501081344)) **failed on macos-15** — but not because #623 regressed. #623 Linux-only-gated **S1 + S11-b** and they behaved perfectly (`skipped (linux-only-gate)`). The failure was their **sibling S11-a**, which #623 (and the review) missed:

```
| S1    | p95_ms | 592.97 | 554.25 |  -6.5% | ⏭ skipped (linux-only-gate) |
| S2-a  | p95_ms |   1.30 |   1.32 |  +1.9% | ✅ pass                      |
| S11-a | p95_ms | 168.50 | 265.78 | +57.7% | ⚠️ delta-fail (floor 40.0%) |  ← this
| S11-b | p95_ms | 172.62 | 259.75 | +50.5% | ⏭ skipped (linux-only-gate) |
```

S11-a is the same warm-CLI **process-spawn** surface as S11-b. The +57.7% swing happened on a **no-code-change release-version-bump commit** (#622) — pure shared-runner jitter.

## Fix

Add `linuxOnlyGate: true` to **S11-a**, matching S1 / S11-b / S7. It is the **last gated spawn-dominated latency surface**:
- Spawn/latency surfaces (S1, S11-a, S11-b, S7) → Linux-only-gated.
- In-process surfaces (S2-a, S2-b) → still gated on every runner (deterministic, low-noise).

`gha-ubuntu` + `reference-m1air` still enforce the 1500 ms ceiling + 40% floor (real regression catch); on macOS/Windows the delta is shown in the PR comment but no longer gates.

## Verification
- 216 perf tests pass (extended `linuxOnlyGate` coverage {S1,S11-b} → {S1,S11-a,S11-b}).
- gateway `tsc --noEmit` clean, biome clean, `regen-slo.ts --check` clean (no SLO-doc drift).

This is a stop-gap completing #623. The principled fix (partition *all* spawn/latency surfaces to trend-not-gate) is the hybrid-perf-strategy design in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for surface configuration to include `S11-a` alongside existing surfaces in linux-only gating behavior validation.

* **Bug Fixes**
  * Updated performance thresholds for `S11-a` surface with linux-only gating configuration and latency jitter documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->