### PR TITLE
fix: add repository field to client, sdk, and root for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "nimbus",
   "version": "0.7.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nimbus-agent/Nimbus.git"
+  },
   "overrides": {
     "sharp": "0.34.5",
     "protobufjs": "7.5.8",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.1",
   "license": "MIT",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nimbus-agent/Nimbus.git",
+    "directory": "packages/client"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,6 +2,11 @@
   "name": "@nimbus-dev/sdk",
   "version": "1.1.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nimbus-agent/Nimbus.git",
+    "directory": "packages/sdk"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",


### PR DESCRIPTION
## Why

The `Publish @nimbus-dev/client` workflow has been failing — first on `EOTP` (npm 2FA, fixed via an automation/granular token), and on re-run with:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT .../@nimbus-dev%2fclient -
  Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match "https://github.com/nimbus-agent/Nimbus" from provenance
```

`npm publish --provenance` signs a sigstore attestation tying the tarball to the GitHub OIDC build source (`nimbus-agent/Nimbus`). The registry then cross-checks the tarball's `package.json#repository.url` against that source. The published `package.json` had **no `repository` field**, so the registry refused the upload with `E422`.

As a result, `@nimbus-dev/client` has **never** actually landed on npm (404 today) — every release attempt died before upload. `@nimbus-dev/sdk` would hit the identical failure on its first provenance publish.

## What

Add the `repository` field (with the monorepo `directory` pointer where applicable) to:

- `packages/client/package.json` — `fix(client):` → release-please cuts **0.2.2**; `client-v0.2.2` re-fires `publish-client.yml`.
- `packages/sdk/package.json` — `fix(sdk):` → cuts a fresh sdk patch ahead of its first provenance publish.
- root `package.json` — metadata consistency only (private, never published).

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/nimbus-agent/Nimbus.git",
  "directory": "packages/<pkg>"
}
```

## Follow-ups (not in this PR)

- `@nimbus-dev/client` depends on `@nimbus-dev/sdk` via `workspace:*`; `npm publish` rewrites that to a version range, so `@nimbus-dev/sdk` must also be on npm or `npm install @nimbus-dev/client` won't resolve. Publish sdk too.
- Migrate to npm Trusted Publishing (token-less OIDC) now that first versions will exist — the workflow already has `id-token: write` and a comment anticipating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata configuration across the client, SDK, and root package manifests to include the GitHub repository details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->