### PR TITLE
fix(sdk): point published entry points at dist so the package is usable

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,24 +8,31 @@
     "directory": "packages/sdk"
   },
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./testing": {
-      "import": "./src/testing/index.ts",
-      "types": "./src/testing/index.ts"
+      "bun": "./src/testing/index.ts",
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js",
+      "default": "./dist/testing/index.js"
     },
     "./ipc": {
-      "import": "./src/ipc/index.ts",
-      "types": "./src/ipc/index.ts"
+      "bun": "./src/ipc/index.ts",
+      "types": "./dist/ipc/index.d.ts",
+      "import": "./dist/ipc/index.js",
+      "default": "./dist/ipc/index.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "dev": "bun run --watch src/index.ts",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,11 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    // Prefer the "bun" export condition so in-repo TypeScript resolves workspace
+    // packages (notably @nimbus-dev/sdk) to their TS source rather than built dist,
+    // matching Bun's runtime resolution. Published npm consumers don't set this
+    // condition and fall through to the "types"/"default" (dist) targets.
+    "customConditions": ["bun"],
     "lib": ["ESNext"],
 
     "strict": true,


### PR DESCRIPTION
## Why

`@nimbus-dev/sdk` has **never** been published to npm (404 today), and as written its first publish would produce a **broken package**: `package.json` declared `main`/`types`/`exports` against `./src/index.ts`, but the tarball ships only `dist` (`files: ["dist"]`). So every entry point pointed at source that isn't in the package — `import "@nimbus-dev/sdk"` resolves to a missing file.

This is on the critical path for the client publish: `@nimbus-dev/client` depends on `@nimbus-dev/sdk` via `workspace:*` (npm rewrites to `^1.1.x` on publish), so `npm install @nimbus-dev/client` can't resolve until sdk is on npm — and sdk's ESM entry must actually work, since client's unbundled ESM `dist/index.js` imports sdk at runtime.

The entry points were aimed at `src` so that in-monorepo consumers (gateway + every connector) resolve sdk's TypeScript directly via Bun without a build step. The fix preserves that while making the *published* package correct.

## What

`packages/sdk/package.json`:
- `main`/`types`/`exports` → built `dist` (mirrors `@nimbus-dev/client`).
- Added a `"bun"` export condition → `src`, so Bun (in-repo **and** published Bun consumers) resolves the TS source directly.
- `files: ["dist", "src"]` so the `bun`-condition target ships in the tarball.

`tsconfig.base.json`:
- Added `customConditions: ["bun"]` so in-repo `tsc` also prefers the `bun`→`src` condition (no `dist` build needed for typecheck). Published npm consumers don't set this condition and fall through to `types`/`default` (dist).

Resolution matrix after this change:

| Consumer | Condition | Resolves to |
|---|---|---|
| In-repo Bun runtime / tsc | `bun` | `src/*.ts` (no build needed) |
| Published, Node/npm | `types` / `import` / `default` | `dist/*` |
| Published, Bun | `bun` | `src/*.ts` (now shipped) |

## Verification

- **Full sequential typecheck across all 99 packages passes with `packages/sdk/dist` removed** — proves in-repo `tsc` resolves sdk to `src` via the `bun` condition (the blast-radius check for the global `customConditions` change). Client imports both `@nimbus-dev/sdk` and `@nimbus-dev/sdk/ipc` and typechecks clean.
- sdk unit tests: 131 pass / 0 fail.
- Built `dist` confirmed to contain every `exports` target (`index`, `testing`, `ipc` — `.js` + `.d.ts`).
- biome clean on changed files.
- In-repo **runtime** behavior is unchanged: Bun already resolved sdk to `src` (via `import`), and still does (via the higher-priority `bun` condition).

## Sequencing

This rides into the open sdk release PR (release-please **#636**, `sdk 1.1.2`). Merge order to get both packages live:
1. Merge this PR.
2. Merge **#636** (`sdk 1.1.2`) → `publish-sdk.yml` publishes sdk with correct, usable entry points.
3. Merge **#634** (`client 0.2.2`) → client publishes and now resolves its sdk dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)