### PR TITLE
fix(ci): build @nimbus-dev/sdk before client in node-compat job

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -910,6 +910,18 @@ jobs:
           security unlock-keychain -p "" nimbus-ci.keychain
           security set-keychain-settings -lut 7200 nimbus-ci.keychain
 
+      # Build sdk's dist first: this job runs client's UNBUNDLED ESM build
+      # (tsc output) under real Node via tsx, so `@nimbus-dev/sdk/ipc` is
+      # resolved at runtime. Since #637 the sdk's `import`/`default` export
+      # conditions point at `dist` (Node doesn't honour the `bun`→`src`
+      # condition), so without sdk's dist present Node throws
+      # ERR_MODULE_NOT_FOUND for `@nimbus-dev/sdk/dist/ipc/index.js`. The
+      # client build does not build sdk, and this job has no other step that
+      # does — so build it explicitly. (Published npm consumers get sdk's
+      # dist from the registry; this CI job uses the workspace symlink.)
+      - name: Build @nimbus-dev/sdk
+        run: bun run --filter @nimbus-dev/sdk build
+
       - name: Build @nimbus-dev/client
         run: cd packages/client && bun run build
 


### PR DESCRIPTION
## Why

The **PR quality / Client node-compat** job (ubuntu/macOS/windows) is failing on `main`-based PRs (e.g. release PR #635) with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'…\packages\client\node_modules\@nimbus-dev\sdk\dist\ipc\index.js'
imported from …\packages\client\dist\ipc-transport.js
```

The `client-node-compat` job runs the client's **unbundled ESM** build (`tsc` output) under **real Node** (`node --import tsx/esm`), so `@nimbus-dev/sdk/ipc` is resolved at runtime.

**#637** repointed the sdk's `import`/`default` export conditions from `./src/*.ts` → `./dist/*.js`. Node does **not** honour the `bun`→`src` condition (only Bun does), so runtime resolution now lands on `packages/sdk/dist/ipc/index.js`. This job builds only the client (which doesn't build sdk) and has no other step that builds sdk → the file is absent → `ERR_MODULE_NOT_FOUND`.

- Worked before #637 because the `import` condition pointed at `src/ipc/index.ts`, which `tsx` strips at runtime (no sdk build needed).
- Passes locally only when `packages/sdk/dist` happens to already be built — exactly the trap called out in **#638**. #638 fixed only the **CJS** publish bundle (`--conditions=bun`), not this **ESM-under-Node** job.

## What

Add an explicit **Build @nimbus-dev/sdk** step before the client build in the `client-node-compat` job (`.github/workflows/_test-suite.yml`). Published npm consumers get sdk's `dist` from the registry; this CI job uses the workspace symlink, so it must build `dist` itself.

## Blast radius

Only `client-node-compat` runs the client ESM under Node. All other test jobs run under Bun (`bun` condition → `src`), so they're unaffected.

## Verification

Reproduced the **exact** CI error in a proper workspace checkout by removing `packages/sdk/dist` and importing the client ESM under `node --import tsx/esm`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '…\@nimbus-dev\sdk\dist\ipc\index.js' …
```

Then built sdk (what this step does) and re-ran → `IMPORT OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite workflow to ensure SDK build artifacts are available before running client node-compatibility tests, improving test reliability and preventing build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->