### PR TITLE
fix(ci): publish package managers after Release uploads assets (kill the asset-race)

### DIFF
--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -1,13 +1,24 @@
 name: Publish Linux repo
 
-# `released` (not `published`) fires only for non-prerelease releases, so
-# rc/beta/alpha tags are skipped automatically (the apt/yum channel tracks
-# stable only). `workflow_dispatch` lets a maintainer re-publish a tag if a
-# push failed transiently — re-running is safe (it republishes the same
-# inputs; signature timestamps mean a re-run lands a fresh commit, not a no-op).
+# Triggered by the Release workflow COMPLETING — not the `release: released`
+# event. release-please publishes the (empty) GitHub Release the instant the
+# release PR merges, which fires `released` ~18 min before release.yml finishes
+# building + attaching SHA256SUMS/.deb/.rpm. Keying off `released` therefore
+# always raced an asset-less release ("no assets to download"). `workflow_run`
+# fires only after release.yml has uploaded every asset.
+#
+# The job `if` gates on: the Release run SUCCEEDED, the ref is a `v*` tag (so
+# sdk-*/client-* releases — which never build installers and don't trigger
+# release.yml anyway — are doubly excluded), and the tag is NON-prerelease (no
+# `-`, matching the old "released only fires for stable" behavior).
+#
+# `workflow_dispatch` lets a maintainer re-publish a tag if a run failed
+# transiently — re-running is safe (it republishes the same inputs; signature
+# timestamps mean a re-run lands a fresh commit, not a no-op).
 on:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag_name:
@@ -16,7 +27,7 @@ on:
         type: string
 
 concurrency:
-  group: publish-linux-repo-${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+  group: publish-linux-repo-${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
   cancel-in-progress: false
 
 permissions:
@@ -27,6 +38,13 @@ jobs:
     name: Build + publish apt/yum repo
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    # Stable `v*` tags whose Release build succeeded (or a manual re-run). See the
+    # `on:` header for why this replaces the `release: released` trigger.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v') &&
+      !contains(github.event.workflow_run.head_branch, '-'))
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -36,6 +54,10 @@ jobs:
       - name: Checkout Nimbus
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # workflow_run defaults to the default branch; check out the released
+          # tag's tree instead (head_sha = the commit release.yml built from).
+          # Manual dispatch falls back to the tag input.
+          ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.tag_name }}
           persist-credentials: false
 
       - name: Setup Bun and install dependencies
@@ -72,7 +94,7 @@ jobs:
       - name: Download released .deb + .rpm + SHA256SUMS
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           mkdir -p out
@@ -85,7 +107,7 @@ jobs:
       - name: Resolve + verify artifact checksums
         id: art
         env:
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
@@ -126,7 +148,7 @@ jobs:
 
       - name: Build the apt repo (reprepro) + the yum repo (createrepo_c)
         env:
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
@@ -170,7 +192,7 @@ jobs:
       - name: Commit + push to linux-repo
         env:
           GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           cd repo

--- a/.github/workflows/publish-package-managers.yml
+++ b/.github/workflows/publish-package-managers.yml
@@ -1,12 +1,23 @@
 name: Publish package managers
 
-# `released` (not `published`) fires only for non-prerelease releases, so
-# rc/beta/alpha tags are skipped automatically (channels track stable only).
-# `workflow_dispatch` lets a maintainer re-run a publish by tag if the push failed
+# Triggered by the Release workflow COMPLETING — not the `release: released`
+# event. release-please publishes the (empty) GitHub Release the instant the
+# release PR merges, which fires `released` ~18 min before release.yml finishes
+# building + attaching SHA256SUMS/.msi/binaries. Keying off `released` therefore
+# always raced an asset-less release ("no assets to download"). `workflow_run`
+# fires only after release.yml has uploaded every asset.
+#
+# Each job's `if` gates on: the Release run SUCCEEDED, the ref is a `v*` tag (so
+# sdk-*/client-* releases — which never build installers and don't trigger
+# release.yml anyway — are doubly excluded), and the tag is NON-prerelease (no
+# `-`, matching the old "released only fires for stable" behavior).
+#
+# `workflow_dispatch` lets a maintainer re-run a publish by tag if a run failed
 # transiently (GitHub outage, expired PAT) — re-running is idempotent (no-op if unchanged).
 on:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag_name:
@@ -15,7 +26,7 @@ on:
         type: string
 
 concurrency:
-  group: publish-pkgmgr-${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+  group: publish-pkgmgr-${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
   cancel-in-progress: false
 
 permissions:
@@ -26,6 +37,13 @@ jobs:
     name: Generate + publish brew/scoop manifests
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    # Stable `v*` tags whose Release build succeeded (or a manual re-run). See the
+    # `on:` header for why this replaces the `release: released` trigger.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v') &&
+      !contains(github.event.workflow_run.head_branch, '-'))
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -35,6 +53,10 @@ jobs:
       - name: Checkout Nimbus
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # workflow_run defaults to the default branch; check out the released
+          # tag's tree instead (head_sha = the commit release.yml built from).
+          # Manual dispatch falls back to the tag input.
+          ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.tag_name }}
           persist-credentials: false
 
       - name: Setup Bun and install dependencies
@@ -59,7 +81,7 @@ jobs:
       - name: Download SHA256SUMS from the release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           mkdir -p out
@@ -67,7 +89,7 @@ jobs:
 
       - name: Generate manifests
         env:
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
@@ -82,7 +104,7 @@ jobs:
       - name: Publish to homebrew-tap
         env:
           GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/nimbus-agent/homebrew-tap.git" tap
@@ -102,7 +124,7 @@ jobs:
       - name: Publish to scoop-bucket
         env:
           GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/nimbus-agent/scoop-bucket.git" bucket
@@ -122,11 +144,22 @@ jobs:
     name: Submit winget manifest PR
     runs-on: windows-latest
     timeout-minutes: 20
+    # Stable `v*` tags whose Release build succeeded (or a manual re-run). See the
+    # `on:` header for why this replaces the `release: released` trigger.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v') &&
+      !contains(github.event.workflow_run.head_branch, '-'))
     # No step-security/harden-runner here: it supports Linux runners only.
     steps:
       - name: Checkout Nimbus
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # workflow_run defaults to the default branch; check out the released
+          # tag's tree instead (head_sha = the commit release.yml built from).
+          # Manual dispatch falls back to the tag input.
+          ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.tag_name }}
           persist-credentials: false
 
       - name: Setup Bun and install dependencies
@@ -152,7 +185,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           New-Item -ItemType Directory -Force -Path out | Out-Null
           gh release download "$env:TAG" --repo "$env:GITHUB_REPOSITORY" `
@@ -163,7 +196,7 @@ jobs:
         id: msi
         shell: pwsh
         env:
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           $version = $env:TAG -replace '^v',''
           bun scripts/release/winget-manifest.ts `
@@ -200,7 +233,7 @@ jobs:
         shell: pwsh
         env:
           WINGET_PAT: ${{ secrets.WINGET_PAT }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           $version = $env:TAG -replace '^v',''
           $url = "${{ steps.msi.outputs.url }}"


### PR DESCRIPTION
## Problem

The `Publish package managers` (brew/scoop + winget) and `Publish Linux repo` (apt/yum) workflows trigger on `release: [released]`. release-please publishes the **(empty)** GitHub Release the instant the release PR merges, which fires `released` **~18 min before** `release.yml` finishes building and attaching `SHA256SUMS` / `.deb` / `.rpm` / `.msi` / binaries.

So the publish jobs always raced an asset-less release and died:

```
gh release download v0.9.1 ... → "no assets to download" → exit 1
```

This has reddened these two jobs on **every release since v0.7.0** (v0.7.0, v0.8.0, v0.9.0, v0.9.1, plus sdk-*/client-* tags that have no installers at all). The assets *do* land eventually (v0.9.0 has 33), but the publish jobs already failed and don't auto-retry.

Root-cause runs: [27631725421](https://github.com/nimbus-agent/Nimbus/actions/runs/27631725421) · [27631724623](https://github.com/nimbus-agent/Nimbus/actions/runs/27631724623).

## Fix

Re-trigger the publish workflows via **`workflow_run` on the `Release` workflow completing**, so assets are guaranteed present before `gh release download` runs.

Each job's `if` gates on:
- `conclusion == 'success'` — never publish off a failed build
- `startsWith(head_branch, 'v')` — installer-bearing app releases only (sdk-*/client-* don't trigger `release.yml` anyway → doubly excluded)
- `!contains(head_branch, '-')` — non-prerelease only, preserving the old "`released` fires only for stable" semantics

Side benefit: prerelease/failed Release runs now yield **skipped** (neutral) jobs instead of red, so the chronic red in the run list stops.

### Details
- Tag plumbing: `github.event.release.tag_name` → `github.event.workflow_run.head_branch` throughout; the `workflow_dispatch` tag-input path is unchanged for manual re-runs.
- Checkout pins `ref: head_sha` (workflow_run otherwise defaults to the default branch) so helper scripts come from the released tag's tree — matching the prior `release:`-event behavior.

## Follow-up (not in this PR)
- **v0.9.1 still needs a one-time manual publish** once its in-flight Release build attaches assets — `workflow_run` only engages for releases *after* this merges to main:
  ```
  gh workflow run publish-package-managers.yml -f tag_name=v0.9.1
  gh workflow run publish-linux-repo.yml      -f tag_name=v0.9.1
  ```

## Validation
- Both workflows parse cleanly; no stray `github.event.release` references remain.
- Pure CI-workflow change — no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing workflows to improve deployment reliability and consistency across Linux package repositories and package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->