### PR TITLE
feat(perf): wire up the sustained-drift detector (daily _perf-drift.yml)

### DIFF
--- a/.github/workflows/_perf-drift.yml
+++ b/.github/workflows/_perf-drift.yml
@@ -1,0 +1,69 @@
+name: Performance Drift Check
+
+# Daily sustained-drift watch over recent `main` perf history. Downloads the last
+# 14 gha-ubuntu run-history artifacts, runs the rolling-median detector, and files
+# ONE `perf-drift` issue per sustained-regressing trend surface (create-only: an
+# already-open issue is left untouched — no daily re-comment). Advisory: it never
+# gates a build.
+#
+# Triggers:
+#   - schedule (06:00 UTC daily) — ~2h after _perf.yml's 04:00 bench crons so the
+#     latest artifact exists. GitHub runs `schedule` only on this repo's default
+#     branch, never for forks/fork PRs, so the `issues: write` grant is
+#     non-fork-triggered by construction.
+#   - workflow_dispatch — manual smoke test from the Actions UI.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+# Default-deny baseline (Scorecard Token-Permissions); the job grants only what
+# it uses (per-job, mirroring _perf.yml).
+permissions: {}
+
+jobs:
+  drift-check:
+    name: Perf sustained-drift check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read # checkout
+      actions: read # gh run list + gh run download (perf artifacts)
+      issues: write # gh label create + gh issue list/create (perf-drift)
+    concurrency:
+      group: perf-drift
+      cancel-in-progress: false
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-nimbus-ci
+
+      - name: Ensure perf-drift label exists
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # `gh issue create --label` FAILS on a missing label (it does not
+          # auto-create); --force makes this idempotent (create or update).
+          gh label create perf-drift \
+            --color B60205 \
+            --description "Sustained performance drift detected on a trend surface" \
+            --force
+
+      - name: Run drift check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIMBUS_PERF_RUNNER: gha-ubuntu
+        run: bun scripts/perf/drift-check.ts

--- a/docs/superpowers/plans/2026-06-16-perf-drift-wiring-review.md
+++ b/docs/superpowers/plans/2026-06-16-perf-drift-wiring-review.md
@@ -1,0 +1,47 @@
+# Review & Suggestions — Perf Drift-Check Wiring Implementation Plan
+
+**Reviewer:** AI Coding Assistant (Antigravity)  
+**Date:** 2026-06-16  
+**Target Plan:** `2026-06-16-perf-drift-wiring.md`
+
+This document details feedback, verification points, and small improvements for the Perf Drift-Check Wiring Implementation Plan.
+
+---
+
+## 1. Plan Verification & Edge Cases
+
+### A. Retention of `GhIssue` Definition in `drift-check.ts`
+
+* **Observation**: In Task 5 (Step 3), the plan notes to "delete `ghSpawn` + `ghIssueList`" and rewrite `upsertDriftIssue` to accept `existingIssues: GhIssue[]`.
+* **Suggestion**: The plan does not explicitly mention keeping the `GhIssue` interface definition in `drift-check.ts`. To avoid a compiler error, ensure the step retains:
+
+  ```ts
+  interface GhIssue {
+    number: number;
+    title: string;
+  }
+  ```
+
+  or imports/aliases the type returned by `GhCli.issueList`. Keeping it as a local interface in `drift-check.ts` is the simplest path.
+
+### B. Inconsistency in `DRIFT_NOISE_FLOOR_PCT`
+
+* **Observation**: The Design Spec (§2) lists `DRIFT_NOISE_FLOOR_PCT=20`, whereas the Implementation Plan (Task 5 / Notes) specifies `DRIFT_NOISE_FLOOR_PCT=10`.
+* **Verification**: The codebase currently defines `const DRIFT_NOISE_FLOOR_PCT = 10;`. The implementation plan correctly notes that thresholds are "untouched" and should stay at `10%` to match existing behavior. We should proceed with `10%` as outlined in the plan.
+
+### C. Mock Spawn Return in `fakeGh` Test helper
+
+* **Observation**: In Task 5 (Step 1), the `fakeGh` test helper mocks the `GhSpawnFn` by returning `{ exitCode: 0, stdout: "", stderr: "" }` for artifact download.
+* **Impact**: This is highly correct. Since `GhCli` internally wraps `Bun.spawn` via its constructor `spawn` option, returning exit code `0` causes the high-level `GhCli.runDownloadArtifact` method to resolve to `true`, which perfectly validates the file-creation flow on the filesystem.
+
+---
+
+## 2. Strengths of the Plan
+
+### A. Idempotent Label Creation
+
+* **Impact**: The inclusion of `gh label create perf-drift --force` in `.github/workflows/_perf-drift.yml` is an excellent design choice. It solves the missing-label issue idempotently, ensuring the GHA run never crashes if the label is absent, without needing manual setup in repository settings.
+
+### B. Prevention of Comment Spam
+
+* **Impact**: Transitioning the upsert logic to a create-only behavior (`if (existingIssues.some(...)) return`) prevents GitHub issue notification noise entirely. This ensures the daily cron job only acts when a new regression is identified, without clogging existing open issues with repeated comments.

--- a/docs/superpowers/plans/2026-06-16-perf-drift-wiring.md
+++ b/docs/superpowers/plans/2026-06-16-perf-drift-wiring.md
@@ -559,7 +559,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { parseLastHistoryLine } from "./history-jsonl.ts";
 ```
 
-(c) Delete the local `ghSpawn` function and the local `ghIssueList` function entirely (both are replaced by `GhCli` methods).
+(c) Delete the local `ghSpawn` function and the local `ghIssueList` function entirely (both are replaced by `GhCli` methods). **Keep the `GhIssue` interface** (`interface GhIssue { number: number; title: string }`) — it sits right above those functions but is still used by `upsertDriftIssue` and `runDriftCheckMain`, so deleting it would break the compile.
 
 (d) Replace the exported `parseHistoryLines` function:
 

--- a/docs/superpowers/plans/2026-06-16-perf-drift-wiring.md
+++ b/docs/superpowers/plans/2026-06-16-perf-drift-wiring.md
@@ -1,0 +1,917 @@
+# Perf Drift-Check Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activate the dormant sustained-drift detector — a daily `_perf-drift.yml` runs `drift-check.ts` over recent `main` perf history and files one `perf-drift` GitHub issue per sustained-regressing trend surface — while clearing the four #642-deferred refactors so the unattended issue-filing path is fully tested before it goes live.
+
+**Architecture:** Four small units. A shared `parseLastHistoryLine` (extracted from `emit-benchmark-json.ts`); two new injectable `GhCli` issue methods (`issueList`/`issueCreate`); a `drift-check.ts` refactor (reuse `medianOf`, route `gh` through `GhCli`, switch to one-sample-per-run parsing, make the upsert **create-only** to kill daily-comment spam); and a new daily scheduled workflow that ensures the label exists then runs the script.
+
+**Tech Stack:** Bun + TypeScript (strict), `bun:test`, GitHub Actions, `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `scripts/perf/history-jsonl.ts` | Create | Shared `parseLastHistoryLine(text)` — last non-blank JSONL line → `HistoryLine` |
+| `scripts/perf/history-jsonl.test.ts` | Create | Unit tests for the shared parser |
+| `scripts/perf/emit-benchmark-json.ts` | Modify | Import the shared parser; delete its private copy |
+| `packages/gateway/src/perf/bench-ci-gh.ts` | Modify | Add `issueList` + `issueCreate` to `GhCli` |
+| `packages/gateway/src/perf/bench-ci-gh.test.ts` | Modify | Tests for the two new methods |
+| `scripts/perf/drift-check.ts` | Modify | `medianOf` reuse; `GhCli` issue ops; one-sample-per-run; create-only upsert |
+| `scripts/perf/drift-check.test.ts` | Modify | Migrate `parseHistoryLines` tests → `parseLatestV2Line`; add `runDriftCheckMain` wrapper tests |
+| `.github/workflows/_perf-drift.yml` | Create | Daily scheduled workflow: ensure label → run drift-check |
+
+**Single PR.** No schema migration, no new security invariant.
+
+**Branch note:** this branch (`dev/asafgolombek/perf-drift-wiring`) is stacked on the Biome-2.5.0/ovsx fix branch (PR #656). After #656 merges, rebase onto `main`; the two duplicate fix commits drop out cleanly.
+
+---
+
+### Task 1: Shared `parseLastHistoryLine` helper
+
+**Files:**
+
+- Create: `scripts/perf/history-jsonl.ts`
+- Create: `scripts/perf/history-jsonl.test.ts`
+
+The identical "last non-blank line of a `run-history.jsonl` → `HistoryLine`" parse is duplicated (private in `emit-benchmark-json.ts`, and drift-check reads all lines). Extract one shared thin parser. Behavior matches the existing `emit-benchmark-json.ts` copy exactly (throws on empty input).
+
+- [ ] **Step 1: Write the failing test.** Create `scripts/perf/history-jsonl.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import type { HistoryLine } from "../../packages/gateway/src/perf/history-line.ts";
+import { parseLastHistoryLine } from "./history-jsonl.ts";
+
+function v2(p95: number): string {
+  const line: HistoryLine = {
+    schema_version: 2,
+    run_id: "r",
+    timestamp: "2026-06-16T00:00:00Z",
+    runner: "gha-ubuntu",
+    os_version: "ubuntu-24.04",
+    nimbus_git_sha: "abc",
+    bun_version: "1.3.14",
+    surfaces: { S1: { samples_count: 301, p95_ms: p95 } },
+  };
+  return JSON.stringify(line);
+}
+
+describe("parseLastHistoryLine", () => {
+  test("returns the only line", () => {
+    const out = parseLastHistoryLine(`${v2(100)}\n`);
+    expect(out.surfaces["S1"]?.p95_ms).toBe(100);
+  });
+
+  test("returns the LAST of several lines", () => {
+    const out = parseLastHistoryLine(`${v2(100)}\n${v2(200)}\n${v2(300)}\n`);
+    expect(out.surfaces["S1"]?.p95_ms).toBe(300);
+  });
+
+  test("tolerates trailing blank lines / whitespace", () => {
+    const out = parseLastHistoryLine(`${v2(100)}\n${v2(250)}\n\n   \n`);
+    expect(out.surfaces["S1"]?.p95_ms).toBe(250);
+  });
+
+  test("throws on empty input", () => {
+    expect(() => parseLastHistoryLine("   \n\n")).toThrow("run-history.jsonl is empty");
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/history-jsonl.test.ts`. Expected: `error: Cannot find module './history-jsonl.ts'` — the implementation does not exist yet.
+
+- [ ] **Step 3: Implement.** Create `scripts/perf/history-jsonl.ts`:
+
+```ts
+import type { HistoryLine } from "../../packages/gateway/src/perf/history-line.ts";
+
+/**
+ * Parse the last non-blank line of a `run-history.jsonl` text blob into a
+ * HistoryLine. Each perf run writes a fresh single-run history file, so the
+ * last line is that run's result. Throws on empty input. Callers that need a
+ * schema-version guard apply it to the returned line.
+ */
+export function parseLastHistoryLine(text: string): HistoryLine {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  const last = lines.at(-1);
+  if (last === undefined) {
+    throw new Error("run-history.jsonl is empty");
+  }
+  return JSON.parse(last) as HistoryLine;
+}
+```
+
+- [ ] **Step 4: Run it, expect PASS.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/history-jsonl.test.ts`. Expected: `4 pass, 0 fail`.
+
+- [ ] **Step 5: Typecheck + lint.** Commands: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring/packages/gateway" && bun run typecheck` (expected: no errors) and `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bunx biome check scripts/perf/history-jsonl.ts scripts/perf/history-jsonl.test.ts` (expected: no diagnostics).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring"
+git add scripts/perf/history-jsonl.ts scripts/perf/history-jsonl.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(perf): extract shared parseLastHistoryLine helper
+
+One thin last-non-blank-JSONL-line parser, to be shared by
+emit-benchmark-json.ts and drift-check.ts (next two tasks). Behavior is
+identical to emit's previous private copy: throws on empty input.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Point `emit-benchmark-json.ts` at the shared parser
+
+**Files:**
+
+- Modify `scripts/perf/emit-benchmark-json.ts` (delete the private `parseLastHistoryLine`, import the shared one)
+- Test: `scripts/perf/emit-benchmark-json.test.ts` (unchanged — it exercises `runEmitBenchmarkJsonMain`, which must stay green)
+
+- [ ] **Step 1: Confirm the current tests pass (baseline).** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/emit-benchmark-json.test.ts`. Expected: all pass (establishes the green baseline before the refactor).
+
+- [ ] **Step 2: Delete the private copy and import the shared one.** In `scripts/perf/emit-benchmark-json.ts`, remove the local function:
+
+```ts
+function parseLastHistoryLine(text: string): HistoryLine {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  const last = lines.at(-1);
+  if (last === undefined) {
+    throw new Error("run-history.jsonl is empty");
+  }
+  return JSON.parse(last) as HistoryLine;
+}
+```
+
+Then add the import alongside the existing imports at the top of the file (after the existing `import type { HistoryLine, ... }` line):
+
+```ts
+import { parseLastHistoryLine } from "./history-jsonl.ts";
+```
+
+The call site in `runEmitBenchmarkJsonMain` (`const line = parseLastHistoryLine(text);`) is unchanged.
+
+- [ ] **Step 3: Run the tests, expect PASS.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/emit-benchmark-json.test.ts`. Expected: all pass (same count as Step 1 — behavior is unchanged; the empty-input `runEmitBenchmarkJsonMain` error-path test still hits the shared parser's throw).
+
+- [ ] **Step 4: Typecheck + lint.** Commands: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring/packages/gateway" && bun run typecheck` (expected: no errors) and `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bunx biome check scripts/perf/emit-benchmark-json.ts` (expected: no diagnostics; in particular confirm `HistoryLine` is still imported as a type — it is still used by `toBenchmarkPoints`).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring"
+git add scripts/perf/emit-benchmark-json.ts
+git commit -m "$(cat <<'EOF'
+refactor(perf): emit-benchmark-json uses shared parseLastHistoryLine
+
+Drop the private copy in favour of the shared scripts/perf/history-jsonl.ts
+helper. No behavior change; runEmitBenchmarkJsonMain tests stay green.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add `issueList` + `issueCreate` to `GhCli`
+
+**Files:**
+
+- Modify `packages/gateway/src/perf/bench-ci-gh.ts` (add two methods after `prCommentEdit`, before the closing `}` of the class)
+- Test: `packages/gateway/src/perf/bench-ci-gh.test.ts` (append tests inside the existing `describe("GhCli", ...)` block)
+
+These mirror the existing `prComment*` methods: routed through the retry-wrapped `#run`, body via `--body-file`, list parsed with the existing `parseJsonObjectArray`. `bench-ci-gh.ts` is coverage-floor-gated (≥80% line+branch), so both methods get direct unit tests.
+
+- [ ] **Step 1: Write the failing tests.** Append inside the existing `describe("GhCli", () => { ... })` block in `packages/gateway/src/perf/bench-ci-gh.test.ts` (before its closing `});`):
+
+```ts
+  test("issueList: parses number+title array and passes the open+label+json args", async () => {
+    const { spawn, calls } = makeFakeRunner([
+      {
+        exitCode: 0,
+        stdout: '[{"number":12,"title":"perf drift A"},{"number":9,"title":"perf drift B"}]\n',
+        stderr: "",
+      },
+    ]);
+    const gh = new GhCli({ spawn });
+    const out = await gh.issueList({ label: "perf-drift" });
+    expect(out).toEqual([
+      { number: 12, title: "perf drift A" },
+      { number: 9, title: "perf drift B" },
+    ]);
+    expect(calls[0]?.args).toEqual([
+      "issue",
+      "list",
+      "--state",
+      "open",
+      "--label",
+      "perf-drift",
+      "--json",
+      "number,title",
+    ]);
+  });
+
+  test("issueList: empty stdout → empty array", async () => {
+    const { spawn } = makeFakeRunner([{ exitCode: 0, stdout: "\n", stderr: "" }]);
+    const gh = new GhCli({ spawn });
+    expect(await gh.issueList({ label: "perf-drift" })).toEqual([]);
+  });
+
+  test("issueList: non-array JSON → empty array (no throw)", async () => {
+    const { spawn } = makeFakeRunner([{ exitCode: 0, stdout: '{"oops":true}\n', stderr: "" }]);
+    const gh = new GhCli({ spawn });
+    expect(await gh.issueList({ label: "perf-drift" })).toEqual([]);
+  });
+
+  test("issueCreate: passes title, label, and --body-file", async () => {
+    const { spawn, calls } = makeFakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    const gh = new GhCli({ spawn });
+    await gh.issueCreate({ title: "perf drift on S1", label: "perf-drift", bodyFile: "/tmp/b.md" });
+    expect(calls[0]?.args).toEqual([
+      "issue",
+      "create",
+      "--title",
+      "perf drift on S1",
+      "--label",
+      "perf-drift",
+      "--body-file",
+      "/tmp/b.md",
+    ]);
+  });
+```
+
+- [ ] **Step 2: Run, expect FAIL.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring/packages/gateway" && bun test src/perf/bench-ci-gh.test.ts`. Expected: TypeScript error `Property 'issueList' does not exist on type 'GhCli'` (and `issueCreate`), so the four new tests fail to compile.
+
+- [ ] **Step 3: Implement the methods.** In `packages/gateway/src/perf/bench-ci-gh.ts`, add these two methods inside the `GhCli` class, immediately after `prCommentEdit` (before the class's closing `}`):
+
+```ts
+  async issueList(args: { label: string }): Promise<{ number: number; title: string }[]> {
+    const r = await this.#run([
+      "issue",
+      "list",
+      "--state",
+      "open",
+      "--label",
+      args.label,
+      "--json",
+      "number,title",
+    ]);
+    const out = r.stdout.trim();
+    if (out === "") return [];
+    return parseJsonObjectArray(
+      out,
+      (rec) => typeof rec["number"] === "number" && typeof rec["title"] === "string",
+      (rec) => ({ number: rec["number"] as number, title: rec["title"] as string }),
+    );
+  }
+
+  async issueCreate(args: { title: string; label: string; bodyFile: string }): Promise<void> {
+    await this.#run([
+      "issue",
+      "create",
+      "--title",
+      args.title,
+      "--label",
+      args.label,
+      "--body-file",
+      args.bodyFile,
+    ]);
+  }
+```
+
+- [ ] **Step 4: Run, expect PASS.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring/packages/gateway" && bun test src/perf/bench-ci-gh.test.ts`. Expected: all GhCli tests pass (the four new + all pre-existing). `0 fail`.
+
+- [ ] **Step 5: Typecheck + lint.** Commands: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring/packages/gateway" && bun run typecheck` (expected: no errors) and `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bunx biome check packages/gateway/src/perf/bench-ci-gh.ts packages/gateway/src/perf/bench-ci-gh.test.ts` (expected: no diagnostics).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring"
+git add packages/gateway/src/perf/bench-ci-gh.ts packages/gateway/src/perf/bench-ci-gh.test.ts
+git commit -m "$(cat <<'EOF'
+feat(perf): add GhCli.issueList + issueCreate (injectable, retry-wrapped)
+
+Mirror the prComment* methods: routed through #run (retry/backoff) with the
+spawn injection seam, body via --body-file, list parsed by parseJsonObjectArray.
+Lets drift-check route its gh issue ops through the injectable GhCli (next task)
+instead of an ad-hoc ghSpawn, so the upsert path becomes unit-testable.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: drift-check — replace `rollingMedian` with `medianOf`
+
+**Files:**
+
+- Modify `scripts/perf/drift-check.ts` (add the `medianOf` import; inline it in `detectDrift`; delete the local `rollingMedian`)
+- Test: `scripts/perf/drift-check.test.ts` (the existing `describe("detectDrift", ...)` block must stay green — no edits)
+
+`medianOf` (`baseline-median.ts`) is the byte-for-byte same median algorithm but throws on empty input; `rollingMedian` returned `0`. `detectDrift` only ever passes a fixed-size `k`-element window, so an empty window never occurs — the guard is defensive and preserves the contract.
+
+- [ ] **Step 1: Confirm `detectDrift` tests pass (baseline).** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/drift-check.test.ts -t detectDrift`. Expected: the 7 `detectDrift` tests pass (green baseline before the swap).
+
+- [ ] **Step 2: Add the import.** In `scripts/perf/drift-check.ts`, add to the import group (after the existing `import { SLO_THRESHOLDS } ...` line):
+
+```ts
+import { medianOf } from "../../packages/gateway/src/perf/baseline-median.ts";
+```
+
+- [ ] **Step 3: Inline `medianOf` in `detectDrift` and delete `rollingMedian`.** In `detectDrift`, change the line:
+
+```ts
+    const med = rollingMedian(window);
+```
+
+to:
+
+```ts
+    const med = window.length === 0 ? 0 : medianOf(window);
+```
+
+Then delete the now-unused local function entirely:
+
+```ts
+function rollingMedian(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length === 0) return 0;
+  if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+  const lo = sorted[mid - 1] ?? 0;
+  const hi = sorted[mid] ?? 0;
+  return (lo + hi) / 2;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/drift-check.test.ts`. Expected: all tests still pass (the `detectDrift` block is behavior-identical; `parseHistoryLines` / `isRunnerKind` blocks untouched). `0 fail`.
+
+- [ ] **Step 5: Typecheck + lint.** Commands: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring/packages/gateway" && bun run typecheck` (expected: no errors) and `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bunx biome check scripts/perf/drift-check.ts` (expected: no diagnostics — in particular, no "unused function `rollingMedian`").
+
+- [ ] **Step 6: Commit.**
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring"
+git add scripts/perf/drift-check.ts
+git commit -m "$(cat <<'EOF'
+refactor(perf): drift-check reuses medianOf instead of local rollingMedian
+
+medianOf (baseline-median.ts) is the same median algorithm. detectDrift only
+ever passes a fixed-size k-element window, so the empty->0 guard is defensive;
+the existing detectDrift unit tests stay green.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: drift-check — one-sample-per-run + create-only upsert via `GhCli`
+
+**Files:**
+
+- Modify `scripts/perf/drift-check.ts` (replace `parseHistoryLines` with `parseLatestV2Line`; rewrite `upsertDriftIssue` + `runDriftCheckMain`; delete `ghSpawn` + `ghIssueList`)
+- Test: `scripts/perf/drift-check.test.ts` (migrate the `parseHistoryLines` describe → `parseLatestV2Line`; add a `runDriftCheckMain` describe)
+
+This is the core wiring change. After it, drift-check depends only on the injectable `GhCli`, reads exactly one sample per run, and never re-comments on an already-open issue.
+
+- [ ] **Step 1: Write the failing tests.** Edit `scripts/perf/drift-check.test.ts`.
+
+First, update the imports. Change the `./drift-check.ts` import line:
+
+```ts
+import { detectDrift, isRunnerKind, parseHistoryLines } from "./drift-check.ts";
+```
+
+to:
+
+```ts
+import {
+  detectDrift,
+  isRunnerKind,
+  parseLatestV2Line,
+  runDriftCheckMain,
+} from "./drift-check.ts";
+```
+
+Change the existing `node:path` import line `import { join } from "node:path";` to add `basename` (merge — do not add a second `node:path` line):
+
+```ts
+import { basename, join } from "node:path";
+```
+
+And add the `GhCli` import (the existing `node:fs` line already imports `mkdtempSync` + `writeFileSync`, which is all the new tests need — no `mkdirSync`, since `runDriftCheckMain` creates the per-run dir before the fake `gh` writes into it):
+
+```ts
+import { GhCli, type GhSpawnFn } from "../../packages/gateway/src/perf/bench-ci-gh.ts";
+```
+
+Replace the entire existing `describe("parseHistoryLines", () => { ... });` block with this migrated block (one line per run; returns the line or `null`):
+
+```ts
+describe("parseLatestV2Line", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "drift-parse-"));
+  function writeFile(contents: string): string {
+    const p = join(tmp, `h-${Math.random().toString(36).slice(2)}.jsonl`);
+    writeFileSync(p, contents, "utf8");
+    return p;
+  }
+  function v2(p95: number): string {
+    return JSON.stringify({
+      schema_version: 2,
+      run_id: "r",
+      timestamp: "2026-06-16T00:00:00Z",
+      runner: "gha-ubuntu",
+      os_version: "ubuntu-24.04",
+      nimbus_git_sha: "abc",
+      bun_version: "1.3.14",
+      surfaces: { S1: { samples_count: 301, p95_ms: p95 } },
+    });
+  }
+  const v1 = JSON.stringify({ schema_version: 1, surfaces: { S1: { samples_count: 1, p95_ms: 1 } } });
+
+  test("returns null when the file is unreadable", () => {
+    expect(parseLatestV2Line(join(tmpdir(), "definitely-missing-drift.jsonl"))).toBeNull();
+  });
+
+  test("returns the last v2 line", () => {
+    const line = parseLatestV2Line(writeFile(`${v2(100)}\n${v2(250)}\n`));
+    expect(line?.surfaces["S1"]?.p95_ms).toBe(250);
+  });
+
+  test("returns null when the last line is schema_version 1 (non-comparable)", () => {
+    expect(parseLatestV2Line(writeFile(`${v2(100)}\n${v1}\n`))).toBeNull();
+  });
+
+  test("returns null when the last line is malformed JSON", () => {
+    expect(parseLatestV2Line(writeFile(`${v2(100)}\n{not json\n`))).toBeNull();
+  });
+
+  test("returns null on an empty file", () => {
+    expect(parseLatestV2Line(writeFile("\n  \n"))).toBeNull();
+  });
+});
+
+describe("runDriftCheckMain", () => {
+  // 14 runs, oldest-first sha-0..sha-13. The newest 3 (>=11) regress to 130 over
+  // a stable 100 baseline → a sustained drift on S1 (and only S1).
+  const shas = Array.from({ length: 14 }, (_, i) => `sha-${i}`);
+  const driftValue = (sha: string): number => (Number(sha.slice(4)) >= 11 ? 130 : 100);
+
+  function v2Line(p95: number): string {
+    return JSON.stringify({
+      schema_version: 2,
+      run_id: "r",
+      timestamp: "2026-06-16T00:00:00Z",
+      runner: "gha-ubuntu",
+      os_version: "ubuntu-24.04",
+      nimbus_git_sha: "abc",
+      bun_version: "1.3.14",
+      surfaces: { S1: { samples_count: 301, p95_ms: p95 } },
+    });
+  }
+
+  function fakeGh(opts: {
+    valueForSha: (sha: string) => number;
+    existingIssues: { number: number; title: string }[];
+    calls: string[][];
+  }): GhCli {
+    const spawn: GhSpawnFn = async (args) => {
+      const a = [...args];
+      opts.calls.push(a);
+      if (a[0] === "run" && a[1] === "list") {
+        const newestFirst = [...shas]
+          .reverse()
+          .map((sha, i) => ({ databaseId: 1000 + i, headSha: sha }));
+        return { exitCode: 0, stdout: `${JSON.stringify(newestFirst)}\n`, stderr: "" };
+      }
+      if (a[0] === "run" && a[1] === "download") {
+        const dir = a[a.indexOf("--dir") + 1] as string;
+        const sha = basename(dir);
+        writeFileSync(join(dir, "run-history.jsonl"), `${v2Line(opts.valueForSha(sha))}\n`, "utf8");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (a[0] === "issue" && a[1] === "list") {
+        return { exitCode: 0, stdout: `${JSON.stringify(opts.existingIssues)}\n`, stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    return new GhCli({ spawn, sleep: async () => {} });
+  }
+
+  test("files exactly one issue for a sustained-drifting surface with no open issue", async () => {
+    const calls: string[][] = [];
+    const gh = fakeGh({ valueForSha: driftValue, existingIssues: [], calls });
+    const tmpDir = mkdtempSync(join(tmpdir(), "drift-wrap-"));
+    await runDriftCheckMain({ gh, runner: "gha-ubuntu", tmpDir, stderr: () => {} });
+    const creates = calls.filter((c) => c[0] === "issue" && c[1] === "create");
+    expect(creates).toHaveLength(1);
+    expect(creates[0]).toContain("perf: sustained drift detected on S1 (gha-ubuntu)");
+  });
+
+  test("does NOT create when an open issue already exists (create-only)", async () => {
+    const calls: string[][] = [];
+    const gh = fakeGh({
+      valueForSha: driftValue,
+      existingIssues: [{ number: 7, title: "perf: sustained drift detected on S1 (gha-ubuntu)" }],
+      calls,
+    });
+    const tmpDir = mkdtempSync(join(tmpdir(), "drift-wrap-"));
+    await runDriftCheckMain({ gh, runner: "gha-ubuntu", tmpDir, stderr: () => {} });
+    expect(calls.filter((c) => c[0] === "issue" && c[1] === "create")).toHaveLength(0);
+  });
+
+  test("a flat (non-drifting) series files nothing and never lists issues", async () => {
+    const calls: string[][] = [];
+    const gh = fakeGh({ valueForSha: () => 100, existingIssues: [], calls });
+    const tmpDir = mkdtempSync(join(tmpdir(), "drift-wrap-"));
+    await runDriftCheckMain({ gh, runner: "gha-ubuntu", tmpDir, stderr: () => {} });
+    expect(calls.filter((c) => c[0] === "issue")).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/drift-check.test.ts`. Expected: compile/resolve failure — `parseLatestV2Line` and `runDriftCheckMain` behaviors don't match yet (`parseLatestV2Line` is not exported; the create-only / lazy-list logic is not implemented). The `detectDrift` and `isRunnerKind` blocks still pass.
+
+- [ ] **Step 3: Rewrite the drift-check internals.** Edit `scripts/perf/drift-check.ts`.
+
+(a) Update the `node:fs` import to add `writeFileSync` and drop nothing it still uses:
+
+```ts
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+```
+
+(b) Add the shared-parser import (after the `medianOf` import added in Task 4):
+
+```ts
+import { parseLastHistoryLine } from "./history-jsonl.ts";
+```
+
+(c) Delete the local `ghSpawn` function and the local `ghIssueList` function entirely (both are replaced by `GhCli` methods).
+
+(d) Replace the exported `parseHistoryLines` function:
+
+```ts
+export function parseHistoryLines(path: string): HistoryLine[] {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const lines: HistoryLine[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (isHistoryLineV2(parsed)) lines.push(parsed);
+      // skip schema_version 1 (non-comparable) or otherwise malformed lines
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return lines;
+}
+```
+
+with the one-sample-per-run reader:
+
+```ts
+/**
+ * Read the LAST line of a per-run `run-history.jsonl` artifact and return it only
+ * if it is a comparable v2 HistoryLine. Each perf run writes a fresh single-run
+ * file, so the last line is that run's result — one sample per run. A missing /
+ * unreadable / malformed / non-v2 artifact yields null (skipped by the caller).
+ */
+export function parseLatestV2Line(path: string): HistoryLine | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  let line: HistoryLine;
+  try {
+    line = parseLastHistoryLine(raw);
+  } catch {
+    return null;
+  }
+  return isHistoryLineV2(line) ? line : null;
+}
+```
+
+(e) Rewrite `upsertDriftIssue` to take the `GhCli` + a tmp root and be create-only:
+
+```ts
+async function upsertDriftIssue(
+  gh: GhCli,
+  surfaceId: BenchSurfaceId,
+  runner: RunnerKind,
+  existingIssues: GhIssue[],
+  tmpRoot: string,
+  stderr: (s: string) => void,
+): Promise<void> {
+  const issueTitle = `perf: sustained drift detected on ${surfaceId} (${runner})`;
+  if (existingIssues.some((i) => i.title === issueTitle)) {
+    // Create-only: a standing open issue already represents this drift. Posting a
+    // fresh comment every daily run would just be noise, so leave it untouched.
+    stderr(`drift-check: open issue already tracks ${surfaceId} (${runner}); leaving it`);
+    return;
+  }
+  const bodyDir = mkdtempSync(join(tmpRoot, "drift-issue-"));
+  const bodyFile = join(bodyDir, "body.md");
+  writeFileSync(
+    bodyFile,
+    `The rolling-median drift detector has flagged surface \`${surfaceId}\` on runner \`${runner}\`.\n\n` +
+      `The last 3+ consecutive \`main\` samples are each more than ${String(DRIFT_NOISE_FLOOR_PCT)}% worse than the rolling median of the preceding 7. This is a sustained regression, not a one-off spike.\n\n` +
+      `See the [/dev/bench dashboard](https://github.com/nimbus-agent/Nimbus/tree/perf-data/dev/bench) and investigate recent commits for a regression on this surface.\n`,
+    "utf8",
+  );
+  await gh.issueCreate({ title: issueTitle, label: DRIFT_ISSUE_LABEL, bodyFile });
+}
+```
+
+(f) Rewrite `runDriftCheckMain` so it parses one sample per run, computes drift first, and only touches the issue API when something drifts:
+
+```ts
+export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> {
+  const runner = deps.runner;
+  const tmpRoot = deps.tmpDir ?? tmpdir();
+  const stderr = deps.stderr ?? ((s: string) => process.stderr.write(`${s}\n`));
+
+  let runs: { databaseId: number; headSha: string }[];
+  try {
+    runs = await deps.gh.runListRecentSuccesses({
+      workflow: PERF_WORKFLOW,
+      branch: "main",
+      limit: DRIFT_HISTORY_RUNS,
+    });
+  } catch (err) {
+    stderr(`drift-check: gh run list failed: ${errMsg(err)}; aborting`);
+    return;
+  }
+  if (runs.length === 0) {
+    stderr("drift-check: no successful main runs found; nothing to check");
+    return;
+  }
+
+  // `gh run list` is newest-first; detectDrift walks the series as a time axis
+  // (index 0 = oldest), so reverse to oldest-first before collecting.
+  runs.reverse();
+
+  const scratchDir = mkdtempSync(join(tmpRoot, "drift-check-"));
+  const historyLines: HistoryLine[] = [];
+  for (const { databaseId, headSha } of runs) {
+    const dir = join(scratchDir, headSha);
+    mkdirSync(dir, { recursive: true });
+    let downloaded = false;
+    try {
+      downloaded = await deps.gh.runDownloadArtifact({
+        runId: databaseId,
+        name: `perf-${runner}-${headSha}`,
+        dir,
+      });
+    } catch (err) {
+      stderr(`drift-check: download (${headSha}) failed: ${errMsg(err)}; skipping`);
+      continue;
+    }
+    if (!downloaded) continue;
+    const line = parseLatestV2Line(join(dir, "run-history.jsonl"));
+    if (line !== null) historyLines.push(line);
+  }
+  if (historyLines.length === 0) {
+    stderr("drift-check: no history lines collected; nothing to check");
+    return;
+  }
+
+  // First pass: which trend (smaller-is-better) surfaces are drifting?
+  const drifting: BenchSurfaceId[] = [];
+  for (const [surfaceId, field] of TREND_METRIC_BY_SURFACE) {
+    const series: DriftSample[] = historyLines
+      .map((line) => {
+        const surface: HistoryLineSurface | undefined = line.surfaces[surfaceId];
+        if (surface === undefined) return null;
+        const val = surface[field];
+        return typeof val === "number" ? { value: val } : null;
+      })
+      .filter((s): s is DriftSample => s !== null);
+    if (detectDrift(series, DRIFT_NOISE_FLOOR_PCT)) drifting.push(surfaceId);
+  }
+  if (drifting.length === 0) return; // no drift → no issue API calls at all
+
+  // Fetch open drift issues once (best-effort: a list failure must not abort the
+  // create path — worst case is a duplicate issue a human dedups).
+  let existingIssues: GhIssue[] = [];
+  try {
+    existingIssues = await deps.gh.issueList({ label: DRIFT_ISSUE_LABEL });
+  } catch (err) {
+    stderr(`drift-check: gh issue list failed: ${errMsg(err)}; proceeding with none known`);
+  }
+
+  for (const surfaceId of drifting) {
+    stderr(`drift-check: drift detected on ${surfaceId} (${runner}); upserting gh issue`);
+    try {
+      await upsertDriftIssue(deps.gh, surfaceId, runner, existingIssues, tmpRoot, stderr);
+    } catch (err) {
+      stderr(`drift-check: upsert failed for ${surfaceId}: ${errMsg(err)}`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/drift-check.test.ts`. Expected: all pass — `detectDrift` (7), `parseLatestV2Line` (5), `runDriftCheckMain` (3), `isRunnerKind` (2). `0 fail`.
+
+- [ ] **Step 5: Typecheck + lint.** Commands: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring/packages/gateway" && bun run typecheck` (expected: no errors — confirms no dangling reference to `ghSpawn`/`ghIssueList`/`parseHistoryLines`) and `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bunx biome check scripts/perf/drift-check.ts scripts/perf/drift-check.test.ts` (expected: no diagnostics — in particular no unused `GhIssue`/imports).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring"
+git add scripts/perf/drift-check.ts scripts/perf/drift-check.test.ts
+git commit -m "$(cat <<'EOF'
+feat(perf): drift-check one-sample-per-run + create-only upsert via GhCli
+
+Route gh issue ops through the injectable GhCli (issueList/issueCreate),
+making runDriftCheckMain unit-testable (new wrapper tests: drift+no-issue ->
+one create; drift+open-issue -> no create; flat series -> no issue API calls).
+Read one v2 sample per run (parseLatestV2Line + shared parser) instead of all
+lines. Upsert is now create-only: an open issue is left untouched, killing the
+daily re-comment spam. Drops the ad-hoc ghSpawn/ghIssueList.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Create the `_perf-drift.yml` scheduled workflow
+
+**Files:**
+
+- Create: `.github/workflows/_perf-drift.yml`
+
+No unit test (workflow YAML). Verify with `actionlint` (if available) + a Bun YAML parse asserting triggers/permissions.
+
+- [ ] **Step 1: Write the workflow.** Create `.github/workflows/_perf-drift.yml`:
+
+```yaml
+name: Performance Drift Check
+
+# Daily sustained-drift watch over recent `main` perf history. Downloads the last
+# 14 gha-ubuntu run-history artifacts, runs the rolling-median detector, and files
+# ONE `perf-drift` issue per sustained-regressing trend surface (create-only: an
+# already-open issue is left untouched — no daily re-comment). Advisory: it never
+# gates a build.
+#
+# Triggers:
+#   - schedule (06:00 UTC daily) — ~2h after _perf.yml's 04:00 bench crons so the
+#     latest artifact exists. GitHub runs `schedule` only on this repo's default
+#     branch, never for forks/fork PRs, so the `issues: write` grant is
+#     non-fork-triggered by construction.
+#   - workflow_dispatch — manual smoke test from the Actions UI.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+# Default-deny baseline (Scorecard Token-Permissions); the job grants only what
+# it uses (per-job, mirroring _perf.yml).
+permissions: {}
+
+jobs:
+  drift-check:
+    name: Perf sustained-drift check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read # checkout
+      actions: read # gh run list + gh run download (perf artifacts)
+      issues: write # gh label create + gh issue list/create (perf-drift)
+    concurrency:
+      group: perf-drift
+      cancel-in-progress: false
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-nimbus-ci
+
+      - name: Ensure perf-drift label exists
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # `gh issue create --label` FAILS on a missing label (it does not
+          # auto-create); --force makes this idempotent (create or update).
+          gh label create perf-drift \
+            --color B60205 \
+            --description "Sustained performance drift detected on a trend surface" \
+            --force
+
+      - name: Run drift check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIMBUS_PERF_RUNNER: gha-ubuntu
+        run: bun scripts/perf/drift-check.ts
+```
+
+- [ ] **Step 2: Verify with actionlint (best-effort).** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bunx actionlint .github/workflows/_perf-drift.yml`. Expected: exits 0, no output. If `bunx actionlint` cannot fetch the binary in this environment, skip to Step 3 (the YAML parse is the floor).
+
+- [ ] **Step 3: Verify it parses and the triggers/permissions are exactly as intended.** Command:
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun -e '
+import { parse } from "yaml";
+const doc = parse(await Bun.file(".github/workflows/_perf-drift.yml").text());
+const on = doc.on ?? doc[true];
+if (!Array.isArray(on.schedule) || on.schedule[0].cron !== "0 6 * * *") throw new Error("bad schedule: " + JSON.stringify(on.schedule));
+if (!("workflow_dispatch" in on)) throw new Error("missing workflow_dispatch");
+if (Object.keys(doc.permissions ?? {}).length !== 0) throw new Error("workflow permissions not default-deny");
+const job = doc.jobs["drift-check"];
+if (job.permissions.contents !== "read" || job.permissions["actions"] !== "read" || job.permissions.issues !== "write")
+  throw new Error("wrong job permissions: " + JSON.stringify(job.permissions));
+const steps = job.steps.map((s) => s.name);
+if (!steps.includes("Ensure perf-drift label exists")) throw new Error("missing label step");
+if (!steps.includes("Run drift check")) throw new Error("missing run step");
+if (job.concurrency.group !== "perf-drift") throw new Error("wrong concurrency group");
+console.log("OK steps:", steps.join(" | "));
+'
+```
+
+Expected output: a single line `OK steps: Harden Runner | Checkout | Setup Bun and install dependencies | Ensure perf-drift label exists | Run drift check` and exit 0.
+
+- [ ] **Step 4: Lint the workflow comment block (yaml-lint via biome is not applicable; confirm no markdown/format gate touches it).** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && git diff --stat`. Expected: shows only `.github/workflows/_perf-drift.yml` newly added. (Workflow YAML is not covered by biome; the actionlint + parse checks above are the gates.)
+
+- [ ] **Step 5: Commit.**
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring"
+git add .github/workflows/_perf-drift.yml
+git commit -m "$(cat <<'EOF'
+ci(perf): daily _perf-drift.yml runs the sustained-drift detector
+
+Schedule (06:00 UTC) + workflow_dispatch. Ensures the perf-drift label exists
+(idempotent gh label create --force — gh issue create --label fails on a missing
+label), then runs scripts/perf/drift-check.ts over the gha-ubuntu history.
+Workflow-level permissions: {} default-deny; job grants contents:read +
+actions:read + issues:write. Advisory only — never gates a build.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Full pre-flight before pushing
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full perf suite.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun test scripts/perf/ packages/gateway/src/perf/`. Expected: `0 fail` across all perf script + gateway-perf tests.
+
+- [ ] **Step 2: Run the fast static gates.** Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun run preflight:fast`. Expected: typecheck ✓, lint ✓. (`lint:markdown` may report pre-existing untracked Slice-8 docs unrelated to this branch — confirm any failure is only those files, not anything in this branch's diff.)
+
+- [ ] **Step 3: Confirm the coverage-floor for the touched gateway file (Docker-Linux-authoritative).** `bench-ci-gh.ts` gained two methods; confirm it still clears ≥80% line+branch. Command: `cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring" && bun run audit:coverage-floor` (or the Docker-Linux variant per the `nimbus-coverage-floor` skill if local Bun coverage diverges from CI). Expected: `bench-ci-gh.ts` is at or above the floor (the four new GhCli tests cover both new methods + their empty/non-array branches). `scripts/perf/*` are not under the floor scan roots, so the new script files are not floor-gated.
+
+- [ ] **Step 4: Push and open the PR.** Command:
+
+```bash
+cd "C:/gitrep/Nimbus/.claude/worktrees/perf-drift-wiring"
+git push -u origin dev/asafgolombek/perf-drift-wiring
+```
+
+Then open a PR titled `feat(perf): wire up the sustained-drift detector (daily _perf-drift.yml)` with the spec summary in the body. Label it `perf` if the bench should validate on-PR. Note in the body that it is stacked on #656 and should merge after it (or rebase onto `main` once #656 lands).
+
+---
+
+## Notes for the executing session
+
+- **Branch is stacked on #656.** The first two commits on this branch are the Biome-2.5.0/ovsx gate fixes. After #656 merges to `main`, run `git fetch origin main && git rebase origin/main` — the two duplicate commits drop out (identical patches), leaving only the drift-wiring commits.
+- **`detectDrift` thresholds are untouched** (`k=7`, `n=3`, `DRIFT_NOISE_FLOOR_PCT=10`, `DRIFT_HISTORY_RUNS=14`) — do not change them.
+- **The wrapper test's fake `gh`** writes the staged `run-history.jsonl` into the `--dir` that `runDownloadArtifact` is told to use (dir basename = headSha), because `runDriftCheckMain` reads that file after the download returns. This is the only way to drive the real download→read flow with an injected spawn.
+- **`gh label create --force`** needs `issues: write` (already granted) — labels are part of the issues write scope.

--- a/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design-review.md
+++ b/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design-review.md
@@ -1,0 +1,49 @@
+# Review & Suggestions — Perf Drift-Check Wiring Design Spec
+
+**Reviewer:** AI Coding Assistant (Antigravity)  
+**Date:** 2026-06-16  
+**Target Spec:** `2026-06-16-perf-drift-wiring-design.md`
+
+This document details feedback, open questions, and recommended improvements for the Perf Drift-Check Wiring Design Spec.
+
+---
+
+## 1. Major Feedback & Suggestions
+
+### A. Github Issue Label Lifecycle Verification
+
+* **Issue**: The spec states in §7 that: "The `perf-drift` issue label is created on first use by `gh issue create --label` (or pre-created in the repo)."
+* **Detail**: In standard GitHub CLI operations, passing `--label <label>` to `gh issue create` does *not* automatically create a missing label in the repository. If the label does not exist, the command will either fail or drop the label depending on the environment.
+* **Suggestion**: We should either:
+  1. Pre-create the `perf-drift` label in the repository settings manually before merging the PR.
+  2. Or, add a defensive creation step using `gh label create perf-drift --color <color> --description <description> --force` (or wrapped in a try/catch) prior to creating the issue in the script.
+
+### B. Mitigating Issue Comment Noise (Spam)
+
+* **Issue**: The scheduled workflow runs daily at 06:00 UTC. If a regression persists and is unresolved for several days or weeks, the script will find the existing open issue and call `GhCli.issueComment` daily.
+* **Detail**: This will result in daily duplicate comments with static text: `"Drift re-detected on..."` which clutters the issue timeline with redundant noise.
+* **Suggestions**:
+  * **Option 1 (Throttling)**: Avoid adding comments if the last comment on the issue was posted within the last 3 days or 3 runs.
+  * **Option 2 (Informative Metrics)**: Instead of a static message, make the comment informative by appending the current p95/median values, the percentage deviation, and a list of new commits since the last run.
+  * **Option 3 (No Daily Comments)**: If the issue is already open, do not post any follow-up comments unless the drift recovers and then regresses again.
+
+### C. Issue Resolution (Auto-Closing)
+
+* **Issue**: The spec defines when an issue is created or commented on, but it does not specify how or when an issue is resolved and closed.
+* **Detail**: If a developer fixes the performance regression, the daily run will no longer detect drift. However, the issue will remain open indefinitely until manually closed.
+* **Suggestion**:
+  * Consider adding an auto-close mechanism. If the drift detector returns `false` (no drift) for a surface that has an open issue with the `perf-drift` label, the script could post a final comment: `"Performance drift resolved. Closing issue."` and automatically close it using `gh issue close <number>`.
+  * Alternatively, if manual verification/close is preferred (to prevent flapping), the spec should explicitly state that issue resolution and closure is a manual process.
+
+---
+
+## 2. Praise & Core Successes
+
+### A. Fixing the History Duplication Bug
+
+* **Detail**: In the existing `drift-check.ts` codebase, `parseHistoryLines` reads and parses *every* line of the downloaded `run-history.jsonl` files. Since each run's artifact contains the full accumulated history up to that point, combining all lines from multiple runs results in severe duplicated history records.
+* **Impact**: Extracting `parseLastHistoryLine` to parse only the latest line of each run's artifact (as described in §3.4 and §3.3) correctly fixes this duplication issue and ensures a clean, chronological time-series.
+
+### B. Strict Security Scoping
+
+* **Impact**: The proposed `.github/workflows/_perf-drift.yml` permissions are scoped defensively (`contents: read`, `actions: read`, `issues: write`), which satisfies all GitHub security standards and prevents unauthorized escalation.

--- a/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md
@@ -1,0 +1,169 @@
+# Perf Drift-Check Wiring — Design
+
+**Status:** approved (2026-06-16) · **Author:** Asaf Golombek
+**Predecessor:** [`2026-06-14-hybrid-perf-strategy-design.md`](./2026-06-14-hybrid-perf-strategy-design.md) (Phase 1, shipped #642)
+
+## 1. Problem
+
+The hybrid perf strategy (Phase 1, PR #642) shipped a complete sustained-drift
+detector — `scripts/perf/drift-check.ts` with a fully unit-tested pure
+`detectDrift(history, noiseFloorPct, k=7, n=3)` core plus an I/O wrapper
+`runDriftCheckMain` that reads recent `main` perf history and upserts one GitHub
+issue per drifting `trend`-class surface. **But nothing invokes it** — no
+workflow calls `drift-check.ts`, so the alerting is dormant. `_perf.yml` only
+wires `emit-benchmark-json.ts` (the dashboard publish).
+
+Two consequences:
+
+1. A sustained regression on a `trend`-class surface (the spawn/IO-noisy
+   latency/RSS surfaces that intentionally stopped hard-gating on shared GHA
+   runners) is charted on the `/dev/bench` dashboard but raises no alert — a
+   human has to notice the chart.
+2. The `runDriftCheckMain` I/O wrapper is **untested** (the #642 review deferred
+   the refactors that would make it testable: its `gh` calls go through a local
+   `ghSpawn` pass-through, not the injectable `GhCli`). Wiring an unattended,
+   issue-filing path into CI before it is tested risks issue spam from a logic
+   bug.
+
+## 2. Goals / non-goals
+
+**Goals:**
+
+- Activate drift alerting via a daily scheduled workflow that runs
+  `drift-check.ts` over recent `main` history and files/updates issues.
+- Clear the four #642-deferred refactors so the issue-filing path is tested
+  before it goes live:
+  1. `ghSpawn` → injectable `GhCli` issue methods.
+  2. local `rollingMedian` → existing `medianOf` (`baseline-median.ts`).
+  3. duplicated last-JSONL-line parse → one shared helper.
+  4. add a `runDriftCheckMain` wrapper test.
+
+**Non-goals (explicitly out of scope):**
+
+- The M1 Air `reference-m1air` self-hosted runner (separate ops task).
+- Phase 2 (Bencher).
+- Any change to detection thresholds — `k=7`, `n=3`, `DRIFT_NOISE_FLOOR_PCT=20`,
+  `DRIFT_RUN_COUNT=14` stay exactly as shipped.
+- Per-OS drift (drift-check reads one runner's history; this phase uses
+  `gha-ubuntu`, the trend-baseline runner that runs daily Mon–Sat).
+
+## 3. Architecture
+
+Four units, each independently testable:
+
+### 3.1 `.github/workflows/_perf-drift.yml` (new)
+
+- **Triggers:** `schedule` daily at `0 6 * * *` (06:00 UTC, ~2h after the
+  `_perf.yml` 04:00 bench crons so the latest `gha-ubuntu` `run-history`
+  artifact exists) + `workflow_dispatch` (manual, no inputs).
+- **Workflow-level `permissions: {}`** (Scorecard default-deny). The single job
+  grants exactly: `contents: read` (checkout), `actions: read` (`gh run list` +
+  `gh run download` of perf artifacts), `issues: write` (upsert drift issues).
+- **`concurrency`** group `perf-drift` with `cancel-in-progress: false` (a
+  queued run waits rather than racing on issue upserts).
+- **Job (ubuntu-24.04):** `step-security/harden-runner` (egress audit, mirroring
+  the other perf workflows) → `actions/checkout` → setup Bun + install →
+  `bun scripts/perf/drift-check.ts`, with `NIMBUS_PERF_RUNNER: gha-ubuntu` in
+  the env. All action refs SHA-pinned to match repo convention.
+- `schedule` fires only on the default branch of this repo — never on forks/fork
+  PRs — so the `issues: write` grant is non-fork-triggered by construction.
+
+### 3.2 `GhCli` issue methods (`packages/gateway/src/perf/bench-ci-gh.ts`)
+
+Add three methods mirroring the existing body-file-based, retry-wrapped
+`prComment*` methods (so issue ops inherit the `#run` retry/backoff and the
+`spawn` injection seam):
+
+- `issueList({ label }): Promise<{ number: number; title: string }[]>` —
+  `gh issue list --state open --label <label> --json number,title`, parsed via
+  the existing tolerant JSON-array reader (degrades to `[]` on non-JSON/notice
+  output, matching `prCommentList`).
+- `issueCreate({ title, label, bodyFile }): Promise<void>` —
+  `gh issue create --title <title> --label <label> --body-file <bodyFile>`.
+- `issueComment({ number, bodyFile }): Promise<void>` —
+  `gh issue comment <number> --body-file <bodyFile>`.
+
+Body-file (not `--body`) keeps multi-line bodies out of argv and matches the
+`prComment*` precedent. These methods are exercised by new unit tests (required —
+`bench-ci-gh.ts` is coverage-floor-gated at ≥80% line+branch).
+
+### 3.3 `scripts/perf/drift-check.ts` refactor
+
+- Delete the local `ghSpawn` pass-through; route `issueList/create/comment`
+  through the injected `deps.gh: GhCli`. `upsertDriftIssue` writes its computed
+  body to a temp file (`mkdtempSync` + `join`, cross-platform) and passes it via
+  `bodyFile`. Net: the wrapper now depends only on `GhCli`, which is injectable.
+- Replace local `rollingMedian` with `medianOf` from `baseline-median.ts`,
+  guarding the empty case (`window.length === 0 ? 0 : medianOf(window)`) to
+  preserve `detectDrift`'s exact contract. `medianOf` is byte-for-byte the same
+  median algorithm, so the existing `detectDrift` unit tests stay green. (The
+  `detectDrift` loop only ever passes a fixed-size `k`-element window, so the
+  guard is defensive, not load-bearing.)
+- Use the shared last-line parser (§3.4) in `downloadRecentMainLines` instead of
+  its inline `split("\n").filter(...).at(-1)`.
+
+### 3.4 Shared JSONL parser (`scripts/perf/history-jsonl.ts`, new)
+
+Extract `parseLastHistoryLine(text: string): HistoryLine` (currently private in
+`emit-benchmark-json.ts`) into a small shared module; both `emit-benchmark-json.ts`
+and `drift-check.ts` import it. Same behavior: split on newlines, drop blank
+lines, `JSON.parse` the last, throw on empty input.
+
+## 4. Data flow
+
+```text
+06:00 UTC daily
+  └─ _perf-drift.yml (ubuntu, gha-ubuntu history)
+       └─ drift-check.ts → runDriftCheckMain({ gh, runner: "gha-ubuntu" })
+            ├─ GhCli.runListRecentSuccesses(_perf.yml, branch=main, limit=14)
+            ├─ for each run (oldest-first): GhCli.runDownloadArtifact → parseLastHistoryLine
+            ├─ per trend, smaller-is-better surface: build DriftSample[] → detectDrift(series, 20)
+            └─ if drifting: GhCli.issueList(label=perf-drift)
+                 ├─ no matching open issue → GhCli.issueCreate(title, label, bodyFile)
+                 └─ matching open issue    → GhCli.issueComment(number, bodyFile)
+```
+
+## 5. Error handling
+
+Unchanged from the shipped wrapper: drift-check is advisory and fail-soft. A
+failed `gh run list` logs to stderr and returns `[]` (no issues filed); an
+unreadable artifact is skipped; an issue-upsert failure for one surface logs and
+continues to the next. The workflow itself does not gate any build — a non-zero
+exit would only mark the scheduled run red, and `runDriftCheckMain` returns
+normally on all handled errors.
+
+## 6. Testing
+
+- **`detectDrift`** — existing unit tests, kept green through the `medianOf` swap
+  (no new assertions needed; the swap is behavior-preserving).
+- **`parseLastHistoryLine`** (new, `history-jsonl.test.ts`) — empty input throws;
+  last-of-many wins; trailing-newline tolerated.
+- **`GhCli` issue methods** (new, in the existing `bench-ci-gh` test file) —
+  injected `spawn` asserts exact argv for list/create/comment and the
+  tolerant-JSON parse for `issueList` (incl. the non-JSON-notice → `[]` arm).
+- **`runDriftCheckMain` wrapper** (new) — injected `GhCli` (canned `spawn`
+  sequence) + fake `run-history.jsonl` artifacts staged in a temp dir, mirroring
+  the `bench-ci.test.ts` fixture pattern. Three cases: a drifting series →
+  exactly one `issueCreate`; a drifting series with a matching open issue →
+  `issueComment` (no create); a flat series → neither.
+
+## 7. Rollout
+
+Single PR (workflow + GhCli methods + drift-check refactor + shared parser +
+tests). No schema migration, no new security invariant (perf is not an invariant
+surface; the `issues: write` grant is scoped to one non-fork-triggered workflow).
+First scheduled run lands the day after merge; can be smoke-tested immediately
+via `workflow_dispatch`. The `perf-drift` issue label is created on first use by
+`gh issue create --label` (or pre-created in the repo).
+
+## 8. Risks & mitigations
+
+- *Unattended issue spam from a wrapper bug* → mitigated by the new wrapper test
+  plus the upsert dedup (one open issue per surface title) that already exists.
+- *14-artifact download cost daily* → low; one ubuntu job, ~14 small JSONL
+  artifacts, once/day.
+- *`gha-ubuntu` history sparse early on* → `detectDrift` needs `≥ k+n` samples
+  and returns `false` otherwise, so it no-ops until enough history accrues.
+- *Stale duplicate of the two #656 gate fixes on this branch* → this branch is
+  stacked on the Biome-2.5.0/ovsx fix branch; rebase onto `main` after #656
+  merges drops the duplicates.

--- a/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md
@@ -42,7 +42,7 @@ Two consequences:
 
 - The M1 Air `reference-m1air` self-hosted runner (separate ops task).
 - Phase 2 (Bencher).
-- Any change to detection thresholds — `k=7`, `n=3`, `DRIFT_NOISE_FLOOR_PCT=20`,
+- Any change to detection thresholds — `k=7`, `n=3`, `DRIFT_NOISE_FLOOR_PCT=10`,
   `DRIFT_RUN_COUNT=14` stay exactly as shipped.
 - Per-OS drift (drift-check reads one runner's history; this phase uses
   `gha-ubuntu`, the trend-baseline runner that runs daily Mon–Sat).
@@ -82,8 +82,10 @@ Add two methods mirroring the existing body-file-based, retry-wrapped
 
 - `issueList({ label }): Promise<{ number: number; title: string }[]>` —
   `gh issue list --state open --label <label> --json number,title`, parsed via
-  the existing tolerant JSON-array reader (degrades to `[]` on non-JSON/notice
-  output, matching `prCommentList`).
+  the existing `parseJsonObjectArray` helper (empty stdout → `[]`), exactly like
+  `prCommentList`. `runDriftCheckMain` wraps the call in a `try/catch` and falls
+  back to `[]` on any failure (best-effort dedup), preserving the shipped
+  `ghIssueList` tolerance at the call site rather than inside `GhCli`.
 - `issueCreate({ title, label, bodyFile }): Promise<void>` —
   `gh issue create --title <title> --label <label> --body-file <bodyFile>`.
 
@@ -139,7 +141,7 @@ call site. `parseHistoryLines` (the all-lines reader) is removed.
        └─ drift-check.ts → runDriftCheckMain({ gh, runner: "gha-ubuntu" })
             ├─ GhCli.runListRecentSuccesses(_perf.yml, branch=main, limit=14)
             ├─ for each run (oldest-first): GhCli.runDownloadArtifact → parseLastHistoryLine (one/run)
-            ├─ per trend, smaller-is-better surface: build DriftSample[] → detectDrift(series, 20)
+            ├─ per trend, smaller-is-better surface: build DriftSample[] → detectDrift(series, 10)
             └─ if drifting: GhCli.issueList(label=perf-drift)
                  ├─ no matching open issue → GhCli.issueCreate(title, label, bodyFile)
                  └─ matching open issue    → no-op (create-only; no daily re-comment)

--- a/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md
@@ -63,14 +63,20 @@ Four units, each independently testable:
   queued run waits rather than racing on issue upserts).
 - **Job (ubuntu-24.04):** `step-security/harden-runner` (egress audit, mirroring
   the other perf workflows) → `actions/checkout` → setup Bun + install →
+  **ensure the `perf-drift` label exists** (`gh label create perf-drift --color
+  … --description … --force` — idempotent; `--force` updates if present) →
   `bun scripts/perf/drift-check.ts`, with `NIMBUS_PERF_RUNNER: gha-ubuntu` in
-  the env. All action refs SHA-pinned to match repo convention.
+  the env. All action refs SHA-pinned to match repo convention. The label step
+  is required because `gh issue create --label <l>` **fails** on a missing label
+  (it does not auto-create) — without it the per-surface try/catch would swallow
+  the error and silently file nothing. `gh label create` is covered by the
+  `issues: write` grant already requested.
 - `schedule` fires only on the default branch of this repo — never on forks/fork
   PRs — so the `issues: write` grant is non-fork-triggered by construction.
 
 ### 3.2 `GhCli` issue methods (`packages/gateway/src/perf/bench-ci-gh.ts`)
 
-Add three methods mirroring the existing body-file-based, retry-wrapped
+Add two methods mirroring the existing body-file-based, retry-wrapped
 `prComment*` methods (so issue ops inherit the `#run` retry/backoff and the
 `spawn` injection seam):
 
@@ -80,47 +86,63 @@ Add three methods mirroring the existing body-file-based, retry-wrapped
   output, matching `prCommentList`).
 - `issueCreate({ title, label, bodyFile }): Promise<void>` —
   `gh issue create --title <title> --label <label> --body-file <bodyFile>`.
-- `issueComment({ number, bodyFile }): Promise<void>` —
-  `gh issue comment <number> --body-file <bodyFile>`.
 
-Body-file (not `--body`) keeps multi-line bodies out of argv and matches the
-`prComment*` precedent. These methods are exercised by new unit tests (required —
-`bench-ci-gh.ts` is coverage-floor-gated at ≥80% line+branch).
+There is intentionally **no `issueComment`** method: the upsert is *create-only*
+(see §3.3) — an already-open issue is left untouched, so daily re-commenting
+never happens. Body-file (not `--body`) keeps multi-line bodies out of argv and
+matches the `prComment*` precedent. Both methods are exercised by new unit tests
+(required — `bench-ci-gh.ts` is coverage-floor-gated at ≥80% line+branch).
 
 ### 3.3 `scripts/perf/drift-check.ts` refactor
 
-- Delete the local `ghSpawn` pass-through; route `issueList/create/comment`
-  through the injected `deps.gh: GhCli`. `upsertDriftIssue` writes its computed
-  body to a temp file (`mkdtempSync` + `join`, cross-platform) and passes it via
-  `bodyFile`. Net: the wrapper now depends only on `GhCli`, which is injectable.
+- **Create-only upsert.** Delete the local `ghSpawn` pass-through and route the
+  upsert through the injected `deps.gh: GhCli`. `upsertDriftIssue` calls
+  `issueList(perf-drift)`; if an open issue whose title matches the surface
+  already exists it **does nothing** (the open issue is the standing signal),
+  otherwise it writes the body to a temp file (`mkdtempSync` + `join`,
+  cross-platform) and calls `issueCreate`. This removes the shipped behavior of
+  posting a fresh comment on every daily run while a regression persists (the
+  reviewer's spam concern). Net: the wrapper depends only on `GhCli`, injectable.
 - Replace local `rollingMedian` with `medianOf` from `baseline-median.ts`,
   guarding the empty case (`window.length === 0 ? 0 : medianOf(window)`) to
   preserve `detectDrift`'s exact contract. `medianOf` is byte-for-byte the same
   median algorithm, so the existing `detectDrift` unit tests stay green. (The
   `detectDrift` loop only ever passes a fixed-size `k`-element window, so the
   guard is defensive, not load-bearing.)
-- Use the shared last-line parser (§3.4) in `downloadRecentMainLines` instead of
-  its inline `split("\n").filter(...).at(-1)`.
+- **One sample per run.** The shipped `downloadRecentMainLines` uses
+  `parseHistoryLines`, which parses *every* line of each artifact. Each `_perf.yml`
+  run writes a fresh single-run `run-history.jsonl` (its `RUNNER_TEMP` is per-run),
+  so today that is one line per artifact and there is no live duplication — but
+  reading *all* lines is fragile: an artifact that ever carried more than one line
+  would inject multiple samples for a single run and distort the series. Switch to
+  the shared last-line parser (§3.4) so each run contributes exactly one sample,
+  preserving the existing `isHistoryLineV2` guard (a non-v2 / unreadable artifact
+  is skipped, as today).
 
 ### 3.4 Shared JSONL parser (`scripts/perf/history-jsonl.ts`, new)
 
 Extract `parseLastHistoryLine(text: string): HistoryLine` (currently private in
 `emit-benchmark-json.ts`) into a small shared module; both `emit-benchmark-json.ts`
-and `drift-check.ts` import it. Same behavior: split on newlines, drop blank
-lines, `JSON.parse` the last, throw on empty input.
+and `drift-check.ts` import it. Behavior: split on newlines, drop blank lines,
+`JSON.parse` the last, throw on empty input. `drift-check.ts` applies its
+existing `isHistoryLineV2` check to the returned line inside its per-artifact
+try/catch (skipping a non-v2 / unparseable artifact), so the shared helper stays
+a thin parser and the v2-guard semantics drift-check needs are preserved at the
+call site. `parseHistoryLines` (the all-lines reader) is removed.
 
 ## 4. Data flow
 
 ```text
 06:00 UTC daily
   └─ _perf-drift.yml (ubuntu, gha-ubuntu history)
+       ├─ gh label create perf-drift --force   (idempotent; ensures the label exists)
        └─ drift-check.ts → runDriftCheckMain({ gh, runner: "gha-ubuntu" })
             ├─ GhCli.runListRecentSuccesses(_perf.yml, branch=main, limit=14)
-            ├─ for each run (oldest-first): GhCli.runDownloadArtifact → parseLastHistoryLine
+            ├─ for each run (oldest-first): GhCli.runDownloadArtifact → parseLastHistoryLine (one/run)
             ├─ per trend, smaller-is-better surface: build DriftSample[] → detectDrift(series, 20)
             └─ if drifting: GhCli.issueList(label=perf-drift)
                  ├─ no matching open issue → GhCli.issueCreate(title, label, bodyFile)
-                 └─ matching open issue    → GhCli.issueComment(number, bodyFile)
+                 └─ matching open issue    → no-op (create-only; no daily re-comment)
 ```
 
 ## 5. Error handling
@@ -139,13 +161,14 @@ normally on all handled errors.
 - **`parseLastHistoryLine`** (new, `history-jsonl.test.ts`) — empty input throws;
   last-of-many wins; trailing-newline tolerated.
 - **`GhCli` issue methods** (new, in the existing `bench-ci-gh` test file) —
-  injected `spawn` asserts exact argv for list/create/comment and the
+  injected `spawn` asserts exact argv for `issueList`/`issueCreate` and the
   tolerant-JSON parse for `issueList` (incl. the non-JSON-notice → `[]` arm).
 - **`runDriftCheckMain` wrapper** (new) — injected `GhCli` (canned `spawn`
   sequence) + fake `run-history.jsonl` artifacts staged in a temp dir, mirroring
-  the `bench-ci.test.ts` fixture pattern. Three cases: a drifting series →
-  exactly one `issueCreate`; a drifting series with a matching open issue →
-  `issueComment` (no create); a flat series → neither.
+  the `bench-ci.test.ts` fixture pattern. Three cases: a drifting series with no
+  matching open issue → exactly one `issueCreate`; a drifting series **with** a
+  matching open issue → **no** `issueCreate` (create-only no-op, the anti-spam
+  behavior); a flat series → no `issueList`/`issueCreate` at all.
 
 ## 7. Rollout
 
@@ -153,13 +176,25 @@ Single PR (workflow + GhCli methods + drift-check refactor + shared parser +
 tests). No schema migration, no new security invariant (perf is not an invariant
 surface; the `issues: write` grant is scoped to one non-fork-triggered workflow).
 First scheduled run lands the day after merge; can be smoke-tested immediately
-via `workflow_dispatch`. The `perf-drift` issue label is created on first use by
-`gh issue create --label` (or pre-created in the repo).
+via `workflow_dispatch`. The `perf-drift` label is guaranteed by the idempotent
+`gh label create … --force` step at the top of the job (§3.1), so the run is
+self-contained and needs no manual repo setup.
+
+**Issue resolution is manual** in this phase: when a regression is fixed the
+daily run simply stops finding drift and files nothing further, but the existing
+open `perf-drift` issue is **not** auto-closed — a human verifies the fix and
+closes it. This is deliberate: these are intentionally noisy `trend` surfaces, so
+auto-closing on the first no-drift run would flap the issue open/closed. (A
+future enhancement could auto-close only after *N* consecutive clean runs — §9.)
 
 ## 8. Risks & mitigations
 
-- *Unattended issue spam from a wrapper bug* → mitigated by the new wrapper test
-  plus the upsert dedup (one open issue per surface title) that already exists.
+- *Unattended issue spam* → create-only upsert (§3.3): an already-open issue is
+  left untouched, so there is no daily re-comment; one standing issue per drifting
+  surface. Backed by the new wrapper test.
+- *`gh issue create --label` fails on a missing label* → idempotent
+  `gh label create perf-drift --force` step runs before drift-check (§3.1), so
+  the label always exists.
 - *14-artifact download cost daily* → low; one ubuntu job, ~14 small JSONL
   artifacts, once/day.
 - *`gha-ubuntu` history sparse early on* → `detectDrift` needs `≥ k+n` samples
@@ -167,3 +202,18 @@ via `workflow_dispatch`. The `perf-drift` issue label is created on first use by
 - *Stale duplicate of the two #656 gate fixes on this branch* → this branch is
   stacked on the Biome-2.5.0/ovsx fix branch; rebase onto `main` after #656
   merges drops the duplicates.
+
+## 9. Deferred enhancements (out of scope, noted for later)
+
+These were raised in review and intentionally deferred to keep this PR focused on
+*activating* alerting safely:
+
+- **Informative comment body.** A future iteration could re-introduce a comment
+  (re-adding `GhCli.issueComment`) carrying the current p95/median, the deviation
+  vs. the rolling median, and the commits since the last clean run — gated by a
+  throttle (e.g. no comment unless the prior one is ≥ *N* days old) so it never
+  becomes daily noise.
+- **Auto-close after sustained recovery.** Close an open `perf-drift` issue
+  automatically once drift has been absent for *N* consecutive runs (not a single
+  run — that would flap), with a closing comment. Requires tracking per-surface
+  clean-run streaks, which this phase does not model.

--- a/packages/gateway/src/perf/bench-ci-gh.test.ts
+++ b/packages/gateway/src/perf/bench-ci-gh.test.ts
@@ -192,4 +192,74 @@ describe("GhCli", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("issueList: parses number+title array and passes the open+label+json args", async () => {
+    const { spawn, calls } = makeFakeRunner([
+      {
+        exitCode: 0,
+        stdout: '[{"number":12,"title":"perf drift A"},{"number":9,"title":"perf drift B"}]\n',
+        stderr: "",
+      },
+    ]);
+    const gh = new GhCli({ spawn });
+    const out = await gh.issueList({ label: "perf-drift" });
+    expect(out).toEqual([
+      { number: 12, title: "perf drift A" },
+      { number: 9, title: "perf drift B" },
+    ]);
+    expect(calls[0]?.args).toEqual([
+      "issue",
+      "list",
+      "--state",
+      "open",
+      "--label",
+      "perf-drift",
+      "--json",
+      "number,title",
+    ]);
+  });
+
+  test("issueList: empty stdout → empty array", async () => {
+    const { spawn } = makeFakeRunner([{ exitCode: 0, stdout: "\n", stderr: "" }]);
+    const gh = new GhCli({ spawn });
+    expect(await gh.issueList({ label: "perf-drift" })).toEqual([]);
+  });
+
+  test("issueList: non-array JSON → empty array (no throw)", async () => {
+    const { spawn } = makeFakeRunner([{ exitCode: 0, stdout: '{"oops":true}\n', stderr: "" }]);
+    const gh = new GhCli({ spawn });
+    expect(await gh.issueList({ label: "perf-drift" })).toEqual([]);
+  });
+
+  test("issueList: drops entries missing number or title", async () => {
+    const { spawn } = makeFakeRunner([
+      {
+        exitCode: 0,
+        stdout: '[{"number":1},{"title":"only-title"},{"number":2,"title":"ok"}]\n',
+        stderr: "",
+      },
+    ]);
+    const gh = new GhCli({ spawn });
+    expect(await gh.issueList({ label: "perf-drift" })).toEqual([{ number: 2, title: "ok" }]);
+  });
+
+  test("issueCreate: passes title, label, and --body-file", async () => {
+    const { spawn, calls } = makeFakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    const gh = new GhCli({ spawn });
+    await gh.issueCreate({
+      title: "perf drift on S1",
+      label: "perf-drift",
+      bodyFile: "fake-body.md",
+    });
+    expect(calls[0]?.args).toEqual([
+      "issue",
+      "create",
+      "--title",
+      "perf drift on S1",
+      "--label",
+      "perf-drift",
+      "--body-file",
+      "fake-body.md",
+    ]);
+  });
 });

--- a/packages/gateway/src/perf/bench-ci-gh.ts
+++ b/packages/gateway/src/perf/bench-ci-gh.ts
@@ -180,4 +180,37 @@ export class GhCli {
       `body=${body}`,
     ]);
   }
+
+  async issueList(args: { label: string }): Promise<{ number: number; title: string }[]> {
+    const r = await this.#run([
+      "issue",
+      "list",
+      "--state",
+      "open",
+      "--label",
+      args.label,
+      "--json",
+      "number,title",
+    ]);
+    const out = r.stdout.trim();
+    if (out === "") return [];
+    return parseJsonObjectArray(
+      out,
+      (rec) => typeof rec["number"] === "number" && typeof rec["title"] === "string",
+      (rec) => ({ number: rec["number"] as number, title: rec["title"] as string }),
+    );
+  }
+
+  async issueCreate(args: { title: string; label: string; bodyFile: string }): Promise<void> {
+    await this.#run([
+      "issue",
+      "create",
+      "--title",
+      args.title,
+      "--label",
+      args.label,
+      "--body-file",
+      args.bodyFile,
+    ]);
+  }
 }

--- a/scripts/perf/drift-check.test.ts
+++ b/scripts/perf/drift-check.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
-import { detectDrift, isRunnerKind, parseHistoryLines } from "./drift-check.ts";
+import { GhCli, type GhSpawnFn } from "../../packages/gateway/src/perf/bench-ci-gh.ts";
+import { detectDrift, isRunnerKind, parseLatestV2Line, runDriftCheckMain } from "./drift-check.ts";
 
 describe("detectDrift", () => {
   test("returns false when there is not enough history to fill the window", () => {
@@ -107,43 +108,127 @@ describe("detectDrift", () => {
   });
 });
 
-describe("parseHistoryLines", () => {
-  function writeLines(lines: string[]): string {
-    const dir = mkdtempSync(join(tmpdir(), "drift-parse-"));
-    const path = join(dir, "run-history.jsonl");
-    writeFileSync(path, `${lines.join("\n")}\n`, "utf8");
-    return path;
+describe("parseLatestV2Line", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "drift-parse-"));
+  function writeFile(contents: string): string {
+    const p = join(tmp, `h-${Math.random().toString(36).slice(2)}.jsonl`);
+    writeFileSync(p, contents, "utf8");
+    return p;
+  }
+  function v2(p95: number): string {
+    return JSON.stringify({
+      schema_version: 2,
+      run_id: "r",
+      timestamp: "2026-06-16T00:00:00Z",
+      runner: "gha-ubuntu",
+      os_version: "ubuntu-24.04",
+      nimbus_git_sha: "abc",
+      bun_version: "1.3.14",
+      surfaces: { S1: { samples_count: 301, p95_ms: p95 } },
+    });
+  }
+  const v1 = JSON.stringify({
+    schema_version: 1,
+    surfaces: { S1: { samples_count: 1, p95_ms: 1 } },
+  });
+
+  test("returns null when the file is unreadable", () => {
+    expect(parseLatestV2Line(join(tmpdir(), "definitely-missing-drift.jsonl"))).toBeNull();
+  });
+
+  test("returns the last v2 line", () => {
+    const line = parseLatestV2Line(writeFile(`${v2(100)}\n${v2(250)}\n`));
+    expect(line?.surfaces["S1"]?.p95_ms).toBe(250);
+  });
+
+  test("returns null when the last line is schema_version 1 (non-comparable)", () => {
+    expect(parseLatestV2Line(writeFile(`${v2(100)}\n${v1}\n`))).toBeNull();
+  });
+
+  test("returns null when the last line is malformed JSON", () => {
+    expect(parseLatestV2Line(writeFile(`${v2(100)}\n{not json\n`))).toBeNull();
+  });
+
+  test("returns null on an empty file", () => {
+    expect(parseLatestV2Line(writeFile("\n  \n"))).toBeNull();
+  });
+});
+
+describe("runDriftCheckMain", () => {
+  // 14 runs, oldest-first sha-0..sha-13. The newest 3 (>=11) regress to 130 over
+  // a stable 100 baseline → a sustained drift on S1 (and only S1).
+  const shas = Array.from({ length: 14 }, (_, i) => `sha-${i}`);
+  const driftValue = (sha: string): number => (Number(sha.slice(4)) >= 11 ? 130 : 100);
+
+  function v2Line(p95: number): string {
+    return JSON.stringify({
+      schema_version: 2,
+      run_id: "r",
+      timestamp: "2026-06-16T00:00:00Z",
+      runner: "gha-ubuntu",
+      os_version: "ubuntu-24.04",
+      nimbus_git_sha: "abc",
+      bun_version: "1.3.14",
+      surfaces: { S1: { samples_count: 301, p95_ms: p95 } },
+    });
   }
 
-  const v2Line = JSON.stringify({
-    schema_version: 2,
-    run_id: "run-1",
-    timestamp: "2026-06-14T00:00:00.000Z",
-    runner: "gha-ubuntu",
-    os_version: "linux x64",
-    nimbus_git_sha: "abc123",
-    bun_version: "1.2.0",
-    surfaces: { S1: { samples_count: 5, p95_ms: 800 } },
+  function fakeGh(opts: {
+    valueForSha: (sha: string) => number;
+    existingIssues: { number: number; title: string }[];
+    calls: string[][];
+  }): GhCli {
+    const spawn: GhSpawnFn = async (args) => {
+      const a = [...args];
+      opts.calls.push(a);
+      if (a[0] === "run" && a[1] === "list") {
+        const newestFirst = [...shas]
+          .reverse()
+          .map((sha, i) => ({ databaseId: 1000 + i, headSha: sha }));
+        return { exitCode: 0, stdout: `${JSON.stringify(newestFirst)}\n`, stderr: "" };
+      }
+      if (a[0] === "run" && a[1] === "download") {
+        const dir = a[a.indexOf("--dir") + 1] as string;
+        const sha = basename(dir);
+        writeFileSync(join(dir, "run-history.jsonl"), `${v2Line(opts.valueForSha(sha))}\n`, "utf8");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (a[0] === "issue" && a[1] === "list") {
+        return { exitCode: 0, stdout: `${JSON.stringify(opts.existingIssues)}\n`, stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    return new GhCli({ spawn, sleep: async () => {} });
+  }
+
+  test("files exactly one issue for a sustained-drifting surface with no open issue", async () => {
+    const calls: string[][] = [];
+    const gh = fakeGh({ valueForSha: driftValue, existingIssues: [], calls });
+    const tmpDir = mkdtempSync(join(tmpdir(), "drift-wrap-"));
+    await runDriftCheckMain({ gh, runner: "gha-ubuntu", tmpDir, stderr: () => {} });
+    const creates = calls.filter((c) => c[0] === "issue" && c[1] === "create");
+    expect(creates).toHaveLength(1);
+    expect(creates[0]).toContain("perf: sustained drift detected on S1 (gha-ubuntu)");
   });
 
-  test("returns [] when the file is unreadable", () => {
-    expect(parseHistoryLines(join(tmpdir(), "definitely-missing-drift.jsonl"))).toEqual([]);
+  test("does NOT create when an open issue already exists (create-only)", async () => {
+    const calls: string[][] = [];
+    const gh = fakeGh({
+      valueForSha: driftValue,
+      existingIssues: [{ number: 7, title: "perf: sustained drift detected on S1 (gha-ubuntu)" }],
+      calls,
+    });
+    const tmpDir = mkdtempSync(join(tmpdir(), "drift-wrap-"));
+    await runDriftCheckMain({ gh, runner: "gha-ubuntu", tmpDir, stderr: () => {} });
+    expect(calls.filter((c) => c[0] === "issue" && c[1] === "create")).toHaveLength(0);
   });
 
-  test("keeps well-formed schema_version 2 lines", () => {
-    const lines = parseHistoryLines(writeLines([v2Line]));
-    expect(lines).toHaveLength(1);
-    expect(lines[0]?.surfaces.S1?.p95_ms).toBe(800);
-  });
-
-  test("skips schema_version 1 lines (non-comparable semantics)", () => {
-    const v1Line = JSON.stringify({ schema_version: 1, runner: "gha-ubuntu", surfaces: {} });
-    expect(parseHistoryLines(writeLines([v1Line, v2Line]))).toHaveLength(1);
-  });
-
-  test("skips malformed JSON and objects missing surfaces", () => {
-    const noSurfaces = JSON.stringify({ schema_version: 2, runner: "gha-ubuntu" });
-    expect(parseHistoryLines(writeLines(["{not json", noSurfaces, v2Line]))).toHaveLength(1);
+  test("a flat (non-drifting) series files nothing and never lists issues", async () => {
+    const calls: string[][] = [];
+    const gh = fakeGh({ valueForSha: () => 100, existingIssues: [], calls });
+    const tmpDir = mkdtempSync(join(tmpdir(), "drift-wrap-"));
+    await runDriftCheckMain({ gh, runner: "gha-ubuntu", tmpDir, stderr: () => {} });
+    expect(calls.filter((c) => c[0] === "issue")).toHaveLength(0);
   });
 });
 

--- a/scripts/perf/drift-check.ts
+++ b/scripts/perf/drift-check.ts
@@ -3,7 +3,7 @@
 import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import { medianOf } from "../../packages/gateway/src/perf/baseline-median.ts";
 import { GhCli } from "../../packages/gateway/src/perf/bench-ci-gh.ts";
 import type {
   HistoryLine,
@@ -37,7 +37,7 @@ export function detectDrift(
   let consecutive = 0;
   for (let i = k; i < history.length; i += 1) {
     const window = history.slice(i - k, i).map((s) => s.value);
-    const med = rollingMedian(window);
+    const med = window.length === 0 ? 0 : medianOf(window);
     const current = history[i]?.value;
     if (current === undefined || med <= 0) {
       consecutive = 0;
@@ -52,16 +52,6 @@ export function detectDrift(
     }
   }
   return false;
-}
-
-function rollingMedian(values: readonly number[]): number {
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  if (sorted.length === 0) return 0;
-  if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
-  const lo = sorted[mid - 1] ?? 0;
-  const hi = sorted[mid] ?? 0;
-  return (lo + hi) / 2;
 }
 
 // ─── I/O wrapper ─────────────────────────────────────────────────────────────

--- a/scripts/perf/drift-check.ts
+++ b/scripts/perf/drift-check.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { medianOf } from "../../packages/gateway/src/perf/baseline-median.ts";
@@ -13,6 +13,7 @@ import type { SloThreshold } from "../../packages/gateway/src/perf/slo-threshold
 import { SLO_THRESHOLDS } from "../../packages/gateway/src/perf/slo-thresholds.ts";
 import { isFloorMetric } from "../../packages/gateway/src/perf/threshold-comparator.ts";
 import type { BenchSurfaceId, RunnerKind } from "../../packages/gateway/src/perf/types.ts";
+import { parseLastHistoryLine } from "./history-jsonl.ts";
 
 // ─── Pure core ───────────────────────────────────────────────────────────────
 
@@ -89,91 +90,6 @@ interface GhIssue {
   title: string;
 }
 
-async function ghSpawn(
-  args: readonly string[],
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
-  const exitCode = await proc.exited;
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
-  return { exitCode, stdout, stderr };
-}
-
-async function ghIssueList(label: string): Promise<GhIssue[]> {
-  const r = await ghSpawn([
-    "issue",
-    "list",
-    "--label",
-    label,
-    "--state",
-    "open",
-    "--json",
-    "number,title",
-  ]);
-  if (r.exitCode !== 0) return [];
-  const text = r.stdout.trim();
-  if (text === "") return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(parsed)) return [];
-  const result: GhIssue[] = [];
-  for (const x of parsed) {
-    if (
-      typeof x === "object" &&
-      x !== null &&
-      typeof (x as Record<string, unknown>)["number"] === "number" &&
-      typeof (x as Record<string, unknown>)["title"] === "string"
-    ) {
-      result.push({
-        number: (x as Record<string, unknown>)["number"] as number,
-        title: (x as Record<string, unknown>)["title"] as string,
-      });
-    }
-  }
-  return result;
-}
-
-async function upsertDriftIssue(
-  surfaceId: BenchSurfaceId,
-  runner: RunnerKind,
-  existingIssues: GhIssue[],
-  stderr: (s: string) => void,
-): Promise<void> {
-  const issueTitle = `perf: sustained drift detected on ${surfaceId} (${runner})`;
-  const existing = existingIssues.find((i) => i.title === issueTitle);
-
-  if (existing !== undefined) {
-    const r = await ghSpawn([
-      "issue",
-      "comment",
-      String(existing.number),
-      "--body",
-      `Drift re-detected on \`${surfaceId}\` for runner \`${runner}\`. The rolling-median detector has flagged a sustained regression again.`,
-    ]);
-    if (r.exitCode !== 0) {
-      stderr(`drift-check: gh issue comment failed for #${String(existing.number)}: ${r.stderr}`);
-    }
-  } else {
-    const r = await ghSpawn([
-      "issue",
-      "create",
-      "--title",
-      issueTitle,
-      "--label",
-      DRIFT_ISSUE_LABEL,
-      "--body",
-      `The rolling-median drift detector has flagged surface \`${surfaceId}\` on runner \`${runner}\`.\n\nThe last 3+ consecutive samples are each more than ${String(DRIFT_NOISE_FLOOR_PCT)}% worse than the rolling median of the preceding 7 samples. This indicates a sustained regression rather than a one-off spike.\n\nPlease investigate recent commits for performance regressions on this surface.`,
-    ]);
-    if (r.exitCode !== 0) {
-      stderr(`drift-check: gh issue create failed for ${surfaceId}: ${r.stderr}`);
-    }
-  }
-}
-
 /**
  * A v2 HistoryLine carries a `surfaces` map and `schema_version: 2`. v1 history
  * (median-of-per-run-p95 aggregation) is non-comparable, so it is skipped rather
@@ -189,30 +105,57 @@ function isHistoryLineV2(parsed: unknown): parsed is HistoryLine {
   );
 }
 
-export function parseHistoryLines(path: string): HistoryLine[] {
+/**
+ * Read the LAST line of a per-run `run-history.jsonl` artifact and return it only
+ * if it is a comparable v2 HistoryLine. Each perf run writes a fresh single-run
+ * file, so the last line is that run's result — one sample per run. A missing /
+ * unreadable / malformed / non-v2 artifact yields null (skipped by the caller).
+ */
+export function parseLatestV2Line(path: string): HistoryLine | null {
   let raw: string;
   try {
     raw = readFileSync(path, "utf8");
   } catch {
-    return [];
+    return null;
   }
-  const lines: HistoryLine[] = [];
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    try {
-      const parsed: unknown = JSON.parse(trimmed);
-      if (isHistoryLineV2(parsed)) lines.push(parsed);
-      // skip schema_version 1 (non-comparable) or otherwise malformed lines
-    } catch {
-      // skip malformed lines
-    }
+  let line: HistoryLine;
+  try {
+    line = parseLastHistoryLine(raw);
+  } catch {
+    return null;
   }
-  return lines;
+  return isHistoryLineV2(line) ? line : null;
 }
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+async function upsertDriftIssue(
+  gh: GhCli,
+  surfaceId: BenchSurfaceId,
+  runner: RunnerKind,
+  existingIssues: GhIssue[],
+  tmpRoot: string,
+  stderr: (s: string) => void,
+): Promise<void> {
+  const issueTitle = `perf: sustained drift detected on ${surfaceId} (${runner})`;
+  if (existingIssues.some((i) => i.title === issueTitle)) {
+    // Create-only: a standing open issue already represents this drift. Posting a
+    // fresh comment every daily run would just be noise, so leave it untouched.
+    stderr(`drift-check: open issue already tracks ${surfaceId} (${runner}); leaving it`);
+    return;
+  }
+  const bodyDir = mkdtempSync(join(tmpRoot, "drift-issue-"));
+  const bodyFile = join(bodyDir, "body.md");
+  writeFileSync(
+    bodyFile,
+    `The rolling-median drift detector has flagged surface \`${surfaceId}\` on runner \`${runner}\`.\n\n` +
+      `The last 3+ consecutive \`main\` samples are each more than ${String(DRIFT_NOISE_FLOOR_PCT)}% worse than the rolling median of the preceding 7. This is a sustained regression, not a one-off spike.\n\n` +
+      `See the [/dev/bench dashboard](https://github.com/nimbus-agent/Nimbus/tree/perf-data/dev/bench) and investigate recent commits for a regression on this surface.\n`,
+    "utf8",
+  );
+  await gh.issueCreate({ title: issueTitle, label: DRIFT_ISSUE_LABEL, bodyFile });
 }
 
 export interface RunDriftCheckDeps {
@@ -227,7 +170,6 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
   const tmpRoot = deps.tmpDir ?? tmpdir();
   const stderr = deps.stderr ?? ((s: string) => process.stderr.write(`${s}\n`));
 
-  // Fetch recent successful main runs
   let runs: { databaseId: number; headSha: string }[];
   try {
     runs = await deps.gh.runListRecentSuccesses({
@@ -239,28 +181,25 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
     stderr(`drift-check: gh run list failed: ${errMsg(err)}; aborting`);
     return;
   }
-
   if (runs.length === 0) {
     stderr("drift-check: no successful main runs found; nothing to check");
     return;
   }
 
-  // `gh run list` returns runs newest-first; detectDrift walks the series as a
-  // time axis (index 0 = oldest), so reverse to oldest-first before collecting.
+  // `gh run list` is newest-first; detectDrift walks the series as a time axis
+  // (index 0 = oldest), so reverse to oldest-first before collecting.
   runs.reverse();
 
-  // Download artifacts and collect HistoryLines, oldest-first
   const scratchDir = mkdtempSync(join(tmpRoot, "drift-check-"));
   const historyLines: HistoryLine[] = [];
   for (const { databaseId, headSha } of runs) {
-    const artifactName = `perf-${runner}-${headSha}`;
     const dir = join(scratchDir, headSha);
     mkdirSync(dir, { recursive: true });
     let downloaded = false;
     try {
       downloaded = await deps.gh.runDownloadArtifact({
         runId: databaseId,
-        name: artifactName,
+        name: `perf-${runner}-${headSha}`,
         dir,
       });
     } catch (err) {
@@ -268,35 +207,42 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
       continue;
     }
     if (!downloaded) continue;
-    const lines = parseHistoryLines(join(dir, "run-history.jsonl"));
-    historyLines.push(...lines);
+    const line = parseLatestV2Line(join(dir, "run-history.jsonl"));
+    if (line !== null) historyLines.push(line);
   }
-
   if (historyLines.length === 0) {
     stderr("drift-check: no history lines collected; nothing to check");
     return;
   }
 
-  // Load existing open drift issues once (to avoid N issue-list calls)
-  const existingIssues = await ghIssueList(DRIFT_ISSUE_LABEL);
-
-  // Check each trend (smaller-is-better) surface for drift
+  // First pass: which trend (smaller-is-better) surfaces are drifting?
+  const drifting: BenchSurfaceId[] = [];
   for (const [surfaceId, field] of TREND_METRIC_BY_SURFACE) {
     const series: DriftSample[] = historyLines
       .map((line) => {
         const surface: HistoryLineSurface | undefined = line.surfaces[surfaceId];
         if (surface === undefined) return null;
         const val = surface[field];
-        if (typeof val !== "number") return null;
-        return { value: val };
+        return typeof val === "number" ? { value: val } : null;
       })
       .filter((s): s is DriftSample => s !== null);
+    if (detectDrift(series, DRIFT_NOISE_FLOOR_PCT)) drifting.push(surfaceId);
+  }
+  if (drifting.length === 0) return; // no drift → no issue API calls at all
 
-    if (!detectDrift(series, DRIFT_NOISE_FLOOR_PCT)) continue;
+  // Fetch open drift issues once (best-effort: a list failure must not abort the
+  // create path — worst case is a duplicate issue a human dedups).
+  let existingIssues: GhIssue[] = [];
+  try {
+    existingIssues = await deps.gh.issueList({ label: DRIFT_ISSUE_LABEL });
+  } catch (err) {
+    stderr(`drift-check: gh issue list failed: ${errMsg(err)}; proceeding with none known`);
+  }
 
+  for (const surfaceId of drifting) {
     stderr(`drift-check: drift detected on ${surfaceId} (${runner}); upserting gh issue`);
     try {
-      await upsertDriftIssue(surfaceId, runner, existingIssues, stderr);
+      await upsertDriftIssue(deps.gh, surfaceId, runner, existingIssues, tmpRoot, stderr);
     } catch (err) {
       stderr(`drift-check: upsert failed for ${surfaceId}: ${errMsg(err)}`);
     }

--- a/scripts/perf/emit-benchmark-json.ts
+++ b/scripts/perf/emit-benchmark-json.ts
@@ -10,6 +10,7 @@ import {
   SLO_THRESHOLDS,
   thresholdsBySurface,
 } from "../../packages/gateway/src/perf/slo-thresholds.ts";
+import { parseLastHistoryLine } from "./history-jsonl.ts";
 
 /** A github-action-benchmark `customSmallerIsBetter` data point. */
 export interface BenchmarkPoint {
@@ -53,15 +54,6 @@ export function toBenchmarkPoints(line: HistoryLine): BenchmarkPoint[] {
     }
   }
   return out;
-}
-
-function parseLastHistoryLine(text: string): HistoryLine {
-  const lines = text.split("\n").filter((l) => l.trim().length > 0);
-  const last = lines.at(-1);
-  if (last === undefined) {
-    throw new Error("run-history.jsonl is empty");
-  }
-  return JSON.parse(last) as HistoryLine;
 }
 
 function takeFlag(args: string[], flag: string): string | undefined {

--- a/scripts/perf/history-jsonl.test.ts
+++ b/scripts/perf/history-jsonl.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import type { HistoryLine } from "../../packages/gateway/src/perf/history-line.ts";
+import { parseLastHistoryLine } from "./history-jsonl.ts";
+
+function v2(p95: number): string {
+  const line: HistoryLine = {
+    schema_version: 2,
+    run_id: "r",
+    timestamp: "2026-06-16T00:00:00Z",
+    runner: "gha-ubuntu",
+    os_version: "ubuntu-24.04",
+    nimbus_git_sha: "abc",
+    bun_version: "1.3.14",
+    surfaces: { S1: { samples_count: 301, p95_ms: p95 } },
+  };
+  return JSON.stringify(line);
+}
+
+describe("parseLastHistoryLine", () => {
+  test("returns the only line", () => {
+    const out = parseLastHistoryLine(`${v2(100)}\n`);
+    expect(out.surfaces["S1"]?.p95_ms).toBe(100);
+  });
+
+  test("returns the LAST of several lines", () => {
+    const out = parseLastHistoryLine(`${v2(100)}\n${v2(200)}\n${v2(300)}\n`);
+    expect(out.surfaces["S1"]?.p95_ms).toBe(300);
+  });
+
+  test("tolerates trailing blank lines / whitespace", () => {
+    const out = parseLastHistoryLine(`${v2(100)}\n${v2(250)}\n\n   \n`);
+    expect(out.surfaces["S1"]?.p95_ms).toBe(250);
+  });
+
+  test("throws on empty input", () => {
+    expect(() => parseLastHistoryLine("   \n\n")).toThrow("run-history.jsonl is empty");
+  });
+});

--- a/scripts/perf/history-jsonl.ts
+++ b/scripts/perf/history-jsonl.ts
@@ -1,0 +1,16 @@
+import type { HistoryLine } from "../../packages/gateway/src/perf/history-line.ts";
+
+/**
+ * Parse the last non-blank line of a `run-history.jsonl` text blob into a
+ * HistoryLine. Each perf run writes a fresh single-run history file, so the
+ * last line is that run's result. Throws on empty input. Callers that need a
+ * schema-version guard apply it to the returned line.
+ */
+export function parseLastHistoryLine(text: string): HistoryLine {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  const last = lines.at(-1);
+  if (last === undefined) {
+    throw new Error("run-history.jsonl is empty");
+  }
+  return JSON.parse(last) as HistoryLine;
+}


### PR DESCRIPTION
## Problem

The hybrid perf strategy (#642) shipped a complete sustained-drift detector (`scripts/perf/drift-check.ts`) but **nothing invoked it** — the alerting was dormant, and its issue-filing I/O wrapper was untested.

## What this does

Activates the detector via a new daily workflow and clears the four #642-deferred refactors so the unattended issue-filing path is **tested before it goes live**.

- **`scripts/perf/history-jsonl.ts`** (new) — shared `parseLastHistoryLine`, now used by both `emit-benchmark-json.ts` and `drift-check.ts` (dedup).
- **`GhCli.issueList` + `issueCreate`** — injectable, retry-wrapped, `--body-file`, mirroring the existing `prComment*` methods (so the upsert path becomes unit-testable).
- **`drift-check.ts`** — `rollingMedian` → shared `medianOf`; gh issue ops routed through the injectable `GhCli`; **one v2 sample per run** (`parseLatestV2Line`); **create-only** upsert (an already-open issue is left untouched — no daily re-comment); lazy issue fetch (no issue API calls unless a surface drifts); dropped the ad-hoc `ghSpawn`/`ghIssueList`.
- **`.github/workflows/_perf-drift.yml`** (new) — daily `schedule` (06:00 UTC) + `workflow_dispatch`; workflow-level `permissions: {}` default-deny with minimal job grants (`contents:read`, `actions:read`, `issues:write`); idempotent `gh label create perf-drift --force` (because `gh issue create --label` fails on a missing label); runs the detector over `gha-ubuntu` history. Advisory — never gates a build.

Thresholds are **untouched** (`k=7`, `n=3`, floor 10%, 14-run window). No schema migration, no new security invariant. Issue resolution is **manual** in this phase (auto-close deferred — these are noisy trend surfaces that would flap; see spec §9).

## Tests

New: `parseLastHistoryLine` (4), `GhCli.issueList/issueCreate` (5), `runDriftCheckMain` wrapper (3, injected `GhCli` + staged artifacts — exercises the real download→parse→detect→create-only pipeline). Existing `detectDrift` (7) stay green through the `medianOf` swap.

## Verification

Full local pre-flight: 278 perf tests pass; typecheck clean (all packages); biome clean (2766 files); markdownlint clean. Coverage-floor: the only floor-gated file touched (`bench-ci-gh.ts`) is not flagged; the CI-Linux coverage job is authoritative.

Spec: `docs/superpowers/specs/2026-06-16-perf-drift-wiring-design.md` · Plan: `docs/superpowers/plans/2026-06-16-perf-drift-wiring.md`. Both incorporate an external design + plan review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented daily automated performance drift detection workflow that runs on schedule and on manual dispatch.
  * Added GitHub issue management for drift alerts with create-only behavior to prevent duplicate notifications.

* **Tests**
  * Added comprehensive test coverage for drift detection logic and GitHub issue operations.

* **Documentation**
  * Added design specifications and implementation plans for performance drift monitoring system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->