### PR TITLE
chore(sonar): cleanup 8 — clear 11 smells, cut duplication, raise coverage

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -228,6 +228,11 @@ jobs:
           # mail-core, mcp-tool-kit, run-cli-json, search-filter) are measured.
           run_pkg "packages/mcp-connectors/shared"
 
+          # `github-actions/shared` is the same case: a package.json-less relative-import
+          # folder (gha-io.ts) shared by the preflight-query + annotate-action actions,
+          # with its own *.test.ts. Run it explicitly so it is exercised in CI.
+          run_pkg "packages/github-actions/shared"
+
           # Union the per-process istanbul shards (coverage/.nyc-tmp/*.json)
           # written by the report-coverage preload into a single repo-root
           # coverage/lcov.info carrying BRDA branch records.

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -78,6 +78,13 @@ jobs:
           lychee --version
 
       - name: Run lychee
+        # Pass the workflow token so lychee resolves github.com links via the GitHub
+        # API instead of scraping HTML. Unauthenticated commit-page requests from the
+        # runner's egress get rate-limited to 500s (verified: CHANGELOG.md commit
+        # permalinks fail intermittently); the API path is rate-limit-resistant and
+        # still genuinely validates each link. Needs only `contents: read`.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lychee --config lychee.toml --no-progress 'docs/**/*.md' '*.md'
 
   markdownlint:

--- a/packages/cli/src/commands/connector.test.ts
+++ b/packages/cli/src/commands/connector.test.ts
@@ -752,3 +752,97 @@ describe("runConnector auth — help + flag edges", () => {
     }
   });
 });
+
+describe("runConnector list — relative-time + truncation formatting", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  function row(overrides: Record<string, unknown>): Record<string, unknown> {
+    return {
+      serviceId: "svc",
+      status: "ok",
+      lastSyncAt: null,
+      nextSyncAt: null,
+      intervalMs: 60_000,
+      itemCount: 0,
+      lastError: null,
+      consecutiveFailures: 0,
+      healthState: "healthy",
+      healthRetryAfterMs: null,
+      ...overrides,
+    };
+  }
+
+  it("renders every relTime / fmtNextSync bucket, truncation, and health-retry formatting", async () => {
+    const now = Date.now();
+    const rows = [
+      // relTime buckets: seconds / minutes / hours / days ago
+      row({ serviceId: "secs", lastSyncAt: now - 5_000 }),
+      row({ serviceId: "mins", lastSyncAt: now - 5 * 60_000 }),
+      row({ serviceId: "hours", lastSyncAt: now - 5 * 3_600_000 }),
+      row({ serviceId: "days", lastSyncAt: now - 5 * 86_400_000 }),
+      // fmtNextSync buckets: due / in-seconds / in-minutes / in-hours / in-days
+      row({ serviceId: "due", nextSyncAt: now - 5_000 }),
+      row({ serviceId: "innext-s", nextSyncAt: now + 5_000 }),
+      row({ serviceId: "innext-m", nextSyncAt: now + 5 * 60_000 }),
+      row({ serviceId: "innext-h", nextSyncAt: now + 5 * 3_600_000 }),
+      row({ serviceId: "innext-d", nextSyncAt: now + 5 * 86_400_000 }),
+      // truncateText: a lastError longer than the 40-char cap; valid + invalid health-retry stamps
+      row({
+        serviceId: "longerr",
+        lastError: "this is a very long connector error message that exceeds the column cap",
+        healthState: null,
+        healthRetryAfterMs: now + 60_000,
+      }),
+      row({ serviceId: "nanretry", healthRetryAfterMs: Number.NaN }),
+    ];
+    const ipc = createMockIpcClient([rows]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["list"]);
+    expect(out.stdout).toContain("s ago");
+    expect(out.stdout).toContain("m ago");
+    expect(out.stdout).toContain("h ago");
+    expect(out.stdout).toContain("d ago");
+    expect(out.stdout).toContain("due");
+    expect(out.stdout).toMatch(/in \d+s/);
+    expect(out.stdout).toMatch(/in \d+m/);
+    expect(out.stdout).toMatch(/in \d+h/);
+    expect(out.stdout).toMatch(/in \d+d/);
+    // truncated error ends with an ellipsis (40-char cap)
+    expect(out.stdout).toContain("…");
+    // valid health-retry stamp renders as ISO; the NaN one falls back to the em dash
+    expect(out.stdout).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("runConnector flag-value validation edges", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  it("throws when a value-taking flag is given no value", async () => {
+    await expect(runConnector(["auth", "github", "--token"])).rejects.toThrow(
+      /Missing value for --token/,
+    );
+  });
+
+  it("throws when --token is whitespace-only", async () => {
+    await expect(runConnector(["auth", "github", "--token", "   "])).rejects.toThrow(
+      /Invalid --token \(empty\)/,
+    );
+  });
+});

--- a/packages/gateway/src/agents/huddle.ts
+++ b/packages/gateway/src/agents/huddle.ts
@@ -41,6 +41,26 @@ function lite(it: {
   return { title: it.title, snippet: it.snippet, service: it.service, modifiedAt: it.modifiedAt };
 }
 
+/** Classify a peer's items into the contribution buckets, skipping anything older than the cutoff. */
+function collectPeerItems(
+  contrib: HuddleContribution,
+  items: ReadonlyArray<{
+    type: string;
+    title: string;
+    snippet: string;
+    service: string;
+    modifiedAt: number;
+  }>,
+  cutoff: number,
+): void {
+  for (const it of items) {
+    if (it.modifiedAt < cutoff) continue;
+    if (it.type === "pr") contrib.prs.push(lite(it));
+    else if (it.type === "issue") contrib.tickets.push(lite(it));
+    else if (it.type === "incident") contrib.incidents.push(lite(it));
+  }
+}
+
 function aggregateContributions(
   queryResults: Array<Awaited<ReturnType<typeof fanOutQuery>>>,
   cutoff: number,
@@ -59,12 +79,7 @@ function aggregateContributions(
           tickets: [],
           incidents: [],
         } satisfies HuddleContribution);
-      for (const it of peer.items) {
-        if (it.modifiedAt < cutoff) continue;
-        if (it.type === "pr") contrib.prs.push(lite(it));
-        else if (it.type === "issue") contrib.tickets.push(lite(it));
-        else if (it.type === "incident") contrib.incidents.push(lite(it));
-      }
+      collectPeerItems(contrib, peer.items, cutoff);
       byPeer.set(peer.peerId, contrib);
     }
   }

--- a/packages/gateway/src/audit/format-audit-payload.ts
+++ b/packages/gateway/src/audit/format-audit-payload.ts
@@ -21,7 +21,7 @@ const SENSITIVE_KEY = /(token|key|secret|password|credential|bearer|auth|^pat$)/
  */
 export const SENSITIVE_VALUE_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
   ["github_classic", /(?<![A-Za-z0-9])gh[pousr]_[A-Za-z0-9]{20,}(?![A-Za-z0-9])/g],
-  ["github_fine_grained", /(?<![A-Za-z0-9])github_pat_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])/g],
+  ["github_fine_grained", /(?<![A-Za-z0-9])github_pat_\w{20,}(?!\w)/g],
   ["openai", /(?<![A-Za-z0-9])sk-(?:proj-)?[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
   ["anthropic", /(?<![A-Za-z0-9])sk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g],
   ["slack", /(?<![A-Za-z0-9])xox[boapr]s?-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])/g],

--- a/packages/gateway/src/config/nimbus-toml-connectors.ts
+++ b/packages/gateway/src/config/nimbus-toml-connectors.ts
@@ -22,7 +22,8 @@ export type ConnectorsConfig = ReadonlyMap<TeamCredentialConnector, ConnectorCre
 
 const TABLE_PREFIX = "[connectors.";
 
-export function parseNimbusConnectorsToml(source: string): ConnectorsConfig {
+/** Phase 1: accumulate `[connectors.<name>]` tables into a name → key/value bag map. */
+function accumulateConnectorTables(source: string): Map<string, Record<string, string>> {
   const accum = new Map<string, Record<string, string>>();
   let current: string | undefined;
   for (const line of source.split(/\r?\n/)) {
@@ -42,35 +43,44 @@ export function parseNimbusConnectorsToml(source: string): ConnectorsConfig {
     const bag = accum.get(current);
     if (bag !== undefined) bag[kv.key] = parseString(kv.valRaw);
   }
+  return accum;
+}
 
+/** Phase 2: validate one accumulated table into a typed connector credential config (throws on error). */
+function resolveConnectorConfig(
+  name: string,
+  kv: Record<string, string>,
+): ConnectorCredentialConfig {
+  if (!(TEAM_CREDENTIAL_CONNECTORS as readonly string[]).includes(name)) {
+    throw new Error(
+      `connectors.${name} is not a supported team-credential connector (one of: ${TEAM_CREDENTIAL_CONNECTORS.join(", ")})`,
+    );
+  }
+  const credential = kv["credential"] ?? "personal";
+  if (credential !== "personal" && credential !== "team") {
+    throw new Error(
+      `connectors.${name}.credential must be "personal" or "team" (got: ${credential})`,
+    );
+  }
+  if (credential === "personal") {
+    return { credential: "personal" };
+  }
+  const teamEntry = (kv["team_entry"] ?? "").trim();
+  if (teamEntry === "") {
+    throw new Error(`[connectors.${name}] requires team_entry when credential = "team"`);
+  }
+  if (!ENTRY_RE.test(teamEntry)) {
+    throw new Error(
+      `[connectors.${name}] team_entry "${teamEntry}" is invalid (lowercase alphanumerics + dashes, no dots)`,
+    );
+  }
+  return { credential: "team", teamEntry };
+}
+
+export function parseNimbusConnectorsToml(source: string): ConnectorsConfig {
   const out = new Map<TeamCredentialConnector, ConnectorCredentialConfig>();
-  for (const [name, kv] of accum) {
-    if (!(TEAM_CREDENTIAL_CONNECTORS as readonly string[]).includes(name)) {
-      throw new Error(
-        `connectors.${name} is not a supported team-credential connector (one of: ${TEAM_CREDENTIAL_CONNECTORS.join(", ")})`,
-      );
-    }
-    const connector = name as TeamCredentialConnector;
-    const credential = kv["credential"] ?? "personal";
-    if (credential !== "personal" && credential !== "team") {
-      throw new Error(
-        `connectors.${name}.credential must be "personal" or "team" (got: ${credential})`,
-      );
-    }
-    if (credential === "personal") {
-      out.set(connector, { credential: "personal" });
-      continue;
-    }
-    const teamEntry = (kv["team_entry"] ?? "").trim();
-    if (teamEntry === "") {
-      throw new Error(`[connectors.${name}] requires team_entry when credential = "team"`);
-    }
-    if (!ENTRY_RE.test(teamEntry)) {
-      throw new Error(
-        `[connectors.${name}] team_entry "${teamEntry}" is invalid (lowercase alphanumerics + dashes, no dots)`,
-      );
-    }
-    out.set(connector, { credential: "team", teamEntry });
+  for (const [name, kv] of accumulateConnectorTables(source)) {
+    out.set(name as TeamCredentialConnector, resolveConnectorConfig(name, kv));
   }
   return out;
 }

--- a/packages/gateway/src/config/nimbus-toml-connectors.ts
+++ b/packages/gateway/src/config/nimbus-toml-connectors.ts
@@ -22,26 +22,39 @@ export type ConnectorsConfig = ReadonlyMap<TeamCredentialConnector, ConnectorCre
 
 const TABLE_PREFIX = "[connectors.";
 
+function processConnectorLine(
+  trimmed: string,
+  state: { current: string | undefined },
+  accum: Map<string, Record<string, string>>,
+): void {
+  if (isTableHeader(trimmed)) {
+    state.current =
+      trimmed.startsWith(TABLE_PREFIX) && trimmed.endsWith("]")
+        ? trimmed.slice(TABLE_PREFIX.length, -1)
+        : undefined;
+    if (state.current !== undefined && !accum.has(state.current)) {
+      accum.set(state.current, {});
+    }
+    return;
+  }
+  if (state.current === undefined) return;
+  const kv = splitKeyValue(trimmed);
+  if (kv === undefined) return;
+  const bag = accum.get(state.current);
+  if (bag !== undefined) {
+    bag[kv.key] = parseString(kv.valRaw);
+  }
+}
+
 /** Phase 1: accumulate `[connectors.<name>]` tables into a name → key/value bag map. */
 function accumulateConnectorTables(source: string): Map<string, Record<string, string>> {
   const accum = new Map<string, Record<string, string>>();
-  let current: string | undefined;
+  const state = { current: undefined as string | undefined };
   for (const line of source.split(/\r?\n/)) {
     const trimmed = stripComment(line).trim();
-    if (trimmed === "") continue;
-    if (isTableHeader(trimmed)) {
-      current =
-        trimmed.startsWith(TABLE_PREFIX) && trimmed.endsWith("]")
-          ? trimmed.slice(TABLE_PREFIX.length, -1)
-          : undefined;
-      if (current !== undefined && !accum.has(current)) accum.set(current, {});
-      continue;
+    if (trimmed !== "") {
+      processConnectorLine(trimmed, state, accum);
     }
-    if (current === undefined) continue;
-    const kv = splitKeyValue(trimmed);
-    if (kv === undefined) continue;
-    const bag = accum.get(current);
-    if (bag !== undefined) bag[kv.key] = parseString(kv.valRaw);
   }
   return accum;
 }

--- a/packages/gateway/src/embedding/embedding-worker-core.ts
+++ b/packages/gateway/src/embedding/embedding-worker-core.ts
@@ -159,13 +159,14 @@ export class EmbeddingWorkerCore {
    * Test seam: awaits all detached init/embed_texts work AND the serialized
    * embed_item queue. Every tracked path always resolves (init/embed_texts errors
    * are posted as messages, never thrown), so this cannot hang. The trailing await
-   * is a defensive re-snapshot of `inFlight` in case a test interleaves more
-   * detached work; the core never self-dispatches, so no re-entrancy occurs here.
+   * re-reads `inFlight` (Promise.all snapshots the Set's iterator synchronously at
+   * call time) in case a test interleaves more detached work after the queue drains;
+   * the core never self-dispatches, so no re-entrancy occurs here.
    */
   async idle(): Promise<void> {
-    await Promise.all([...this.inFlight]);
+    await Promise.all(this.inFlight);
     await this.embedChain;
-    await Promise.all([...this.inFlight]);
+    await Promise.all(this.inFlight);
   }
 
   /** Track a detached promise so `idle()` can await it; auto-remove when settled. */

--- a/packages/gateway/src/federation/invoke-gate.ts
+++ b/packages/gateway/src/federation/invoke-gate.ts
@@ -170,7 +170,7 @@ export async function answerLocalOperatorList(
     return { kind: "error", error: "identity_invalid" };
   }
   const entryDef = ctx.store.getEntry(req.entry);
-  if (entryDef === undefined || entryDef.service !== req.service) {
+  if (entryDef?.service !== req.service) {
     appendTeamVaultAudit(ctx.db, {
       principal: { kind: "localOperator" },
       entry: req.entry,
@@ -252,7 +252,7 @@ export async function answerLocalOperatorInvoke(
     return { kind: "error", error: "identity_invalid" };
   }
   const entryDef = ctx.store.getEntry(req.entry);
-  if (entryDef === undefined || entryDef.service !== req.service) {
+  if (entryDef?.service !== req.service) {
     appendTeamVaultAudit(ctx.db, {
       principal: { kind: "localOperator" },
       entry: req.entry,

--- a/packages/gateway/src/federation/mdns-discovery-provider.ts
+++ b/packages/gateway/src/federation/mdns-discovery-provider.ts
@@ -20,9 +20,9 @@ export interface BonjourLike {
 }
 export type BonjourFactory = () => BonjourLike;
 
-// The real bonjour-service instance structurally satisfies BonjourLike; the `as unknown as`
-// bridges the wider real type to the seam interface used for testability.
-const defaultBonjourFactory: BonjourFactory = () => new BonjourLib() as unknown as BonjourLike;
+// The real bonjour-service instance structurally satisfies BonjourLike (the seam interface used for
+// testability), so it is assigned directly without a bridging type assertion.
+const defaultBonjourFactory: BonjourFactory = () => new BonjourLib();
 
 // MdnsDiscoveryProvider is a thin bonjour-service socket shell (advertise/browse _nimbus._tcp).
 // Real multicast cannot run on CI, so the bonjour client is injected via a factory (default = the

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -17,6 +17,7 @@ import {
 import type { ChatMessage, ReplyTarget } from "../chatops/types.ts";
 import { loadNimbusFilesystemRootsFromConfigDir } from "../config/filesystem-toml.ts";
 import {
+  type ConnectorsConfig,
   loadNimbusAuditFromConfigDir,
   loadNimbusAutomationFromConfigDir,
   loadNimbusChatopsFromConfigDir,
@@ -1135,41 +1136,40 @@ async function bootTribalKnowledge(deps: {
   return { tribalBoot, tribalInterceptCommand };
 }
 
-export async function assemblePlatformServices(paths: PlatformPaths): Promise<PlatformServices> {
-  const assemblyStartedMs = performance.now();
-  const sidecarStops: Array<() => void> = [];
-  await ensurePlatformDirectories(paths);
-  const vault = await createNimbusVault(paths);
-  const sandboxRunner = await createSandboxRunner();
-  const db = openGatewaySqlite(paths.dataDir, sidecarStops);
-  const notifications = createStubNotifications();
-  const syncLogger: Logger = createGatewayPinoLogger(paths.logDir);
-  const rateLimiter = new ProviderRateLimiter();
-  const activeTomlPath = resolveNimbusTomlForProfile(paths.configDir);
-  const sessionToml = loadNimbusSessionFromPath(activeTomlPath);
-  const llmRegistry = buildLlmRegistryFromToml(db, activeTomlPath);
+/** Wave 7b/7c — build the team-shared credential contexts (I19 secret-consumption chokepoint).
+ *  `credentialFor` reads the per-connector [connectors.<name>] pin (default personal); the
+ *  localOperator list/invoke paths route through the principal-polymorphic gate. identityBoot is
+ *  built later in assembly, so operator-validity is late-bound through `identityBootRefHolder` and
+ *  fails closed until identity has booted (I18: identity-enabled but unbooted is treated as invalid).
+ *  Extracted from assemblePlatformServices to keep its cognitive complexity in budget. */
+function buildTeamCredentialContexts(deps: {
+  db: Database;
+  vault: NimbusVault;
+  paths: PlatformPaths;
+  connectorsConfig: ConnectorsConfig;
+  identityEnabled: boolean;
+  identityBootRefHolder: { current: ReturnType<typeof buildIdentityBoot> | undefined };
+}): {
+  teamCredentialExtras: Pick<SyncContext, "sandboxCwd" | "credentialFor" | "runTeamList">;
+  warehouseWriteDeps: WarehouseWriteContext;
+} {
+  const { db, vault, paths, connectorsConfig, identityEnabled, identityBootRefHolder } = deps;
+  // Shared by the list + invoke ctxs (previously duplicated): the late-bound operator-validity guard.
+  const identitySpread = identityEnabled
+    ? {
+        identity: {
+          enabled: true,
+          isOperatorValid: () => {
+            const ref = identityBootRefHolder.current;
+            const store = ref?.store;
+            const issuer = ref?.issuer;
+            if (store === undefined || issuer === undefined) return false; // fail-closed until booted
+            return isOperatorValid(store, issuer, Date.now(), ref?.graceSeconds ?? 0);
+          },
+        },
+      }
+    : {};
 
-  const { localIndex, scheduleItemEmbedding, rt } = await createLocalIndexWithEmbeddingRuntime(
-    db,
-    paths,
-    vault,
-    syncLogger,
-    activeTomlPath,
-  );
-  await ensureGithubCircleCiSchedulerCompanions(localIndex, vault);
-
-  await migrateToPerServiceOAuthKeys(vault);
-
-  await resumePendingRemovals(vault, localIndex);
-
-  // Wave 7b — team-shared credentials. `credentialFor` reads the per-connector [connectors.<name>]
-  // pin (default personal); `runTeamList` routes the localOperator path through the principal-
-  // polymorphic gate (I19 — the one secret-consumption chokepoint). identityBoot is built later in
-  // assembly, so the operator-validity check is late-bound through `identityBootRef` and fails closed
-  // until identity has booted (I18: identity-enabled but unbooted is treated as invalid).
-  const connectorsConfig = loadNimbusConnectorsFromConfigDir(paths.configDir);
-  const identityEnabled = loadNimbusIdentityFromConfigDir(paths.configDir).enabled;
-  let identityBootRef: ReturnType<typeof buildIdentityBoot> | undefined;
   const localOpListCtx: LocalOperatorListCtx = {
     db,
     store: new TeamVaultStore(db),
@@ -1189,19 +1189,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
         },
         input,
       ),
-    ...(identityEnabled
-      ? {
-          identity: {
-            enabled: true,
-            isOperatorValid: () => {
-              const store = identityBootRef?.store;
-              const issuer = identityBootRef?.issuer;
-              if (store === undefined || issuer === undefined) return false; // fail-closed until booted
-              return isOperatorValid(store, issuer, Date.now(), identityBootRef?.graceSeconds ?? 0);
-            },
-          },
-        }
-      : {}),
+    ...identitySpread,
   };
   const teamCredentialExtras: Pick<SyncContext, "sandboxCwd" | "credentialFor" | "runTeamList"> = {
     sandboxCwd: paths.dataDir,
@@ -1236,19 +1224,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
         },
         input,
       ),
-    ...(identityEnabled
-      ? {
-          identity: {
-            enabled: true,
-            isOperatorValid: () => {
-              const store = identityBootRef?.store;
-              const issuer = identityBootRef?.issuer;
-              if (store === undefined || issuer === undefined) return false;
-              return isOperatorValid(store, issuer, Date.now(), identityBootRef?.graceSeconds ?? 0);
-            },
-          },
-        }
-      : {}),
+    ...identitySpread,
   };
 
   const warehouseWriteDeps: WarehouseWriteContext = {
@@ -1264,6 +1240,172 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
         return r.result;
       }),
   };
+
+  return { teamCredentialExtras, warehouseWriteDeps };
+}
+
+/** ChatOps (Phase 6 Slice 5) boot wiring. When [chatops].enabled, build the Slack/Teams bot graph
+ *  and wire it into the IPC + HTTP sidecar opts; returns the live ChatopsBoot (or undefined when
+ *  disabled). Extracted from assemblePlatformServices to keep its cognitive complexity in budget;
+ *  the chatops↔tribal reply cycle is preserved by rebinding `tribalSendHolder.current` here. */
+function bootChatopsIntoAssembly(deps: {
+  chatopsCfg: ReturnType<typeof loadNimbusChatopsFromConfigDir>;
+  policyGate: Parameters<typeof buildChatopsBoot>[0]["policyGate"];
+  tribalBoot: TribalBoot | undefined;
+  tribalInterceptCommand: ((m: ChatMessage) => Promise<boolean>) | undefined;
+  identityBoot: ReturnType<typeof buildIdentityBoot> | undefined;
+  vault: NimbusVault;
+  paths: PlatformPaths;
+  db: Database;
+  connectorMesh: Awaited<ReturnType<typeof createSchedulerWithMesh>>["connectorMesh"];
+  syncLogger: Logger;
+  ipcOpts: Parameters<typeof createIpcServer>[0];
+  httpSidecarOpts: HttpSidecarOpts;
+  sidecarStops: Array<() => void>;
+  tribalSendHolder: { current: (target: ReplyTarget, text: string) => Promise<void> };
+}): ChatopsBoot | undefined {
+  const {
+    chatopsCfg,
+    policyGate,
+    tribalBoot,
+    tribalInterceptCommand,
+    identityBoot,
+    vault,
+    paths,
+    db,
+    connectorMesh,
+    syncLogger,
+    ipcOpts,
+    httpSidecarOpts,
+    sidecarStops,
+    tribalSendHolder,
+  } = deps;
+  if (!chatopsCfg.enabled) return undefined;
+  const identityBootRef = identityBoot;
+  // E2E seam (NIMBUS_CHATOPS_E2E_SINK_DIR, precedent: NIMBUS_SKIP_EMBEDDING_RUNTIME): swap the
+  // real bot-credentialed connector spawn + mesh dispatch for a file-backed mock — the "mock
+  // Slack/Teams transport" the real-gateway e2e drives. Unset in production (the real spawn).
+  const chatopsE2eSinkDir = processEnvGet("NIMBUS_CHATOPS_E2E_SINK_DIR");
+  const chatopsBoot = buildChatopsBoot({
+    cfg: chatopsCfg,
+    policyGate,
+    ...(tribalBoot === undefined ? {} : { onInboundMessage: tribalBoot.onInboundMessage }),
+    ...(tribalInterceptCommand === undefined ? {} : { interceptCommand: tribalInterceptCommand }),
+    ...(identityBootRef === undefined
+      ? {}
+      : {
+          identity: {
+            findScimByEmail: (email: string) => {
+              const scim = identityBootRef.store.findScimByEmail(email);
+              if (scim === undefined) return undefined;
+              return {
+                externalId: scim.externalId,
+                email: scim.email ?? email,
+                active: scim.active,
+                issuer: identityBootRef.issuer,
+              };
+            },
+            isOperatorValid: (issuer: string) =>
+              isOperatorValid(
+                identityBootRef.store,
+                issuer,
+                Date.now(),
+                identityBootRef.graceSeconds,
+              ),
+          },
+        }),
+    runTool:
+      chatopsE2eSinkDir === undefined || chatopsE2eSinkDir === ""
+        ? buildChatopsToolRunner({
+            vault,
+            botVaultEntry: chatopsCfg.botVaultEntry,
+            sandboxCwd: paths.dataDir,
+          })
+        : buildE2eSinkRunChatopsTool(chatopsE2eSinkDir),
+    audit: { recordAudit: (entry) => appendAuditEntry(db, entry) },
+    dispatcher:
+      chatopsE2eSinkDir === undefined || chatopsE2eSinkDir === ""
+        ? createConnectorDispatcher({
+            listTools: () => connectorMesh.listToolsForDispatcher(),
+            getToolsEpoch: () => connectorMesh.getToolsEpoch(),
+          })
+        : buildE2eSinkDispatcher(chatopsE2eSinkDir),
+    ...(chatopsCfg.teamsEnabled && chatopsCfg.teamsBotAppId !== ""
+      ? {
+          validateTeamsJwt: buildTeamsBotJwtValidator({
+            db,
+            teamsBotAppId: chatopsCfg.teamsBotAppId,
+            log: (m) => syncLogger.warn(m),
+          }),
+        }
+      : {}),
+    log: (m) => syncLogger.warn(m),
+  });
+  ipcOpts.chatopsRpcCtx = chatopsBoot.rpcCtx;
+  const teamsSurface = chatopsBoot.teamsSurface;
+  if (teamsSurface !== undefined) {
+    httpSidecarOpts.resolveTeamsEventsSurface = () => Promise.resolve(teamsSurface);
+  }
+  const stopChatops = chatopsBoot;
+  sidecarStops.push(() => void stopChatops.stop());
+  // Resolve the chatops↔tribal cycle: rebind the tribal watcher's `send` (the shared holder the
+  // tribal `send` closure reads at post time) to the chatops I23 reply seam now that it exists.
+  // Without chatops, the holder stays the no-op (detection still records clusters; CLI capture
+  // works; only auto-suggestion posts are suppressed).
+  if (tribalBoot !== undefined) {
+    const replyTo = chatopsBoot.replyTo;
+    tribalSendHolder.current = (target, text) => replyTo(target, text);
+  }
+  return chatopsBoot;
+}
+
+export async function assemblePlatformServices(paths: PlatformPaths): Promise<PlatformServices> {
+  const assemblyStartedMs = performance.now();
+  const sidecarStops: Array<() => void> = [];
+  await ensurePlatformDirectories(paths);
+  const vault = await createNimbusVault(paths);
+  const sandboxRunner = await createSandboxRunner();
+  const db = openGatewaySqlite(paths.dataDir, sidecarStops);
+  const notifications = createStubNotifications();
+  const syncLogger: Logger = createGatewayPinoLogger(paths.logDir);
+  const rateLimiter = new ProviderRateLimiter();
+  const activeTomlPath = resolveNimbusTomlForProfile(paths.configDir);
+  const sessionToml = loadNimbusSessionFromPath(activeTomlPath);
+  const llmRegistry = buildLlmRegistryFromToml(db, activeTomlPath);
+
+  const { localIndex, scheduleItemEmbedding, rt } = await createLocalIndexWithEmbeddingRuntime(
+    db,
+    paths,
+    vault,
+    syncLogger,
+    activeTomlPath,
+  );
+  await ensureGithubCircleCiSchedulerCompanions(localIndex, vault);
+
+  await migrateToPerServiceOAuthKeys(vault);
+
+  await resumePendingRemovals(vault, localIndex);
+
+  // Wave 7b — team-shared credentials. `credentialFor` reads the per-connector [connectors.<name>]
+  // pin (default personal); `runTeamList` routes the localOperator path through the principal-
+  // polymorphic gate (I19 — the one secret-consumption chokepoint). identityBoot is built later in
+  // assembly, so the operator-validity check is late-bound through `identityBootRef` and fails closed
+  // until identity has booted (I18: identity-enabled but unbooted is treated as invalid).
+  const connectorsConfig = loadNimbusConnectorsFromConfigDir(paths.configDir);
+  const identityEnabled = loadNimbusIdentityFromConfigDir(paths.configDir).enabled;
+  // identityBoot is built later in assembly; the operator-validity check is late-bound through this
+  // holder and fails closed until identity has booted (I18). Rebound to the live boot below.
+  const identityBootRefHolder: { current: ReturnType<typeof buildIdentityBoot> | undefined } = {
+    current: undefined,
+  };
+  const { teamCredentialExtras, warehouseWriteDeps } = buildTeamCredentialContexts({
+    db,
+    vault,
+    paths,
+    connectorsConfig,
+    identityEnabled,
+    identityBootRefHolder,
+  });
 
   const syncBase: SyncContext = {
     vault,
@@ -1389,7 +1531,7 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     httpSidecarOpts,
   });
   // Bind the late-bound operator-validity guard used by the Wave 7b team-credential sync path (I18).
-  identityBootRef = identityBoot;
+  identityBootRefHolder.current = identityBoot;
 
   const chatopsCfg = loadNimbusChatopsFromConfigDir(paths.configDir);
 
@@ -1433,83 +1575,22 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
   // does not exist yet); the local-consent fallback binds to the delegated-approval broker after
   // the IPC server exists. Identity disabled → every chat user resolves unmapped (fail-closed).
   // (`chatopsBoot` is declared above so the tribal in-chat capture interceptor can late-bind to it.)
-  if (chatopsCfg.enabled) {
-    const identityBootRef = identityBoot;
-    // E2E seam (NIMBUS_CHATOPS_E2E_SINK_DIR, precedent: NIMBUS_SKIP_EMBEDDING_RUNTIME): swap the
-    // real bot-credentialed connector spawn + mesh dispatch for a file-backed mock — the "mock
-    // Slack/Teams transport" the real-gateway e2e drives. Unset in production (the real spawn).
-    const chatopsE2eSinkDir = processEnvGet("NIMBUS_CHATOPS_E2E_SINK_DIR");
-    chatopsBoot = buildChatopsBoot({
-      cfg: chatopsCfg,
-      policyGate,
-      ...(tribalBoot === undefined ? {} : { onInboundMessage: tribalBoot.onInboundMessage }),
-      ...(tribalInterceptCommand === undefined ? {} : { interceptCommand: tribalInterceptCommand }),
-      ...(identityBootRef === undefined
-        ? {}
-        : {
-            identity: {
-              findScimByEmail: (email: string) => {
-                const scim = identityBootRef.store.findScimByEmail(email);
-                if (scim === undefined) return undefined;
-                return {
-                  externalId: scim.externalId,
-                  email: scim.email ?? email,
-                  active: scim.active,
-                  issuer: identityBootRef.issuer,
-                };
-              },
-              isOperatorValid: (issuer: string) =>
-                isOperatorValid(
-                  identityBootRef.store,
-                  issuer,
-                  Date.now(),
-                  identityBootRef.graceSeconds,
-                ),
-            },
-          }),
-      runTool:
-        chatopsE2eSinkDir === undefined || chatopsE2eSinkDir === ""
-          ? buildChatopsToolRunner({
-              vault,
-              botVaultEntry: chatopsCfg.botVaultEntry,
-              sandboxCwd: paths.dataDir,
-            })
-          : buildE2eSinkRunChatopsTool(chatopsE2eSinkDir),
-      audit: { recordAudit: (entry) => appendAuditEntry(db, entry) },
-      dispatcher:
-        chatopsE2eSinkDir === undefined || chatopsE2eSinkDir === ""
-          ? createConnectorDispatcher({
-              listTools: () => connectorMesh.listToolsForDispatcher(),
-              getToolsEpoch: () => connectorMesh.getToolsEpoch(),
-            })
-          : buildE2eSinkDispatcher(chatopsE2eSinkDir),
-      ...(chatopsCfg.teamsEnabled && chatopsCfg.teamsBotAppId !== ""
-        ? {
-            validateTeamsJwt: buildTeamsBotJwtValidator({
-              db,
-              teamsBotAppId: chatopsCfg.teamsBotAppId,
-              log: (m) => syncLogger.warn(m),
-            }),
-          }
-        : {}),
-      log: (m) => syncLogger.warn(m),
-    });
-    ipcOpts.chatopsRpcCtx = chatopsBoot.rpcCtx;
-    const teamsSurface = chatopsBoot.teamsSurface;
-    if (teamsSurface !== undefined) {
-      httpSidecarOpts.resolveTeamsEventsSurface = () => Promise.resolve(teamsSurface);
-    }
-    const stopChatops = chatopsBoot;
-    sidecarStops.push(() => void stopChatops.stop());
-    // Resolve the chatops↔tribal cycle: rebind the tribal watcher's `send` (the shared holder the
-    // tribal `send` closure reads at post time) to the chatops I23 reply seam now that it exists.
-    // Without chatops, the holder stays the no-op (detection still records clusters; CLI capture
-    // works; only auto-suggestion posts are suppressed).
-    if (tribalBoot !== undefined) {
-      const replyTo = chatopsBoot.replyTo;
-      tribalSendHolder.current = (target, text) => replyTo(target, text);
-    }
-  }
+  chatopsBoot = bootChatopsIntoAssembly({
+    chatopsCfg,
+    policyGate,
+    tribalBoot,
+    tribalInterceptCommand,
+    identityBoot,
+    vault,
+    paths,
+    db,
+    connectorMesh,
+    syncLogger,
+    ipcOpts,
+    httpSidecarOpts,
+    sidecarStops,
+    tribalSendHolder,
+  });
 
   // Observability snapshot (Task 15). Cheap, synchronous readers assembled here where every
   // subsystem is in scope. Wired into BOTH the IPC server (admin.status) and the read-only HTTP

--- a/packages/github-actions/annotate-action/dist/index.js
+++ b/packages/github-actions/annotate-action/dist/index.js
@@ -38,7 +38,9 @@ function writeJobSummary(md) {
 `);
 }
 function emitAnnotation(level, message) {
-  process.stdout.write(`::${level}::${message}
+  const safe = message.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll(`
+`, "%0A");
+  process.stdout.write(`::${level}::${safe}
 `);
 }
 function makeSetOutput(allowedNames) {

--- a/packages/github-actions/annotate-action/dist/index.js
+++ b/packages/github-actions/annotate-action/dist/index.js
@@ -1,21 +1,9 @@
-// src/main.ts
+import { createRequire } from "node:module";
+var __require = /* @__PURE__ */ createRequire(import.meta.url);
+
+// ../shared/gha-io.ts
+import { randomUUID } from "node:crypto";
 import { appendFileSync } from "node:fs";
-
-// src/render.ts
-function renderSummary(input) {
-  const verb = input.isNew ? "Recorded" : "Updated";
-  const eligible = input.doraEligible ? "✅ DORA-eligible" : "ℹ️ not counted in DORA deploy-frequency";
-  return [
-    `### ${verb} deployment — ${input.service} → ${input.environment}`,
-    "",
-    `- **External ID:** \`${input.externalId}\``,
-    `- **Status:** \`${input.status}\``,
-    `- **DORA:** ${eligible}`
-  ].join(`
-`);
-}
-
-// src/main.ts
 var DENY_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 function safeString(raw, maxLen) {
   const s = typeof raw === "string" ? raw : "";
@@ -24,19 +12,6 @@ function safeString(raw, maxLen) {
 function safeInt(raw) {
   const n = typeof raw === "number" ? raw : Number(raw);
   return Number.isFinite(n) ? Math.trunc(n) : 0;
-}
-function safeBool(raw) {
-  return raw === true;
-}
-function safeAnnotateEnvelope(raw) {
-  const o = raw !== null && typeof raw === "object" ? raw : {};
-  return {
-    external_id: safeString(o.external_id, 512),
-    service: safeString(o.service, 64),
-    stored_at_ms: safeInt(o.stored_at_ms),
-    is_new: safeBool(o.is_new),
-    dora_eligible: safeBool(o.dora_eligible)
-  };
 }
 function getInput(name) {
   const envName = `INPUT_${name.toUpperCase().replaceAll("-", "_")}`;
@@ -53,27 +28,6 @@ function getIntInput(name, fallback) {
   const n = Number.parseInt(raw, 10);
   return Number.isInteger(n) ? n : fallback;
 }
-var ALLOWED_OUTPUT_NAMES = new Set([
-  "external-id",
-  "is-new",
-  "dora-eligible"
-]);
-function setOutput(name, value) {
-  if (!ALLOWED_OUTPUT_NAMES.has(name)) {
-    throw new Error(`refusing to set unknown output: ${name}`);
-  }
-  const outFile = process.env.GITHUB_OUTPUT;
-  if (outFile === undefined)
-    return;
-  let delim;
-  do {
-    delim = `EOF_${Math.random().toString(36).slice(2)}`;
-  } while (value.includes(delim));
-  appendFileSync(outFile, `${name}<<${delim}
-${value}
-${delim}
-`);
-}
 var STEP_SUMMARY_MAX_BYTES = 64 * 1024;
 function writeJobSummary(md) {
   const file = process.env.GITHUB_STEP_SUMMARY;
@@ -86,6 +40,61 @@ function writeJobSummary(md) {
 function emitAnnotation(level, message) {
   process.stdout.write(`::${level}::${message}
 `);
+}
+function makeSetOutput(allowedNames) {
+  return (name, value) => {
+    if (!allowedNames.has(name)) {
+      throw new Error(`refusing to set unknown output: ${name}`);
+    }
+    const outFile = process.env.GITHUB_OUTPUT;
+    if (outFile === undefined)
+      return;
+    let delim;
+    do {
+      delim = `EOF_${randomUUID().replaceAll("-", "")}`;
+    } while (value.includes(delim));
+    appendFileSync(outFile, `${name}<<${delim}
+${value}
+${delim}
+`);
+  };
+}
+
+// src/output.ts
+var ALLOWED_OUTPUT_NAMES = new Set([
+  "external-id",
+  "is-new",
+  "dora-eligible"
+]);
+var setOutput = makeSetOutput(ALLOWED_OUTPUT_NAMES);
+
+// src/render.ts
+function renderSummary(input) {
+  const verb = input.isNew ? "Recorded" : "Updated";
+  const eligible = input.doraEligible ? "✅ DORA-eligible" : "ℹ️ not counted in DORA deploy-frequency";
+  return [
+    `### ${verb} deployment — ${input.service} → ${input.environment}`,
+    "",
+    `- **External ID:** \`${input.externalId}\``,
+    `- **Status:** \`${input.status}\``,
+    `- **DORA:** ${eligible}`
+  ].join(`
+`);
+}
+
+// src/main.ts
+function safeBool(raw) {
+  return raw === true;
+}
+function safeAnnotateEnvelope(raw) {
+  const o = raw !== null && typeof raw === "object" ? raw : {};
+  return {
+    external_id: safeString(o.external_id, 512),
+    service: safeString(o.service, 64),
+    stored_at_ms: safeInt(o.stored_at_ms),
+    is_new: safeBool(o.is_new),
+    dora_eligible: safeBool(o.dora_eligible)
+  };
 }
 async function postAnnotation(gatewayUrl, token, payload, timeoutMs) {
   const url = new URL("/v1/deployments", gatewayUrl);
@@ -134,65 +143,73 @@ async function postAnnotation(gatewayUrl, token, payload, timeoutMs) {
     clearTimeout(timer);
   }
 }
-async function main() {
-  const service = getInput("service");
-  if (service === "") {
-    emitAnnotation("error", "missing required input: service");
+function requireInput(name) {
+  const value = getInput(name);
+  if (value === "") {
+    emitAnnotation("error", `missing required input: ${name}`);
     process.exit(1);
   }
-  const environment = getInput("environment");
-  if (environment === "") {
-    emitAnnotation("error", "missing required input: environment");
+  return value;
+}
+function parseTimestampOrExit(name, raw) {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) {
+    emitAnnotation("error", `invalid input: ${name} must be a unix-ms integer, got '${raw}'`);
     process.exit(1);
   }
-  const status = getInput("status");
-  if (status === "") {
-    emitAnnotation("error", "missing required input: status");
-    process.exit(1);
+  return n;
+}
+function buildPayload() {
+  const startedAtRaw = getInput("started-at");
+  const startedAtMs = startedAtRaw === "" ? Date.now() : parseTimestampOrExit("started-at", startedAtRaw);
+  const payload = {
+    service: getInput("service"),
+    provider: "github-actions",
+    environment: getInput("environment"),
+    sha: getInput("sha"),
+    ref: getInput("target-ref"),
+    status: getInput("status"),
+    started_at_ms: startedAtMs
+  };
+  const finishedAtRaw = getInput("finished-at");
+  if (finishedAtRaw !== "") {
+    payload.finished_at_ms = parseTimestampOrExit("finished-at", finishedAtRaw);
   }
-  const token = getInput("token");
-  if (token === "") {
-    emitAnnotation("error", "missing required input: token");
-    process.exit(1);
-  }
-  const sha = getInput("sha");
-  const targetRef = getInput("target-ref");
   const workflowUrl = getInput("workflow-url");
   const runId = getInput("run-id");
   const jobId = getInput("job-id");
-  const startedAtRaw = getInput("started-at");
-  const finishedAtRaw = getInput("finished-at");
-  const gatewayUrl = getInput("gateway-url") || "http://localhost:7474";
-  const timeoutMs = getIntInput("timeout-ms", 1e4);
-  const allowGatewayFailure = getBooleanInput("allow-gateway-failure");
-  const startedAtMs = startedAtRaw === "" ? Date.now() : Number.parseInt(startedAtRaw, 10);
-  if (!Number.isFinite(startedAtMs)) {
-    emitAnnotation("error", `invalid input: started-at must be a unix-ms integer, got '${startedAtRaw}'`);
-    process.exit(1);
-  }
-  const payload = {
-    service,
-    provider: "github-actions",
-    environment,
-    sha,
-    ref: targetRef,
-    status,
-    started_at_ms: startedAtMs
-  };
-  if (finishedAtRaw !== "") {
-    const finishedAtMs = Number.parseInt(finishedAtRaw, 10);
-    if (!Number.isFinite(finishedAtMs)) {
-      emitAnnotation("error", `invalid input: finished-at must be a unix-ms integer, got '${finishedAtRaw}'`);
-      process.exit(1);
-    }
-    payload.finished_at_ms = finishedAtMs;
-  }
   if (workflowUrl !== "")
     payload.workflow_url = workflowUrl;
   if (runId !== "")
     payload.run_id = runId;
   if (jobId !== "")
     payload.job_id = jobId;
+  return payload;
+}
+function warningFor(result, gatewayUrl) {
+  if (result.status === "auth_failed") {
+    return "Nimbus Gateway rejected the bearer token (401). Confirm the GitHub secret matches the vault key " + "http_api.deployment_token configured via 'nimbus vault set http_api.deployment_token <value>'.";
+  }
+  if (result.status === "rate_limited") {
+    const retry = result.retryAfter === undefined ? "" : ` Retry-After: ${result.retryAfter}s.`;
+    return `Nimbus Gateway rate-limited the annotation (429).${retry}`;
+  }
+  if (result.status === "surface_disabled") {
+    const hint = result.hint ?? "set http_api.deployment_token via 'nimbus vault set http_api.deployment_token <value>'";
+    return `Nimbus deployment write surface is disabled (503): ${hint}`;
+  }
+  const detail = result.body === undefined ? "" : `: ${result.body.slice(0, 200)}`;
+  return `Nimbus Gateway unreachable at ${gatewayUrl}${detail}`;
+}
+async function main() {
+  requireInput("service");
+  requireInput("environment");
+  requireInput("status");
+  const token = requireInput("token");
+  const gatewayUrl = getInput("gateway-url") || "http://localhost:7474";
+  const timeoutMs = getIntInput("timeout-ms", 1e4);
+  const allowGatewayFailure = getBooleanInput("allow-gateway-failure");
+  const payload = buildPayload();
   const result = await postAnnotation(gatewayUrl, token, payload, timeoutMs);
   if (result.status === "ok") {
     const env = safeAnnotateEnvelope(result.envelope);
@@ -201,34 +218,30 @@ async function main() {
     setOutput("dora-eligible", env.dora_eligible ? "true" : "false");
     writeJobSummary(renderSummary({
       service: env.service,
-      environment: safeString(environment, 64),
-      status: safeString(status, 32),
+      environment: safeString(getInput("environment"), 64),
+      status: safeString(getInput("status"), 32),
       externalId: env.external_id,
       isNew: env.is_new,
       doraEligible: env.dora_eligible
     }));
     process.exit(0);
   }
-  let warning;
-  if (result.status === "auth_failed") {
-    warning = "Nimbus Gateway rejected the bearer token (401). Confirm the GitHub secret matches the vault key " + "http_api.deployment_token configured via 'nimbus vault set http_api.deployment_token <value>'.";
-  } else if (result.status === "rate_limited") {
-    const retry = result.retryAfter === undefined ? "" : ` Retry-After: ${result.retryAfter}s.`;
-    warning = `Nimbus Gateway rate-limited the annotation (429).${retry}`;
-  } else if (result.status === "surface_disabled") {
-    const hint = result.hint === undefined ? "set http_api.deployment_token via 'nimbus vault set http_api.deployment_token <value>'" : result.hint;
-    warning = `Nimbus deployment write surface is disabled (503): ${hint}`;
-  } else {
-    const detail = result.body === undefined ? "" : `: ${result.body.slice(0, 200)}`;
-    warning = `Nimbus Gateway unreachable at ${gatewayUrl}${detail}`;
-  }
-  emitAnnotation("warning", warning);
+  emitAnnotation("warning", warningFor(result, gatewayUrl));
   if (allowGatewayFailure) {
     process.exit(0);
   }
   process.exit(1);
 }
-await main();
+if (__require.main == __require.module) {
+  await main();
+}
 export {
-  main
+  safeString,
+  safeInt,
+  safeBool,
+  safeAnnotateEnvelope,
+  main,
+  getIntInput,
+  getInput,
+  getBooleanInput
 };

--- a/packages/github-actions/annotate-action/src/main.ts
+++ b/packages/github-actions/annotate-action/src/main.ts
@@ -1,19 +1,17 @@
-import { appendFileSync } from "node:fs";
+import {
+  emitAnnotation,
+  getBooleanInput,
+  getInput,
+  getIntInput,
+  safeInt,
+  safeString,
+  writeJobSummary,
+} from "../../shared/gha-io.ts";
 import { setOutput } from "./output.ts";
 import { type AnnotateResult, renderSummary } from "./render.ts";
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: explicit byte ranges define the sanitizer barrier
-const DENY_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
-
-export function safeString(raw: unknown, maxLen: number): string {
-  const s = typeof raw === "string" ? raw : "";
-  return s.replace(DENY_CHARS, "").slice(0, maxLen);
-}
-
-export function safeInt(raw: unknown): number {
-  const n = typeof raw === "number" ? raw : Number(raw);
-  return Number.isFinite(n) ? Math.trunc(n) : 0;
-}
+// Re-exported so this package's unit tests can import the pure helpers from main.ts.
+export { getBooleanInput, getInput, getIntInput, safeInt, safeString };
 
 export function safeBool(raw: unknown): boolean {
   return raw === true;
@@ -36,36 +34,6 @@ export function safeAnnotateEnvelope(raw: unknown): SanitizedAnnotateEnvelope {
     is_new: safeBool(o.is_new),
     dora_eligible: safeBool(o.dora_eligible),
   };
-}
-
-export function getInput(name: string): string {
-  const envName = `INPUT_${name.toUpperCase().replaceAll("-", "_")}`;
-  return process.env[envName] ?? "";
-}
-
-export function getBooleanInput(name: string): boolean {
-  const raw = getInput(name).toLowerCase();
-  return raw === "true" || raw === "1" || raw === "yes";
-}
-
-export function getIntInput(name: string, fallback: number): number {
-  const raw = getInput(name);
-  if (raw === "") return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isInteger(n) ? n : fallback;
-}
-
-const STEP_SUMMARY_MAX_BYTES = 64 * 1024;
-
-function writeJobSummary(md: string): void {
-  const file = process.env.GITHUB_STEP_SUMMARY;
-  if (file === undefined) return;
-  const safe = md.length > STEP_SUMMARY_MAX_BYTES ? md.slice(0, STEP_SUMMARY_MAX_BYTES) : md;
-  appendFileSync(file, `${safe}\n`);
-}
-
-function emitAnnotation(level: "warning" | "error", message: string): void {
-  process.stdout.write(`::${level}::${message}\n`);
 }
 
 type PostOk = {

--- a/packages/github-actions/annotate-action/src/output.ts
+++ b/packages/github-actions/annotate-action/src/output.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto";
-import { appendFileSync } from "node:fs";
+import { makeSetOutput } from "../../shared/gha-io.ts";
 
 export const ALLOWED_OUTPUT_NAMES: ReadonlySet<string> = new Set([
   "external-id",
@@ -7,15 +6,4 @@ export const ALLOWED_OUTPUT_NAMES: ReadonlySet<string> = new Set([
   "dora-eligible",
 ]);
 
-export function setOutput(name: string, value: string): void {
-  if (!ALLOWED_OUTPUT_NAMES.has(name)) {
-    throw new Error(`refusing to set unknown output: ${name}`);
-  }
-  const outFile = process.env.GITHUB_OUTPUT;
-  if (outFile === undefined) return;
-  let delim: string;
-  do {
-    delim = `EOF_${randomUUID().replaceAll("-", "")}`;
-  } while (value.includes(delim));
-  appendFileSync(outFile, `${name}<<${delim}\n${value}\n${delim}\n`);
-}
+export const setOutput: (name: string, value: string) => void = makeSetOutput(ALLOWED_OUTPUT_NAMES);

--- a/packages/github-actions/preflight-query/dist/index.js
+++ b/packages/github-actions/preflight-query/dist/index.js
@@ -1,5 +1,74 @@
-// src/main.ts
+import { createRequire } from "node:module";
+var __require = /* @__PURE__ */ createRequire(import.meta.url);
+
+// ../shared/gha-io.ts
+import { randomUUID } from "node:crypto";
 import { appendFileSync } from "node:fs";
+var DENY_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
+function safeString(raw, maxLen) {
+  const s = typeof raw === "string" ? raw : "";
+  return s.replace(DENY_CHARS, "").slice(0, maxLen);
+}
+function safeInt(raw) {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? Math.trunc(n) : 0;
+}
+function getInput(name) {
+  const envName = `INPUT_${name.toUpperCase().replaceAll("-", "_")}`;
+  return process.env[envName] ?? "";
+}
+function getBooleanInput(name) {
+  const raw = getInput(name).toLowerCase();
+  return raw === "true" || raw === "1" || raw === "yes";
+}
+function getIntInput(name, fallback) {
+  const raw = getInput(name);
+  if (raw === "")
+    return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) ? n : fallback;
+}
+var STEP_SUMMARY_MAX_BYTES = 64 * 1024;
+function writeJobSummary(md) {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (file === undefined)
+    return;
+  const safe = md.length > STEP_SUMMARY_MAX_BYTES ? md.slice(0, STEP_SUMMARY_MAX_BYTES) : md;
+  appendFileSync(file, `${safe}
+`);
+}
+function emitAnnotation(level, message) {
+  process.stdout.write(`::${level}::${message}
+`);
+}
+function makeSetOutput(allowedNames) {
+  return (name, value) => {
+    if (!allowedNames.has(name)) {
+      throw new Error(`refusing to set unknown output: ${name}`);
+    }
+    const outFile = process.env.GITHUB_OUTPUT;
+    if (outFile === undefined)
+      return;
+    let delim;
+    do {
+      delim = `EOF_${randomUUID().replaceAll("-", "")}`;
+    } while (value.includes(delim));
+    appendFileSync(outFile, `${name}<<${delim}
+${value}
+${delim}
+`);
+  };
+}
+
+// src/output.ts
+var ALLOWED_OUTPUT_NAMES = new Set([
+  "verdict",
+  "incident-count",
+  "failing-ci-count",
+  "merge-conflict-count",
+  "result-json"
+]);
+var setOutput = makeSetOutput(ALLOWED_OUTPUT_NAMES);
 
 // src/render.ts
 var CHECK_LABELS = {
@@ -10,13 +79,7 @@ var CHECK_LABELS = {
 var CHECK_ORDER = ["active_p1_incidents", "failing_ci_runs", "merge_conflicts"];
 function renderJobSummary(env) {
   const lines = [];
-  lines.push(`### Nimbus pre-deploy preflight — ${env.service} @ \`${env.target_ref}\``);
-  lines.push("");
-  lines.push(`**Verdict:** \`${env.verdict}\``);
-  lines.push(`**Computed at:** ${env.computed_at}`);
-  lines.push("");
-  lines.push("| Check | Count | Gap |");
-  lines.push("|---|---:|---|");
+  lines.push(`### Nimbus pre-deploy preflight — ${env.service} @ \`${env.target_ref}\``, "", `**Verdict:** \`${env.verdict}\``, `**Computed at:** ${env.computed_at}`, "", "| Check | Count | Gap |", "|---|---:|---|");
   for (const key of CHECK_ORDER) {
     const m = env.checks[key];
     const gap = m.gap === null ? "" : `\`${m.gap}\``;
@@ -26,9 +89,7 @@ function renderJobSummary(env) {
     const m = env.checks[key];
     if (m.findings.length === 0)
       continue;
-    lines.push("");
-    lines.push(`<details><summary>${CHECK_LABELS[key]} (${m.count})</summary>`);
-    lines.push("");
+    lines.push("", `<details><summary>${CHECK_LABELS[key]} (${m.count})</summary>`, "");
     for (const f of m.findings) {
       const linkPart = f.url ? ` — ${f.url}` : "";
       lines.push(`- \`${f.id}\` — ${f.title}${linkPart}`);
@@ -67,15 +128,6 @@ function decideExitCode(args) {
 }
 
 // src/main.ts
-var DENY_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
-function safeString(raw, maxLen) {
-  const s = typeof raw === "string" ? raw : "";
-  return s.replace(DENY_CHARS, "").slice(0, maxLen);
-}
-function safeInt(raw) {
-  const n = typeof raw === "number" ? raw : Number(raw);
-  return Number.isFinite(n) ? Math.trunc(n) : 0;
-}
 function safeVerdict(raw) {
   return raw === "warn" ? "warn" : "ok";
 }
@@ -112,57 +164,6 @@ function sanitizeEnvelope(raw) {
       }
     }
   };
-}
-function getInput(name) {
-  const envName = `INPUT_${name.toUpperCase().replaceAll("-", "_")}`;
-  return process.env[envName] ?? "";
-}
-function getBooleanInput(name) {
-  const raw = getInput(name).toLowerCase();
-  return raw === "true" || raw === "1" || raw === "yes";
-}
-function getIntInput(name, fallback) {
-  const raw = getInput(name);
-  if (raw === "")
-    return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isInteger(n) ? n : fallback;
-}
-var ALLOWED_OUTPUT_NAMES = new Set([
-  "verdict",
-  "incident-count",
-  "failing-ci-count",
-  "merge-conflict-count",
-  "result-json"
-]);
-function setOutput(name, value) {
-  if (!ALLOWED_OUTPUT_NAMES.has(name)) {
-    throw new Error(`refusing to set unknown output: ${name}`);
-  }
-  const outFile = process.env.GITHUB_OUTPUT;
-  if (outFile === undefined)
-    return;
-  let delim;
-  do {
-    delim = `EOF_${Math.random().toString(36).slice(2)}`;
-  } while (value.includes(delim));
-  appendFileSync(outFile, `${name}<<${delim}
-${value}
-${delim}
-`);
-}
-var STEP_SUMMARY_MAX_BYTES = 64 * 1024;
-function writeJobSummary(md) {
-  const file = process.env.GITHUB_STEP_SUMMARY;
-  if (file === undefined)
-    return;
-  const safe = md.length > STEP_SUMMARY_MAX_BYTES ? md.slice(0, STEP_SUMMARY_MAX_BYTES) : md;
-  appendFileSync(file, `${safe}
-`);
-}
-function emitAnnotation(level, message) {
-  process.stdout.write(`::${level}::${message}
-`);
 }
 function parseMode(raw) {
   if (raw === "block" || raw === "off")
@@ -216,7 +217,8 @@ async function main() {
       unreachable: true,
       allowGatewayFailure
     });
-    setOutput("verdict", code2 === 1 ? "block" : mode === "off" ? "ok" : "warn");
+    const nonBlockVerdict = mode === "off" ? "ok" : "warn";
+    setOutput("verdict", code2 === 1 ? "block" : nonBlockVerdict);
     setOutput("result-json", "{}");
     process.exit(code2);
   }
@@ -239,7 +241,15 @@ async function main() {
   });
   process.exit(code);
 }
-await main();
+if (__require.main == __require.module) {
+  await main();
+}
 export {
-  main
+  sanitizeEnvelope,
+  safeString,
+  parseMode,
+  main,
+  getIntInput,
+  getInput,
+  getBooleanInput
 };

--- a/packages/github-actions/preflight-query/dist/index.js
+++ b/packages/github-actions/preflight-query/dist/index.js
@@ -38,7 +38,9 @@ function writeJobSummary(md) {
 `);
 }
 function emitAnnotation(level, message) {
-  process.stdout.write(`::${level}::${message}
+  const safe = message.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll(`
+`, "%0A");
+  process.stdout.write(`::${level}::${safe}
 `);
 }
 function makeSetOutput(allowedNames) {

--- a/packages/github-actions/preflight-query/src/main.ts
+++ b/packages/github-actions/preflight-query/src/main.ts
@@ -1,4 +1,12 @@
-import { appendFileSync } from "node:fs";
+import {
+  emitAnnotation,
+  getBooleanInput,
+  getInput,
+  getIntInput,
+  safeInt,
+  safeString,
+  writeJobSummary,
+} from "../../shared/gha-io.ts";
 import { setOutput } from "./output.ts";
 import {
   decideExitCode,
@@ -8,18 +16,8 @@ import {
   renderJobSummary,
 } from "./render.ts";
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: explicit byte ranges define the sanitizer barrier
-const DENY_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
-
-export function safeString(raw: unknown, maxLen: number): string {
-  const s = typeof raw === "string" ? raw : "";
-  return s.replace(DENY_CHARS, "").slice(0, maxLen);
-}
-
-function safeInt(raw: unknown): number {
-  const n = typeof raw === "number" ? raw : Number(raw);
-  return Number.isFinite(n) ? Math.trunc(n) : 0;
-}
+// Re-exported so this package's unit tests can import the pure helpers from main.ts.
+export { getBooleanInput, getInput, getIntInput, safeString };
 
 function safeVerdict(raw: unknown): "ok" | "warn" {
   return raw === "warn" ? "warn" : "ok";
@@ -75,36 +73,6 @@ export function sanitizeEnvelope(raw: Envelope): Envelope {
       },
     },
   };
-}
-
-export function getInput(name: string): string {
-  const envName = `INPUT_${name.toUpperCase().replaceAll("-", "_")}`;
-  return process.env[envName] ?? "";
-}
-
-export function getBooleanInput(name: string): boolean {
-  const raw = getInput(name).toLowerCase();
-  return raw === "true" || raw === "1" || raw === "yes";
-}
-
-export function getIntInput(name: string, fallback: number): number {
-  const raw = getInput(name);
-  if (raw === "") return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isInteger(n) ? n : fallback;
-}
-
-const STEP_SUMMARY_MAX_BYTES = 64 * 1024;
-
-function writeJobSummary(md: string): void {
-  const file = process.env.GITHUB_STEP_SUMMARY;
-  if (file === undefined) return;
-  const safe = md.length > STEP_SUMMARY_MAX_BYTES ? md.slice(0, STEP_SUMMARY_MAX_BYTES) : md;
-  appendFileSync(file, `${safe}\n`);
-}
-
-function emitAnnotation(level: "warning" | "error", message: string): void {
-  process.stdout.write(`::${level}::${message}\n`);
 }
 
 export function parseMode(raw: string): PreflightMode {

--- a/packages/github-actions/preflight-query/src/output.ts
+++ b/packages/github-actions/preflight-query/src/output.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto";
-import { appendFileSync } from "node:fs";
+import { makeSetOutput } from "../../shared/gha-io.ts";
 
 export const ALLOWED_OUTPUT_NAMES: ReadonlySet<string> = new Set([
   "verdict",
@@ -9,15 +8,4 @@ export const ALLOWED_OUTPUT_NAMES: ReadonlySet<string> = new Set([
   "result-json",
 ]);
 
-export function setOutput(name: string, value: string): void {
-  if (!ALLOWED_OUTPUT_NAMES.has(name)) {
-    throw new Error(`refusing to set unknown output: ${name}`);
-  }
-  const outFile = process.env.GITHUB_OUTPUT;
-  if (outFile === undefined) return;
-  let delim: string;
-  do {
-    delim = `EOF_${randomUUID().replaceAll("-", "")}`;
-  } while (value.includes(delim));
-  appendFileSync(outFile, `${name}<<${delim}\n${value}\n${delim}\n`);
-}
+export const setOutput: (name: string, value: string) => void = makeSetOutput(ALLOWED_OUTPUT_NAMES);

--- a/packages/github-actions/shared/gha-io.test.ts
+++ b/packages/github-actions/shared/gha-io.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { emitAnnotation, getIntInput, makeSetOutput, safeInt, safeString } from "./gha-io.ts";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  emitAnnotation,
+  getBooleanInput,
+  getInput,
+  getIntInput,
+  makeSetOutput,
+  safeInt,
+  safeString,
+  writeJobSummary,
+} from "./gha-io.ts";
 
 describe("emitAnnotation — workflow-command injection hardening", () => {
   let written = "";
@@ -84,6 +96,86 @@ describe("scalar input helpers", () => {
     } finally {
       if (saved === undefined) delete process.env.INPUT_TIMEOUT_MS;
       else process.env.INPUT_TIMEOUT_MS = saved;
+    }
+  });
+
+  test("getInput and getBooleanInput read INPUT_* env vars", () => {
+    const savedString = process.env.INPUT_SOME_STRING;
+    const savedBool = process.env.INPUT_SOME_BOOL;
+    try {
+      process.env.INPUT_SOME_STRING = " hello ";
+      expect(getInput("some-string")).toBe(" hello ");
+
+      process.env.INPUT_SOME_BOOL = "true";
+      expect(getBooleanInput("some-bool")).toBe(true);
+
+      process.env.INPUT_SOME_BOOL = "YES";
+      expect(getBooleanInput("some-bool")).toBe(true);
+
+      process.env.INPUT_SOME_BOOL = "1";
+      expect(getBooleanInput("some-bool")).toBe(true);
+
+      process.env.INPUT_SOME_BOOL = "false";
+      expect(getBooleanInput("some-bool")).toBe(false);
+
+      delete process.env.INPUT_SOME_BOOL;
+      expect(getBooleanInput("some-bool")).toBe(false);
+    } finally {
+      if (savedString !== undefined) process.env.INPUT_SOME_STRING = savedString;
+      else delete process.env.INPUT_SOME_STRING;
+      if (savedBool !== undefined) process.env.INPUT_SOME_BOOL = savedBool;
+      else delete process.env.INPUT_SOME_BOOL;
+    }
+  });
+});
+
+describe("writeJobSummary", () => {
+  test("writeJobSummary writes to process.env.GITHUB_STEP_SUMMARY", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "gha-summary-"));
+    const summaryFile = join(tmpDir, "summary.md");
+    const saved = process.env.GITHUB_STEP_SUMMARY;
+    process.env.GITHUB_STEP_SUMMARY = summaryFile;
+    try {
+      writeJobSummary("hello world");
+      expect(readFileSync(summaryFile, "utf8")).toBe("hello world\n");
+      const huge = "A".repeat(70000);
+      writeJobSummary(huge);
+      const content = readFileSync(summaryFile, "utf8");
+      expect(content.length).toBe(12 + 65536 + 1); // "hello world\n" + 64kb + "\n"
+    } finally {
+      if (saved === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+      else process.env.GITHUB_STEP_SUMMARY = saved;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("writeJobSummary does nothing when GITHUB_STEP_SUMMARY is unset", () => {
+    const saved = process.env.GITHUB_STEP_SUMMARY;
+    delete process.env.GITHUB_STEP_SUMMARY;
+    try {
+      expect(() => writeJobSummary("hello")).not.toThrow();
+    } finally {
+      if (saved !== undefined) process.env.GITHUB_STEP_SUMMARY = saved;
+    }
+  });
+});
+
+describe("makeSetOutput file writing", () => {
+  test("makeSetOutput writes correct heredoc format to GITHUB_OUTPUT", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "gha-output-"));
+    const outFile = join(tmpDir, "output.txt");
+    const saved = process.env.GITHUB_OUTPUT;
+    process.env.GITHUB_OUTPUT = outFile;
+    try {
+      const setOutput = makeSetOutput(new Set(["my-out"]));
+      setOutput("my-out", "hello\nworld");
+      const content = readFileSync(outFile, "utf8");
+      expect(content).toContain("my-out<<EOF_");
+      expect(content).toContain("\nhello\nworld\nEOF_");
+    } finally {
+      if (saved === undefined) delete process.env.GITHUB_OUTPUT;
+      else process.env.GITHUB_OUTPUT = saved;
+      rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/github-actions/shared/gha-io.test.ts
+++ b/packages/github-actions/shared/gha-io.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { emitAnnotation, getIntInput, makeSetOutput, safeInt, safeString } from "./gha-io.ts";
+
+describe("emitAnnotation — workflow-command injection hardening", () => {
+  let written = "";
+  const original = process.stdout.write.bind(process.stdout);
+  afterEach(() => {
+    process.stdout.write = original;
+    written = "";
+  });
+
+  function capture(): void {
+    written = "";
+    // biome-ignore lint/suspicious/noExplicitAny: minimal stdout.write spy for the test
+    process.stdout.write = ((chunk: any) => {
+      written += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+  }
+
+  test("escapes newlines so a message cannot inject a second workflow command", () => {
+    capture();
+    emitAnnotation("error", "boom\n::add-mask::secret");
+    process.stdout.write = original;
+    // The injected newline is encoded; no raw second `::command` line is emitted.
+    expect(written).toBe("::error::boom%0A::add-mask::secret\n");
+    expect(written.split("\n")).toHaveLength(2); // only the trailing terminator newline
+  });
+
+  test("escapes carriage returns and percent signs (GitHub data encoding)", () => {
+    capture();
+    emitAnnotation("warning", "100% done\rX");
+    process.stdout.write = original;
+    expect(written).toBe("::warning::100%25 done%0DX\n");
+  });
+
+  test("leaves an ordinary message untouched apart from the terminator", () => {
+    capture();
+    emitAnnotation("warning", "missing required input: service");
+    process.stdout.write = original;
+    expect(written).toBe("::warning::missing required input: service\n");
+  });
+});
+
+describe("makeSetOutput", () => {
+  test("rejects an output name outside the allow-list", () => {
+    const setOutput = makeSetOutput(new Set(["verdict"]));
+    expect(() => setOutput("not-allowed", "x")).toThrow(/refusing to set unknown output/);
+  });
+
+  test("is a no-op when GITHUB_OUTPUT is unset", () => {
+    const saved = process.env.GITHUB_OUTPUT;
+    delete process.env.GITHUB_OUTPUT;
+    try {
+      const setOutput = makeSetOutput(new Set(["verdict"]));
+      expect(() => setOutput("verdict", "ok")).not.toThrow();
+    } finally {
+      if (saved !== undefined) process.env.GITHUB_OUTPUT = saved;
+    }
+  });
+});
+
+describe("scalar input helpers", () => {
+  test("safeString strips control chars and clamps length", () => {
+    expect(safeString("ab", 10)).toBe("ab");
+    expect(safeString("abcdef", 3)).toBe("abc");
+    expect(safeString(42, 10)).toBe("");
+  });
+
+  test("safeInt coerces and truncates; non-finite → 0", () => {
+    expect(safeInt("12.9")).toBe(12);
+    expect(safeInt("nope")).toBe(0);
+    expect(safeInt(7)).toBe(7);
+  });
+
+  test("getIntInput falls back when empty or non-integer", () => {
+    const saved = process.env.INPUT_TIMEOUT_MS;
+    try {
+      delete process.env.INPUT_TIMEOUT_MS;
+      expect(getIntInput("timeout-ms", 5)).toBe(5);
+      process.env.INPUT_TIMEOUT_MS = "abc";
+      expect(getIntInput("timeout-ms", 5)).toBe(5);
+      process.env.INPUT_TIMEOUT_MS = "8";
+      expect(getIntInput("timeout-ms", 5)).toBe(8);
+    } finally {
+      if (saved === undefined) delete process.env.INPUT_TIMEOUT_MS;
+      else process.env.INPUT_TIMEOUT_MS = saved;
+    }
+  });
+});

--- a/packages/github-actions/shared/gha-io.test.ts
+++ b/packages/github-actions/shared/gha-io.test.ts
@@ -11,9 +11,8 @@ describe("emitAnnotation — workflow-command injection hardening", () => {
 
   function capture(): void {
     written = "";
-    // biome-ignore lint/suspicious/noExplicitAny: minimal stdout.write spy for the test
-    process.stdout.write = ((chunk: any) => {
-      written += String(chunk);
+    process.stdout.write = ((chunk: Parameters<typeof process.stdout.write>[0]): boolean => {
+      written += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
       return true;
     }) as typeof process.stdout.write;
   }

--- a/packages/github-actions/shared/gha-io.ts
+++ b/packages/github-actions/shared/gha-io.ts
@@ -51,9 +51,15 @@ export function writeJobSummary(md: string): void {
   appendFileSync(file, `${safe}\n`);
 }
 
-/** Emit a GitHub Actions workflow annotation command on stdout. */
+/**
+ * Emit a GitHub Actions workflow annotation command on stdout. The message is escaped with the
+ * GitHub-documented encoding (`%`→`%25`, CR→`%0D`, LF→`%0A`) so that gateway-supplied content (error
+ * bodies, hints) containing newlines or `::` cannot inject additional workflow commands; GitHub
+ * decodes the escapes back when rendering the annotation, so multi-line messages still display.
+ */
 export function emitAnnotation(level: "warning" | "error", message: string): void {
-  process.stdout.write(`::${level}::${message}\n`);
+  const safe = message.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+  process.stdout.write(`::${level}::${safe}\n`);
 }
 
 /**

--- a/packages/github-actions/shared/gha-io.ts
+++ b/packages/github-actions/shared/gha-io.ts
@@ -1,0 +1,79 @@
+// Shared GitHub Actions I/O helpers for the first-party Nimbus actions (preflight-query +
+// annotate-action). These were byte-identical across both actions' main.ts/output.ts; hoisting them
+// here removes the duplication. The packages are bundled standalone via `bun build`, so this relative
+// module is inlined at build time (no workspace/package dependency is introduced).
+
+import { randomUUID } from "node:crypto";
+import { appendFileSync } from "node:fs";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: explicit byte ranges define the sanitizer barrier
+const DENY_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
+
+/** Strip control characters and clamp to maxLen. Non-string input → "". */
+export function safeString(raw: unknown, maxLen: number): string {
+  const s = typeof raw === "string" ? raw : "";
+  return s.replace(DENY_CHARS, "").slice(0, maxLen);
+}
+
+/** Coerce to a finite truncated integer; non-finite input → 0. */
+export function safeInt(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? Math.trunc(n) : 0;
+}
+
+/** Read an action input from its `INPUT_<NAME>` env var (missing → ""). */
+export function getInput(name: string): string {
+  const envName = `INPUT_${name.toUpperCase().replaceAll("-", "_")}`;
+  return process.env[envName] ?? "";
+}
+
+/** Read a boolean action input ("true"/"1"/"yes" → true, case-insensitive). */
+export function getBooleanInput(name: string): boolean {
+  const raw = getInput(name).toLowerCase();
+  return raw === "true" || raw === "1" || raw === "yes";
+}
+
+/** Read an integer action input, falling back when empty or non-integer. */
+export function getIntInput(name: string, fallback: number): number {
+  const raw = getInput(name);
+  if (raw === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) ? n : fallback;
+}
+
+const STEP_SUMMARY_MAX_BYTES = 64 * 1024;
+
+/** Append markdown to the job summary file (capped), if `GITHUB_STEP_SUMMARY` is set. */
+export function writeJobSummary(md: string): void {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (file === undefined) return;
+  const safe = md.length > STEP_SUMMARY_MAX_BYTES ? md.slice(0, STEP_SUMMARY_MAX_BYTES) : md;
+  appendFileSync(file, `${safe}\n`);
+}
+
+/** Emit a GitHub Actions workflow annotation command on stdout. */
+export function emitAnnotation(level: "warning" | "error", message: string): void {
+  process.stdout.write(`::${level}::${message}\n`);
+}
+
+/**
+ * Build a `setOutput(name, value)` bound to an action's allow-list of output names. Uses the
+ * heredoc-delimiter form to support multi-line values; refuses unknown output names (each action
+ * declares exactly the outputs in its action.yml). No-op when `GITHUB_OUTPUT` is unset.
+ */
+export function makeSetOutput(
+  allowedNames: ReadonlySet<string>,
+): (name: string, value: string) => void {
+  return (name: string, value: string): void => {
+    if (!allowedNames.has(name)) {
+      throw new Error(`refusing to set unknown output: ${name}`);
+    }
+    const outFile = process.env.GITHUB_OUTPUT;
+    if (outFile === undefined) return;
+    let delim: string;
+    do {
+      delim = `EOF_${randomUUID().replaceAll("-", "")}`;
+    } while (value.includes(delim));
+    appendFileSync(outFile, `${name}<<${delim}\n${value}\n${delim}\n`);
+  };
+}

--- a/packages/mcp-connectors/monte-carlo/src/search-filter.ts
+++ b/packages/mcp-connectors/monte-carlo/src/search-filter.ts
@@ -1,23 +1,11 @@
-import { asRecord, makeQueryFilter, type SearchMatchOptions } from "../../shared/search-filter.ts";
+import {
+  fieldsFromKeys,
+  makeQueryFilter,
+  type SearchMatchOptions,
+} from "../../shared/search-filter.ts";
 
 export type MonteCarloSearchMatchOptions = SearchMatchOptions;
 
-function stringAt(row: Record<string, unknown>, key: string): string {
-  const v = row[key];
-  return typeof v === "string" ? v : "";
-}
-
-function fieldsOf(item: unknown): readonly string[] | null {
-  const row = asRecord(item);
-  if (row === undefined) {
-    return null;
-  }
-  return [
-    stringAt(row, "incidentId"),
-    stringAt(row, "status"),
-    stringAt(row, "severity"),
-    stringAt(row, "monitoredTable"),
-  ];
-}
-
-export const filterMonteCarloIncidents = makeQueryFilter(fieldsOf);
+export const filterMonteCarloIncidents = makeQueryFilter(
+  fieldsFromKeys(["incidentId", "status", "severity", "monitoredTable"]),
+);

--- a/packages/mcp-connectors/snowflake/src/server.ts
+++ b/packages/mcp-connectors/snowflake/src/server.ts
@@ -59,7 +59,7 @@ function assertSfIdentifier(name: string, label: string): string {
 
 // String literals are escaped by doubling single quotes (the only Snowflake literal-injection vector).
 function sfLiteral(v: string): string {
-  return `'${v.replace(/'/g, "''")}'`;
+  return `'${v.replaceAll("'", "''")}'`;
 }
 
 const TABLES_SQL =

--- a/scripts/coverage/instrument-scope.ts
+++ b/scripts/coverage/instrument-scope.ts
@@ -3,10 +3,11 @@
 // node_modules re-enter the onLoad hook and crashes Babel internals.
 const FIRST_PARTY = /\/packages\/(?:gateway|cli|sdk|client)\/src\//;
 const CONNECTOR_SRC = /\/packages\/mcp-connectors\/[^/]+\/src\//;
+const GHA_SRC = /\/packages\/github-actions\/(?:shared|[^/]+\/src)\//;
 
 export function shouldInstrument(absPath: string): boolean {
   const p = absPath.replaceAll("\\", "/");
   if (p.includes("/node_modules/")) return false;
   if (/\.(test|spec)\.[cm]?tsx?$/.test(p)) return false;
-  return FIRST_PARTY.test(p) || CONNECTOR_SRC.test(p);
+  return FIRST_PARTY.test(p) || CONNECTOR_SRC.test(p) || GHA_SRC.test(p);
 }


### PR DESCRIPTION
## Summary

SonarCloud hygiene pass (cleanup 8). The quality gate on `main` was already **PASS** (0 bugs, 0 vulns, 0 unreviewed hotspots) — this clears the 11 outstanding `CODE_SMELL` findings, reduces duplication, and raises coverage on the most tractable partial file. Fix-not-exclude per repo convention.

## Issues cleared (11)
- **3× S3776** (cognitive complexity): `parseNimbusConnectorsToml` → `accumulateConnectorTables` + `resolveConnectorConfig`; `assemblePlatformServices` → `buildTeamCredentialContexts` + `bootChatopsIntoAssembly` (the late-bound `identityBootRef` became a holder; the two duplicated identity spreads collapsed into one); `aggregateContributions` → `collectPeerItems`
- **2× S6582**: optional-chain in `invoke-gate.ts` (I19/I26 load-bearing — behavior identical, invariants preserved)
- **2× S7747**: dropped redundant array-spread in `embedding-worker-core` `idle()`
- **2× S6353**: `\w` over `[A-Za-z0-9_]` in `format-audit-payload` (`_`-boundary semantics preserved)
- **S4325**: removed redundant `BonjourLike` type assertion
- **S7781**: `replaceAll` over `replace(/'/g)` in snowflake `sfLiteral`

## Duplication
- Hoisted the byte-identical GitHub Actions I/O helpers (`safeString`/`safeInt`/`getInput`/`getBooleanInput`/`getIntInput`/`writeJobSummary`/`emitAnnotation`) plus a `makeSetOutput(allowedNames)` factory into a new `packages/github-actions/shared/gha-io.ts`. `preflight-query` + `annotate-action` import and re-export what their tests need; dist bundles rebuilt. Kills the 83%/81% `output.ts` and the `main.ts` scaffolding twins.
- `monte-carlo/search-filter` now uses the shared `fieldsFromKeys` (drops its duplicate `stringAt`/`fieldsOf`), matching the bitrise/codemagic pattern.

## Coverage
- `connector.ts` **91.2% → 95.6%**: real behavior tests for the `relTime`/`fmtNextSync` time buckets, `truncateText`, `fmtHealthRetry`, and flag-value validation edges.
- `assemble-sync-registrations.ts` (53%) intentionally **not** chased — it is explicitly excluded from the coverage floor as boot wiring-glue, and covering its ~95 connector closures would require running 95 real sync paths for zero gate value.

## Validation
- Full sequential typecheck (all packages) ✓
- Gateway full suite (10006 pass) + CLI (1693) + monte-carlo + gha (55) ✓
- Security-invariant structure audit (I19/I22/I25) ✓
- **Docker Linux-authoritative coverage-floor: ok** (1002 files scanned) ✓
- Biome (`bunx biome check packages scripts`, 2765 files) ✓
- Independent code review of the diff: no blocking issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized GitHub Actions input/output, annotations, and job summaries into a shared module; updated related actions to re-use shared helpers.
  * Refined Nimbus TOML connector parsing/validation and improved gateway contribution aggregation; extracted helpers across related query and assembly flows.
* **Bug Fixes**
  * Tightened fine-grained GitHub credential redaction patterns and improved Snowflake single-quote escaping.
* **Tests**
  * Expanded CLI list/auth edge-case tests (time/health buckets, formatting, truncation) and added shared action utility unit tests.
* **Documentation / CI**
  * Updated link checking to use an API token and improved CI coverage for shared action utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->