### PR TITLE
fix(ci): session-memory getRecentTurns must not require sqlite-vec (share e2e I27)

### DIFF
--- a/packages/gateway/src/memory/session-memory-store.ts
+++ b/packages/gateway/src/memory/session-memory-store.ts
@@ -126,7 +126,13 @@ export class SessionMemoryStore {
     sessionId: string,
     limit: number,
   ): Promise<Array<{ text: string; role: SessionMemoryRole; createdAt: number }>> {
-    if (!this.ensureReady()) {
+    // This read touches only the `session_memory` table — never a vec virtual table — so it must
+    // NOT gate on ensureReady() (which also requires the sqlite-vec extension to load). On a runner
+    // where sqlite-vec is unavailable (no npm prebuilt + no sidecar), the table still holds the
+    // no-vec rows append() wrote; gating on vec readiness here silently dropped them (empty turns),
+    // which is why the I27 share e2e redaction round-trip failed on all 3 OS legs. Gate on table
+    // existence (V10) only, mirroring listSessions()/deleteSession().
+    if (readIndexedUserVersion(this.db) < 10) {
       return [];
     }
     const k = Math.min(200, Math.max(1, Math.floor(limit)));


### PR DESCRIPTION
## Problem

The I27 share e2e redaction round-trip (`approved create redacts PII, signs, writes the file; verify reports a VALID signature`) fails **identically on all 3 OS legs** of the push-to-`main` matrix (run 27642549323). It is a logic bug, not a platform flake.

The written share body carried `"turns":[]`, `"toolCalls":[]`, `"redactionSet":[]`, so redaction had no PII to strip and the `expect(fileText).toContain("[REDACTED]")` assertion failed.

## Root cause

`SessionMemoryStore.getRecentTurns` gated on `ensureReady()`, which requires the **optional sqlite-vec extension** to load (`ensureSqliteVecForConnection`). On CI runners with no sqlite-vec prebuilt and no `vec0.*` sidecar, the read short-circuited to `[]` — even though the seeded `session_memory` rows were present and the `SELECT` touches only the `session_memory` table, never a vec virtual table.

The unit suite is `describe.skipIf(!VEC_AVAILABLE)`, so it's silently skipped on those runners — only the unguarded e2e test caught the regression. The sibling reads (`listSessions`, `deleteSession`) correctly gate on table existence (`user_version >= 10`) only.

## Fix

Gate `getRecentTurns` on `readIndexedUserVersion(this.db) < 10` (table existence) only, mirroring `listSessions()`/`deleteSession()`. The vec dependency was spurious for this read.

This also restores **platform equality** (Non-Negotiable #5): session-transcript recall now works on any box at schema V10, regardless of whether the optional vec extension loaded.

## Verification

- `bun test packages/gateway/src/memory/session-memory-store.test.ts packages/gateway/test/e2e/share-e2e.test.ts` → 23 pass / 0 fail.
- `bun run preflight:fast` → PASSED (typecheck, biome, all static audits, duplication).
- The `version < 10 → []` unit case is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session memory retrieval to work reliably without requiring optional extension support, ensuring consistent access to session data across all environments and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->