### PR TITLE
fix(ci): gitleaks allowlist synthetic TestFlight PEM fixture

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -44,6 +44,13 @@
 #        sees it in historical commits — a path allowlist is the durable fix
 #        (same rationale as entry 1's secret-patterns.test.ts).
 #
+#   5. packages/gateway/src/connectors/lazy-mesh/phase3-config.test.ts
+#      — the lazy-mesh phase-3 connector spawn test sets a synthetic TestFlight
+#        credential (`testflight.private_key`, `-----BEGIN PRIVATE KEY-----\nabc\n`)
+#        to assert the connector spawns when all three creds are present. The PEM
+#        header trips the default `private-key` rule, but the body is the literal
+#        `abc` — never a real key. Path allowlist, same rationale as entry 1.
+#
 # Why path-based instead of fingerprint pins in `.gitleaksignore`:
 # fingerprints are `<commit-sha>:<path>:<rule>:<line>`. Squash-merges rewrite
 # the SHA, rebases shift line numbers, and the pin then misses the (now
@@ -59,6 +66,7 @@ description = "Synthetic fixtures for the secret-pattern + log-scrubber unit tes
 paths = [
   '''packages/gateway/src/security/secret-patterns\.test\.ts''',
   '''packages/gateway/src/platform/gateway-log-file\.test\.ts''',
+  '''packages/gateway/src/connectors/lazy-mesh/phase3-config\.test\.ts''',
   '''docs/superpowers/plans/.*\.md''',
   '''\.claude/agents/.*\.md''',
 ]


### PR DESCRIPTION
## Summary

Adds `packages/gateway/src/connectors/lazy-mesh/phase3-config.test.ts` to the `.gitleaks.toml` path allowlist.

## Why

The lazy-mesh phase-3 connector spawn test sets a **synthetic** TestFlight credential:

```ts
await vault.set("testflight.private_key", "-----BEGIN PRIVATE KEY-----\nabc\n");
```

The `-----BEGIN PRIVATE KEY-----` header trips gitleaks' default `private-key` rule on the full-history/all-refs scan, but the body is the literal `abc` — **never a real key**. This is the same false-positive class already handled for four other fixture files (secret-patterns.test.ts, gateway-log-file.test.ts, etc.), so it gets the same durable **path-based** allowlist (fingerprint pins break on squash-merge — see the config header).

The fixture was introduced on a coverage branch and surfaced gitleaks failures across unrelated PRs (e.g. a docs-only PR) because the scan crosses refs. Landing the allowlist on `main` clears it for every branch on update.

No code change; one path added to the existing allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to accommodate test fixtures containing synthetic credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->