### PR TITLE
refactor(dedup): Stage B1 — MCP search-tool scaffolding → shared/ (44 connectors)

### DIFF
--- a/docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md
+++ b/docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md
@@ -333,7 +333,7 @@ Same as Task 2 — `extra=none` + guarded tail → apply **both**.
 | stripe | 100 | keyed | filterStripeInvoices | both |
 | vercel | 100 | keyed | filterVercelDeployments | both |
 | zendesk | 100 | keyed | filterZendeskTickets | both |
-| zoom | 100 | keyed | filterZoomMeetings | both |
+| ~~zoom~~ | — | — | — | **SKIPPED at execution** — `filterZoomMeetings` uses a custom `ZoomSearchOptions` type incompatible with the generic helper under `exactOptionalPropertyTypes` (no force-fit) |
 | semgrep | 200 | keyed | filterSemgrepFindings | both |
 
 - [ ] **Step 1: Apply both transforms** to each file per the Transformation Reference. Note `semgrep` cap is **200**. Update imports per the import rule.

--- a/docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md
+++ b/docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md
@@ -62,6 +62,8 @@ Root category (X = `root`):
     },
 ```
 
+**Pass `p` directly — do not destructure or rebuild it.** For the extra-field connectors (Task 7, e.g. `p` also carries `appId`/`orgId`/`projectKey`), write `matchesResult(X, filterFn, p)`. Passing the `p` *variable* is correct and typechecks: TS excess-property checks fire only on fresh object literals, not on a variable with extra fields (verified 2026-06-17). Do **not** "helpfully" rewrite it to `matchesResult(X, filterFn, { query: p.query, limit: p.limit })` — that adds noise and is unnecessary.
+
 Keyed category (X = the extracted variable; **keep that extract line unchanged**):
 
 ```ts
@@ -85,9 +87,8 @@ Keyed category (X = the extracted variable; **keep that extract line unchanged**
 ### Import rule
 
 - Add to the top imports: `import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";` — include only the name(s) actually used by that file's transforms.
-- After editing, remove `import { z } from "zod";` **only if** `z` is no longer referenced anywhere in the file (grep `\bz\.` — many files keep other zod schemas for list/get tools).
-- Remove the `mcpJsonResult as jsonResult` (or `mcpJsonResult`) import **only if** `jsonResult`/`mcpJsonResult` is no longer referenced (grep the file).
-- tsc + Biome `noUnusedImports` (run in the per-task verify step) catch a missed/over-eager removal.
+- **Do NOT remove `import { z }` or the `mcpJsonResult as jsonResult` import by hand.** After the code edits, let Biome do it deterministically: `bunx biome check --write <edited server.ts files>`. Biome's `noUnusedImports` removes a now-unused import (and leaves `z`/`jsonResult` in place when another tool in the file still uses them) — far safer than manual grep-and-delete. `--write` also normalizes formatting on the touched lines, which is expected.
+- The per-task verify step then re-runs `bunx biome check` (read-only) + tsc to confirm nothing is unused or broken.
 
 ### Verify (each sweep task)
 
@@ -97,13 +98,13 @@ Run the edited connectors' tests (replace the names):
 bun test packages/mcp-connectors/<conn1>/ packages/mcp-connectors/<conn2>/ …
 ```
 
-Expected: all pass (skips OK), **0 fail**, with no test file modified. Then typecheck the connectors package:
+Expected: all pass (skips OK), **0 fail**, with no test file modified. Then typecheck each edited connector. Each connector has its own `tsconfig.json` (`include: ["src/**/*"]`) and tsc follows the `../../shared/mcp-search-tool.ts` import, so the shared helper is checked transitively here:
 
 ```bash
-bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json
+for c in <this batch's connectors, space-separated>; do bunx tsc --noEmit -p packages/mcp-connectors/$c/tsconfig.json || break; done
 ```
 
-Expected: no errors. (If the connectors package has no own tsconfig, the root `bun run typecheck` covers it — the final task runs full preflight regardless.)
+Expected: no errors. (The authoritative full check is `bun run typecheck`, run in Task 8's preflight; the per-connector loop is the fast inner-loop equivalent.)
 
 ---
 
@@ -230,7 +231,7 @@ export function searchToolInputSchema(maxLimit = 100): ZodObjectSchema<SearchMat
   return z.object({
     query: z.string().min(1),
     limit: z.number().int().min(1).max(maxLimit).optional(),
-  }) as unknown as ZodObjectSchema<SearchMatchOptions>;
+  });
 }
 
 /**
@@ -250,7 +251,7 @@ export function matchesResult(
 }
 ```
 
-> Note on the cast: the existing tool-kit already accepts `z.object(...)` where `ZodObjectSchema<T>` is expected. If tsc accepts `as ZodObjectSchema<SearchMatchOptions>` (single cast) or no cast at all, prefer the simpler form; `as unknown as` is the fallback if zod's inferred type does not structurally match. Verify with the typecheck in Step 5 and use the least-cast form that compiles.
+> Note on the cast (empirically verified 2026-06-17 via a scoped tsc probe in this worktree): **no cast is needed.** `return z.object({...})` assigns directly to the declared `ZodObjectSchema<SearchMatchOptions>` return type. This is consistent with the existing connectors, which pass `z.object(...)` straight into `reg` (a `ZodObjectSchema<T>` parameter) with no cast — proving zod's `ZodError` is already assignable to the structural `{ error: { message: string } }`. Do NOT add `as unknown as ...` (it would erase type checking for no benefit, against Non-Negotiable #7). If a future zod bump ever breaks the direct assignment, escalate minimally: try a single `as ZodObjectSchema<SearchMatchOptions>` first, and only then `as unknown as`. Step 5's typecheck is the gate.
 
 - [ ] **Step 4: Run the test to verify it passes**
 
@@ -260,8 +261,13 @@ Expected: PASS — all tests green.
 - [ ] **Step 5: Typecheck + lint the new files**
 
 Run: `bunx biome check packages/mcp-connectors/shared/mcp-search-tool.ts packages/mcp-connectors/shared/mcp-search-tool.test.ts`
-Then: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` (or root `bun run typecheck` if no package tsconfig).
-Expected: no errors. Tighten the cast to the least form that compiles.
+Then typecheck. The `shared/` directory has **no tsconfig of its own** and is not under any connector's `include`, so at this point the helper is only type-checked transitively once a connector imports it (Task 2). For a fast standalone check now, run the scoped form (matches `tsconfig.base.json`'s settings, with node globals for the transitive `mcp-tool-kit.ts`):
+
+```bash
+bunx tsc --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler --allowImportingTsExtensions --types node packages/mcp-connectors/shared/mcp-search-tool.ts
+```
+
+Expected: no errors (no cast on the schema — see the note above). The authoritative full check is `bun run typecheck` in Task 8's preflight; Task 2's per-connector typecheck is the first place the helper is checked in-project.
 
 - [ ] **Step 6: Commit**
 
@@ -302,7 +308,7 @@ Expected: all pass (skips OK), 0 fail. Confirm `git status` shows no `*.test.ts`
 
 - [ ] **Step 3: Typecheck + lint**
 
-Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{zotero,greenhouse,netlify,intercom,lever,mercury,pipedrive,raindrop}/src/server.ts`
+Run: `for c in <this batch's connectors, space-separated>; do bunx tsc --noEmit -p packages/mcp-connectors/$c/tsconfig.json || break; done` and `bunx biome check packages/mcp-connectors/{zotero,greenhouse,netlify,intercom,lever,mercury,pipedrive,raindrop}/src/server.ts`
 Expected: no errors.
 
 - [ ] **Step 4: Commit**
@@ -339,7 +345,7 @@ Expected: all pass, 0 fail; no `*.test.ts` modified.
 
 - [ ] **Step 3: Typecheck + lint**
 
-Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{readwise,stackoverflow,stripe,vercel,zendesk,zoom,semgrep}/src/server.ts`
+Run: `for c in <this batch's connectors, space-separated>; do bunx tsc --noEmit -p packages/mcp-connectors/$c/tsconfig.json || break; done` and `bunx biome check packages/mcp-connectors/{readwise,stackoverflow,stripe,vercel,zendesk,zoom,semgrep}/src/server.ts`
 Expected: no errors.
 
 - [ ] **Step 4: Commit**
@@ -377,7 +383,7 @@ Expected: all pass, 0 fail; no `*.test.ts` modified.
 
 - [ ] **Step 3: Typecheck + lint**
 
-Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{airflow,argocd,bigeye,canva,dagster,databricks,dependencytrack,figma}/src/server.ts`
+Run: `for c in <this batch's connectors, space-separated>; do bunx tsc --noEmit -p packages/mcp-connectors/$c/tsconfig.json || break; done` and `bunx biome check packages/mcp-connectors/{airflow,argocd,bigeye,canva,dagster,databricks,dependencytrack,figma}/src/server.ts`
 Expected: no errors.
 
 - [ ] **Step 4: Commit**
@@ -414,7 +420,7 @@ Expected: all pass, 0 fail; no `*.test.ts` modified.
 
 - [ ] **Step 3: Typecheck + lint**
 
-Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{hubspot,looker,metabase,miro,mlflow,monte-carlo,powerbi}/src/server.ts`
+Run: `for c in <this batch's connectors, space-separated>; do bunx tsc --noEmit -p packages/mcp-connectors/$c/tsconfig.json || break; done` and `bunx biome check packages/mcp-connectors/{hubspot,looker,metabase,miro,mlflow,monte-carlo,powerbi}/src/server.ts`
 Expected: no errors.
 
 - [ ] **Step 4: Commit**
@@ -451,7 +457,7 @@ Expected: all pass, 0 fail; no `*.test.ts` modified.
 
 - [ ] **Step 3: Typecheck + lint**
 
-Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{prefect,ramp,salesforce,snowflake,superset,tableau,wiz}/src/server.ts`
+Run: `for c in <this batch's connectors, space-separated>; do bunx tsc --noEmit -p packages/mcp-connectors/$c/tsconfig.json || break; done` and `bunx biome check packages/mcp-connectors/{prefect,ramp,salesforce,snowflake,superset,tableau,wiz}/src/server.ts`
 Expected: no errors.
 
 - [ ] **Step 4: Commit**
@@ -489,7 +495,7 @@ Expected: all pass, 0 fail; no `*.test.ts` modified.
 
 - [ ] **Step 3: Typecheck + lint**
 
-Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{mendeley,bitrise,codemagic,firebase,launchdarkly,testflight,snyk,sonarqube}/src/server.ts`
+Run: `for c in <this batch's connectors, space-separated>; do bunx tsc --noEmit -p packages/mcp-connectors/$c/tsconfig.json || break; done` and `bunx biome check packages/mcp-connectors/{mendeley,bitrise,codemagic,firebase,launchdarkly,testflight,snyk,sonarqube}/src/server.ts`
 Expected: no errors.
 
 - [ ] **Step 4: Commit**

--- a/docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md
+++ b/docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md
@@ -1,0 +1,552 @@
+# jscpd Stage B1 — MCP search-tool scaffolding sweep — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut strict jscpd duplication by collapsing the cloned MCP connector search-tool schema + result-envelope into two small shared helpers and sweeping the ~45 connectors that match the canonical shape.
+
+**Architecture:** Add `packages/mcp-connectors/shared/mcp-search-tool.ts` with two pure helpers — `searchToolInputSchema(maxLimit)` (collapses the `{query, limit}` zod schema, cap parameterized to preserve each connector's exact limit) and `matchesResult(rows, filter, opts)` (collapses the `Array.isArray(X) ? filter(X, …) : [] → jsonResult({matches})` tail). Then mechanically apply them to each connector's search tool. Pure dedup, zero behavior change — every edit is a verbatim-equivalent transformation; each connector's `sandbox.test.ts` + `search-filter.test.ts` stay green unedited.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6 strict, zod, Biome. MCP connectors (AGPL) under `packages/mcp-connectors/*`, sharing relative-imported helpers from `packages/mcp-connectors/shared/`.
+
+**Spec:** [`docs/superpowers/specs/2026-06-17-jscpd-stage-b1-search-tool-scaffolding-design.md`](../specs/2026-06-17-jscpd-stage-b1-search-tool-scaffolding-design.md)
+
+## Global Constraints
+
+- **No `any`** (Non-Negotiable #7) — external payloads stay `unknown` at the boundary; helpers are generic/structural.
+- **Pure dedup — zero behavior change.** Preserve each connector's exact `limit` cap, `query.min(1)`, fetch URL, keyed-extract expression, and filter function. No connector test (`sandbox.test.ts`, `search-filter.test.ts`, etc.) may be edited.
+- **No force-fit.** Migrate only connectors matching the exact shapes below. Skip `dbt`, `flagsmith`, `flux` (extra schema field AND no `Array.isArray` guard — neither helper applies).
+- **Target `mcp-connectors/shared/`**, relative-imported (`../../shared/…`). NOT the SDK.
+- **Do not** touch other tool handlers (list/get/etc.), the CI lenient duplication gate (`pr-quality-duplication` — tightening is the program's final stage), perf surfaces, or `.jscpd.json`.
+- **Prereq (already done in this worktree; redo if the worktree is recreated):** `cd packages/sdk && bun run build` and `cd packages/client && bun run build` — otherwise `sandbox.test.ts` fails with `Cannot find module '@nimbus-dev/sdk/testing'`.
+- **Strict jscpd baseline (clean main `8f346bac`):** 4.98% (637 clones). Re-measure after the sweep.
+
+---
+
+## Transformation Reference (applies to every sweep task: Tasks 2–7)
+
+Each connector's search tool is in `packages/mcp-connectors/<conn>/src/server.ts`. Apply whichever of the two transforms the connector's row in the task table calls for (`schema`, `tail`, or `both`). **Leave everything else byte-identical** — name string, description string, fetch URL, the keyed `const X = (root as {…})?.key;` line, and the filter function.
+
+### Transform 1 — schema collapse (`searchToolInputSchema(<cap>)`)
+
+Replace the inline 3-line zod object with one call, passing the connector's **exact** existing cap:
+
+```ts
+// before
+    z.object({
+      query: z.string().min(1),
+      limit: z.number().int().min(1).max(100).optional(),
+    }),
+// after
+    searchToolInputSchema(100),
+```
+
+### Transform 2 — tail collapse (`matchesResult(X, filterFn, p)`)
+
+Replace the guarded `Array.isArray(X) ? filter : [] → jsonResult({matches})` tail with one return. `X` is whatever the existing code guards (`root` for the root category, or the already-extracted keyed variable). `p` is the handler arg.
+
+Root category (X = `root`):
+
+```ts
+// before
+    async (p) => {
+      const root = await zoteroGet(`…`);
+      const matches = Array.isArray(root)
+        ? filterZoteroItems(root, { query: p.query, limit: p.limit })
+        : [];
+      return jsonResult({ matches });
+    },
+// after
+    async (p) => {
+      const root = await zoteroGet(`…`);
+      return matchesResult(root, filterZoteroItems, p);
+    },
+```
+
+Keyed category (X = the extracted variable; **keep that extract line unchanged**):
+
+```ts
+// before
+    async (p) => {
+      const root = await zendeskGet(`…`);
+      const tickets = (root as { tickets?: unknown[] } | null)?.tickets;
+      const matches = Array.isArray(tickets)
+        ? filterZendeskTickets(tickets, { query: p.query, limit: p.limit })
+        : [];
+      return jsonResult({ matches });
+    },
+// after
+    async (p) => {
+      const root = await zendeskGet(`…`);
+      const tickets = (root as { tickets?: unknown[] } | null)?.tickets;
+      return matchesResult(tickets, filterZendeskTickets, p);
+    },
+```
+
+### Import rule
+
+- Add to the top imports: `import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";` — include only the name(s) actually used by that file's transforms.
+- After editing, remove `import { z } from "zod";` **only if** `z` is no longer referenced anywhere in the file (grep `\bz\.` — many files keep other zod schemas for list/get tools).
+- Remove the `mcpJsonResult as jsonResult` (or `mcpJsonResult`) import **only if** `jsonResult`/`mcpJsonResult` is no longer referenced (grep the file).
+- tsc + Biome `noUnusedImports` (run in the per-task verify step) catch a missed/over-eager removal.
+
+### Verify (each sweep task)
+
+Run the edited connectors' tests (replace the names):
+
+```bash
+bun test packages/mcp-connectors/<conn1>/ packages/mcp-connectors/<conn2>/ …
+```
+
+Expected: all pass (skips OK), **0 fail**, with no test file modified. Then typecheck the connectors package:
+
+```bash
+bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json
+```
+
+Expected: no errors. (If the connectors package has no own tsconfig, the root `bun run typecheck` covers it — the final task runs full preflight regardless.)
+
+---
+
+## Task 1: Create the `mcp-search-tool` shared helpers
+
+**Files:**
+
+- Create: `packages/mcp-connectors/shared/mcp-search-tool.ts`
+- Test: `packages/mcp-connectors/shared/mcp-search-tool.test.ts`
+
+**Interfaces:**
+
+- Consumes: `mcpJsonResult`, `McpListResult`, `ZodObjectSchema<T>` from `./mcp-tool-kit.ts`; `SearchMatchOptions` from `./search-filter.ts`; `z` from `zod`.
+- Produces:
+  - `searchToolInputSchema(maxLimit = 100): ZodObjectSchema<SearchMatchOptions>`
+  - `matchesResult(rows: unknown, filter: SearchFilter, opts: SearchMatchOptions): McpListResult`
+  - `type SearchFilter = (rows: readonly unknown[], opts: SearchMatchOptions) => readonly unknown[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/mcp-connectors/shared/mcp-search-tool.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { matchesResult, searchToolInputSchema } from "./mcp-search-tool.ts";
+
+describe("searchToolInputSchema", () => {
+  test("accepts query alone and query+limit", () => {
+    const s = searchToolInputSchema();
+    const a = s.safeParse({ query: "x" });
+    expect(a.success).toBe(true);
+    if (a.success) {
+      expect(a.data).toEqual({ query: "x" });
+    }
+    const b = s.safeParse({ query: "x", limit: 5 });
+    expect(b.success).toBe(true);
+    if (b.success) {
+      expect(b.data).toEqual({ query: "x", limit: 5 });
+    }
+  });
+
+  test("rejects empty query", () => {
+    expect(searchToolInputSchema().safeParse({ query: "" }).success).toBe(false);
+  });
+
+  test("rejects limit over the default cap of 100, below 1, or non-integer", () => {
+    const s = searchToolInputSchema();
+    expect(s.safeParse({ query: "x", limit: 101 }).success).toBe(false);
+    expect(s.safeParse({ query: "x", limit: 0 }).success).toBe(false);
+    expect(s.safeParse({ query: "x", limit: 1.5 }).success).toBe(false);
+  });
+
+  test("honors a custom cap", () => {
+    const s = searchToolInputSchema(200);
+    expect(s.safeParse({ query: "x", limit: 200 }).success).toBe(true);
+    expect(s.safeParse({ query: "x", limit: 201 }).success).toBe(false);
+  });
+
+  test("exposes a .shape for tool registration", () => {
+    expect(typeof searchToolInputSchema().shape).toBe("object");
+  });
+});
+
+describe("matchesResult", () => {
+  const filter = (rows: readonly unknown[], opts: { query: string; limit?: number }) =>
+    rows.filter((r) => String(r).includes(opts.query)).slice(0, opts.limit ?? rows.length);
+
+  test("filters array rows into a { matches } envelope", () => {
+    const res = matchesResult(["apple", "banana", "grape"], filter, { query: "a" });
+    expect(JSON.parse(res.content[0].text)).toEqual({ matches: ["apple", "banana", "grape"] });
+  });
+
+  test("non-array rows yield empty matches", () => {
+    for (const bad of [null, undefined, {}, "str", 42] as unknown[]) {
+      const res = matchesResult(bad, filter, { query: "a" });
+      expect(JSON.parse(res.content[0].text)).toEqual({ matches: [] });
+    }
+  });
+
+  test("passes query+limit through to the filter unchanged", () => {
+    const seen: unknown[] = [];
+    const spy = (rows: readonly unknown[], opts: { query: string; limit?: number }) => {
+      seen.push(opts);
+      return rows;
+    };
+    matchesResult([1, 2], spy, { query: "q", limit: 7 });
+    expect(seen[0]).toEqual({ query: "q", limit: 7 });
+  });
+
+  test("returns a single text-part McpListResult", () => {
+    const res = matchesResult([], filter, { query: "x" });
+    expect(res.content).toHaveLength(1);
+    expect(res.content[0].type).toBe("text");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test packages/mcp-connectors/shared/mcp-search-tool.test.ts`
+Expected: FAIL — `Cannot find module './mcp-search-tool.ts'`.
+
+- [ ] **Step 3: Write the helper**
+
+Create `packages/mcp-connectors/shared/mcp-search-tool.ts`:
+
+```ts
+import { z } from "zod";
+import { mcpJsonResult, type McpListResult, type ZodObjectSchema } from "./mcp-tool-kit.ts";
+import type { SearchMatchOptions } from "./search-filter.ts";
+
+/** A `makeQueryFilter(...)` result — the shape every connector search filter has. */
+export type SearchFilter = (
+  rows: readonly unknown[],
+  opts: SearchMatchOptions,
+) => readonly unknown[];
+
+/**
+ * Build the shared connector search input schema. `query` is always a non-empty
+ * string; `maxLimit` is the per-connector cap (varies: 100/200/500/50/1000/2000)
+ * and MUST be passed verbatim from each call site so behavior is unchanged.
+ */
+export function searchToolInputSchema(maxLimit = 100): ZodObjectSchema<SearchMatchOptions> {
+  return z.object({
+    query: z.string().min(1),
+    limit: z.number().int().min(1).max(maxLimit).optional(),
+  }) as unknown as ZodObjectSchema<SearchMatchOptions>;
+}
+
+/**
+ * Build the `{ matches }` envelope: filter the rows when they are an array, else
+ * return an empty match set. Verbatim equivalent of the per-connector tail
+ * `const matches = Array.isArray(X) ? filter(X, { query, limit }) : []; return jsonResult({ matches })`.
+ * `rows` stays `unknown` because external payloads are untyped at the boundary
+ * (Non-Negotiable #7).
+ */
+export function matchesResult(
+  rows: unknown,
+  filter: SearchFilter,
+  opts: SearchMatchOptions,
+): McpListResult {
+  const matches = Array.isArray(rows) ? filter(rows, opts) : [];
+  return mcpJsonResult({ matches });
+}
+```
+
+> Note on the cast: the existing tool-kit already accepts `z.object(...)` where `ZodObjectSchema<T>` is expected. If tsc accepts `as ZodObjectSchema<SearchMatchOptions>` (single cast) or no cast at all, prefer the simpler form; `as unknown as` is the fallback if zod's inferred type does not structurally match. Verify with the typecheck in Step 5 and use the least-cast form that compiles.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test packages/mcp-connectors/shared/mcp-search-tool.test.ts`
+Expected: PASS — all tests green.
+
+- [ ] **Step 5: Typecheck + lint the new files**
+
+Run: `bunx biome check packages/mcp-connectors/shared/mcp-search-tool.ts packages/mcp-connectors/shared/mcp-search-tool.test.ts`
+Then: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` (or root `bun run typecheck` if no package tsconfig).
+Expected: no errors. Tighten the cast to the least form that compiles.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/mcp-connectors/shared/mcp-search-tool.ts packages/mcp-connectors/shared/mcp-search-tool.test.ts
+git commit -m "feat(dedup): add shared MCP search-tool scaffolding helpers
+
+searchToolInputSchema(cap) + matchesResult(rows, filter, opts) collapse the
+cloned connector search-tool schema and result envelope. Stage B1 of the jscpd
+program."
+```
+
+---
+
+## Task 2: Sweep core clique — batch A1 (schema + tail)
+
+These have `extra=none` (schema collapse) AND the guarded tail (tail collapse) → apply **both** transforms.
+
+**Files (each `packages/mcp-connectors/<conn>/src/server.ts`):**
+
+| conn | cap | category | filter fn | apply |
+| --- | --- | --- | --- | --- |
+| zotero | 100 | root | filterZoteroItems | both |
+| greenhouse | 100 | root | filterGreenhouseJobs | both |
+| netlify | 100 | root | filterNetlifySites | both |
+| intercom | 100 | keyed | filterIntercomConversations | both |
+| lever | 100 | keyed | filterLeverPostings | both |
+| mercury | 100 | keyed | filterMercuryAccounts | both |
+| pipedrive | 100 | keyed | filterPipedriveDeals | both |
+| raindrop | 100 | keyed | filterRaindropBookmarks | both |
+
+- [ ] **Step 1: Apply both transforms** to each file above, per the Transformation Reference (schema collapse with the listed cap; tail collapse — `root` or `keyed` variant per the category). Update imports per the import rule.
+
+- [ ] **Step 2: Verify tests stay green (unedited)**
+
+Run: `bun test packages/mcp-connectors/zotero/ packages/mcp-connectors/greenhouse/ packages/mcp-connectors/netlify/ packages/mcp-connectors/intercom/ packages/mcp-connectors/lever/ packages/mcp-connectors/mercury/ packages/mcp-connectors/pipedrive/ packages/mcp-connectors/raindrop/`
+Expected: all pass (skips OK), 0 fail. Confirm `git status` shows no `*.test.ts` modified.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{zotero,greenhouse,netlify,intercom,lever,mercury,pipedrive,raindrop}/src/server.ts`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/mcp-connectors/{zotero,greenhouse,netlify,intercom,lever,mercury,pipedrive,raindrop}/src/server.ts
+git commit -m "refactor(dedup): search-tool helpers — batch A1 (8 connectors)"
+```
+
+---
+
+## Task 3: Sweep core clique — batch A2 (schema + tail)
+
+Same as Task 2 — `extra=none` + guarded tail → apply **both**.
+
+**Files:**
+
+| conn | cap | category | filter fn | apply |
+| --- | --- | --- | --- | --- |
+| readwise | 100 | keyed | filterReadwiseHighlights | both |
+| stackoverflow | 100 | keyed | filterStackOverflowQuestions | both |
+| stripe | 100 | keyed | filterStripeInvoices | both |
+| vercel | 100 | keyed | filterVercelDeployments | both |
+| zendesk | 100 | keyed | filterZendeskTickets | both |
+| zoom | 100 | keyed | filterZoomMeetings | both |
+| semgrep | 200 | keyed | filterSemgrepFindings | both |
+
+- [ ] **Step 1: Apply both transforms** to each file per the Transformation Reference. Note `semgrep` cap is **200**. Update imports per the import rule.
+
+- [ ] **Step 2: Verify tests stay green**
+
+Run: `bun test packages/mcp-connectors/readwise/ packages/mcp-connectors/stackoverflow/ packages/mcp-connectors/stripe/ packages/mcp-connectors/vercel/ packages/mcp-connectors/zendesk/ packages/mcp-connectors/zoom/ packages/mcp-connectors/semgrep/`
+Expected: all pass, 0 fail; no `*.test.ts` modified.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{readwise,stackoverflow,stripe,vercel,zendesk,zoom,semgrep}/src/server.ts`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/mcp-connectors/{readwise,stackoverflow,stripe,vercel,zendesk,zoom,semgrep}/src/server.ts
+git commit -m "refactor(dedup): search-tool helpers — batch A2 (7 connectors)"
+```
+
+---
+
+## Task 4: Sweep fromHelper — batch B1 (schema only)
+
+These are `extra=none` but use a `<x>From(root)` extractor with **no** `Array.isArray` guard (e.g. `filterAirflowDags(dagsFrom(root), {query, limit})`). Apply **schema collapse only** — do NOT touch the tail (no `matchesResult`; the tail is sub-threshold and changing it risks behavior).
+
+**Files:**
+
+| conn | cap | apply |
+| --- | --- | --- |
+| airflow | 100 | schema |
+| argocd | 200 | schema |
+| bigeye | 200 | schema |
+| canva | 100 | schema |
+| dagster | 2000 | schema |
+| databricks | 100 | schema |
+| dependencytrack | 100 | schema |
+| figma | 200 | schema |
+
+- [ ] **Step 1: Apply Transform 1 (schema collapse)** to each file with the listed cap. Do not modify the handler body. Update imports (add `searchToolInputSchema`; drop `z` only if unused elsewhere).
+
+- [ ] **Step 2: Verify tests stay green**
+
+Run: `bun test packages/mcp-connectors/airflow/ packages/mcp-connectors/argocd/ packages/mcp-connectors/bigeye/ packages/mcp-connectors/canva/ packages/mcp-connectors/dagster/ packages/mcp-connectors/databricks/ packages/mcp-connectors/dependencytrack/ packages/mcp-connectors/figma/`
+Expected: all pass, 0 fail; no `*.test.ts` modified.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{airflow,argocd,bigeye,canva,dagster,databricks,dependencytrack,figma}/src/server.ts`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/mcp-connectors/{airflow,argocd,bigeye,canva,dagster,databricks,dependencytrack,figma}/src/server.ts
+git commit -m "refactor(dedup): search-tool schema helper — batch B1 (8 connectors)"
+```
+
+---
+
+## Task 5: Sweep fromHelper — batch B2 (schema only)
+
+Same as Task 4 — schema collapse only.
+
+**Files:**
+
+| conn | cap | apply |
+| --- | --- | --- |
+| hubspot | 100 | schema |
+| looker | 200 | schema |
+| metabase | 200 | schema |
+| miro | 50 | schema |
+| mlflow | 100 | schema |
+| monte-carlo | 200 | schema |
+| powerbi | 200 | schema |
+
+- [ ] **Step 1: Apply Transform 1 (schema collapse)** to each. Note `miro` cap is **50**. Update imports.
+
+- [ ] **Step 2: Verify tests stay green**
+
+Run: `bun test packages/mcp-connectors/hubspot/ packages/mcp-connectors/looker/ packages/mcp-connectors/metabase/ packages/mcp-connectors/miro/ packages/mcp-connectors/mlflow/ packages/mcp-connectors/monte-carlo/ packages/mcp-connectors/powerbi/`
+Expected: all pass, 0 fail; no `*.test.ts` modified.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{hubspot,looker,metabase,miro,mlflow,monte-carlo,powerbi}/src/server.ts`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/mcp-connectors/{hubspot,looker,metabase,miro,mlflow,monte-carlo,powerbi}/src/server.ts
+git commit -m "refactor(dedup): search-tool schema helper — batch B2 (7 connectors)"
+```
+
+---
+
+## Task 6: Sweep fromHelper — batch B3 (schema only)
+
+Same as Task 4 — schema collapse only.
+
+**Files:**
+
+| conn | cap | apply |
+| --- | --- | --- |
+| prefect | 100 | schema |
+| ramp | 100 | schema |
+| salesforce | 2000 | schema |
+| snowflake | 200 | schema |
+| superset | 200 | schema |
+| tableau | 200 | schema |
+| wiz | 200 | schema |
+
+- [ ] **Step 1: Apply Transform 1 (schema collapse)** to each. Note `salesforce` cap is **2000**. Update imports.
+
+- [ ] **Step 2: Verify tests stay green**
+
+Run: `bun test packages/mcp-connectors/prefect/ packages/mcp-connectors/ramp/ packages/mcp-connectors/salesforce/ packages/mcp-connectors/snowflake/ packages/mcp-connectors/superset/ packages/mcp-connectors/tableau/ packages/mcp-connectors/wiz/`
+Expected: all pass, 0 fail; no `*.test.ts` modified.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{prefect,ramp,salesforce,snowflake,superset,tableau,wiz}/src/server.ts`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/mcp-connectors/{prefect,ramp,salesforce,snowflake,superset,tableau,wiz}/src/server.ts
+git commit -m "refactor(dedup): search-tool schema helper — batch B3 (7 connectors)"
+```
+
+---
+
+## Task 7: Sweep extra-field connectors — batch C (tail only)
+
+These have an EXTRA required schema field (e.g. `appId`, `projectKey`, `orgId`) so the schema stays untouched, but the tail is the canonical guarded shape → apply **tail collapse only** (`matchesResult`). Category gives the `X`.
+
+**Files:**
+
+| conn | category | X (keep its extract line) | filter fn | apply |
+| --- | --- | --- | --- | --- |
+| mendeley | root | root | filterMendeleyDocuments | tail |
+| bitrise | keyed | data | filterBitriseBuilds | tail |
+| codemagic | keyed | builds | filterCodemagicBuilds | tail |
+| firebase | keyed | releases | filterFirebaseReleases | tail |
+| launchdarkly | keyed | flags (from `items`) | filterLaunchDarklyFlags | tail |
+| testflight | keyed | data | filterTestflightBuilds | tail |
+| snyk | keyed | issues | filterSnykAggregatedIssues | tail |
+| sonarqube | keyed | issues | filterSonarIssues | tail |
+
+- [ ] **Step 1: Apply Transform 2 (tail collapse) only** to each. Keep the full `z.object({ …extra…, query, limit })` schema unchanged. Keep the keyed extract line (`const <X> = (root as {…})?.<key>;`) unchanged; replace only the `const matches = Array.isArray(<X>) ? … : []; return jsonResult({ matches });` with `return matchesResult(<X>, <filterFn>, p);`. For `mendeley` (root), `X = root`. Add only the `matchesResult` import; drop `jsonResult`/`z` only if unused elsewhere in the file.
+
+- [ ] **Step 2: Verify tests stay green**
+
+Run: `bun test packages/mcp-connectors/mendeley/ packages/mcp-connectors/bitrise/ packages/mcp-connectors/codemagic/ packages/mcp-connectors/firebase/ packages/mcp-connectors/launchdarkly/ packages/mcp-connectors/testflight/ packages/mcp-connectors/snyk/ packages/mcp-connectors/sonarqube/`
+Expected: all pass, 0 fail; no `*.test.ts` modified.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bunx tsc --noEmit -p packages/mcp-connectors/tsconfig.json` and `bunx biome check packages/mcp-connectors/{mendeley,bitrise,codemagic,firebase,launchdarkly,testflight,snyk,sonarqube}/src/server.ts`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/mcp-connectors/{mendeley,bitrise,codemagic,firebase,launchdarkly,testflight,snyk,sonarqube}/src/server.ts
+git commit -m "refactor(dedup): search-tool tail helper — batch C (8 extra-field connectors)"
+```
+
+---
+
+## Task 8: Measure, full verification, finalize
+
+**Files:** none (verification + measurement only).
+
+- [ ] **Step 1: Re-measure strict jscpd**
+
+Run: `bunx jscpd packages 2>&1 | tail -6`
+Record the `Total:` strict % (baseline 4.98%). Expect a strict drop. (Non-zero exit while still > 3% is expected — the program isn't done; this PR does not tighten the gate.)
+
+- [ ] **Step 2: Confirm the search clique collapsed**
+
+Run: `bunx jscpd packages --reporters json --output /tmp/jscpd-b1 2>&1 | tail -1` then inspect `zotero/src/server.ts` clone count (was 21). Confirm it dropped materially (search-tool fragment gone). Quick check:
+
+```bash
+bun -e 'const r=require("fs").readFileSync("/tmp/jscpd-b1/jscpd-report.json","utf8");const j=JSON.parse(r);let n=0;for(const d of j.duplicates){if(JSON.stringify(d).includes("zotero/src/server.ts"))n++;}console.log("zotero/server.ts clones:",n)'
+```
+
+- [ ] **Step 3: Full mcp-connectors test suite**
+
+Run: `bun test packages/mcp-connectors/ 2>&1 | tail -8`
+Expected: all pass (skips OK), 0 fail. Confirm `git status` shows no `*.test.ts` modified across the whole sweep.
+
+- [ ] **Step 4: Full preflight (CI parity — required before first push)**
+
+Run: `bun run preflight`
+Expected: green (tsc all packages, lint, lint:markdown, structure audits, tests). Fix any failure locally before pushing. (Note: the strict `audit:duplication` gate inside structure audits may still be red while > 3% — that gate is the program's target, not tightened here; confirm the run's other gates pass and the duplication % improved vs. baseline.)
+
+- [ ] **Step 5: Docs gates (a `.md` — the spec + plan — is in this branch)**
+
+Run: `bunx markdownlint-cli2 "docs/superpowers/specs/2026-06-17-jscpd-stage-b1-search-tool-scaffolding-design.md" "docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md"`
+Then: `~/.cargo/bin/lychee --config lychee.toml --no-progress "docs/superpowers/specs/2026-06-17-jscpd-stage-b1-search-tool-scaffolding-design.md" "docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md"`
+Expected: 0 errors each. **Do NOT commit any `*-review.md` scratch file** (untracked review companions break lychee/markdownlint).
+
+- [ ] **Step 6: Whole-branch review + push**
+
+Run a `/code-review` (or code-reviewer subagent) over `git diff main...HEAD`; fold in findings. Then push the branch and open the PR. PR description records: strict 4.98% → <after>%; helpers added to `mcp-connectors/shared/`; N connectors swept; 3 skipped (dbt/flagsmith/flux); CI lenient gate untightened.
+
+- [ ] **Step 7: Update memory**
+
+Append the Stage B1 outcome to `jscpd-dedup-stage-a.md` (or a new `jscpd-dedup-stage-b1.md`) and the `MEMORY.md` index line: PR #, strict delta, helper names, the shared/-not-SDK decision, and that the named-A2 nine were deprioritized after re-measurement.
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** helper file + both helpers (Task 1) ✓; schema-collapse sweep across all `extra=none` connectors (Tasks 2–6) ✓; tail-collapse across guarded connectors incl. extra-field (Tasks 2,3,7) ✓; outliers skipped (dbt/flagsmith/flux, stated in Global Constraints + by omission) ✓; `shared/` not SDK ✓; unit test for the helper (Task 1) ✓; measurement + preflight + docs gates (Task 8) ✓; CI lenient gate untightened ✓.
+- **Placeholder scan:** no TBD/TODO; all transforms shown as concrete before/after code; all test code complete; every connector has cap + category + filter listed.
+- **Type consistency:** `searchToolInputSchema`/`matchesResult`/`SearchFilter`/`SearchMatchOptions`/`McpListResult`/`ZodObjectSchema` names consistent across Task 1 and the reference; `safeParse` (not `.parse`) used in tests to match `ZodObjectSchema`'s structural type.
+- **Coverage note:** 45 connectors swept (15 both, 22 schema-only, 8 tail-only); 3 skipped; 48 total search tools accounted for.

--- a/docs/superpowers/specs/2026-06-17-jscpd-stage-b1-search-tool-scaffolding-design.md
+++ b/docs/superpowers/specs/2026-06-17-jscpd-stage-b1-search-tool-scaffolding-design.md
@@ -1,0 +1,293 @@
+# Design — jscpd Stage B1: MCP search-tool scaffolding → `mcp-connectors/shared/`
+
+**Date:** 2026-06-17
+**Branch:** `worktree-jscpd-dedup-a2` (worktree off `origin/main` @ `8f346bac`)
+**Status:** approved design → ready for implementation plan
+**Parent program:** [`2026-06-17-jscpd-duplication-reduction-design.md`](./2026-06-17-jscpd-duplication-reduction-design.md)
+
+## Context
+
+The jscpd duplication-reduction program drives the **strict** duplication
+(`bunx jscpd packages`, reading `.jscpd.json`: `min-lines 5 / min-tokens 50 /
+threshold 3`) under 3% by extracting shared scaffolding into helpers — never by
+adding jscpd ignores to handwritten source. Stage A (PR #673, merged `8c3bbb35`)
+extracted the gateway single-pass paginated-sync helper and migrated 20
+connectors; strict dropped 5.51% → 5.09%.
+
+**Re-measurement on current main (`8f346bac`, this worktree):** strict is
+**4.98%** (637 clones). This re-measurement changed the program's leverage map:
+
+- The originally-named "Stage A2" nine multi-resource HTTP syncs
+  (databricks/dbt/flagsmith/launchdarkly/mendeley/ramp/semgrep/sonarqube/wiz) are
+  now **low-leverage** — 2–6 scattered clones each, no longer a tight clique
+  (they clone against the new sync centroids, not each other). Deferred.
+- The single highest-leverage cluster is the **MCP `server.ts` family**: 313
+  clone-involvements (~25% of all 1274 side-involvements), led by outlook (27),
+  zotero (21), gmail (18), gitlab (17), github (15). This is Stage B of the
+  program.
+
+Stage B is multi-pattern. Full Stage B moves strict only ~1–1.3pt (still > 3%),
+so the program continues after it regardless of how B is sliced. This spec scopes
+the **first, lowest-risk, Stage-A-shaped** slice: **B1 — the search-tool
+scaffolding sweep**.
+
+## Two corrections to the parent design (Stage B section)
+
+Verified against the code in this worktree:
+
+1. **Target `mcp-connectors/shared/`, NOT `@nimbus-dev/sdk`.** The parent design
+   proposed hoisting MCP scaffolding to a new `@nimbus-dev/sdk/mcp` subpath. But
+   the established precedent for code shared *among mcp-connectors* is the
+   relative-imported `packages/mcp-connectors/shared/` directory — it already
+   holds 19 helper files (`mcp-tool-kit.ts`, `fetch-bearer-json.ts`,
+   `search-filter.ts`, `run-read-only-mcp-connector.ts`, `safe-cli-arg.ts`,
+   `imap-mail-core.ts`, …), each with a co-located `*.test.ts`. The SDK precedent
+   (channel-resolver, cross-boundary signer) was for code shared between
+   *different packages* (installer/gateway); that does not apply here. Using
+   `shared/` avoids a new SDK export, a dependency-cruiser change, and the
+   coverage-floor ratchet (which covers gateway/cli/sdk/client, not
+   mcp-connectors).
+
+2. **MCP stdio bootstrap is already deduped.** The parent design listed
+   "tool-registration scaffolding (`new McpServer` → register → connect)" as a
+   target. That bootstrap already lives in
+   `shared/run-read-only-mcp-connector.ts` (`runReadOnlyMcpConnector(name, reg =>
+   …)`). The residual `server.ts` clones are *per-tool handler bodies*, not
+   bootstrap. B1 targets the most uniform of those: the **search tool**.
+
+## Problem (B1-specific)
+
+Across ~48 read-only connectors, the search tool repeats two near-identical
+fragments that jscpd flags as a large clone clique (zotero `server.ts` is its
+centroid with 21 clones, every one the search-tool fragment cloned against a
+different partner):
+
+1. **The input schema** (universal `query`, per-connector `limit` cap):
+
+   ```ts
+   z.object({
+     query: z.string().min(1),
+     limit: z.number().int().min(1).max(100).optional(),
+   })
+   ```
+
+2. **The result envelope tail**:
+
+   ```ts
+   const matches = Array.isArray(X)
+     ? filterX(X, { query: p.query, limit: p.limit })
+     : [];
+   return jsonResult({ matches });
+   ```
+
+   where `X` is either `root` directly (zotero-style) or a keyed sub-array
+   (`(root as { tickets?: unknown[] } | null)?.tickets`, zendesk-style).
+
+**Measured uniformity (this worktree):**
+
+- `query: z.string().min(1)` — 52 occurrences, **invariant**.
+- `limit: …max(N).optional()` caps **vary**: max 100 (×36), 200 (×28), 500
+  (×18), 50 (×6), 2000 (×4), 1000 (×1). The helper MUST parameterize the cap to
+  preserve each connector's exact behavior.
+- `jsonResult({ matches })` — 48 connector `server.ts` files.
+- The `Array.isArray(X) ? filter : []` guard appears in the majority; a few
+  connectors (e.g. hubspot) skip the guard (`filterX(dealsFrom(root), …)`) — those
+  are outliers, not swept.
+
+## Goal
+
+Collapse the two shared fragments into small pure helpers in
+`mcp-connectors/shared/`, then mechanically migrate every connector whose search
+tool matches the canonical shape — so the per-connector search tool drops below
+the 5-line / 50-token clone threshold and the zotero-centroid clique collapses.
+
+**Non-goals / constraints:**
+
+- **Pure dedup — zero behavior change.** Every connector's
+  `*-fake-server.test.ts` (and any other per-connector test) stays green
+  **unedited**. Each connector's exact `limit` cap and `query.min(1)` are
+  preserved.
+- **No force-fit.** Connectors whose search tool has extra schema fields, no
+  `Array.isArray` guard, a non-`{matches}` envelope, or a non-`{query, limit}`
+  shape are left untouched. Migrate only exact matches.
+- **Do not touch** other tool handlers (list/get), other stages' targets, the CI
+  lenient duplication gate (tightening is the program's final stage), or
+  perf surfaces.
+- **Scope to B1.** The email-family twin (imap/protonmail `server.ts` +
+  `tools.ts`) and the github/gitlab/Graph per-tool REST blocks are deferred to
+  later Stage-B slices.
+
+## Design
+
+### New file: `packages/mcp-connectors/shared/mcp-search-tool.ts`
+
+Two pure, tree-shakeable helpers. Imports `z` (zod), `mcpJsonResult` /
+`McpListResult` / `ZodObjectSchema` from `./mcp-tool-kit.ts`, and the existing
+`SearchMatchOptions` type from `./search-filter.ts` (no circular dependency —
+neither imported file imports this one).
+
+The connector filters are all `makeQueryFilter(...)` results from
+`shared/search-filter.ts`, with the exact type
+`(items: readonly unknown[], options: SearchMatchOptions) => unknown[]` and
+`SearchMatchOptions = { readonly query: string; readonly limit?: number | undefined }`.
+The helper reuses that type so every connector's filter assigns without a cast
+and the `readonly`-array variance trap is avoided.
+
+```ts
+import { z } from "zod";
+import { mcpJsonResult, type McpListResult, type ZodObjectSchema } from "./mcp-tool-kit.ts";
+import type { SearchMatchOptions } from "./search-filter.ts";
+
+/** A `makeQueryFilter(...)` result: the shape every connector search filter has. */
+export type SearchFilter = (
+  rows: readonly unknown[],
+  opts: SearchMatchOptions,
+) => readonly unknown[];
+
+/**
+ * Build the shared search input schema. `query` is always a non-empty string;
+ * `maxLimit` is the per-connector cap (varies: 100/200/500/50/1000/2000) and is
+ * preserved verbatim per call site so behavior is unchanged.
+ */
+export function searchToolInputSchema(maxLimit = 100): ZodObjectSchema<SearchMatchOptions> {
+  return z.object({
+    query: z.string().min(1),
+    limit: z.number().int().min(1).max(maxLimit).optional(),
+  }) as ZodObjectSchema<SearchMatchOptions>;
+}
+
+/**
+ * Build the `{ matches }` envelope: filter the rows when they are an array, else
+ * return an empty match set. Mirrors the per-connector tail
+ * `const matches = Array.isArray(X) ? filter(X, { query, limit }) : []; return jsonResult({ matches })`
+ * verbatim. `rows` is the already-extracted candidate array (`root`, or a keyed
+ * sub-array the caller pulled out) — kept as `unknown` because external payloads
+ * are untyped at the boundary (Non-Negotiable #7: no `any`).
+ */
+export function matchesResult(
+  rows: unknown,
+  filter: SearchFilter,
+  opts: SearchMatchOptions,
+): McpListResult {
+  const matches = Array.isArray(rows) ? filter(rows, opts) : [];
+  return mcpJsonResult({ matches });
+}
+```
+
+(`ZodObjectSchema<T>` is the structural schema type already exported by
+`mcp-tool-kit.ts` and consumed by `ZodToolRegistrar`. The `as` cast bridges
+zod's inferred type to that structural type, matching how the existing tool-kit
+already types schemas. The exact cast/return-type wiring is a plan detail —
+verified against `mcp-tool-kit.ts` and `run-read-only-mcp-connector.ts` during
+planning; if zod's inferred type assigns directly, the cast is dropped. The
+handler arg `p` is `SearchMatchOptions`, passed straight into `matchesResult`.)
+
+### Per-connector migration (mechanical)
+
+Root-is-array case (zotero-style):
+
+```ts
+// before
+reg(
+  "zotero_search",
+  "…description…",
+  z.object({
+    query: z.string().min(1),
+    limit: z.number().int().min(1).max(100).optional(),
+  }),
+  async (p) => {
+    const root = await zoteroGet(`…`);
+    const matches = Array.isArray(root)
+      ? filterZoteroItems(root, { query: p.query, limit: p.limit })
+      : [];
+    return jsonResult({ matches });
+  },
+);
+
+// after
+reg(
+  "zotero_search",
+  "…description…",
+  searchToolInputSchema(100),
+  async (p) => matchesResult(await zoteroGet(`…`), filterZoteroItems, p),
+);
+```
+
+Keyed-sub-array case (zendesk-style): the unique extraction line stays inline (it
+is per-connector and below the clone threshold), only the tail collapses:
+
+```ts
+async (p) => {
+  const root = await zendeskGet(`/api/v2/tickets.json?page[size]=100`);
+  return matchesResult((root as { tickets?: unknown[] } | null)?.tickets, filterZendeskTickets, p);
+}
+```
+
+`z` import is dropped from a connector's `server.ts` only if no other tool in
+that file still uses it (most files keep `z` for other tools). The
+`mcpJsonResult`/`jsonResult` import is dropped only if no other tool uses it.
+
+### Why this kills the clone
+
+The cloned fragment is the contiguous schema (3 lines) + handler tail (3 lines).
+Replacing the schema with `searchToolInputSchema(N)` (1 line) and the tail with
+`matchesResult(...)` (1 line) shrinks each connector's search tool to 2–4 unique
+lines (name, description, fetch URL, optional keyed-extract) — below the 5-line /
+50-token threshold. The `searchToolInputSchema(N)` and `matchesResult(...)` call
+sites differ per connector (cap, fetch fn, filter fn, key) and are single lines,
+so they do not form a new clone clique.
+
+### Testing
+
+- **New helper unit test** `mcp-connectors/shared/mcp-search-tool.test.ts`
+  (the `shared/` convention; feeds the "Coverage — MCP" CI gate):
+  - `searchToolInputSchema()`: parses `{ query }`, `{ query, limit }`; rejects
+    empty query; rejects `limit` over the cap / below 1 / non-integer; honors a
+    custom `maxLimit`.
+  - `matchesResult()`: array rows → filter applied + `{ matches }` envelope;
+    non-array rows (null/undefined/object) → empty `matches`; passes
+    `{ query, limit }` through to the filter unchanged; returns a valid
+    `McpListResult` (single text part containing the JSON).
+- **Per-connector guardrails:** every migrated connector's existing
+  `*-fake-server.test.ts` MUST pass unedited — this is the behavior-fidelity
+  proof. Run the full `mcp-connectors` test suite after each batch.
+
+### Measurement protocol
+
+- Re-run `bunx jscpd packages`; record `Total:` strict % before (4.98%) → after
+  in the PR description.
+- Regenerate the report and confirm the zotero-centroid search clique collapsed
+  (zotero `server.ts` clone count drops from 21).
+- Note the CI lenient gate stays untightened (final program stage).
+
+## Risks & mitigations
+
+- **`limit`-cap fidelity.** The #1 behavior-change risk. Each call site must pass
+  the connector's *current* cap. Mitigation: per-connector audit reads the exact
+  `max(N)` before editing; the fake-server tests catch a wrong cap if a test
+  exercises the boundary.
+- **Coverage — MCP gate.** New `shared/` file needs ≥ the MCP coverage threshold.
+  The unit test plus all migrating connectors exercising the helper cover it.
+  (Coverage-floor ratchet does not apply — it skips mcp-connectors.)
+- **Typing (no `any`).** Helper is generic/structural; external payloads stay
+  `unknown` at the boundary, exactly as the connectors already do.
+- **Outlier misclassification.** A connector that *looks* like the canonical
+  shape but differs (extra field, different guard) must be skipped, not
+  force-fit. Mitigation: the migration is gated on an exact-shape match and the
+  unedited fake-server test.
+- **Import cleanup.** Removing a now-unused `z` / `jsonResult` import while
+  another tool still uses it would break typecheck/lint. Mitigation: drop an
+  import only after confirming no other use in the file (Biome `noUnusedImports`
+  and tsc catch mistakes in preflight).
+
+## Success criteria
+
+1. `mcp-search-tool.ts` + test added under `mcp-connectors/shared/`; helper
+   covered to the MCP gate.
+2. Every canonical-shape connector search tool migrated; the zotero search clique
+   collapsed (zotero `server.ts` clone count drops materially).
+3. `bunx jscpd packages` strict % strictly below 4.98% (record exact delta).
+4. All `mcp-connectors` tests green with **no** `*-fake-server.test.ts` edited.
+5. Full `bun run preflight` + (docs gates if any `.md` changed) green before the
+   first push. No behavior change; no new jscpd ignores; CI lenient gate
+   untightened.

--- a/packages/mcp-connectors/airflow/src/server.ts
+++ b/packages/mcp-connectors/airflow/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { encodeBasicAuthHeader, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterAirflowDags } from "./search-filter.ts";
@@ -74,10 +75,7 @@ await runReadOnlyMcpConnector("nimbus-airflow", (reg) => {
   reg(
     "airflow_search",
     "Substring search across the first page of Airflow DAGs. Matches the query (case-insensitive) against the dag_id, description, owners, and tag names. Returns a matches envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await airflowGet("/api/v1/dags?limit=100&offset=0");
       const matches = filterAirflowDags(dagsFrom(root), {

--- a/packages/mcp-connectors/argocd/src/server.ts
+++ b/packages/mcp-connectors/argocd/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterArgocdApplications } from "./search-filter.ts";
@@ -76,10 +77,7 @@ await runReadOnlyMcpConnector("nimbus-argocd", (reg) => {
   reg(
     "argocd_search",
     "Substring search across ArgoCD applications. Matches the query (case-insensitive) against application name, project, source repo URL, sync status, and health status. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const root = await agGet("/applications");
       const matches = filterArgocdApplications(applicationsFrom(root), {

--- a/packages/mcp-connectors/bigeye/src/server.ts
+++ b/packages/mcp-connectors/bigeye/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { fetchWithTimeout, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import {
   runReadOnlyMcpConnector,
@@ -103,10 +104,7 @@ export function registerBigeyeTools(reg: ZodToolRegistrar): void {
   reg(
     "bigeye_search",
     "Substring search across Bigeye data-quality issues. Matches the query (case-insensitive) against issue summary, title, and description. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const issues = await fetchIssues(500, 0);
       const matches = filterBigeyeIssues(issues, { query: p.query, limit: p.limit });

--- a/packages/mcp-connectors/bitrise/src/server.ts
+++ b/packages/mcp-connectors/bitrise/src/server.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterBitriseBuilds } from "./search-filter.ts";
@@ -77,10 +77,7 @@ await runReadOnlyMcpConnector("nimbus-bitrise", (reg) => {
     async (p) => {
       const root = await bitriseGet(`/v0.1/apps/${encodeURIComponent(p.appSlug)}/builds?limit=50`);
       const data = (root as { data?: unknown[] } | null)?.data;
-      const matches = Array.isArray(data)
-        ? filterBitriseBuilds(data, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(data, filterBitriseBuilds, p);
     },
   );
 });

--- a/packages/mcp-connectors/canva/src/server.ts
+++ b/packages/mcp-connectors/canva/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterCanvaDesigns } from "./search-filter.ts";
@@ -63,10 +64,7 @@ await runReadOnlyMcpConnector("nimbus-canva", (reg) => {
   reg(
     "canva_search",
     "**Substring search over the FIRST PAGE only** of the authenticated user's Canva designs. This tool fetches GET /rest/v1/designs once and matches the query locally (case-insensitive) against the design title. **Designs beyond the first page are not searchable here — query the local Nimbus index instead for full coverage.** Returns a { matches: [...] } envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await canvaGet("/rest/v1/designs");
       const matches = filterCanvaDesigns(designsFrom(root), {

--- a/packages/mcp-connectors/codemagic/src/server.ts
+++ b/packages/mcp-connectors/codemagic/src/server.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterCodemagicBuilds } from "./search-filter.ts";
@@ -68,10 +68,7 @@ await runReadOnlyMcpConnector("nimbus-codemagic", (reg) => {
     async (p) => {
       const root = await codemagicGet(`/builds?appId=${encodeURIComponent(p.appId)}&limit=50`);
       const builds = (root as { builds?: unknown[] } | null)?.builds;
-      const matches = Array.isArray(builds)
-        ? filterCodemagicBuilds(builds, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(builds, filterCodemagicBuilds, p);
     },
   );
 });

--- a/packages/mcp-connectors/dagster/src/server.ts
+++ b/packages/mcp-connectors/dagster/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterDagsterJobs } from "./search-filter.ts";
@@ -207,10 +208,7 @@ await runReadOnlyMcpConnector("nimbus-dagster", (reg) => {
   reg(
     "dagster_search",
     "Substring search across Dagster jobs. Matches the query (case-insensitive) against the job name, repository, code location, description, and tag keys/values. Returns a { matches: [...] } envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(2000).optional(),
-    }),
+    searchToolInputSchema(2000),
     async (p) => {
       const jobs = await listJobs();
       const matches = filterDagsterJobs(jobs, { query: p.query, limit: p.limit });

--- a/packages/mcp-connectors/databricks/src/server.ts
+++ b/packages/mcp-connectors/databricks/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterDatabricksJobs } from "./search-filter.ts";
@@ -66,10 +67,7 @@ await runReadOnlyMcpConnector("nimbus-databricks", (reg) => {
   reg(
     "databricks_search",
     "Substring search across Databricks jobs. Matches the query (case-insensitive) against the job's `settings.name`, `creator_user_name`, and `job_id`. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const params = new URLSearchParams({ limit: "100" });
       const root = await dbGet(`/api/2.1/jobs/list?${params.toString()}`);

--- a/packages/mcp-connectors/dependencytrack/src/server.ts
+++ b/packages/mcp-connectors/dependencytrack/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterDependencyTrackProjects } from "./search-filter.ts";
@@ -66,10 +67,7 @@ await runReadOnlyMcpConnector("nimbus-dependencytrack", (reg) => {
   reg(
     "dependencytrack_search",
     "Substring search across the first page of Dependency-Track projects. Matches the query (case-insensitive) against the project name, version, classifier, and tag names. Returns a matches envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await dtGet("/api/v1/project?pageSize=100&pageNumber=1&excludeInactive=false");
       const matches = filterDependencyTrackProjects(projectsFrom(root), {

--- a/packages/mcp-connectors/figma/src/server.ts
+++ b/packages/mcp-connectors/figma/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterFigmaFiles } from "./search-filter.ts";
@@ -106,10 +107,7 @@ await runReadOnlyMcpConnector("nimbus-figma", (reg) => {
   reg(
     "figma_search",
     "Substring search across the configured team's Figma files. Runs the same two-level fetch as figma_list (team projects, then files per project), flattens the result, and matches the query locally (case-insensitive) against each file name and its project name. Returns a { matches: [...] } envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const files = await listTeamFiles();
       const matches = filterFigmaFiles(files, { query: p.query, limit: p.limit });

--- a/packages/mcp-connectors/firebase/src/server.ts
+++ b/packages/mcp-connectors/firebase/src/server.ts
@@ -1,6 +1,6 @@
 import { mintGoogleAccessToken } from "@nimbus-dev/sdk";
 import { z } from "zod";
-
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterFirebaseReleases } from "./search-filter.ts";
@@ -88,10 +88,7 @@ await runReadOnlyMcpConnector("nimbus-firebase", (reg) => {
     async (p) => {
       const root = await appDistGet(releasesPath(p.appId, 100));
       const releases = (root as { releases?: unknown[] } | null)?.releases;
-      const matches = Array.isArray(releases)
-        ? filterFirebaseReleases(releases, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(releases, filterFirebaseReleases, p);
     },
   );
 });

--- a/packages/mcp-connectors/greenhouse/src/server.ts
+++ b/packages/mcp-connectors/greenhouse/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { encodeBasicAuthHeader, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterGreenhouseJobs } from "./search-filter.ts";
@@ -53,17 +54,11 @@ await runReadOnlyMcpConnector("nimbus-greenhouse", (reg) => {
   reg(
     "greenhouse_search",
     "Substring search across the company's Greenhouse job openings (first page only). Matches the query against the job name, status, requisition id, the department names, and the office names + locations (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const search = new URLSearchParams({ per_page: "100", page: "1" });
       const root = await greenhouseGet(`/v1/jobs?${search.toString()}`);
-      const matches = Array.isArray(root)
-        ? filterGreenhouseJobs(root, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(root, filterGreenhouseJobs, p);
     },
   );
 });

--- a/packages/mcp-connectors/hubspot/src/server.ts
+++ b/packages/mcp-connectors/hubspot/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterHubspotDeals } from "./search-filter.ts";
@@ -66,10 +67,7 @@ await runReadOnlyMcpConnector("nimbus-hubspot", (reg) => {
   reg(
     "hubspot_search",
     "**Substring search over the FIRST PAGE only** (up to 100 most-recently-listed deals) of the authenticated portal's HubSpot deals. This tool fetches GET /crm/v3/objects/deals?limit=100 once and matches the query locally (case-insensitive) against the deal name, deal stage, and pipeline. **Deals beyond the first page are not searchable here — query the local Nimbus index instead for full coverage.** Returns a { matches: [...] } envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const params = new URLSearchParams({ limit: "100", properties: DEAL_PROPERTIES });
       const root = await hubspotGet(`/crm/v3/objects/deals?${params.toString()}`);

--- a/packages/mcp-connectors/intercom/src/server.ts
+++ b/packages/mcp-connectors/intercom/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterIntercomConversations } from "./search-filter.ts";
@@ -54,17 +55,11 @@ await runReadOnlyMcpConnector("nimbus-intercom", (reg) => {
   reg(
     "intercom_search",
     "Substring search across the user's Intercom conversations (first page only). Matches the query against the conversation subject, the source message body, the state, the source author name + email, and the tags (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await intercomGet(`/conversations?per_page=150`);
       const conversations = (root as { conversations?: unknown[] } | null)?.conversations;
-      const matches = Array.isArray(conversations)
-        ? filterIntercomConversations(conversations, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(conversations, filterIntercomConversations, p);
     },
   );
 });

--- a/packages/mcp-connectors/launchdarkly/src/server.ts
+++ b/packages/mcp-connectors/launchdarkly/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterLaunchDarklyFlags } from "./search-filter.ts";
@@ -72,10 +73,7 @@ await runReadOnlyMcpConnector("nimbus-launchdarkly", (reg) => {
       const search = new URLSearchParams({ summary: "true", limit: "500" });
       const root = await ldGet(`/flags/${encodeURIComponent(p.projectKey)}?${search.toString()}`);
       const flags = (root as { items?: unknown[] } | null)?.items;
-      const matches = Array.isArray(flags)
-        ? filterLaunchDarklyFlags(flags, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(flags, filterLaunchDarklyFlags, p);
     },
   );
 });

--- a/packages/mcp-connectors/lever/src/server.ts
+++ b/packages/mcp-connectors/lever/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { encodeBasicAuthHeader, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterLeverPostings } from "./search-filter.ts";
@@ -50,17 +51,11 @@ await runReadOnlyMcpConnector("nimbus-lever", (reg) => {
   reg(
     "lever_search",
     "Substring search across the company's Lever job postings (first page only). Matches the query against the posting text (title), state, and the team/department/location categories and tags (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await leverGet(`/v1/postings?limit=100`);
       const data = (root as { data?: unknown[] } | null)?.data;
-      const matches = Array.isArray(data)
-        ? filterLeverPostings(data, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(data, filterLeverPostings, p);
     },
   );
 });

--- a/packages/mcp-connectors/looker/src/server.ts
+++ b/packages/mcp-connectors/looker/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { fetchWithTimeout, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import {
   runReadOnlyMcpConnector,
@@ -156,10 +157,7 @@ export function registerLookerTools(reg: ZodToolRegistrar): void {
   reg(
     "looker_search",
     "Substring search across Looker dashboards. Matches the query (case-insensitive) against dashboard title and id. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const token = await lookerLogin();
       const dashboards = await listDashboards(token);

--- a/packages/mcp-connectors/mendeley/src/server.ts
+++ b/packages/mcp-connectors/mendeley/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterMendeleyDocuments } from "./search-filter.ts";
@@ -52,10 +53,7 @@ await runReadOnlyMcpConnector("nimbus-mendeley", (reg) => {
     z.object({ query: z.string().min(1), limit: z.number().int().min(1).max(100).optional() }),
     async (p) => {
       const root = await mendeleyGet(`/documents?view=all&limit=100`);
-      const matches = Array.isArray(root)
-        ? filterMendeleyDocuments(root, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(root, filterMendeleyDocuments, p);
     },
   );
 });

--- a/packages/mcp-connectors/mercury/src/server.ts
+++ b/packages/mcp-connectors/mercury/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterMercuryAccounts } from "./search-filter.ts";
@@ -50,17 +51,11 @@ await runReadOnlyMcpConnector("nimbus-mercury", (reg) => {
   reg(
     "mercury_search",
     "Substring search across the user's Mercury accounts. Matches the query against id, name, status, type, kind, and the legal business name (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await mercuryGet(`/api/v1/accounts`);
       const accounts = (root as { accounts?: unknown[] } | null)?.accounts;
-      const matches = Array.isArray(accounts)
-        ? filterMercuryAccounts(accounts, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(accounts, filterMercuryAccounts, p);
     },
   );
 });

--- a/packages/mcp-connectors/metabase/src/server.ts
+++ b/packages/mcp-connectors/metabase/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterMetabaseDashboards } from "./search-filter.ts";
@@ -69,10 +70,7 @@ await runReadOnlyMcpConnector("nimbus-metabase", (reg) => {
   reg(
     "metabase_search",
     "Substring search across Metabase dashboards. Matches the query (case-insensitive) against dashboard name and description. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const root = await mbGet("/api/dashboard");
       const matches = filterMetabaseDashboards(dashboardsFrom(root), {

--- a/packages/mcp-connectors/miro/src/server.ts
+++ b/packages/mcp-connectors/miro/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterMiroBoards } from "./search-filter.ts";
@@ -62,10 +63,7 @@ await runReadOnlyMcpConnector("nimbus-miro", (reg) => {
   reg(
     "miro_search",
     "**Substring search over the FIRST PAGE only** (up to 50 most-recently-listed boards) of the authenticated user's Miro boards. This tool fetches GET /v2/boards?limit=50 once and matches the query locally (case-insensitive) against the board name, description, and owner name. **Boards beyond the first page are not searchable here — query the local Nimbus index instead for full coverage.** Returns a { matches: [...] } envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(50).optional(),
-    }),
+    searchToolInputSchema(50),
     async (p) => {
       const root = await miroGet("/v2/boards?limit=50");
       const matches = filterMiroBoards(boardsFrom(root), {

--- a/packages/mcp-connectors/mlflow/src/server.ts
+++ b/packages/mcp-connectors/mlflow/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterMlflowModels } from "./search-filter.ts";
@@ -70,10 +71,7 @@ await runReadOnlyMcpConnector("nimbus-mlflow", (reg) => {
   reg(
     "mlflow_search",
     "Substring search across MLflow registered models. Matches the query (case-insensitive) against the model's `name`, `description`, and flattened `key=value` tags. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const params = new URLSearchParams({ max_results: "100" });
       const root = await mlflowGet(`/api/2.0/mlflow/registered-models/search?${params.toString()}`);

--- a/packages/mcp-connectors/monte-carlo/src/server.ts
+++ b/packages/mcp-connectors/monte-carlo/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { fetchWithTimeout, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import {
   runReadOnlyMcpConnector,
@@ -177,10 +178,7 @@ export function registerMonteCarloTools(reg: ZodToolRegistrar): void {
   reg(
     "montecarlo_search",
     "Substring search across Monte Carlo incidents. Matches the query (case-insensitive) against incidentId, status, severity, and monitoredTable. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const apiId = requireEnv("MONTECARLO_API_ID");
       const apiToken = requireEnv("MONTECARLO_API_TOKEN");

--- a/packages/mcp-connectors/netlify/src/server.ts
+++ b/packages/mcp-connectors/netlify/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterNetlifySites } from "./search-filter.ts";
@@ -53,17 +54,11 @@ await runReadOnlyMcpConnector("nimbus-netlify", (reg) => {
   reg(
     "netlify_search",
     "Substring search across Netlify sites. Matches the query against id, name, url, ssl_url, the linked git repo + branch, and the published-deploy state / branch / commit ref (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const search = new URLSearchParams({ per_page: "100", page: "1" });
       const root = await netlifyGet(`/api/v1/sites?${search.toString()}`);
-      const matches = Array.isArray(root)
-        ? filterNetlifySites(root, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(root, filterNetlifySites, p);
     },
   );
 });

--- a/packages/mcp-connectors/pipedrive/src/server.ts
+++ b/packages/mcp-connectors/pipedrive/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterPipedriveDeals } from "./search-filter.ts";
@@ -51,17 +52,11 @@ await runReadOnlyMcpConnector("nimbus-pipedrive", (reg) => {
   reg(
     "pipedrive_search",
     "Substring search across the user's Pipedrive deals (first page only). Matches the query against the deal title, status, organization name, person name, owner name, and label (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await pipedriveGet(`/v1/deals?limit=100`, "deals");
       const data = (root as { data?: unknown } | null)?.data;
-      const matches = Array.isArray(data)
-        ? filterPipedriveDeals(data, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(data, filterPipedriveDeals, p);
     },
   );
 });

--- a/packages/mcp-connectors/powerbi/src/server.ts
+++ b/packages/mcp-connectors/powerbi/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { fetchWithTimeout, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import {
   runReadOnlyMcpConnector,
@@ -153,10 +154,7 @@ export function registerPowerBiTools(reg: ZodToolRegistrar): void {
   reg(
     "powerbi_search",
     "Substring search across Power BI reports. Matches the query (case-insensitive) against report name and description. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const tenantId = requireEnv("POWERBI_TENANT_ID");
       const clientId = requireEnv("POWERBI_CLIENT_ID");

--- a/packages/mcp-connectors/prefect/src/server.ts
+++ b/packages/mcp-connectors/prefect/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterPrefectDeployments } from "./search-filter.ts";
@@ -80,10 +81,7 @@ await runReadOnlyMcpConnector("nimbus-prefect", (reg) => {
   reg(
     "prefect_search",
     "Substring search across the first page of Prefect deployments. Matches the query (case-insensitive) against the deployment name, description, work pool, work queue, status, and tags. Returns a matches envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await prefectListDeployments(0, 100);
       const matches = filterPrefectDeployments(deploymentsFrom(root), {

--- a/packages/mcp-connectors/raindrop/src/server.ts
+++ b/packages/mcp-connectors/raindrop/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterRaindropBookmarks } from "./search-filter.ts";
@@ -50,17 +51,11 @@ await runReadOnlyMcpConnector("nimbus-raindrop", (reg) => {
   reg(
     "raindrop_search",
     "Substring search across the user's Raindrop bookmarks (first page only). Matches the query against the bookmark title, excerpt, note, domain, link, type, and tags (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await raindropGet(`/rest/v1/raindrops/0?perpage=50`);
       const items = (root as { items?: unknown[] } | null)?.items;
-      const matches = Array.isArray(items)
-        ? filterRaindropBookmarks(items, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(items, filterRaindropBookmarks, p);
     },
   );
 });

--- a/packages/mcp-connectors/ramp/src/server.ts
+++ b/packages/mcp-connectors/ramp/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterRampTransactions } from "./search-filter.ts";
@@ -95,10 +96,7 @@ await runReadOnlyMcpConnector("nimbus-ramp", (reg) => {
   reg(
     "ramp_search",
     "Substring search across the first page of Ramp transactions. Matches the query (case-insensitive) against merchant name, category, state, currency, memo, and the card holder name/department. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await rampGet("/developer/v1/transactions?page_size=100");
       const matches = filterRampTransactions(transactionsFrom(root), {

--- a/packages/mcp-connectors/readwise/src/server.ts
+++ b/packages/mcp-connectors/readwise/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterReadwiseHighlights } from "./search-filter.ts";
@@ -50,17 +51,11 @@ await runReadOnlyMcpConnector("nimbus-readwise", (reg) => {
   reg(
     "readwise_search",
     "Substring search across the user's Readwise highlights (first page only). Matches the query against the highlight text, the user's note, color, location_type, and tag names (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await readwiseGet(`/api/v2/highlights/?page_size=1000`);
       const results = (root as { results?: unknown[] } | null)?.results;
-      const matches = Array.isArray(results)
-        ? filterReadwiseHighlights(results, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(results, filterReadwiseHighlights, p);
     },
   );
 });

--- a/packages/mcp-connectors/salesforce/src/server.ts
+++ b/packages/mcp-connectors/salesforce/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterSalesforceOpportunities } from "./search-filter.ts";
@@ -80,10 +81,7 @@ await runReadOnlyMcpConnector("nimbus-salesforce", (reg) => {
   reg(
     "salesforce_search",
     "**Substring search over the FIRST PAGE only** (up to the queried limit of most-recently-modified Opportunities) of the authenticated org's Salesforce Opportunities. This tool runs the SOQL query once and matches the query locally (case-insensitive) against each opportunity's name, stage, and type. **Opportunities beyond the first page are not searchable here — query the local Nimbus index instead for full coverage.** Returns a { matches: [...] } envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(2000).optional(),
-    }),
+    searchToolInputSchema(2000),
     async (p) => {
       const root = await salesforceGet(listQueryPath(2000));
       const matches = filterSalesforceOpportunities(recordsFrom(root), {

--- a/packages/mcp-connectors/semgrep/src/server.ts
+++ b/packages/mcp-connectors/semgrep/src/server.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterSemgrepFindings } from "./search-filter.ts";
@@ -92,10 +92,7 @@ await runReadOnlyMcpConnector("nimbus-semgrep", (reg) => {
   reg(
     "semgrep_search",
     "Substring search across the deployment's open findings. Matches the query against `rule_name`, `rule_message`, `location.file_path`, and `repository.name` (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const slug = requireSlug();
       const search = new URLSearchParams({
@@ -105,10 +102,7 @@ await runReadOnlyMcpConnector("nimbus-semgrep", (reg) => {
       const path = `/deployments/${encodeURIComponent(slug)}/findings?${search.toString()}`;
       const root = await semgrepGet(path);
       const findings = (root as { findings?: unknown[] } | null)?.findings;
-      const matches = Array.isArray(findings)
-        ? filterSemgrepFindings(findings, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(findings, filterSemgrepFindings, p);
     },
   );
 });

--- a/packages/mcp-connectors/shared/mcp-search-tool.test.ts
+++ b/packages/mcp-connectors/shared/mcp-search-tool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { matchesResult, searchToolInputSchema } from "./mcp-search-tool.ts";
+import { matchesResult, type SearchFilter, searchToolInputSchema } from "./mcp-search-tool.ts";
+import type { McpListResult } from "./mcp-tool-kit.ts";
 
 describe("searchToolInputSchema", () => {
   test("accepts query alone and query+limit", () => {
@@ -39,25 +40,31 @@ describe("searchToolInputSchema", () => {
 });
 
 describe("matchesResult", () => {
-  const filter = (rows: readonly unknown[], opts: { query: string; limit?: number }) =>
+  // Typed as SearchFilter so opts matches the helper's SearchMatchOptions
+  // (limit is `number | undefined` under exactOptionalPropertyTypes).
+  const filter: SearchFilter = (rows, opts) =>
     rows.filter((r) => String(r).includes(opts.query)).slice(0, opts.limit ?? rows.length);
+
+  // Parse the JSON payload of the single text part (content[0] is optional under
+  // noUncheckedIndexedAccess; matchesResult always emits exactly one part).
+  const payloadOf = (res: McpListResult): unknown => JSON.parse(res.content[0]?.text ?? "{}");
 
   test("filters array rows into a { matches } envelope", () => {
     // query "an" matches only "banana" — proves the filter actually filters (not a no-op).
     const res = matchesResult(["apple", "banana", "grape"], filter, { query: "an" });
-    expect(JSON.parse(res.content[0].text)).toEqual({ matches: ["banana"] });
+    expect(payloadOf(res)).toEqual({ matches: ["banana"] });
   });
 
   test("non-array rows yield empty matches", () => {
     for (const bad of [null, undefined, {}, "str", 42] as unknown[]) {
       const res = matchesResult(bad, filter, { query: "a" });
-      expect(JSON.parse(res.content[0].text)).toEqual({ matches: [] });
+      expect(payloadOf(res)).toEqual({ matches: [] });
     }
   });
 
   test("passes query+limit through to the filter unchanged", () => {
     const seen: unknown[] = [];
-    const spy = (rows: readonly unknown[], opts: { query: string; limit?: number }) => {
+    const spy: SearchFilter = (rows, opts) => {
       seen.push(opts);
       return rows;
     };
@@ -68,6 +75,6 @@ describe("matchesResult", () => {
   test("returns a single text-part McpListResult", () => {
     const res = matchesResult([], filter, { query: "x" });
     expect(res.content).toHaveLength(1);
-    expect(res.content[0].type).toBe("text");
+    expect(res.content[0]?.type).toBe("text");
   });
 });

--- a/packages/mcp-connectors/shared/mcp-search-tool.test.ts
+++ b/packages/mcp-connectors/shared/mcp-search-tool.test.ts
@@ -43,8 +43,9 @@ describe("matchesResult", () => {
     rows.filter((r) => String(r).includes(opts.query)).slice(0, opts.limit ?? rows.length);
 
   test("filters array rows into a { matches } envelope", () => {
-    const res = matchesResult(["apple", "banana", "grape"], filter, { query: "a" });
-    expect(JSON.parse(res.content[0].text)).toEqual({ matches: ["apple", "banana", "grape"] });
+    // query "an" matches only "banana" — proves the filter actually filters (not a no-op).
+    const res = matchesResult(["apple", "banana", "grape"], filter, { query: "an" });
+    expect(JSON.parse(res.content[0].text)).toEqual({ matches: ["banana"] });
   });
 
   test("non-array rows yield empty matches", () => {

--- a/packages/mcp-connectors/shared/mcp-search-tool.test.ts
+++ b/packages/mcp-connectors/shared/mcp-search-tool.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { matchesResult, searchToolInputSchema } from "./mcp-search-tool.ts";
+
+describe("searchToolInputSchema", () => {
+  test("accepts query alone and query+limit", () => {
+    const s = searchToolInputSchema();
+    const a = s.safeParse({ query: "x" });
+    expect(a.success).toBe(true);
+    if (a.success) {
+      expect(a.data).toEqual({ query: "x" });
+    }
+    const b = s.safeParse({ query: "x", limit: 5 });
+    expect(b.success).toBe(true);
+    if (b.success) {
+      expect(b.data).toEqual({ query: "x", limit: 5 });
+    }
+  });
+
+  test("rejects empty query", () => {
+    expect(searchToolInputSchema().safeParse({ query: "" }).success).toBe(false);
+  });
+
+  test("rejects limit over the default cap of 100, below 1, or non-integer", () => {
+    const s = searchToolInputSchema();
+    expect(s.safeParse({ query: "x", limit: 101 }).success).toBe(false);
+    expect(s.safeParse({ query: "x", limit: 0 }).success).toBe(false);
+    expect(s.safeParse({ query: "x", limit: 1.5 }).success).toBe(false);
+  });
+
+  test("honors a custom cap", () => {
+    const s = searchToolInputSchema(200);
+    expect(s.safeParse({ query: "x", limit: 200 }).success).toBe(true);
+    expect(s.safeParse({ query: "x", limit: 201 }).success).toBe(false);
+  });
+
+  test("exposes a .shape for tool registration", () => {
+    expect(typeof searchToolInputSchema().shape).toBe("object");
+  });
+});
+
+describe("matchesResult", () => {
+  const filter = (rows: readonly unknown[], opts: { query: string; limit?: number }) =>
+    rows.filter((r) => String(r).includes(opts.query)).slice(0, opts.limit ?? rows.length);
+
+  test("filters array rows into a { matches } envelope", () => {
+    const res = matchesResult(["apple", "banana", "grape"], filter, { query: "a" });
+    expect(JSON.parse(res.content[0].text)).toEqual({ matches: ["apple", "banana", "grape"] });
+  });
+
+  test("non-array rows yield empty matches", () => {
+    for (const bad of [null, undefined, {}, "str", 42] as unknown[]) {
+      const res = matchesResult(bad, filter, { query: "a" });
+      expect(JSON.parse(res.content[0].text)).toEqual({ matches: [] });
+    }
+  });
+
+  test("passes query+limit through to the filter unchanged", () => {
+    const seen: unknown[] = [];
+    const spy = (rows: readonly unknown[], opts: { query: string; limit?: number }) => {
+      seen.push(opts);
+      return rows;
+    };
+    matchesResult([1, 2], spy, { query: "q", limit: 7 });
+    expect(seen[0]).toEqual({ query: "q", limit: 7 });
+  });
+
+  test("returns a single text-part McpListResult", () => {
+    const res = matchesResult([], filter, { query: "x" });
+    expect(res.content).toHaveLength(1);
+    expect(res.content[0].type).toBe("text");
+  });
+});

--- a/packages/mcp-connectors/shared/mcp-search-tool.ts
+++ b/packages/mcp-connectors/shared/mcp-search-tool.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { type McpListResult, mcpJsonResult, type ZodObjectSchema } from "./mcp-tool-kit.ts";
+import type { SearchMatchOptions } from "./search-filter.ts";
+
+/** A `makeQueryFilter(...)` result — the shape every connector search filter has. */
+export type SearchFilter = (
+  rows: readonly unknown[],
+  opts: SearchMatchOptions,
+) => readonly unknown[];
+
+/**
+ * Build the shared connector search input schema. `query` is always a non-empty
+ * string; `maxLimit` is the per-connector cap (varies: 100/200/500/50/1000/2000)
+ * and MUST be passed verbatim from each call site so behavior is unchanged.
+ */
+export function searchToolInputSchema(maxLimit = 100): ZodObjectSchema<SearchMatchOptions> {
+  return z.object({
+    query: z.string().min(1),
+    limit: z.number().int().min(1).max(maxLimit).optional(),
+  });
+}
+
+/**
+ * Build the `{ matches }` envelope: filter the rows when they are an array, else
+ * return an empty match set. Verbatim equivalent of the per-connector tail
+ * `const matches = Array.isArray(X) ? filter(X, { query, limit }) : []; return jsonResult({ matches })`.
+ * `rows` stays `unknown` because external payloads are untyped at the boundary
+ * (Non-Negotiable #7).
+ */
+export function matchesResult(
+  rows: unknown,
+  filter: SearchFilter,
+  opts: SearchMatchOptions,
+): McpListResult {
+  const matches = Array.isArray(rows) ? filter(rows, opts) : [];
+  return mcpJsonResult({ matches });
+}

--- a/packages/mcp-connectors/snowflake/src/server.ts
+++ b/packages/mcp-connectors/snowflake/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { fetchWithTimeout, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import {
   runReadOnlyMcpConnector,
@@ -167,10 +168,7 @@ export function registerSnowflakeTools(reg: ZodToolRegistrar): void {
   reg(
     "snowflake_search",
     "Substring search across Snowflake tables. Matches the query (case-insensitive) against table name, schema name, and database name. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const tables = await fetchTables();
       const matches = filterSnowflakeTables(tables, { query: p.query, limit: p.limit });

--- a/packages/mcp-connectors/snyk/src/server.ts
+++ b/packages/mcp-connectors/snyk/src/server.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterSnykAggregatedIssues } from "./search-filter.ts";
@@ -138,10 +138,7 @@ await runReadOnlyMcpConnector("nimbus-snyk", (reg) => {
       const path = `/v1/org/${encodeURIComponent(p.orgId)}/project/${encodeURIComponent(p.projectId)}/aggregated-issues`;
       const root = await snykPost(path, body);
       const issues = (root as { issues?: unknown[] } | null)?.issues;
-      const matches = Array.isArray(issues)
-        ? filterSnykAggregatedIssues(issues, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(issues, filterSnykAggregatedIssues, p);
     },
   );
 });

--- a/packages/mcp-connectors/sonarqube/src/server.ts
+++ b/packages/mcp-connectors/sonarqube/src/server.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterSonarIssues } from "./search-filter.ts";
@@ -109,10 +109,7 @@ await runReadOnlyMcpConnector("nimbus-sonarqube", (reg) => {
       });
       const root = await sonarGet(`/api/issues/search?${search.toString()}`);
       const issues = (root as { issues?: unknown[] } | null)?.issues;
-      const matches = Array.isArray(issues)
-        ? filterSonarIssues(issues, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(issues, filterSonarIssues, p);
     },
   );
 });

--- a/packages/mcp-connectors/stackoverflow/src/server.ts
+++ b/packages/mcp-connectors/stackoverflow/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterStackOverflowQuestions } from "./search-filter.ts";
@@ -68,19 +69,13 @@ await runReadOnlyMcpConnector("nimbus-stackoverflow", (reg) => {
   reg(
     "stackoverflow_search",
     "Substring search across the team's Stack Overflow for Teams questions (first page only). Matches the query against the question title, body, tags, and the asking user's name (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await stackOverflowGet(
         `${questionsBasePath()}?page=1&pagesize=100&sort=creation&order=desc`,
       );
       const items = (root as { items?: unknown[] } | null)?.items;
-      const matches = Array.isArray(items)
-        ? filterStackOverflowQuestions(items, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(items, filterStackOverflowQuestions, p);
     },
   );
 });

--- a/packages/mcp-connectors/stripe/src/server.ts
+++ b/packages/mcp-connectors/stripe/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterStripeInvoices } from "./search-filter.ts";
@@ -53,18 +54,12 @@ await runReadOnlyMcpConnector("nimbus-stripe", (reg) => {
   reg(
     "stripe_search",
     "Substring search across recent Stripe invoices. Matches the query against id, number, status, customer id, customer name, customer email, and the description (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const search = new URLSearchParams({ limit: "100" });
       const root = await stripeGet(`/v1/invoices?${search.toString()}`);
       const data = (root as { data?: unknown[] } | null)?.data;
-      const matches = Array.isArray(data)
-        ? filterStripeInvoices(data, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(data, filterStripeInvoices, p);
     },
   );
 });

--- a/packages/mcp-connectors/superset/src/server.ts
+++ b/packages/mcp-connectors/superset/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterSupersetDashboards } from "./search-filter.ts";
@@ -105,10 +106,7 @@ await runReadOnlyMcpConnector("nimbus-superset", (reg) => {
   reg(
     "superset_search",
     "Substring search across Apache Superset dashboards. Matches the query (case-insensitive) against dashboard title and slug. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const root = await supersetGet(dashboardListPath(0, 500));
       const matches = filterSupersetDashboards(dashboardsFrom(root), {

--- a/packages/mcp-connectors/tableau/src/server.ts
+++ b/packages/mcp-connectors/tableau/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { fetchWithTimeout, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import {
   runReadOnlyMcpConnector,
@@ -195,10 +196,7 @@ export function registerTableauTools(reg: ZodToolRegistrar): void {
   reg(
     "tableau_search",
     "Substring search across Tableau views. Matches the query (case-insensitive) against view name and luid. Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const { token, siteId } = await tableauSignin();
       const { views } = await listViews(token, siteId);

--- a/packages/mcp-connectors/testflight/src/server.ts
+++ b/packages/mcp-connectors/testflight/src/server.ts
@@ -1,6 +1,6 @@
 import { signAppStoreConnectJwt } from "@nimbus-dev/sdk";
 import { z } from "zod";
-
+import { matchesResult } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { jwtParamsFromEnv } from "./jwt.ts";
@@ -68,10 +68,7 @@ await runReadOnlyMcpConnector("nimbus-testflight", (reg) => {
     async (p) => {
       const root = await appstoreGet(buildsPath(p.appId, 200));
       const data = (root as { data?: unknown[] } | null)?.data;
-      const matches = Array.isArray(data)
-        ? filterTestflightBuilds(data, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(data, filterTestflightBuilds, p);
     },
   );
 });

--- a/packages/mcp-connectors/vercel/src/server.ts
+++ b/packages/mcp-connectors/vercel/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterVercelDeployments } from "./search-filter.ts";
@@ -67,18 +68,12 @@ await runReadOnlyMcpConnector("nimbus-vercel", (reg) => {
   reg(
     "vercel_search",
     "Substring search across recent Vercel deployments. Matches the query against uid, project name, state, target, the *.vercel.app host, and the git commit message (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const search = new URLSearchParams({ limit: "100" });
       const root = await vercelGet(`/v6/deployments?${search.toString()}`);
       const deployments = (root as { deployments?: unknown[] } | null)?.deployments;
-      const matches = Array.isArray(deployments)
-        ? filterVercelDeployments(deployments, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(deployments, filterVercelDeployments, p);
     },
   );
 });

--- a/packages/mcp-connectors/wiz/src/server.ts
+++ b/packages/mcp-connectors/wiz/src/server.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterWizIssues } from "./search-filter.ts";
@@ -177,10 +178,7 @@ await runReadOnlyMcpConnector("nimbus-wiz", (reg) => {
   reg(
     "wiz_search",
     "Substring search across open issues. Matches the query against `sourceRule.name`, `description`, `entity.name`, `entity.type`, and project names (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(200).optional(),
-    }),
+    searchToolInputSchema(200),
     async (p) => {
       const data = await wizGraphql<IssuesPage>(ISSUES_QUERY, {
         first: 500,

--- a/packages/mcp-connectors/zendesk/src/server.ts
+++ b/packages/mcp-connectors/zendesk/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { encodeBasicAuthHeader, mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterZendeskTickets } from "./search-filter.ts";
@@ -63,17 +64,11 @@ await runReadOnlyMcpConnector("nimbus-zendesk", (reg) => {
   reg(
     "zendesk_search",
     "Substring search across the user's Zendesk tickets (first page only). Matches the query against the ticket subject, description, status, priority, type, and tags (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await zendeskGet(`/api/v2/tickets.json?page[size]=100`);
       const tickets = (root as { tickets?: unknown[] } | null)?.tickets;
-      const matches = Array.isArray(tickets)
-        ? filterZendeskTickets(tickets, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(tickets, filterZendeskTickets, p);
     },
   );
 });

--- a/packages/mcp-connectors/zotero/src/server.ts
+++ b/packages/mcp-connectors/zotero/src/server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { matchesResult, searchToolInputSchema } from "../../shared/mcp-search-tool.ts";
 import { mcpJsonResult as jsonResult } from "../../shared/mcp-tool-kit.ts";
 import { runReadOnlyMcpConnector } from "../../shared/run-read-only-mcp-connector.ts";
 import { filterZoteroItems } from "./search-filter.ts";
@@ -70,18 +71,12 @@ await runReadOnlyMcpConnector("nimbus-zotero", (reg) => {
   reg(
     "zotero_search",
     "Substring search across the library's top-level items (first page only). Matches the query against the title, item type, abstract, DOI, publication title, formatted creator names, and tag names (case-insensitive). Returns a `{ matches: [...] }` envelope.",
-    z.object({
-      query: z.string().min(1),
-      limit: z.number().int().min(1).max(100).optional(),
-    }),
+    searchToolInputSchema(100),
     async (p) => {
       const root = await zoteroGet(
         `${itemsBasePath()}?format=json&limit=100&start=0&sort=dateModified&direction=desc`,
       );
-      const matches = Array.isArray(root)
-        ? filterZoteroItems(root, { query: p.query, limit: p.limit })
-        : [];
-      return jsonResult({ matches });
+      return matchesResult(root, filterZoteroItems, p);
     },
   );
 });


### PR DESCRIPTION
## Stage B1 of the jscpd duplication-reduction program

Second stage after Stage A (#673). Extracts the cloned MCP connector **search-tool scaffolding** into two shared helpers and sweeps the canonical-shape connectors to use them. **Pure dedup — zero behavior change.**

### What changed
- **New** `packages/mcp-connectors/shared/mcp-search-tool.ts` (+ unit test):
  - `searchToolInputSchema(maxLimit = 100)` — collapses the inline `{ query, limit }` zod schema; the cap is **parameterized** so each connector's exact limit (100/200/500/50/1000/2000) is preserved.
  - `matchesResult(rows, filter, opts)` — collapses the `Array.isArray(X) ? filter(X, …) : [] → jsonResult({ matches })` tail; a verbatim equivalent.
- **44 connectors swept** across 6 batches (schema-collapse and/or tail-collapse per each connector's audited shape).
- **4 connectors deliberately skipped (no force-fit):** `dbt`, `flagsmith`, `flux` (extra schema field **and** no `Array.isArray` guard → neither helper applies) and `zoom` (custom `ZoomSearchOptions` filter type, tsc-incompatible with the generic helper under `exactOptionalPropertyTypes`).

### Design correction vs. the parent design
Target is **`mcp-connectors/shared/`**, not `@nimbus-dev/sdk`: the MCP stdio bootstrap is already deduped (`run-read-only-mcp-connector.ts`) and `shared/` is the established 19-file precedent for connector-internal helpers (avoids a new SDK export + the coverage-floor ratchet).

### Measurement (strict `bunx jscpd packages`, min-lines 5 / threshold 3)
- **4.98% → 4.83%** (637 → 604 clones). The zotero search clique collapsed: `zotero/server.ts` **21 → 0** clones; MCP `server.ts` family involvements **313 → 247**.
- Modest %-move as the design predicted for the search sweep (small per-clone line count); the bigger Stage-B clusters (email twins, REST/Graph blocks) are deferred to later slices.
- **CI lenient duplication gate NOT tightened** (final program stage): currently **3.16%** vs threshold 5% — green.

### Verification (all green, run before first push)
- Full `mcp-connectors` suite: **804 pass / 0 fail** — **no connector test file edited** (only the new helper test added).
- Full monorepo typecheck (`typecheck:no-docs`): clean. Per-connector tsc clean for all 44.
- Biome (`packages scripts`): clean. Static invariant audit: clean.
- Docs gates (markdownlint + lychee on spec/plan): clean.
- Whole-branch review: **READY**, no Critical/Important findings.

Spec: `docs/superpowers/specs/2026-06-17-jscpd-stage-b1-search-tool-scaffolding-design.md`
Plan: `docs/superpowers/plans/2026-06-17-jscpd-stage-b1-search-tool-scaffolding.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized MCP search tool input validation and match-result formatting across 40+ connectors using shared search utilities, improving consistency while preserving existing search behavior and response shape.
* **Tests**
  * Added a dedicated test suite for the shared search-tool helpers to verify input validation, filtering behavior, and normalized `{ matches: [...] }` output.
* **Documentation**
  * Added implementation plan and design specification documents covering the duplication-reduction approach and rollout/testing/verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->