### PR TITLE
fix(sonar): clear last 2 S7735 negated-condition smells

### DIFF
--- a/packages/gateway/src/connectors/stripe-sync.ts
+++ b/packages/gateway/src/connectors/stripe-sync.ts
@@ -60,7 +60,7 @@ function parseStripePage(parsed: unknown): ParsedPage {
     return { items, hasMore: false };
   }
   const last = asRecord(items.at(-1));
-  const nextId = last !== undefined ? (stringField(last, "id") ?? "") : "";
+  const nextId = last === undefined ? "" : (stringField(last, "id") ?? "");
   return { items, hasMore: nextId !== "", nextPageCursor: nextId };
 }
 

--- a/packages/gateway/src/connectors/vercel-sync.ts
+++ b/packages/gateway/src/connectors/vercel-sync.ts
@@ -67,7 +67,7 @@ function parseVercelPage(parsed: unknown): {
   return {
     items: deployments,
     hasMore: next !== null && deployments.length > 0,
-    nextPageCursor: next !== null ? String(next) : "",
+    nextPageCursor: next === null ? "" : String(next),
   };
 }
 


### PR DESCRIPTION
## What

SonarCloud audit of `nimbus-agent_Nimbus` showed the project is in excellent shape — gate green, 0 bugs / 0 vulnerabilities / 0 security hotspots, 93.8% coverage, 0.2% duplication, all A ratings. The **only** open issues were 2 minor `typescript:S7735` ("unexpected negated condition") code smells.

This flips both ternaries to put the positive branch first — **no behavior change**:

- `stripe-sync.ts` — `nextId` computation
- `vercel-sync.ts` — `nextPageCursor` computation

Takes the project to **0 open issues**.

## Verification

- `bunx biome check` on both files — clean
- `bun test` stripe-sync + vercel-sync fake-server integration suites — 15 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal optimization of pagination cursor computation in sync connectors with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->