### PR TITLE
chore: housekeeping bundle — architecture.md drift + @mastra/core 1.43 + dep hygiene

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
         "yaml": "^2.9.0",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.14",
         "@types/react": "^19.2.17",
         "ink-testing-library": "^4.0.0",
         "react-devtools-core": "^7.0.1",
@@ -73,7 +73,7 @@
         "@nimbus-dev/sdk": "workspace:*",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.14",
         "tsx": "^4.22.3",
         "typescript": "^6.0.3",
       },
@@ -83,7 +83,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/starlight": "^0.39.3",
-        "astro": "^6.4.4",
+        "astro": "^6.4.7",
         "sharp": "^0.34.5",
         "starlight-links-validator": "0.24.0",
         "typescript": "^6.0.3",
@@ -93,8 +93,8 @@
       "name": "@nimbus/gateway",
       "version": "0.1.0",
       "dependencies": {
-        "@mastra/core": "^1.41.0",
-        "@mastra/mcp": "^1.9.1",
+        "@mastra/core": "^1.43.0",
+        "@mastra/mcp": "^1.10.0",
         "@nimbus-dev/sdk": "workspace:*",
         "@noble/hashes": "^2.2.0",
         "@scure/bip39": "^2.2.0",
@@ -112,7 +112,7 @@
         "zod": "^4.4.2",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.14",
         "@types/js-yaml": "^4.0.9",
         "@types/pidusage": "^2.0.5",
         "@types/semver": "^7.7.1",
@@ -1291,7 +1291,7 @@
       "name": "@nimbus-dev/sdk",
       "version": "1.1.2",
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
       },
     },
@@ -1348,7 +1348,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.2",
-        "esbuild": "^0.28.0",
+        "esbuild": "^0.28.1",
         "jsdom": "^29.1.1",
         "ovsx": "^1.0.1",
         "typescript": "^6.0.3",
@@ -1357,8 +1357,8 @@
     },
   },
   "overrides": {
-    "@mastra/core": "1.40.0",
-    "@mastra/mcp": "1.9.1",
+    "@mastra/core": "1.43.0",
+    "@mastra/mcp": "1.10.0",
     "devalue": "5.8.1",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.2",
@@ -1770,11 +1770,11 @@
 
     "@lukeed/uuid": ["@lukeed/uuid@2.0.1", "", { "dependencies": { "@lukeed/csprng": "^1.1.0" } }, "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w=="],
 
-    "@mastra/core": ["@mastra/core@1.40.0", "", { "dependencies": { "@a2a-js/sdk": "~0.3.13", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.25", "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.27", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.3", "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.10", "@isaacs/ttlcache": "^2.1.4", "@lukeed/uuid": "^2.0.1", "@mastra/schema-compat": "1.2.11", "@modelcontextprotocol/sdk": "^1.29.0", "@sindresorhus/slugify": "^2.2.1", "@standard-schema/spec": "^1.1.0", "ajv": "^8.18.0", "chat": "^4.29.0", "croner": "^10.0.1", "dotenv": "^17.3.1", "execa": "^9.6.1", "fastq": "^1.19.1", "gray-matter": "^4.0.3", "ignore": "^7.0.5", "json-schema": "^0.4.0", "lru-cache": "^11.2.7", "p-map": "^7.0.4", "p-retry": "^7.1.1", "picomatch": "^4.0.3", "posthog-node": "^5.30.6", "tokenx": "^1.3.0", "ws": "^8.20.0", "xxhash-wasm": "^1.1.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-DH46SLPHDRmmJmTozdKdirduzRYvw2kjDcGlfrvLCW6+XypAkHhDpPwJi6iPJV6rBdvNGRDVZy7XscoEh+9/7A=="],
+    "@mastra/core": ["@mastra/core@1.43.0", "", { "dependencies": { "@a2a-js/sdk": "~0.3.13", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.25", "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.27", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.3", "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.10", "@isaacs/ttlcache": "^2.1.4", "@lukeed/uuid": "^2.0.1", "@mastra/schema-compat": "1.2.13", "@modelcontextprotocol/sdk": "^1.29.0", "@sindresorhus/slugify": "^2.2.1", "@standard-schema/spec": "^1.1.0", "ajv": "^8.20.0", "chat": "^4.29.0", "croner": "^10.0.1", "dotenv": "^17.3.1", "execa": "^9.6.1", "fastq": "^1.20.1", "gray-matter": "^4.0.3", "ignore": "^7.0.5", "jpeg-js": "^0.4.4", "json-schema": "^0.4.0", "lru-cache": "^11.2.7", "p-map": "^7.0.4", "p-retry": "^7.1.1", "picomatch": "^4.0.3", "posthog-node": "^5.37.0", "tokenx": "^1.3.0", "ws": "^8.20.0", "xxhash-wasm": "^1.1.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-K8owngADLxIny8h+BTgP+szaGmOIrDLxk6g0rh1o/4b2kERuxNZDIWajK0mFWdIl0LKopfNVHjKYqYwHWTl79A=="],
 
-    "@mastra/mcp": ["@mastra/mcp@1.9.1", "", { "dependencies": { "@modelcontextprotocol/ext-apps": "^1.7.1", "@modelcontextprotocol/sdk": "^1.29.0", "exit-hook": "^5.1.0", "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "@mastra/core": ">=1.0.0-0 <2.0.0-0" } }, "sha512-tQOBxBBpxWeLKxCpv6QgKUxwiH7bEDMkvSat126UIn9L5rr0+4igJ0zmJuGdFCBKPvz7CPo4ykQjkmu7rc/01w=="],
+    "@mastra/mcp": ["@mastra/mcp@1.10.0", "", { "dependencies": { "@modelcontextprotocol/ext-apps": "^1.7.1", "@modelcontextprotocol/sdk": "^1.29.0", "exit-hook": "^5.1.0", "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "@mastra/core": ">=1.0.0-0 <2.0.0-0" } }, "sha512-C28PS6X363t5J6yYzjdqV9PvZDhp2vPIYnU5MkzES9tfPpN6EWrnD6nPRYgKBfIfoT8cteF7oudFhbziFqXmfw=="],
 
-    "@mastra/schema-compat": ["@mastra/schema-compat@1.2.11", "", { "dependencies": { "json-schema-to-zod": "^2.7.0", "zod-from-json-schema": "^0.5.2", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-wN8eTy/g14Mg3kWukhoIjd5SpFtLQ8gOltbELe9nM2Ruzm4jK8tFr1ZZNZwvLYnpq7NJG5a8F0ZFCjXFOEwx0w=="],
+    "@mastra/schema-compat": ["@mastra/schema-compat@1.2.13", "", { "dependencies": { "json-schema-to-zod": "^2.7.0", "zod-from-json-schema": "^0.5.2", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-BimfaruvBm54X8cAnRPGJXySlJsZvM/vOchiP12qqKuKPsj+Ub7NdEa0ofES2B9xdENlcn8LqMGVi7nVJ9dKsA=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -1946,9 +1946,9 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@posthog/core": ["@posthog/core@1.30.5", "", { "dependencies": { "@posthog/types": "1.379.2" } }, "sha512-NGBRhqyMOpiSKd8xtg8dckUxh+kB02LdtnxKYW7ngycJmgM4GBGzSDaATbMQDKaNS9m2FJ9QRZ8nJyelGCoqNQ=="],
+    "@posthog/core": ["@posthog/core@1.35.1", "", { "dependencies": { "@posthog/types": "^1.389.0" } }, "sha512-2a9JgJgR+Ow8lrUQHVZYXH9EgXskYDlpbgNW6UvtsVxp8pEEFD8PxjZMnzq73Dx3NhAwNUrnVpb8KeZzHAtoSA=="],
 
-    "@posthog/types": ["@posthog/types@1.379.2", "", {}, "sha512-quGXOeNewmaGqTxE/eH8MgM/niW1jfgCyzh4bwpXFpDwuQPvWA8WkCFo6k1oKGYV03Go0udw49aGUz6s58cRsA=="],
+    "@posthog/types": ["@posthog/types@1.390.0", "", {}, "sha512-zMjK6nrUWhAlL8ECrM4WldvgawqdoAE5B0ys7eA0lCoWuyzfFoSyh6zYtEuBSDRyN7fQLSfNCK+mQH4ngOl7Zw=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -3088,6 +3088,8 @@
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
+    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
+
     "js-md4": ["js-md4@0.3.2", "", {}, "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="],
 
     "js-stringify": ["js-stringify@1.0.2", "", {}, "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g=="],
@@ -3752,7 +3754,7 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
-    "posthog-node": ["posthog-node@5.35.14", "", { "dependencies": { "@posthog/core": "1.30.5" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-vUO4/MQ+edqSua4jAQY+H8wvVMFOZNoBt72dqnxGkqgES0awW0NPFdDSfEhGhS6BSkydNFkN/4crnOksbCnFlQ=="],
+    "posthog-node": ["posthog-node@5.38.0", "", { "dependencies": { "@posthog/core": "^1.33.0" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-xEojUWq7ajYfsMPZIexG9xtvhewpqrPWvL/qRhnm8W3KVZi6BlXHe29tjywZJglrDwEQpqdtYKbRXyg2zF9MWw=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -687,13 +687,13 @@ Infrastructure resources are indexed with: `provider`, `service`, `resource_type
 
 Alerts are indexed with: `monitor_name`, `severity`, `status`, `service`, `fired_at`, `resolved_at`, `url`. Cross-service correlation (alert → deployment → PR → commit) is performed by the Memory Layer's hybrid search over indexed items from multiple connectors.
 
-#### Data Warehouse, Orchestration, BI & ML (Phase 5/6 — planned)
+#### Data Warehouse, Orchestration, BI & ML (Phase 6 Slice 7 — shipped)
 
-Warehouse, orchestration, BI, and ML/MLOps connectors are forward-looking; the **architectural boundary** they hold is the load-bearing fact here:
+Warehouse, orchestration, BI, and ML/MLOps connectors are live (Snowflake, Tableau, Looker, Power BI, Monte Carlo, Bigeye, dbt, Metabase, Databricks, MLflow, Airflow, Prefect, Dagster, …; see [`CHANGELOG.md`](./CHANGELOG.md) for delivery dates). The **architectural boundary** they hold is the load-bearing fact here:
 
 > **Metadata-only boundary.** These connectors ingest schema definitions (DDL), column tags, job/run status, run history, and query plans — **never row data, binary extracts, or result sets**. There is no code path in any connector that fetches them, and a contract test asserts the absence of row-fetch tools on each connector's MCP surface (see the [Security threat-to-mitigation table](#threat-to-mitigation-table)). The same boundary applies to the Phase 5 local data-file profiler (Parquet / CSV / JSONL / ORC under `[[filesystem.roots]]`): it reads footers, header rows, and line counts to derive column names, types, and row-count estimates — it never reads row groups, samples rows, or captures cell values.
 
-They introduce these item types (write tools — `warehouse.job.trigger`, `dbt.job.trigger`, `bi.dataset.refresh`, `ml.model.promote`, `dq.incident.resolve`, … — are all HITL-gated):
+They introduce these item types. Their write tools are HITL-gated: the warehouse/BI write action types (`snowflake.tag.set`, `snowflake.comment.set`, `tableau.datasource.refresh`, `tableau.workbook.refresh`, `looker.datagroup.trigger`, `looker.schedule.run_once`, `powerbi.dataset.refresh`, `powerbi.dataflow.refresh`, `montecarlo.incident.acknowledge`, `montecarlo.incident.resolve`, `bigeye.issue.acknowledge`, `bigeye.issue.resolve`) are live in the frozen HITL set (I2) — see `HITL_REQUIRED_BACKING` / `WAREHOUSE_BI_WRITES` in `engine/executor.ts`:
 
 | Item type | Source domain | Key indexed fields |
 |---|---|---|

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "ws": "8.21.0",
     "form-data": "4.0.6",
     "hono": "4.12.25",
-    "@mastra/core": "1.40.0",
-    "@mastra/mcp": "1.9.1"
+    "@mastra/core": "1.43.0",
+    "@mastra/mcp": "1.10.0"
   },
   "workspaces": [
     "packages/admin-console",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.14",
     "@types/react": "^19.2.17",
     "ink-testing-library": "^4.0.0",
     "react-devtools-core": "^7.0.1"

--- a/packages/cli/src/lib/nimbus-toml-config.test.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.test.ts
@@ -38,12 +38,12 @@ afterEach(() => {
 
 describe("listTomlKeysWithEnv — llm.* entries", () => {
   test("llm.remote_model surfaces from env when NIMBUS_AGENT_MODEL is set", () => {
-    process.env["NIMBUS_AGENT_MODEL"] = "claude-opus-4-7";
+    process.env["NIMBUS_AGENT_MODEL"] = "claude-opus-4-8";
     const rows = listTomlKeysWithEnv(tomlPath);
     const row = rows.find((r) => r.key === "llm.remote_model");
     expect(row).toEqual({
       key: "llm.remote_model",
-      value: "claude-opus-4-7",
+      value: "claude-opus-4-8",
       source: "env",
       envVar: "NIMBUS_AGENT_MODEL",
     });
@@ -83,11 +83,11 @@ describe("listTomlKeysWithEnv — llm.* entries", () => {
 
   test("env beats file when both are set", () => {
     writeFileSync(tomlPath, `[llm]\nremote_model = "claude-sonnet-4-6"\n`);
-    process.env["NIMBUS_AGENT_MODEL"] = "claude-opus-4-7";
+    process.env["NIMBUS_AGENT_MODEL"] = "claude-opus-4-8";
     const rows = listTomlKeysWithEnv(tomlPath);
     const row = rows.find((r) => r.key === "llm.remote_model");
     expect(row?.source).toBe("env");
-    expect(row?.value).toBe("claude-opus-4-7");
+    expect(row?.value).toBe("claude-opus-4-8");
   });
 
   test("llm.* is omitted when both env and file are unset", () => {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -38,7 +38,7 @@
     "@nimbus-dev/sdk": "workspace:*"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.14",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3"
   }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/starlight": "^0.39.3",
-    "astro": "^6.4.4",
+    "astro": "^6.4.7",
     "sharp": "^0.34.5",
     "starlight-links-validator": "0.24.0",
     "typescript": "^6.0.3"

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -16,8 +16,8 @@
     "test:coverage:lan": "bun test --coverage src/ipc/lan-crypto.test.ts src/ipc/lan-pairing.test.ts src/ipc/lan-rate-limit.test.ts src/ipc/lan-rpc.test.ts src/ipc/lan-server.test.ts"
   },
   "dependencies": {
-    "@mastra/core": "^1.41.0",
-    "@mastra/mcp": "^1.9.1",
+    "@mastra/core": "^1.43.0",
+    "@mastra/mcp": "^1.10.0",
     "@nimbus-dev/sdk": "workspace:*",
     "@noble/hashes": "^2.2.0",
     "@scure/bip39": "^2.2.0",
@@ -35,7 +35,7 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.14",
     "@types/js-yaml": "^4.0.9",
     "@types/pidusage": "^2.0.5",
     "@types/semver": "^7.7.1",

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -39,16 +39,16 @@ describe("getEffectiveAgentModel / getEffectiveClassifierModel", () => {
 
   test("TOML overrides win over hardcoded defaults", () => {
     applyLlmTomlOverrides({
-      agentModel: "claude-opus-4-7",
+      agentModel: "claude-opus-4-8",
       classifierModel: "claude-haiku-4-5-20251001",
     });
-    expect(getEffectiveAgentModel()).toBe("claude-opus-4-7");
+    expect(getEffectiveAgentModel()).toBe("claude-opus-4-8");
     expect(getEffectiveClassifierModel()).toBe("claude-haiku-4-5-20251001");
   });
 
   test("calling applyLlmTomlOverrides({}) resets to hardcoded defaults", () => {
-    applyLlmTomlOverrides({ agentModel: "claude-opus-4-7" });
-    expect(getEffectiveAgentModel()).toBe("claude-opus-4-7");
+    applyLlmTomlOverrides({ agentModel: "claude-opus-4-8" });
+    expect(getEffectiveAgentModel()).toBe("claude-opus-4-8");
     applyLlmTomlOverrides({});
     expect(getEffectiveAgentModel()).toBe("claude-sonnet-4-6");
   });
@@ -60,14 +60,14 @@ describe("getEffectiveAgentModel / getEffectiveClassifierModel", () => {
   });
 
   test("partial overrides leave other field on default", () => {
-    applyLlmTomlOverrides({ agentModel: "claude-opus-4-7" });
-    expect(getEffectiveAgentModel()).toBe("claude-opus-4-7");
+    applyLlmTomlOverrides({ agentModel: "claude-opus-4-8" });
+    expect(getEffectiveAgentModel()).toBe("claude-opus-4-8");
     expect(getEffectiveClassifierModel()).toBe("claude-haiku-4-5-20251001");
   });
 
   test("env var wins over TOML override", () => {
     applyLlmTomlOverrides({
-      agentModel: "claude-opus-4-7",
+      agentModel: "claude-opus-4-8",
       classifierModel: "claude-haiku-4-5-20251001",
     });
     process.env["NIMBUS_AGENT_MODEL"] = "claude-sonnet-from-env";

--- a/packages/gateway/src/config/nimbus-toml-llm.test.ts
+++ b/packages/gateway/src/config/nimbus-toml-llm.test.ts
@@ -128,8 +128,8 @@ describe("loadNimbusLlmPartialFromPath", () => {
   test("returns only explicitly-set keys (no defaults)", () => {
     const dir = mkdtempSync(join(tmpdir(), "nimbus-llm-partial-"));
     const tomlPath = join(dir, "nimbus.toml");
-    writeFileSync(tomlPath, `[llm]\nremote_model = "claude-opus-4-7"\n`);
-    expect(loadNimbusLlmPartialFromPath(tomlPath)).toEqual({ remoteModel: "claude-opus-4-7" });
+    writeFileSync(tomlPath, `[llm]\nremote_model = "claude-opus-4-8"\n`);
+    expect(loadNimbusLlmPartialFromPath(tomlPath)).toEqual({ remoteModel: "claude-opus-4-8" });
   });
 
   test("returns empty object when [llm] section is absent", () => {

--- a/packages/gateway/src/engine/agent.test.ts
+++ b/packages/gateway/src/engine/agent.test.ts
@@ -178,7 +178,7 @@ describe("toMastraModelId (via agentModel)", () => {
     expect(() =>
       createNimbusEngineAgent({
         localIndex,
-        agentModel: "claude-3-5-sonnet-20241022",
+        agentModel: "claude-sonnet-4-6",
       }),
     ).not.toThrow();
   });

--- a/packages/gateway/src/engine/coordinator.test.ts
+++ b/packages/gateway/src/engine/coordinator.test.ts
@@ -176,7 +176,7 @@ describe("AgentCoordinator", () => {
           text: "answer",
           tokensIn: 10,
           tokensOut: 5,
-          modelUsed: "claude-3",
+          modelUsed: "claude-sonnet-4-6",
         }),
       },
     ];
@@ -184,7 +184,7 @@ describe("AgentCoordinator", () => {
     const results = await coordinator.run(tasks);
     expect(results).toHaveLength(1);
     expect(results[0]?.status).toBe("done");
-    expect(results[0]?.modelUsed).toBe("claude-3");
+    expect(results[0]?.modelUsed).toBe("claude-sonnet-4-6");
   });
 
   test("converts non-Error thrown value to string in errorText (L75 branch)", async () => {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.14",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -166,7 +166,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.28.1",
     "jsdom": "^29.1.1",
     "ovsx": "^1.0.1",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

A low-risk housekeeping bundle from a docs/tech/architecture audit. Three buckets: documentation drift, dependency hygiene, and stale test fixtures. No production code behavior changes.

### Docs (`docs/architecture.md`)
- Promote the **Data Warehouse / Orchestration / BI & ML** section from "Phase 5/6 — planned" → "Phase 6 Slice 7 — shipped"; name the live connector roster (delivery dates stay in `CHANGELOG.md` per convention).
- Replace the placeholder write-tool names (`warehouse.job.trigger`, …) with the **12 real wired warehouse/BI HITL action types** (`snowflake.tag.set` … `bigeye.issue.resolve`), pointing at `WAREHOUSE_BI_WRITES` / `HITL_REQUIRED_BACKING` in `engine/executor.ts`.

### Dependencies
- **`@mastra/core` 1.40.0 → 1.43.0**, **`@mastra/mcp` 1.9.1 → 1.10.0** (root `overrides` + gateway aligned). Resolves a silent conflict where the override pinned a version *below* the gateway's declared `^1.41.0`, so the gateway was resolving 1.40.0 despite asking for ≥1.41.0.
- **`@types/bun`: `"latest"` → `"^1.3.14"`** across gateway/cli/sdk/client — removes an unpinned surface that can redden CI on a clean install with zero source change.
- **astro** docs floor `^6.4.4` → `^6.4.7`; **esbuild** (vscode-extension) `^0.28.0` → `^0.28.1` — align declared floors with the enforced override.

### Test fixtures
- Refresh stale model ids: `claude-opus-4-7` → `claude-opus-4-8`; `claude-3-5-sonnet-20241022` / `claude-3` → `claude-sonnet-4-6`. Cosmetic; round-trip assertions preserved.

## Verification
- `bun run preflight` (full): typecheck (all packages) ✅, build ✅, **all 18 static gates** ✅ (incl. `audit:doc-refs`, `audit:status-drift`), 666 targeted tests (engine+agents 518, config/fixtures 148) ✅.
- Mastra 1.40→1.43 is clean — our `anthropic/<model>` string interface insulates us from the AI-SDK v5/v6 provider churn underneath.
- **One known non-blocking flake:** the full local `test:ci` recorded a single timeout in an unrelated connector-OAuth test (`auth.test.ts`) at ~5012ms under full-suite load. It passes **14/14 @ ~200ms in isolation** (3× confirmed); root cause is the pre-existing Windows full-suite timeout flake (`run-tests.ts` runs `bun test <paths>`, which doesn't honor bunfig's `timeout=30000` — see PR #541). Unrelated to this diff; Linux CI runs with proper timeouts.

## Risk
Docs + `package.json`/lockfile + test-fixture strings only. The sole runtime-affecting change is the Mastra minor bump, verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect that Data Warehouse, Orchestration, BI & ML connectors are now live and production-ready.

* **Chores**
  * Updated core and MCP dependencies to latest compatible versions.
  * Pinned development dependencies for improved build stability across multiple packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->