### PR TITLE
refactor(dedup): jscpd Wave-2 — 5 clusters + ratchet 4.5%→4.0% (strict 4.38%→3.98%)

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/kucherenko/jscpd/master/packages/jscpd/schemas/jscpd.json",
   "minTokens": 50,
   "minLines": 5,
-  "threshold": 4.5,
+  "threshold": 4,
   "reporters": ["json", "console"],
   "output": "docs/structure-audit",
   "ignore": [

--- a/bun.lock
+++ b/bun.lock
@@ -1364,8 +1364,10 @@
     "fast-uri": "3.1.2",
     "form-data": "4.0.6",
     "hono": "4.12.25",
+    "nodemailer": "9.0.1",
     "protobufjs": "7.6.4",
     "sharp": "0.34.5",
+    "undici": "7.28.0",
     "vite": "7.3.5",
     "ws": "8.21.0",
   },
@@ -3614,7 +3616,7 @@
 
     "node-sarif-builder": ["node-sarif-builder@3.4.0", "", { "dependencies": { "@types/sarif": "^2.1.7", "fs-extra": "^11.1.1" } }, "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg=="],
 
-    "nodemailer": ["nodemailer@9.0.0", "", {}, "sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw=="],
+    "nodemailer": ["nodemailer@9.0.1", "", {}, "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw=="],
 
     "normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
 
@@ -4216,7 +4218,7 @@
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 
-    "undici": ["undici@7.26.0", "", {}, "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -4609,8 +4611,6 @@
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "imapflow/nodemailer": ["nodemailer@8.0.10", "", {}, "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ=="],
 
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 

--- a/docs/superpowers/plans/2026-06-20-jscpd-wave2-dedup.md
+++ b/docs/superpowers/plans/2026-06-20-jscpd-wave2-dedup.md
@@ -1,0 +1,326 @@
+# jscpd Dedup Wave-2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drive strict `bunx jscpd packages` duplication below the 4.38% baseline by pure extraction across 5 deferred clusters, then lower the `.jscpd.json` ratchet to just above the new strict %.
+
+**Architecture:** Each cluster extracts byte-identical duplicated code into an existing/new shared
+helper (sdk for cli↔gateway, `mcp-connectors/shared/` for connectors, `gateway/_lib/` for gateway),
+migrates the call sites, and proves zero behavior change by keeping every existing test green
+**unedited**. New helpers get co-located TDD tests.
+
+**Tech Stack:** Bun 1.2+ / TypeScript 6 strict, Biome, jscpd, zod, bun:test.
+
+## Global Constraints
+
+- **Pure dedup, zero behavior change.** Every existing connector/guard/sync test stays GREEN UNEDITED. No `.jscpd.json` ignore added.
+- **Defer-on-deviation:** if a candidate cannot be unified byte-faithfully (byte/upsert accounting, error text, TLS config, structural types), revert that part and record the deferral. Do not force-fit.
+- **No `any`** — use `unknown` for external data (Non-Negotiable #7).
+- Cross-package cli↔gateway shared code → `@nimbus-dev/sdk` (MIT). Connector-shared → `packages/mcp-connectors/shared/`. Gateway-shared → `gateway/src/connectors/_lib/`.
+- **sdk uses `exactOptionalPropertyTypes`** — never pass `{ x: undefined }` in sdk tests.
+- **★ After ANY `mcp-connectors/shared/` change**, run the strict tsc loop (the email connectors include `../shared/**` under `noPropertyAccessFromIndexSignature`):
+  `for c in gmail outlook teams google-meet google-photos; do bunx tsc -p packages/mcp-connectors/$c/tsconfig.json || echo "FAIL $c"; done`
+- **`git checkout -- docs/structure-audit/`** before every commit (jscpd + audit:structure regenerate those JSONs).
+- Controller (not subagent) runs the tsc loop + biome + `git commit` + jscpd re-measure after each cluster. Background subagents can run `bun test` but not commit. Verify file state; don't trust self-reports.
+- Build sdk + client first in the worktree (`cd packages/sdk && bun run build`; `cd packages/client && bun run build`) — already done this session; rebuild sdk after C1 before cross-package typecheck.
+
+---
+
+### Task C1: agent-brief guards → sdk guard-factory
+
+**Files:**
+- Create: `packages/sdk/src/agents/guard-factory.ts`
+- Create: `packages/sdk/src/agents/guard-factory.test.ts`
+- Modify: `packages/sdk/src/index.ts` (barrel: export `createBriefGuard`)
+- Modify: `packages/cli/src/types/agents.ts` (replace 8 guard bodies with factory calls, `requireQuery` omitted)
+- Modify: `packages/gateway/src/agents/_lib/findings.ts` (replace 8 guard bodies with factory calls, `requireQuery: true`)
+
+**Interfaces:**
+- Produces: `createBriefGuard<T>(kind: string, extra: (b: Record<string, unknown>) => boolean, opts?: { requireQuery?: boolean }): (x: unknown) => x is T`
+
+- [ ] **Step 1 — Read the two source files fully.** `packages/cli/src/types/agents.ts` (guards at lines ~34–276) and `packages/gateway/src/agents/_lib/findings.ts` (guards at lines ~148–269). Record each guard's exact `extra` predicate (the brief-specific field checks) and confirm gateway adds `typeof b["query"]==="object" && b["query"]!==null` while CLI does not.
+
+- [ ] **Step 2 — Write `guard-factory.test.ts` (failing).** Cover both branches:
+```ts
+import { describe, expect, it } from "bun:test";
+import { createBriefGuard } from "./guard-factory.ts";
+
+describe("createBriefGuard", () => {
+  const base = { kind: "x", agentVersion: 1, generatedAt: 0, latencyMs: 0, gaps: [] };
+  const isX = createBriefGuard<unknown>("x", (b) => Array.isArray(b["items"]));
+  const isXq = createBriefGuard<unknown>("x", (b) => Array.isArray(b["items"]), { requireQuery: true });
+
+  it("matches base shape + extra when requireQuery is off (CLI behaviour)", () => {
+    expect(isX({ ...base, items: [] })).toBe(true);           // no query needed
+    expect(isX({ ...base, items: [] , query: { a: 1 } })).toBe(true);
+  });
+  it("rejects wrong kind / version / non-array gaps / extra-fail", () => {
+    expect(isX({ ...base, kind: "y", items: [] })).toBe(false);
+    expect(isX({ ...base, agentVersion: 2, items: [] })).toBe(false);
+    expect(isX({ ...base, gaps: "no", items: [] })).toBe(false);
+    expect(isX({ ...base, items: "no" })).toBe(false);
+  });
+  it("requires a query object only when requireQuery is on (gateway behaviour)", () => {
+    expect(isXq({ ...base, items: [] })).toBe(false);          // missing query
+    expect(isXq({ ...base, items: [], query: null })).toBe(false);
+    expect(isXq({ ...base, items: [], query: { a: 1 } })).toBe(true);
+  });
+  it("rejects null / non-object", () => {
+    expect(isX(null)).toBe(false);
+    expect(isX("s")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3 — Run it, expect FAIL** (`bun test packages/sdk/src/agents/guard-factory.test.ts`) → "Cannot find module ./guard-factory.ts".
+
+- [ ] **Step 4 — Implement `guard-factory.ts`:**
+```ts
+/**
+ * Build a discriminated-union type guard for an agent brief. The base shape
+ * (kind / agentVersion===1 / Array.isArray(gaps) / numeric generatedAt+latencyMs)
+ * plus a connector-supplied `extra` predicate. `requireQuery` adds the
+ * `typeof query === "object" && query !== null` check used by the gateway-side
+ * guards (the CLI-side guards omit it — preserved by defaulting it off).
+ */
+export function createBriefGuard<T>(
+  kind: string,
+  extra: (b: Record<string, unknown>) => boolean,
+  opts?: { requireQuery?: boolean },
+): (x: unknown) => x is T {
+  const requireQuery = opts?.requireQuery ?? false;
+  return (x: unknown): x is T => {
+    if (x === null || typeof x !== "object") return false;
+    const b = x as Record<string, unknown>;
+    if (
+      b["kind"] !== kind ||
+      b["agentVersion"] !== 1 ||
+      !Array.isArray(b["gaps"]) ||
+      typeof b["generatedAt"] !== "number" ||
+      typeof b["latencyMs"] !== "number"
+    ) {
+      return false;
+    }
+    if (requireQuery && (typeof b["query"] !== "object" || b["query"] === null)) {
+      return false;
+    }
+    return extra(b);
+  };
+}
+```
+
+- [ ] **Step 5 — Run test, expect PASS.**
+
+- [ ] **Step 6 — Barrel export** in `packages/sdk/src/index.ts`: `export { createBriefGuard } from "./agents/guard-factory.ts";` (follow the existing brief-types export style).
+
+- [ ] **Step 7 — Rebuild sdk:** `cd packages/sdk && bun run build`.
+
+- [ ] **Step 8 — Migrate CLI guards** in `packages/cli/src/types/agents.ts`: replace each `export function isXxxBrief(x): x is XxxBrief { … }` body with `export const isXxxBrief = createBriefGuard<XxxBrief>("xxx", (b) => <the exact extra predicate>);` — import `createBriefGuard` from `@nimbus-dev/sdk`. `requireQuery` OMITTED. Match each `extra` to the file's current per-brief checks verbatim (e.g. expert→`Array.isArray(b["ranked"])`, impact→`Array.isArray(b["affected"])`, catchup→`Array.isArray(b["sections"])`, ghost→`Array.isArray(b["findings"])`, conflict→`Array.isArray(b["collisions"])`, huddle→`Array.isArray(b["contributions"])`, janitor→`Array.isArray(b["peersTouched"]) && typeof b["idle"]==="boolean"`, preflight→`Array.isArray(b["downstreams"]) && typeof b["anyFailed"]==="boolean" && typeof b["anyIncomplete"]==="boolean"`). **Verify each predicate against the actual file** — the field names above are from recon; confirm before trusting.
+
+- [ ] **Step 9 — Migrate gateway guards** in `packages/gateway/src/agents/_lib/findings.ts`: same, but pass `{ requireQuery: true }`.
+
+- [ ] **Step 10 — Run both existing guard suites UNEDITED:** `bun test packages/cli/src/types/agents.test.ts packages/gateway/src/agents/_lib/findings.test.ts` → all PASS. If any fail, the `extra`/`requireQuery` mapping is wrong — fix the mapping, never the test.
+
+- [ ] **Step 11 — Controller:** strict tsc (`bunx tsc -p packages/cli/tsconfig.json`, `bunx tsc -p packages/gateway/tsconfig.json`, `bunx tsc -p packages/sdk/tsconfig.json`), `bunx biome check --write packages/sdk packages/cli packages/gateway`, `git checkout -- docs/structure-audit/`, commit `refactor(dedup): C1 agent-brief guards → sdk createBriefGuard`.
+
+- [ ] **Step 12 — jscpd re-measure:** `bunx jscpd packages` — confirm the `cli/types/agents.ts ↔ gateway/agents/_lib/findings.ts` 107-line pair is gone; record new total.
+
+---
+
+### Task C2: imap/protonmail email connectors → shared
+
+**Files:**
+- Modify: `packages/mcp-connectors/shared/imap-mail-core.ts` (add free helpers; attempt shared client base)
+- Modify: `packages/mcp-connectors/shared/imap-tool-kit.ts` (add `registerEmailConnectorTools` factory)
+- Modify/Test: `packages/mcp-connectors/shared/imap-tool-kit.test.ts`, `imap-mail-core.test.ts` (or new co-located tests)
+- Modify: `packages/mcp-connectors/imap/src/server.ts`, `imap/src/tools.ts`
+- Modify: `packages/mcp-connectors/protonmail/src/server.ts`, `protonmail/src/tools.ts`
+
+**Interfaces:**
+- Consumes: existing `emailToolSchemas`, `viewEmailMessage`, `EmailMessageMeta`, `RegisterSimpleToolFn` from `imap-tool-kit.ts`/`mcp-tool-kit.ts`.
+- Produces: free helpers `toImapAddress`, `envelopeFromImap`, `toMessageMeta`, `previewFetchQuery` (exact existing signatures); `registerEmailConnectorTools(opts)` (see spec C2b).
+
+**Sub-part C2a — free helpers (server.ts):**
+
+- [ ] **Step 1 — Confirm byte-identity.** Diff the 4 helpers between `imap/src/server.ts` (~lines 36–94) and `protonmail/src/server.ts` (~lines 38–90). They must be identical modulo whitespace. If any differs, only hoist the identical ones; note the rest.
+
+- [ ] **Step 2 — Write failing co-located test** in `imap-mail-core.test.ts` for at least `envelopeFromImap` + `toMessageMeta` (feed a sample imapflow envelope, assert the mapped shape — copy expected values from the current behavior).
+
+- [ ] **Step 3 — Run, expect FAIL.**
+
+- [ ] **Step 4 — Move the 4 helpers verbatim** into `imap-mail-core.ts`, exported. Keep their exact bodies + types. (If a helper references a connector-local type, widen to the shared `EmailMessageMeta`/a small shared input type without changing runtime behavior.)
+
+- [ ] **Step 5 — Run test, expect PASS.**
+
+- [ ] **Step 6 — Replace both connectors' local copies with imports** from `../../shared/imap-mail-core.ts`.
+
+**Sub-part C2b — tools.ts registration factory:**
+
+- [ ] **Step 7 — Read both `tools.ts` fully** (`imap/src/tools.ts`, `protonmail/src/tools.ts`, ~1–106). Confirm the 4 `registerSimpleTool` blocks differ only in tool-name prefix + description strings + the local client/mailer types.
+
+- [ ] **Step 8 — Write failing test** in `imap-tool-kit.test.ts` for `registerEmailConnectorTools`: pass a fake `registerSimpleTool` that records `(name, description)` tuples + a fake client/mailer, assert it registers exactly `${prefix}_list|_get|_search|_mail_send` with the supplied descriptions, and that invoking the recorded handlers calls the fake client/mailer (1 assertion per tool) and returns `mcpJsonResult`-shaped output.
+
+- [ ] **Step 9 — Run, expect FAIL.**
+
+- [ ] **Step 10 — Implement `registerEmailConnectorTools(opts)`** in `imap-tool-kit.ts` per spec C2b. Internally reuse `emailToolSchemas`, `viewEmailMessage`, and the existing parse-guard pattern (mirror the current tools.ts handler bodies verbatim — same `safeParse`/`clampLimit`/`client.search` calls). Define minimal `EmailClientLike`/`EmailMailerLike` structural interfaces that both connectors' clients satisfy.
+
+- [ ] **Step 11 — Run test, expect PASS.**
+
+- [ ] **Step 12 — Migrate both `tools.ts`** to a single `registerEmailConnectorTools({...})` call, passing each connector's exact tool descriptions verbatim and its client/mailer.
+
+**Sub-part C2c — class-body merge (ATTEMPT, defer-on-deviation):**
+
+- [ ] **Step 13 — Attempt** a shared `newClient`/`withMailbox` factory in `imap-mail-core.ts` parameterized on `{ secure: boolean; tls?: {...}; host; port; auth }` that `ImapFlowClient` and `BridgeImapClient` both delegate to. Preserve protonmail's `secure:false`+`rejectUnauthorized:false` and imap's `secure:true` exactly.
+
+- [ ] **Step 14 — Gate:** run imap + protonmail `sandbox.test.ts` + gateway `imap-sync.test.ts`/`protonmail-sync.test.ts`. If green AND strict tsc clean → keep. If ANY deviation/type-friction → **revert C2c only**, record the deferral in the PR body, keep C2a+C2b.
+
+- [ ] **Step 15 — Run all four connectors' existing tests UNEDITED:** `bun test packages/mcp-connectors/imap packages/mcp-connectors/protonmail` (+ gateway imap/protonmail sync tests) → PASS.
+
+- [ ] **Step 16 — Controller:** **strict tsc loop** (`for c in gmail outlook teams google-meet google-photos; do bunx tsc -p packages/mcp-connectors/$c/tsconfig.json; done`) PLUS `bunx tsc -p packages/mcp-connectors/imap/tsconfig.json` + `…/protonmail/tsconfig.json`; `bunx biome check --write packages/mcp-connectors`; `git checkout -- docs/structure-audit/`; commit `refactor(dedup): C2 imap/protonmail → shared helpers + tool factory`.
+
+- [ ] **Step 17 — jscpd re-measure**, record new total.
+
+---
+
+### Task C3: cloudwatch/sagemaker async-enrichment CLI-shell helper
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/_lib/cli-shell-sync.ts` (add `runAsyncEnrichmentCliShellSync` + spec type)
+- Create: `packages/gateway/src/connectors/_lib/cli-shell-enrich-sync.test.ts` (co-located unit test for the new helper)
+- Modify: `packages/gateway/src/connectors/cloudwatch-sync.ts`, `sagemaker-sync.ts`
+
+**Interfaces:**
+- Consumes: `isSafeCliArg`, `CliShellOutcome`, `ParsedCliPage`, `SyncUpsertRow` from `cli-shell-sync.ts`; `syncPassCursorParseEmpty`/`syncPassCursorSuccess`/`syncNoopResult`.
+- Produces:
+  ```ts
+  export interface AsyncEnrichmentCliShellSyncSpec<C, E> {
+    readonly ensureRunning: () => Promise<void>;
+    readonly loadCreds: () => Promise<C | null>;
+    readonly pass1Cursor: () => string;
+    readonly maxPages: number;
+    readonly maxEnrichmentPerPage?: number;
+    readonly runCliPage: (creds: C, page: number, pageCursor: string) => Promise<CliShellOutcome>;
+    readonly parsePage: (text: string, page: number) => ParsedCliPage;
+    readonly enrichOne?: (creds: C, raw: unknown) => Promise<{ enrichment: E | undefined; bytes: number }>;
+    readonly map: (raw: unknown, enrichment: E | undefined, creds: C, now: number) => SyncUpsertRow | null;
+  }
+  export async function runAsyncEnrichmentCliShellSync<C, E>(ctx: SyncContext, cursor: string | null, spec: AsyncEnrichmentCliShellSyncSpec<C, E>): Promise<SyncResult>
+  ```
+
+- [ ] **Step 1 — Read `cloudwatch-sync.ts` + `sagemaker-sync.ts` fully** and the two test files (`test/unit/connectors/cloudwatch-sync.test.ts`, `sagemaker-sync.test.ts`). Record EXACT accounting: outer page bytes (`state.bytes += res.text.length`), per-enrichment bytes (`state.bytes += summary.bytes` / `+= d.bytes`), enrichment cap (`MAX_DESCRIBE`), best-effort enrichment failure handling (enrich error → still upsert), upsert-count semantics (one per group/model).
+
+- [ ] **Step 2 — Write `cli-shell-enrich-sync.test.ts` (failing)** that drives the helper with fakes and asserts the fidelity rules: (a) total bytes = list-page bytes + Σ enrich bytes within cap; (b) upsert count = mapped non-null items; (c) enrichment beyond `maxEnrichmentPerPage` is NOT called; (d) an `enrichOne` that throws/returns `{enrichment: undefined, bytes: N}` still upserts and still counts its bytes; (e) first-page `ok:false` → `syncPassCursorParseEmpty`; (f) `loadCreds → null` → `syncNoopResult`; (g) token pagination threads `pageCursor`.
+
+- [ ] **Step 3 — Run, expect FAIL.**
+
+- [ ] **Step 4 — Implement `runAsyncEnrichmentCliShellSync`** mirroring `runSinglePassCliShellSync` but: after `parsePage`, iterate items; for each item up to `maxEnrichmentPerPage`, call `enrichOne` (try/catch → `{enrichment:undefined, bytes:0}` on throw, matching connector best-effort), add its bytes, then `map(raw, enrichment, creds, now)`; items beyond the cap call `map(raw, undefined, …)`. **Match the connectors' exact best-effort + byte rules** (read them — if a connector adds enrich bytes even on failure, replicate that). Keep all the single-pass error/cursor handling identical.
+
+- [ ] **Step 5 — Run test, expect PASS.**
+
+- [ ] **Step 6 — Migrate `cloudwatch-sync.ts`** to call the helper: `runCliPage` = describe-log-groups page; `enrichOne` = `peekStreams` returning `{enrichment, bytes}`; `map` builds the log-group row using the enrichment. Preserve `isSafeCliArg` guards, MAX cap, and the exact mapped row.
+
+- [ ] **Step 7 — Migrate `sagemaker-sync.ts`** similarly: `enrichOne` = `describeModel`, cap = `MAX_DESCRIBE`.
+
+- [ ] **Step 8 — Run existing tests UNEDITED:** `bun test packages/gateway/test/unit/connectors/cloudwatch-sync.test.ts packages/gateway/test/unit/connectors/sagemaker-sync.test.ts` → PASS. If byte/upsert assertions fail, the accounting deviates — fix the helper/wiring, never the test. **If cloudwatch or sagemaker cannot reach byte-exactness, defer that connector and record it.**
+
+- [ ] **Step 9 — Leave athena/cloud-logging/vertex-ai untouched** (deferred per spec).
+
+- [ ] **Step 10 — Controller:** `bunx tsc -p packages/gateway/tsconfig.json`, `bunx biome check --write packages/gateway/src/connectors`, `git checkout -- docs/structure-audit/`, commit `refactor(dedup): C3 cloudwatch/sagemaker → async-enrichment CLI-shell helper`.
+
+- [ ] **Step 11 — jscpd re-measure**, record new total. Note: cloudwatch/sagemaker `tools.ts` (34L) — fold into `mcp-search-tool`/`registerZodTool` only if byte-faithful, else leave (record).
+
+---
+
+### Task C4: REST registrar migration (gmail / outlook / onedrive / gitlab)
+
+**Files:**
+- Modify: `packages/mcp-connectors/gmail/src/server.ts`, `outlook/src/server.ts`, `onedrive/src/server.ts`, `gitlab/src/server.ts`
+- (No shared change needed — `registerZodTool`/`createZodToolRegistrar` already exist in `shared/mcp-tool-kit.ts`.)
+
+**Interfaces:**
+- Consumes: `createZodToolRegistrar(registerSimpleTool)` → `<T>(name, description, schema, handler:(args:T)=>Promise<McpListResult>)=>void` from `shared/mcp-tool-kit.ts`. On parse failure it throws `new Error(parsed.error.message)` — identical to the manual guard being removed.
+
+- [ ] **Step 1 — Read gmail/server.ts fully.** Confirm each tool uses `registerSimpleTool(name, desc, schema.shape, async (args:unknown)=>{ const parsed = schema.safeParse(args); if(!parsed.success) throw new Error(parsed.error.message); … })`. Confirm NO tool uses custom error text or extra pre-parse logic (those stay hand-written).
+
+- [ ] **Step 2 — Migrate gmail:** at the top, `const reg = createZodToolRegistrar(registerSimpleTool);` then convert each tool to `reg("gmail_x", "desc", schemaObj, async (data) => { …use data instead of parsed.data… });` removing the manual `safeParse` guard. `schemaObj` must be the `z.object` (with `.safeParse`/`.shape`), not `.shape`. Leave the per-tool URL/fetch/return bodies byte-identical (just rename `parsed.data` → `data`).
+
+- [ ] **Step 3 — Run gmail tests UNEDITED:** `bun test packages/mcp-connectors/gmail` → PASS (incl. the invalid-arg test that asserts the thrown message).
+
+- [ ] **Step 4 — Repeat for outlook** (preserve the `outlookToolShouldRegister(...)` conditional wrapper around each `reg(...)` call — only the parse guard moves into the registrar).
+
+- [ ] **Step 5 — Run outlook tests UNEDITED** → PASS.
+
+- [ ] **Step 6 — Repeat for onedrive and gitlab** where the tool shape matches (manual safeParse guard only). Their custom fetchers (`graphRequest` arrayBuffer/bytes; `glFetch` PRIVATE-TOKEN) stay untouched. Any tool with custom error text → skip, record.
+
+- [ ] **Step 7 — Run onedrive + gitlab tests UNEDITED** → PASS.
+
+- [ ] **Step 8 — Controller:** **strict tsc loop** (gmail/outlook/teams/google-meet/google-photos) + `bunx tsc -p` for onedrive/gitlab; `bunx biome check --write packages/mcp-connectors`; `git checkout -- docs/structure-audit/`; commit `refactor(dedup): C4 gmail/outlook/onedrive/gitlab → shared zod tool registrar`.
+
+- [ ] **Step 9 — jscpd re-measure**, record new total.
+
+---
+
+### Task C5: gateway email-mapping bodies → `_lib`
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/_lib/email-mapping.ts` (+ `buildEmailPayload`), `email-mapping.test.ts`
+- Create (or extend `_lib`): a `parsePortSecret` helper (place in `_lib/cli-shell-sync.ts`'s sibling or a new `_lib/secret-parsers.ts` with co-located test)
+- Modify: `packages/gateway/src/connectors/imap-email-mapping.ts`, `protonmail-email-mapping.ts`, `fastmail-email-mapping.ts`, `imap-sync.ts`, `protonmail-sync.ts`
+
+**Interfaces:**
+- Produces: `buildEmailPayload(input) → { title, bodyPreview, modifiedAt, attachments, participants }` (see spec C5a); `parsePortSecret(raw: string | null | undefined, fallback: number): number`.
+
+- [ ] **Step 1 — Read all three `*-email-mapping.ts` fully.** Confirm the common transform block (subject→title clamp, preview clamp, date→ms, attachment map, participants) is identical modulo field-name aliases. Record the per-connector ID-validation + metadata that must stay inline.
+
+- [ ] **Step 2 — Write failing `buildEmailPayload` tests** in `email-mapping.test.ts`: empty subject → `"(no subject)"`, clamp at `TITLE_MAX`/`PREVIEW_MAX`, `dateMs ?? syncedAt` fallback, attachment `filename ?? name ?? null` aliasing, participants = `[...from, ...to, ...(cc ?? [])]`.
+
+- [ ] **Step 3 — Run, expect FAIL.**
+
+- [ ] **Step 4 — Implement `buildEmailPayload`** in `email-mapping.ts` (reuse the existing `clamp`/`parseDateMs`/`TITLE_MAX`/`PREVIEW_MAX`). Pure function, no I/O.
+
+- [ ] **Step 5 — Run, expect PASS.**
+
+- [ ] **Step 6 — Migrate the three mappers** to call `buildEmailPayload(...)` for the common block, keeping each connector's ID validation + `metadata` object inline.
+
+- [ ] **Step 7 — Write failing `parsePortSecret` test** (empty/whitespace → fallback; valid 1–65535 → trunc; 0/negative/>65535/NaN → fallback).
+
+- [ ] **Step 8 — Implement `parsePortSecret`**, then replace `intFromSecret` in `imap-sync.ts` + `protonmail-sync.ts` with imports.
+
+- [ ] **Step 9 — (Optional C5c) sync batch loop:** if `imap-sync.ts`/`protonmail-sync.ts` share the rate-limit→fetch→map→upsert body byte-faithfully, extract `syncImapLikeBatch(ctx, {...})` to `_lib` with a co-located test; else skip and record.
+
+- [ ] **Step 10 — Run existing tests UNEDITED:** `bun test packages/gateway/test/unit/connectors/imap-sync.test.ts packages/gateway/test/unit/connectors/protonmail-sync.test.ts packages/gateway/test/unit/connectors/fastmail-sync.test.ts packages/gateway/src/connectors/_lib/email-mapping.test.ts` → PASS.
+
+- [ ] **Step 11 — Coverage check:** if extracting pure fns dropped a mapper's branch% under 80, add a co-located test (verify via Docker lcov in the ship task).
+
+- [ ] **Step 12 — Controller:** `bunx tsc -p packages/gateway/tsconfig.json`, `bunx biome check --write packages/gateway/src/connectors`, `git checkout -- docs/structure-audit/`, commit `refactor(dedup): C5 gateway email-mapping → _lib buildEmailPayload + parsePortSecret`.
+
+- [ ] **Step 13 — jscpd re-measure**, record new total.
+
+---
+
+### Task SHIP: lower ratchet + full preflight + push
+
+**Files:**
+- Modify: `.jscpd.json` (`threshold`)
+
+- [ ] **Step 1 — Final strict measure:** `bunx jscpd packages`. Record the new total %.
+
+- [ ] **Step 2 — Lower the ratchet:** set `.jscpd.json` `"threshold"` to just above the new strict total (round up ~0.1, e.g. new 3.7% → `3.8`). Leave `ci.yml` running `bunx jscpd packages`. Re-run `bunx jscpd packages` → must EXIT 0 (under threshold). `git checkout -- docs/structure-audit/` after.
+
+- [ ] **Step 3 — Full preflight:** `bun run preflight` (all-package tsc, lint, lint:markdown, structure audits, full tests). Fix any red.
+
+- [ ] **Step 4 — Coverage-floor (Docker-Linux authoritative):** `bash scripts/coverage-floor/build-lcov.sh && bun scripts/coverage-floor/check.ts`. Trust only files we changed; the 5 false-local violations (ipc-transport/ipc-server/socket-listeners/telemetry/collector) + mcp-connector files are expected noise. If a changed file is under 80, add a co-located test. Use `reseed-docker.sh` for exact CI lcov if in doubt.
+
+- [ ] **Step 5 — markdownlint + lychee** (docs changed): `bunx markdownlint-cli2 "docs/**/*.md" "*.md"` and `lychee --config lychee.toml --no-progress 'docs/**/*.md' '*.md'`. Fix. **Do NOT commit any superpowers `*-review.md` scratch** (rm untracked scratch before re-verifying).
+
+- [ ] **Step 6 — Whole-branch review:** `/code-review` (or a code-reviewer subagent over `git diff main...HEAD`). Fold findings in pre-push.
+
+- [ ] **Step 7 — Final guard:** `git checkout -- docs/structure-audit/`; `git status` clean except intended files; confirm no `*-review.md` tracked.
+
+- [ ] **Step 8 — Push + open PR** with a body listing: clusters landed, deferrals recorded (C2c if reverted, athena, cloud-logging/vertex-ai, gateway-process twin), strict %% before→after, and the ratchet change.
+
+## Self-Review
+
+- **Spec coverage:** C1✓ C2(a/b/c)✓ C3✓ C4✓ C5(a/b/c)✓ ship+ratchet✓ deferrals recorded✓.
+- **Placeholder scan:** new-helper code + test code provided in full; migration steps cite exact files + the verbatim-copy rule for existing bodies (intentional — the implementer copies existing connector code, not re-invents it).
+- **Type consistency:** `createBriefGuard`, `runAsyncEnrichmentCliShellSync`/`AsyncEnrichmentCliShellSyncSpec`, `registerEmailConnectorTools`, `buildEmailPayload`, `parsePortSecret` names are used consistently across tasks and the spec.

--- a/docs/superpowers/plans/2026-06-20-jscpd-wave2-dedup.md
+++ b/docs/superpowers/plans/2026-06-20-jscpd-wave2-dedup.md
@@ -29,6 +29,7 @@ migrates the call sites, and proves zero behavior change by keeping every existi
 ### Task C1: agent-brief guards → sdk guard-factory
 
 **Files:**
+
 - Create: `packages/sdk/src/agents/guard-factory.ts`
 - Create: `packages/sdk/src/agents/guard-factory.test.ts`
 - Modify: `packages/sdk/src/index.ts` (barrel: export `createBriefGuard`)
@@ -36,11 +37,13 @@ migrates the call sites, and proves zero behavior change by keeping every existi
 - Modify: `packages/gateway/src/agents/_lib/findings.ts` (replace 8 guard bodies with factory calls, `requireQuery: true`)
 
 **Interfaces:**
+
 - Produces: `createBriefGuard<T>(kind: string, extra: (b: Record<string, unknown>) => boolean, opts?: { requireQuery?: boolean }): (x: unknown) => x is T`
 
 - [ ] **Step 1 — Read the two source files fully.** `packages/cli/src/types/agents.ts` (guards at lines ~34–276) and `packages/gateway/src/agents/_lib/findings.ts` (guards at lines ~148–269). Record each guard's exact `extra` predicate (the brief-specific field checks) and confirm gateway adds `typeof b["query"]==="object" && b["query"]!==null` while CLI does not.
 
 - [ ] **Step 2 — Write `guard-factory.test.ts` (failing).** Cover both branches:
+
 ```ts
 import { describe, expect, it } from "bun:test";
 import { createBriefGuard } from "./guard-factory.ts";
@@ -75,6 +78,7 @@ describe("createBriefGuard", () => {
 - [ ] **Step 3 — Run it, expect FAIL** (`bun test packages/sdk/src/agents/guard-factory.test.ts`) → "Cannot find module ./guard-factory.ts".
 
 - [ ] **Step 4 — Implement `guard-factory.ts`:**
+
 ```ts
 /**
  * Build a discriminated-union type guard for an agent brief. The base shape
@@ -130,6 +134,7 @@ export function createBriefGuard<T>(
 ### Task C2: imap/protonmail email connectors → shared
 
 **Files:**
+
 - Modify: `packages/mcp-connectors/shared/imap-mail-core.ts` (add free helpers; attempt shared client base)
 - Modify: `packages/mcp-connectors/shared/imap-tool-kit.ts` (add `registerEmailConnectorTools` factory)
 - Modify/Test: `packages/mcp-connectors/shared/imap-tool-kit.test.ts`, `imap-mail-core.test.ts` (or new co-located tests)
@@ -137,6 +142,7 @@ export function createBriefGuard<T>(
 - Modify: `packages/mcp-connectors/protonmail/src/server.ts`, `protonmail/src/tools.ts`
 
 **Interfaces:**
+
 - Consumes: existing `emailToolSchemas`, `viewEmailMessage`, `EmailMessageMeta`, `RegisterSimpleToolFn` from `imap-tool-kit.ts`/`mcp-tool-kit.ts`.
 - Produces: free helpers `toImapAddress`, `envelopeFromImap`, `toMessageMeta`, `previewFetchQuery` (exact existing signatures); `registerEmailConnectorTools(opts)` (see spec C2b).
 
@@ -185,13 +191,16 @@ export function createBriefGuard<T>(
 ### Task C3: cloudwatch/sagemaker async-enrichment CLI-shell helper
 
 **Files:**
+
 - Modify: `packages/gateway/src/connectors/_lib/cli-shell-sync.ts` (add `runAsyncEnrichmentCliShellSync` + spec type)
 - Create: `packages/gateway/src/connectors/_lib/cli-shell-enrich-sync.test.ts` (co-located unit test for the new helper)
 - Modify: `packages/gateway/src/connectors/cloudwatch-sync.ts`, `sagemaker-sync.ts`
 
 **Interfaces:**
+
 - Consumes: `isSafeCliArg`, `CliShellOutcome`, `ParsedCliPage`, `SyncUpsertRow` from `cli-shell-sync.ts`; `syncPassCursorParseEmpty`/`syncPassCursorSuccess`/`syncNoopResult`.
 - Produces:
+
   ```ts
   export interface AsyncEnrichmentCliShellSyncSpec<C, E> {
     readonly ensureRunning: () => Promise<void>;
@@ -234,10 +243,12 @@ export function createBriefGuard<T>(
 ### Task C4: REST registrar migration (gmail / outlook / onedrive / gitlab)
 
 **Files:**
+
 - Modify: `packages/mcp-connectors/gmail/src/server.ts`, `outlook/src/server.ts`, `onedrive/src/server.ts`, `gitlab/src/server.ts`
 - (No shared change needed — `registerZodTool`/`createZodToolRegistrar` already exist in `shared/mcp-tool-kit.ts`.)
 
 **Interfaces:**
+
 - Consumes: `createZodToolRegistrar(registerSimpleTool)` → `<T>(name, description, schema, handler:(args:T)=>Promise<McpListResult>)=>void` from `shared/mcp-tool-kit.ts`. On parse failure it throws `new Error(parsed.error.message)` — identical to the manual guard being removed.
 
 - [ ] **Step 1 — Read gmail/server.ts fully.** Confirm each tool uses `registerSimpleTool(name, desc, schema.shape, async (args:unknown)=>{ const parsed = schema.safeParse(args); if(!parsed.success) throw new Error(parsed.error.message); … })`. Confirm NO tool uses custom error text or extra pre-parse logic (those stay hand-written).
@@ -263,11 +274,13 @@ export function createBriefGuard<T>(
 ### Task C5: gateway email-mapping bodies → `_lib`
 
 **Files:**
+
 - Modify: `packages/gateway/src/connectors/_lib/email-mapping.ts` (+ `buildEmailPayload`), `email-mapping.test.ts`
 - Create (or extend `_lib`): a `parsePortSecret` helper (place in `_lib/cli-shell-sync.ts`'s sibling or a new `_lib/secret-parsers.ts` with co-located test)
 - Modify: `packages/gateway/src/connectors/imap-email-mapping.ts`, `protonmail-email-mapping.ts`, `fastmail-email-mapping.ts`, `imap-sync.ts`, `protonmail-sync.ts`
 
 **Interfaces:**
+
 - Produces: `buildEmailPayload(input) → { title, bodyPreview, modifiedAt, attachments, participants }` (see spec C5a); `parsePortSecret(raw: string | null | undefined, fallback: number): number`.
 
 - [ ] **Step 1 — Read all three `*-email-mapping.ts` fully.** Confirm the common transform block (subject→title clamp, preview clamp, date→ms, attachment map, participants) is identical modulo field-name aliases. Record the per-connector ID-validation + metadata that must stay inline.
@@ -301,6 +314,7 @@ export function createBriefGuard<T>(
 ### Task SHIP: lower ratchet + full preflight + push
 
 **Files:**
+
 - Modify: `.jscpd.json` (`threshold`)
 
 - [ ] **Step 1 — Final strict measure:** `bunx jscpd packages`. Record the new total %.

--- a/docs/superpowers/specs/2026-06-20-jscpd-wave2-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-20-jscpd-wave2-dedup-design.md
@@ -1,0 +1,203 @@
+# jscpd Dedup — Wave 2 Design
+
+**Date:** 2026-06-20 · **Branch:** `worktree-jscpd-dedup-wave2` (off `origin/main` `5613f7d3`)
+**Predecessor:** PR #688 (Big-PR, 10 clusters, strict 4.83%→4.41%). This Wave-2 finishes the
+deferred residuals and lowers the CI ratchet.
+
+## Goal
+
+Drive **strict** jscpd duplication (`bunx jscpd packages`, `.jscpd.json` min-lines 5 / min-tokens 50
+/ threshold 4.5) lower by **pure extraction** (never ignores), then **lower the `.jscpd.json`
+threshold** to just above the new strict %. Standing program target remains **< 3%**.
+
+Fresh-main baseline re-measured live this session: **strict total 4.38%** (5819 dup-lines; typescript
+4.67% / 5701 dup-lines across 559 clones).
+
+## Non-negotiable: pure dedup, zero behavior change
+
+Every connector / guard / sync test stays **GREEN UNEDITED**. No `.jscpd.json` ignore added. Each
+extraction is byte-faithful: if a candidate cannot be unified without changing behavior (byte/upsert
+accounting, error text, TLS config), it is **deferred and reported**, not force-fit (the #688/#673
+fidelity rule).
+
+## Clusters (live-ranked by file-pair dup-lines)
+
+### C1 — agent-brief type guards → sdk guard-factory (~107 dup-lines)
+
+- **Pair:** `cli/src/types/agents.ts` ↔ `gateway/src/agents/_lib/findings.ts` (107L, 9 clones).
+- **What:** 8 byte-mechanical guards (`isExpertBrief`…`isPreflightBrief`). All share the base shape
+  (`kind` / `agentVersion===1` / `Array.isArray(gaps)` / `typeof generatedAt==="number"` /
+  `typeof latencyMs==="number"` + one brief-specific array check; janitor/preflight add boolean
+  checks).
+- **Divergence (must preserve):** the **gateway** guards additionally require
+  `typeof b["query"]==="object" && b["query"]!==null`; the **CLI** guards do **not**. This is a real
+  behavioral difference. The factory parameterizes it; we do **not** silently tighten CLI.
+- **Extraction:** new `packages/sdk/src/agents/guard-factory.ts`:
+  ```ts
+  export function createBriefGuard<T>(
+    kind: string,
+    extra: (b: Record<string, unknown>) => boolean,
+    opts?: { requireQuery?: boolean },
+  ): (x: unknown) => x is T
+  ```
+  Base body checks kind/agentVersion/gaps/generatedAt/latencyMs, then (if `requireQuery`) the query
+  object, then `extra(b)`. Exported from `packages/sdk/src/index.ts` barrel.
+- **Call sites:** CLI `agents.ts` → `createBriefGuard<ExpertBrief>("expert", b => Array.isArray(b["ranked"]))`
+  (requireQuery omitted → false, matches CLI today). Gateway `findings.ts` → same with
+  `{ requireQuery: true }` (matches gateway today).
+- **Tests green unedited:** `cli/src/types/agents.test.ts` (all "true" cases pass a `query`) and
+  `gateway/src/agents/_lib/findings.test.ts` (asserts `query:null → false`). Add a co-located sdk
+  test `guard-factory.test.ts` proving both branches (requireQuery on/off).
+- **Coverage-floor:** extracting the guard bodies out of `findings.ts` may drop its branch% — verify
+  via Docker lcov; add a co-located test if it dips below 80.
+
+### C2 — imap/protonmail email connectors → mcp-connectors/shared (~133 + 86 dup-lines)
+
+Two safe sub-parts plus one attempted-risky part.
+
+- **C2a free helpers (server.ts, ~70L safe):** `toImapAddress`, `envelopeFromImap`, `toMessageMeta`,
+  `previewFetchQuery` are byte-identical across `imap/src/server.ts` and `protonmail/src/server.ts`.
+  Hoist to `shared/imap-mail-core.ts` (existing). Both import.
+- **C2b tools.ts registration factory (~75L safe):** the 4 `registerSimpleTool` blocks
+  (`*_list`/`*_get`/`*_search`/`*_mail_send`) are structurally identical; differ only in tool-name
+  prefix + description text + the local client/mailer types. Add a factory to `shared/imap-tool-kit.ts`:
+  ```ts
+  export function registerEmailConnectorTools(opts: {
+    registerSimpleTool: RegisterSimpleToolFn;
+    toolPrefix: string;            // "imap" | "protonmail"
+    descriptions: { list: string; get: string; search: string; send: string };
+    client: EmailClientLike; mailer: EmailMailerLike;
+    formatAddr: (a) => string;
+  }): void
+  ```
+  Descriptions passed verbatim from each connector so tool metadata is byte-identical.
+- **C2c class-body merge (ATTEMPT, defer-on-deviation):** `ImapFlowClient` (imap) vs
+  `BridgeImapClient` (protonmail) differ in implemented interface (`ImapClient` vs `MailClient`),
+  `newClient()` TLS (`secure:true` vs `secure:false`+`rejectUnauthorized:false`), and env prefixes.
+  Attempt a shared base/factory in `shared/imap-mail-core.ts` parameterized on `{ tls, envPrefix }`
+  that both client classes delegate to (e.g. a shared `withMailbox` + `newClient` factory). **Hard
+  rule:** if structural-type or TLS fidelity forces any behavior change, revert to C2a/C2b only and
+  record the deferral in the PR body. The `*-sync-fake-server`/`sandbox` tests are the guardrail.
+- **Tests green unedited:** imap/protonmail `sandbox.test.ts`, `search-filter.test.ts`, gateway
+  `imap-sync.test.ts` / `protonmail-sync.test.ts`.
+- **FastMail (JMAP) stays out** — different protocol; already diverged in #688.
+
+### C3 — cloudwatch/sagemaker async-enrichment CLI-shell helper (~69 + 34 dup-lines)
+
+- **Pairs:** `cloudwatch-sync.ts` ↔ `sagemaker-sync.ts` (69L); `mcp-connectors/cloudwatch/tools.ts`
+  ↔ `sagemaker/tools.ts` (34L).
+- **Why #688 deferred:** both do **two-tier byte accounting** — bytes accumulate from the list page
+  **and** from each per-item enrichment CLI call (`describe-log-streams` / `describe-model`), with a
+  per-page enrichment cap (`MAX_DESCRIBE`). The existing single-pass `runSinglePassCliShellSync`
+  models only one page's bytes.
+- **Extraction:** new **sibling** helper in `gateway/src/connectors/_lib/cli-shell-sync.ts` (or a new
+  `_lib/cli-shell-enrich-sync.ts`):
+  ```ts
+  export async function runAsyncEnrichmentCliShellSync<C, E>(
+    ctx, cursor, spec: AsyncEnrichmentCliShellSyncSpec<C, E>): Promise<SyncResult>
+  ```
+  Spec adds, on top of `CliShellSyncSpec`: `maxEnrichmentPerPage?: number`;
+  `enrichOne?: (creds, raw) => Promise<{ enrichment: E | undefined; bytes: number }>`;
+  `map: (raw, enrichment: E | undefined, creds, now) => SyncUpsertRow | null`.
+  **Byte fidelity:** `totalBytes += listPage.bytes` then, for each enriched item within the cap,
+  `totalBytes += enrich.bytes`. Enrichment is **best-effort** (a thrown/failed enrich must not stop
+  the upsert and must match the connectors' current behavior). Upsert count = one per mapped item,
+  enrichment success irrelevant — exactly as today.
+- **Defer:** `athena-sync.ts` (3-level catalog→database→table nested walk — does not fit the
+  single-list+enrich shape). Record the deferral.
+- **Residual note:** `cloud-logging-sync ↔ vertex-ai-sync` (46L) is service-specific `gcloud` spawn
+  boilerplate (different argv, region handling) — **not** unifiable without behavior change; leave.
+- **tools.ts (34L):** the cloudwatch/sagemaker MCP `tools.ts` share a search-registration tail —
+  fold into the existing `mcp-search-tool.ts` / `registerZodTool` pattern if byte-faithful, else
+  leave.
+- **Tests green unedited:** `cloudwatch-sync.test.ts`, `sagemaker-sync.test.ts` (and untouched
+  `cloud-logging-sync.test.ts`, `vertex-ai-sync.test.ts`, `athena-sync.test.ts`).
+
+### C4 — REST registrar migration: gmail / outlook / onedrive / gitlab (~60 + 55 + intra-file)
+
+- **Existing primitive:** `shared/mcp-tool-kit.ts` already exports `registerZodTool` /
+  `createZodToolRegistrar`, which calls `schema.safeParse(args)` and on failure
+  `throw new Error(parsed.error.message)` — **byte-identical** to the manual `safeParse` guard the
+  unmigrated connectors repeat. So this is an **error-fidelity-preserving** migration, not risky.
+- **What:** gmail (8 tools, ~75 intra-file dup-L) and outlook (10 tools, ~105 intra-file dup-L) call
+  `registerSimpleTool` with a hand-written 5-line `safeParse`+throw guard per tool. Migrate each to
+  `createZodToolRegistrar` so the parse boilerplate lives once in the shared registrar and the
+  handler receives `parsed.data`. onedrive/gitlab likewise where the tool shape matches (their
+  *fetcher* stays per-connector — gitlab `PRIVATE-TOKEN`, onedrive `arrayBuffer/bytes` — only the
+  registration boilerplate is shared).
+- **Fidelity rule:** the thrown error text must remain `parsed.error.message` (it does). Any tool
+  whose current guard differs (custom error text, extra pre-checks) stays hand-written.
+- **Tests green unedited:** each connector's `sandbox.test.ts` / `search-filter.test.ts`.
+- **tsconfig trap:** gmail & outlook already `include: ["../shared/**/*.ts"]` → they typecheck every
+  shared file incl. new `*.test.ts` under strict `noPropertyAccessFromIndexSignature`. Run the strict
+  tsc loop (below) after any shared change.
+
+### C5 — gateway email-mapping bodies → gateway `_lib` (~55 + 38 + 36 dup-lines)
+
+- **Pairs:** `imap-email-mapping.ts` ↔ `protonmail-email-mapping.ts` (55L); `fastmail-` ↔
+  `protonmail-email-mapping.ts` (38L); `imap-sync.ts` ↔ `protonmail-sync.ts` (36L).
+- **C5a `buildEmailPayload` (common transform):** the subject→title clamp, preview clamp, date→ms,
+  participants aggregation, and attachment-meta map are identical across the three mappers (modulo
+  field-name aliases `filename`/`name`, `date`/`receivedAt`). Extract a pure helper into the existing
+  `gateway/src/connectors/_lib/email-mapping.ts`:
+  ```ts
+  export function buildEmailPayload(input: {
+    subject: string | null; preview: string; dateMs: number | null; syncedAt: number;
+    attachments: readonly { filename?: string|null; name?: string|null; sizeBytes: number|null; mimeType: string|null }[];
+    from: readonly string[]; to: readonly string[]; cc?: readonly string[];
+  }): { title: string; bodyPreview: string; modifiedAt: number; attachments: …[]; participants: string[] }
+  ```
+  Per-connector ID-validation + service-specific `metadata` object **stay inline** (genuinely
+  divergent — not force-fit).
+- **C5b `parsePortSecret` (intFromSecret):** the 7-line port/secret numeric parser duplicated in
+  `imap-sync.ts` + `protonmail-sync.ts` → a pure helper in `_lib` (e.g. `_lib/cli-shell-sync.ts`
+  already hosts `isSafeCliArg`, or a small `_lib/secret-parsers.ts`).
+- **C5c sync fetch/upsert loop (~29L, optional):** `imap-sync.ts` + `protonmail-sync.ts` share the
+  rate-limit→fetch→outcome-check→map-loop→upsert→return body (protonmail already factored
+  `transientResult()`). Extract `syncImapLikeBatch(ctx, { serviceId, ensureMcp, loadConfig,
+  fetchMessages, mapMessage, pass1Cursor })` to `_lib` **only if** byte/upsert/cursor semantics stay
+  exact; else ship C5a/C5b and defer.
+- **Tests green unedited:** `_lib/email-mapping.test.ts` (+ new `buildEmailPayload` cases),
+  `imap-sync.test.ts`, `protonmail-sync.test.ts`, `fastmail-sync.test.ts`. Add a co-located test for
+  any helper that drops a caller's branch% under 80.
+
+## Dependency placement (load-bearing)
+
+- Cross-package types/logic shared by **cli ↔ gateway** → `@nimbus-dev/sdk` (MIT; the only pkg both
+  import). C1 lives here.
+- Shared **mcp-connector** logic → `packages/mcp-connectors/shared/` (NOT sdk). C2, C4 live here.
+- Shared **gateway** logic → `gateway/src/connectors/_lib/`. C3, C5 live here.
+- sdk uses `exactOptionalPropertyTypes` — never pass `{ x: undefined }` in sdk tests.
+
+## Execution discipline (from #688)
+
+- **Subagent-driven TDD**, one cluster per implementer subagent. Background subagents **can** run
+  `bun test` but **cannot** `git commit` — the controller runs the strict tsc loop + biome + commit +
+  jscpd re-measure after each cluster, verifying file state (don't trust self-reports). No
+  `SendMessage` resume of a rested agent → dispatch a fresh "complete from state X".
+- **★ Strict-tsc loop after EVERY `mcp-connectors/shared/` change** (TS4111 trap — `bun test` passes
+  but the email connectors fail):
+  `for c in gmail outlook teams google-meet google-photos; do bunx tsc -p packages/mcp-connectors/$c/tsconfig.json; done`
+- **`git checkout -- docs/structure-audit/`** before every commit (jscpd + `audit:structure`
+  regenerate those JSONs).
+- The 5 false-local coverage-floor violations are ipc-transport / ipc-server / socket-listeners /
+  telemetry / collector — ignore for files we didn't touch.
+- Do **not** put `bun run <script>` / `bunx <tool>` literals in ci.yml comments (the preflight drift
+  guard regex scans comments).
+
+## Ship sequence
+
+1. Land clusters C1→C5 (commit per cluster, jscpd re-measure after each).
+2. Re-measure final strict %; **lower `.jscpd.json` `threshold`** to just above it (round up ~0.1).
+   Keep `ci.yml` → `bunx jscpd packages` (already local==CI).
+3. Full `bun run preflight` (all-package tsc, lint, lint:markdown, structure audits, tests) +
+   Docker coverage-floor (`build-lcov.sh` + `check.ts`) + `bunx markdownlint-cli2` + lychee (docs
+   changed) + whole-branch `/code-review`. Fix findings BEFORE the first push.
+4. Never commit superpowers `*-review.md` scratch.
+
+## Out of scope (deferred, recorded)
+
+- `gateway-process.ts` ↔ `gw-state-helpers.ts` (67L) — documented un-dedupable twin.
+- imap/protonmail SMTP mailer class merge (env-prefix/transport divergence) unless C2c proves clean.
+- athena async-enrichment (3-level nested walk); cloud-logging↔vertex-ai gcloud spawn boilerplate.
+- Wholesale connector-template restructuring for the final push to < 3% (separate future project).

--- a/docs/superpowers/specs/2026-06-20-jscpd-wave2-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-20-jscpd-wave2-dedup-design.md
@@ -33,6 +33,7 @@ fidelity rule).
   `typeof b["query"]==="object" && b["query"]!==null`; the **CLI** guards do **not**. This is a real
   behavioral difference. The factory parameterizes it; we do **not** silently tighten CLI.
 - **Extraction:** new `packages/sdk/src/agents/guard-factory.ts`:
+
   ```ts
   export function createBriefGuard<T>(
     kind: string,
@@ -40,6 +41,7 @@ fidelity rule).
     opts?: { requireQuery?: boolean },
   ): (x: unknown) => x is T
   ```
+
   Base body checks kind/agentVersion/gaps/generatedAt/latencyMs, then (if `requireQuery`) the query
   object, then `extra(b)`. Exported from `packages/sdk/src/index.ts` barrel.
 - **Call sites:** CLI `agents.ts` → `createBriefGuard<ExpertBrief>("expert", b => Array.isArray(b["ranked"]))`
@@ -61,6 +63,7 @@ Two safe sub-parts plus one attempted-risky part.
 - **C2b tools.ts registration factory (~75L safe):** the 4 `registerSimpleTool` blocks
   (`*_list`/`*_get`/`*_search`/`*_mail_send`) are structurally identical; differ only in tool-name
   prefix + description text + the local client/mailer types. Add a factory to `shared/imap-tool-kit.ts`:
+
   ```ts
   export function registerEmailConnectorTools(opts: {
     registerSimpleTool: RegisterSimpleToolFn;
@@ -70,6 +73,7 @@ Two safe sub-parts plus one attempted-risky part.
     formatAddr: (a) => string;
   }): void
   ```
+
   Descriptions passed verbatim from each connector so tool metadata is byte-identical.
 - **C2c class-body merge (ATTEMPT, defer-on-deviation):** `ImapFlowClient` (imap) vs
   `BridgeImapClient` (protonmail) differ in implemented interface (`ImapClient` vs `MailClient`),
@@ -92,10 +96,12 @@ Two safe sub-parts plus one attempted-risky part.
   models only one page's bytes.
 - **Extraction:** new **sibling** helper in `gateway/src/connectors/_lib/cli-shell-sync.ts` (or a new
   `_lib/cli-shell-enrich-sync.ts`):
+
   ```ts
   export async function runAsyncEnrichmentCliShellSync<C, E>(
     ctx, cursor, spec: AsyncEnrichmentCliShellSyncSpec<C, E>): Promise<SyncResult>
   ```
+
   Spec adds, on top of `CliShellSyncSpec`: `maxEnrichmentPerPage?: number`;
   `enrichOne?: (creds, raw) => Promise<{ enrichment: E | undefined; bytes: number }>`;
   `map: (raw, enrichment: E | undefined, creds, now) => SyncUpsertRow | null`.
@@ -140,6 +146,7 @@ Two safe sub-parts plus one attempted-risky part.
   participants aggregation, and attachment-meta map are identical across the three mappers (modulo
   field-name aliases `filename`/`name`, `date`/`receivedAt`). Extract a pure helper into the existing
   `gateway/src/connectors/_lib/email-mapping.ts`:
+
   ```ts
   export function buildEmailPayload(input: {
     subject: string | null; preview: string; dateMs: number | null; syncedAt: number;
@@ -147,6 +154,7 @@ Two safe sub-parts plus one attempted-risky part.
     from: readonly string[]; to: readonly string[]; cc?: readonly string[];
   }): { title: string; bodyPreview: string; modifiedAt: number; attachments: …[]; participants: string[] }
   ```
+
   Per-connector ID-validation + service-specific `metadata` object **stay inline** (genuinely
   divergent — not force-fit).
 - **C5b `parsePortSecret` (intFromSecret):** the 7-line port/secret numeric parser duplicated in

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "form-data": "4.0.6",
     "hono": "4.12.25",
     "@mastra/core": "1.43.0",
-    "@mastra/mcp": "1.10.0"
+    "@mastra/mcp": "1.10.0",
+    "nodemailer": "9.0.1",
+    "undici": "7.28.0"
   },
   "workspaces": [
     "packages/admin-console",

--- a/packages/cli/src/types/agents.ts
+++ b/packages/cli/src/types/agents.ts
@@ -20,6 +20,7 @@ import type {
   JanitorPeerTouch,
   PreflightDownstream,
 } from "@nimbus-dev/sdk";
+import { createBriefGuard } from "@nimbus-dev/sdk";
 
 export type ExpertBrief = {
   kind: "expert";
@@ -31,18 +32,9 @@ export type ExpertBrief = {
   ranked: ExpertFinding[];
 };
 
-export function isExpertBrief(x: unknown): x is ExpertBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "expert" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["ranked"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number"
-  );
-}
+export const isExpertBrief = createBriefGuard<ExpertBrief>("expert", (b) =>
+  Array.isArray(b["ranked"]),
+);
 
 export type ImpactBrief = {
   kind: "impact";
@@ -55,18 +47,9 @@ export type ImpactBrief = {
   affected: ImpactFinding[];
 };
 
-export function isImpactBrief(x: unknown): x is ImpactBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "impact" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["affected"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number"
-  );
-}
+export const isImpactBrief = createBriefGuard<ImpactBrief>("impact", (b) =>
+  Array.isArray(b["affected"]),
+);
 
 export type CatchupBrief = {
   kind: "catchup";
@@ -85,18 +68,9 @@ export type CatchupBrief = {
   sections: CatchupSection[];
 };
 
-export function isCatchupBrief(x: unknown): x is CatchupBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "catchup" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["sections"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number"
-  );
-}
+export const isCatchupBrief = createBriefGuard<CatchupBrief>("catchup", (b) =>
+  Array.isArray(b["sections"]),
+);
 
 export type GhostContextItem = {
   title: string;
@@ -125,20 +99,11 @@ export type GhostBrief = {
   findings: GhostFinding[];
 };
 
-export function isGhostBrief(x: unknown): x is GhostBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "ghost" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["findings"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    b["query"] !== null &&
-    typeof b["query"] === "object"
-  );
-}
+export const isGhostBrief = createBriefGuard<GhostBrief>(
+  "ghost",
+  (b) => Array.isArray(b["findings"]),
+  { requireQuery: true },
+);
 
 export type ConflictCollision = {
   peerId: string;
@@ -162,20 +127,11 @@ export type ConflictBrief = {
   collisions: ConflictCollision[];
 };
 
-export function isConflictBrief(x: unknown): x is ConflictBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "conflict" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["collisions"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    b["query"] !== null &&
-    typeof b["query"] === "object"
-  );
-}
+export const isConflictBrief = createBriefGuard<ConflictBrief>(
+  "conflict",
+  (b) => Array.isArray(b["collisions"]),
+  { requireQuery: true },
+);
 
 /** Mirror of FederatedItemLite in packages/gateway/src/agents/_lib/findings.ts (CLI cannot import gateway). */
 type HuddleItem = { title: string; snippet: string; service: string; modifiedAt: number };
@@ -199,20 +155,11 @@ export type HuddleBrief = {
   contributions: HuddleContribution[];
 };
 
-export function isHuddleBrief(x: unknown): x is HuddleBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "huddle" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["contributions"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    b["query"] !== null &&
-    typeof b["query"] === "object"
-  );
-}
+export const isHuddleBrief = createBriefGuard<HuddleBrief>(
+  "huddle",
+  (b) => Array.isArray(b["contributions"]),
+  { requireQuery: true },
+);
 
 // CLI-side mirror of JanitorBrief in packages/gateway/src/agents/_lib/findings.ts
 export type JanitorBrief = {
@@ -229,21 +176,11 @@ export type JanitorBrief = {
   peersTouched: JanitorPeerTouch[];
 };
 
-export function isJanitorBrief(x: unknown): x is JanitorBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "janitor" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    typeof b["idle"] === "boolean" &&
-    Array.isArray(b["peersTouched"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    b["query"] !== null &&
-    typeof b["query"] === "object"
-  );
-}
+export const isJanitorBrief = createBriefGuard<JanitorBrief>(
+  "janitor",
+  (b) => typeof b["idle"] === "boolean" && Array.isArray(b["peersTouched"]),
+  { requireQuery: true },
+);
 
 // CLI-side mirror of PreflightBrief in packages/gateway/src/agents/_lib/findings.ts
 export type PreflightBrief = {
@@ -258,19 +195,11 @@ export type PreflightBrief = {
   anyIncomplete: boolean;
 };
 
-export function isPreflightBrief(x: unknown): x is PreflightBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "preflight" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
+export const isPreflightBrief = createBriefGuard<PreflightBrief>(
+  "preflight",
+  (b) =>
     Array.isArray(b["downstreams"]) &&
     typeof b["anyFailed"] === "boolean" &&
-    typeof b["anyIncomplete"] === "boolean" &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    b["query"] !== null &&
-    typeof b["query"] === "object"
-  );
-}
+    typeof b["anyIncomplete"] === "boolean",
+  { requireQuery: true },
+);

--- a/packages/gateway/src/agents/_lib/findings.ts
+++ b/packages/gateway/src/agents/_lib/findings.ts
@@ -1,3 +1,5 @@
+import { createBriefGuard } from "@nimbus-dev/sdk";
+
 import type { ExpertiseRank } from "../../federation/types.ts";
 
 export type {
@@ -145,125 +147,53 @@ export type BriefReadyPayload<B extends AgentBrief> = {
   findings: B;
 };
 
-export function isExpertBrief(x: unknown): x is ExpertBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "expert" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["ranked"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+export const isExpertBrief = createBriefGuard<ExpertBrief>(
+  "expert",
+  (b) => Array.isArray(b["ranked"]),
+  { requireQuery: true },
+);
 
-export function isImpactBrief(x: unknown): x is ImpactBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "impact" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["affected"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+export const isImpactBrief = createBriefGuard<ImpactBrief>(
+  "impact",
+  (b) => Array.isArray(b["affected"]),
+  { requireQuery: true },
+);
 
-export function isCatchupBrief(x: unknown): x is CatchupBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "catchup" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["sections"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+export const isCatchupBrief = createBriefGuard<CatchupBrief>(
+  "catchup",
+  (b) => Array.isArray(b["sections"]),
+  { requireQuery: true },
+);
 
-export function isGhostBrief(x: unknown): x is GhostBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "ghost" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["findings"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+export const isGhostBrief = createBriefGuard<GhostBrief>(
+  "ghost",
+  (b) => Array.isArray(b["findings"]),
+  { requireQuery: true },
+);
 
-export function isConflictBrief(x: unknown): x is ConflictBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "conflict" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["collisions"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+export const isConflictBrief = createBriefGuard<ConflictBrief>(
+  "conflict",
+  (b) => Array.isArray(b["collisions"]),
+  { requireQuery: true },
+);
 
-export function isHuddleBrief(x: unknown): x is HuddleBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "huddle" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    Array.isArray(b["contributions"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+export const isHuddleBrief = createBriefGuard<HuddleBrief>(
+  "huddle",
+  (b) => Array.isArray(b["contributions"]),
+  { requireQuery: true },
+);
 
-export function isJanitorBrief(x: unknown): x is JanitorBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "janitor" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
-    typeof b["idle"] === "boolean" &&
-    Array.isArray(b["peersTouched"]) &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+export const isJanitorBrief = createBriefGuard<JanitorBrief>(
+  "janitor",
+  (b) => typeof b["idle"] === "boolean" && Array.isArray(b["peersTouched"]),
+  { requireQuery: true },
+);
 
-export function isPreflightBrief(x: unknown): x is PreflightBrief {
-  if (x === null || typeof x !== "object") return false;
-  const b = x as Record<string, unknown>;
-  return (
-    b["kind"] === "preflight" &&
-    b["agentVersion"] === 1 &&
-    Array.isArray(b["gaps"]) &&
+export const isPreflightBrief = createBriefGuard<PreflightBrief>(
+  "preflight",
+  (b) =>
     Array.isArray(b["downstreams"]) &&
     typeof b["anyFailed"] === "boolean" &&
-    typeof b["anyIncomplete"] === "boolean" &&
-    typeof b["generatedAt"] === "number" &&
-    typeof b["latencyMs"] === "number" &&
-    typeof b["query"] === "object" &&
-    b["query"] !== null
-  );
-}
+    typeof b["anyIncomplete"] === "boolean",
+  { requireQuery: true },
+);

--- a/packages/gateway/src/connectors/_lib/aws-cli.test.ts
+++ b/packages/gateway/src/connectors/_lib/aws-cli.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SyncContext } from "../../sync/types.ts";
+import {
+  awsNextToken,
+  type BaseWalkState,
+  extractArray,
+  parseJson,
+  type RunAwsCli,
+  runAwsCliPaginatedWalk,
+} from "./aws-cli.ts";
+
+const CTX = {} as SyncContext;
+const PASS_1 = "cursor-1";
+
+describe("parseJson", () => {
+  test("parses valid JSON", () => {
+    expect(parseJson('{"a":1}')).toEqual({ a: 1 });
+  });
+  test("returns undefined on invalid JSON", () => {
+    expect(parseJson("not json")).toBeUndefined();
+  });
+});
+
+describe("awsNextToken", () => {
+  test("returns the token under the given key", () => {
+    expect(awsNextToken({ nextToken: "t" }, "nextToken")).toBe("t");
+    expect(awsNextToken({ NextToken: "t2" }, "NextToken")).toBe("t2");
+  });
+  test("returns null for empty / missing / non-object", () => {
+    expect(awsNextToken({ nextToken: "" }, "nextToken")).toBeNull();
+    expect(awsNextToken({}, "nextToken")).toBeNull();
+    expect(awsNextToken(null, "nextToken")).toBeNull();
+  });
+});
+
+describe("extractArray", () => {
+  test("returns the array at key", () => {
+    expect(extractArray({ items: [1, 2] }, "items")).toEqual([1, 2]);
+  });
+  test("returns [] for missing / non-array / non-object", () => {
+    expect(extractArray({ items: "x" }, "items")).toEqual([]);
+    expect(extractArray({}, "items")).toEqual([]);
+    expect(extractArray(null, "items")).toEqual([]);
+  });
+});
+
+/** Build a runner that returns a canned sequence of responses, recording argv. */
+function makeRun(seq: { ok?: boolean; body?: unknown }[]): { run: RunAwsCli; calls: string[][] } {
+  const calls: string[][] = [];
+  let i = 0;
+  const run: RunAwsCli = async (_ctx, args) => {
+    calls.push(args);
+    const r = seq[Math.min(i, seq.length - 1)] ?? { ok: true, body: {} };
+    i += 1;
+    const ok = r.ok ?? true;
+    return { ok, text: ok ? JSON.stringify(r.body ?? {}) : "" };
+  };
+  return { run, calls };
+}
+
+function baseSpec(over: Partial<Parameters<typeof runAwsCliPaginatedWalk>[3]> = {}) {
+  const seen: unknown[] = [];
+  const spec = {
+    ensureRunning: async () => {},
+    loadCreds: async () => ({}),
+    pass1Cursor: () => PASS_1,
+    maxItems: 500,
+    pageSize: 50,
+    tokenKey: "nextToken",
+    arrayKey: "items",
+    initialState: () => ({ upserted: 0, bytes: 0, seen: 0 }) as BaseWalkState,
+    buildPageArgs: (pageSize: number, token: string | null) =>
+      token === null
+        ? ["list", String(pageSize)]
+        : ["list", String(pageSize), "--next-token", token],
+    processEntry: async (_run, _ctx, entry, _now, state) => {
+      seen.push(entry);
+      state.upserted += 1;
+    },
+    ...over,
+  } as Parameters<typeof runAwsCliPaginatedWalk>[3];
+  return { spec, seen };
+}
+
+describe("runAwsCliPaginatedWalk", () => {
+  test("loadCreds → null yields a noop preserving the input cursor", async () => {
+    const { run, calls } = makeRun([]);
+    const { spec } = baseSpec({ loadCreds: async () => null });
+    const res = await runAwsCliPaginatedWalk(CTX, "prev", run, spec);
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.cursor).toBe("prev");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("first-page failure → parse-empty pass cursor, 0 upserts", async () => {
+    const { run } = makeRun([{ ok: false }]);
+    const { spec } = baseSpec();
+    const res = await runAwsCliPaginatedWalk(CTX, null, run, spec);
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.cursor).toBe(PASS_1);
+  });
+
+  test("walks + upserts each entry, single page", async () => {
+    const { run, calls } = makeRun([{ body: { items: [{ id: 1 }, { id: 2 }] } }]);
+    const { spec } = baseSpec();
+    const res = await runAwsCliPaginatedWalk(CTX, null, run, spec);
+    expect(res.itemsUpserted).toBe(2);
+    expect(res.cursor).toBe(PASS_1);
+    expect(res.hasMore).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("paginates via the token key", async () => {
+    const { run, calls } = makeRun([
+      { body: { items: [{ id: 1 }], nextToken: "t2" } },
+      { body: { items: [{ id: 2 }] } },
+    ]);
+    const { spec } = baseSpec();
+    const res = await runAwsCliPaginatedWalk(CTX, null, run, spec);
+    expect(res.itemsUpserted).toBe(2);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toContain("--next-token");
+    expect(calls[1]).toContain("t2");
+  });
+
+  test("a later-page failure breaks without throwing (keeps prior upserts)", async () => {
+    const { run } = makeRun([{ body: { items: [{ id: 1 }], nextToken: "t2" } }, { ok: false }]);
+    const { spec } = baseSpec();
+    const res = await runAwsCliPaginatedWalk(CTX, null, run, spec);
+    expect(res.itemsUpserted).toBe(1);
+    expect(res.cursor).toBe(PASS_1);
+  });
+
+  test("stops at maxItems even when more entries are present", async () => {
+    const { run } = makeRun([{ body: { items: [{ id: 1 }, { id: 2 }, { id: 3 }] } }]);
+    const { spec } = baseSpec({ maxItems: 2 });
+    const res = await runAwsCliPaginatedWalk(CTX, null, run, spec);
+    expect(res.itemsUpserted).toBe(2);
+  });
+});

--- a/packages/gateway/src/connectors/_lib/aws-cli.ts
+++ b/packages/gateway/src/connectors/_lib/aws-cli.ts
@@ -1,6 +1,11 @@
 import { extensionProcessEnv } from "../../extensions/spawn-env.ts";
-import type { SyncContext } from "../../sync/types.ts";
+import {
+  syncPassCursorParseEmpty,
+  syncPassCursorSuccess,
+} from "../../sync/pass-cursor-sync-result.ts";
+import { type SyncContext, type SyncResult, syncNoopResult } from "../../sync/types.ts";
 import { readConnectorSecret } from "../connector-vault.ts";
+import { asRecord, stringField } from "../unknown-record.ts";
 
 /**
  * Resolve the AWS credential environment from the shared `aws.*` vault keys
@@ -65,4 +70,136 @@ export async function awsCliJson(
   const code = await proc.exited;
   const out = await new Response(proc.stdout).text();
   return { ok: code === 0, text: out };
+}
+
+// ---------------------------------------------------------------------------
+// Shared single-pass paginated AWS-CLI walk (cloudwatch, sagemaker, …)
+// ---------------------------------------------------------------------------
+
+/** Injectable AWS-CLI runner — defaults to {@link awsCliJson}; tests pass a stub. */
+export type RunAwsCli = (
+  ctx: SyncContext,
+  args: string[],
+) => Promise<{ ok: boolean; text: string }>;
+
+/** Parse CLI stdout as JSON, returning `undefined` on any parse error. */
+export function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read a non-empty string continuation token under `key` (e.g. `nextToken`/`NextToken`), else `null`. */
+export function awsNextToken(parsed: unknown, key: string): string | null {
+  const rec = asRecord(parsed);
+  if (rec === undefined) {
+    return null;
+  }
+  const tok = stringField(rec, key);
+  return tok !== undefined && tok !== "" ? tok : null;
+}
+
+/** Extract `parsed[key]` as an array (empty array when absent / not an object / not an array). */
+export function extractArray(parsed: unknown, key: string): unknown[] {
+  const rec = asRecord(parsed);
+  if (rec === undefined) {
+    return [];
+  }
+  const arr = rec[key];
+  return Array.isArray(arr) ? arr : [];
+}
+
+/** Mutable counters threaded through a paginated walk. */
+export interface BaseWalkState {
+  upserted: number;
+  bytes: number;
+  seen: number;
+}
+
+/**
+ * Spec for {@link runAwsCliPaginatedWalk}. The connector supplies the list-page
+ * argv, the continuation-token key + result-array key, the per-cycle item cap,
+ * and a `processEntry` callback that enriches/maps/upserts one entry (mutating
+ * the walk state's `upserted`/`bytes` as the hand-written connector bodies did).
+ */
+export interface AwsPaginatedWalkSpec<S extends BaseWalkState> {
+  readonly ensureRunning: () => Promise<void>;
+  /** Resolve credentials (or null → noop). Typically {@link awsCredentialsExtra}. */
+  readonly loadCreds: () => Promise<unknown | null>;
+  readonly pass1Cursor: () => string;
+  readonly maxItems: number;
+  readonly pageSize: number;
+  /** Continuation-token key in the JSON response (`nextToken` / `NextToken`). */
+  readonly tokenKey: string;
+  /** Result-array key in the JSON response (`logGroups` / `Models`). */
+  readonly arrayKey: string;
+  readonly initialState: () => S;
+  /** Build the list-page argv. `token` is null on the first page. */
+  readonly buildPageArgs: (pageSize: number, token: string | null) => string[];
+  /** Enrich + map + upsert one entry, mutating `state.upserted`/`state.bytes`. */
+  readonly processEntry: (
+    run: RunAwsCli,
+    ctx: SyncContext,
+    entry: unknown,
+    now: number,
+    state: S,
+  ) => Promise<void>;
+}
+
+/**
+ * Run a single-pass, token-paginated AWS-CLI walk: ensure-running → load creds
+ * (noop if absent) → page through the list call (first-page failure degrades to
+ * a parse-empty pass-cursor; a later-page failure breaks) → for each entry up to
+ * `maxItems`, delegate to `processEntry` → pass-1 success. Byte/upsert accounting
+ * is owned by `state`, threaded exactly as the hand-written connector `sync()`
+ * bodies did. Per-item enrichment (and its own byte accounting + caps) lives in
+ * the connector's `processEntry`.
+ */
+export async function runAwsCliPaginatedWalk<S extends BaseWalkState>(
+  ctx: SyncContext,
+  cursor: string | null,
+  run: RunAwsCli,
+  spec: AwsPaginatedWalkSpec<S>,
+): Promise<SyncResult> {
+  const t0 = performance.now();
+  await spec.ensureRunning();
+
+  const creds = await spec.loadCreds();
+  if (creds === null) {
+    return syncNoopResult(cursor, t0);
+  }
+
+  const now = Date.now();
+  const state = spec.initialState();
+  let token: string | null = null;
+  let page = 0;
+
+  while (state.seen < spec.maxItems) {
+    const args = spec.buildPageArgs(spec.pageSize, token);
+    const res = await run(ctx, args);
+    state.bytes += res.text.length;
+    if (!res.ok) {
+      if (page === 0) {
+        return syncPassCursorParseEmpty(t0, state.bytes, spec.pass1Cursor());
+      }
+      break;
+    }
+    const parsed = parseJson(res.text);
+    for (const entry of extractArray(parsed, spec.arrayKey)) {
+      if (state.seen >= spec.maxItems) {
+        break;
+      }
+      state.seen += 1;
+      await spec.processEntry(run, ctx, entry, now, state);
+    }
+    token = awsNextToken(parsed, spec.tokenKey);
+    page += 1;
+    if (token === null) {
+      break;
+    }
+  }
+
+  return syncPassCursorSuccess(t0, state.bytes, spec.pass1Cursor(), state.upserted);
 }

--- a/packages/gateway/src/connectors/_lib/imap-sync-core.test.ts
+++ b/packages/gateway/src/connectors/_lib/imap-sync-core.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SyncContext } from "../../sync/types.ts";
+import { type ImapLikeFetchOutcome, parsePortSecret, runImapLikeSync } from "./imap-sync-core.ts";
+import type { SyncUpsertRow } from "./paginated-sync.ts";
+
+describe("parsePortSecret", () => {
+  test("returns fallback for empty / whitespace / nullish", () => {
+    expect(parsePortSecret(null, 993)).toBe(993);
+    expect(parsePortSecret(undefined, 993)).toBe(993);
+    expect(parsePortSecret("", 993)).toBe(993);
+    expect(parsePortSecret("   ", 993)).toBe(993);
+  });
+  test("parses a valid port and truncates floats", () => {
+    expect(parsePortSecret("1143", 993)).toBe(1143);
+    expect(parsePortSecret("993.9", 465)).toBe(993);
+  });
+  test("returns fallback for out-of-range / non-numeric", () => {
+    expect(parsePortSecret("0", 993)).toBe(993);
+    expect(parsePortSecret("65536", 993)).toBe(993);
+    expect(parsePortSecret("-1", 993)).toBe(993);
+    expect(parsePortSecret("nope", 993)).toBe(993);
+  });
+});
+
+type Row = SyncUpsertRow;
+const ROW = { service: "imap", type: "email", externalId: "x" } as unknown as Row;
+
+function fakeCtx(): { ctx: SyncContext; warns: unknown[]; acquired: string[] } {
+  const warns: unknown[] = [];
+  const acquired: string[] = [];
+  const ctx = {
+    logger: { warn: (obj: unknown, _msg?: string) => warns.push(obj) },
+    rateLimiter: {
+      acquire: async (p: string) => {
+        acquired.push(p);
+      },
+    },
+  } as unknown as SyncContext;
+  return { ctx, warns, acquired };
+}
+
+const BASE = {
+  serviceId: "imap" as const,
+  ensureRunning: async () => {},
+  maxMessages: 200,
+  pass1Cursor: () => "PASS1",
+};
+
+describe("runImapLikeSync", () => {
+  test("loadConfig → null yields a noop preserving the cursor (no rate-limit)", async () => {
+    const { ctx, acquired } = fakeCtx();
+    const res = await runImapLikeSync(ctx, "prev", {
+      ...BASE,
+      loadConfig: async () => null,
+      fetchMessages: async () => ({ ok: true, messages: [] }) as ImapLikeFetchOutcome<unknown>,
+      mapMessage: () => ROW,
+    });
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.cursor).toBe("prev");
+    expect(acquired).toHaveLength(0);
+  });
+
+  test("rate-limits before fetching, and an empty success upserts nothing", async () => {
+    const { ctx, acquired } = fakeCtx();
+    const res = await runImapLikeSync(ctx, null, {
+      ...BASE,
+      loadConfig: async () => ({}),
+      fetchMessages: async () => ({ ok: true, messages: [] }),
+      mapMessage: () => ROW,
+    });
+    expect(acquired).toEqual(["imap"]);
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.cursor).toBe("PASS1");
+  });
+
+  test("a thrown fetch degrades to a transient result preserving the cursor", async () => {
+    const { ctx, warns } = fakeCtx();
+    const res = await runImapLikeSync(ctx, "keep", {
+      ...BASE,
+      loadConfig: async () => ({}),
+      fetchMessages: async () => {
+        throw new Error("boom");
+      },
+      mapMessage: () => ROW,
+    });
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.cursor).toBe("keep");
+    expect(warns).toHaveLength(1);
+  });
+
+  test("an {ok:false} outcome degrades to a transient result (cursor falls back to pass1)", async () => {
+    const { ctx, warns } = fakeCtx();
+    const res = await runImapLikeSync(ctx, null, {
+      ...BASE,
+      loadConfig: async () => ({}),
+      fetchMessages: async () => ({ ok: false, error: "conn refused" }),
+      mapMessage: () => ROW,
+    });
+    expect(res.itemsUpserted).toBe(0);
+    expect(res.cursor).toBe("PASS1");
+    expect(warns).toHaveLength(1);
+  });
+});

--- a/packages/gateway/src/connectors/_lib/imap-sync-core.ts
+++ b/packages/gateway/src/connectors/_lib/imap-sync-core.ts
@@ -1,0 +1,100 @@
+import { upsertIndexedItemForSync } from "../../index/item-store.ts";
+import { syncPassCursorSuccess } from "../../sync/pass-cursor-sync-result.ts";
+import type { Provider } from "../../sync/rate-limiter.ts";
+import { type SyncContext, type SyncResult, syncNoopResult } from "../../sync/types.ts";
+import type { SyncUpsertRow } from "./paginated-sync.ts";
+
+/**
+ * Parse a numeric secret (e.g. an IMAP port) in the range [1, 65535]. Returns
+ * `fallback` when the value is absent, empty, non-numeric, or out of range.
+ * Byte-identical to the `intFromSecret` helpers it replaces in the imap +
+ * protonmail sync bodies.
+ */
+export function parsePortSecret(raw: string | null | undefined, fallback: number): number {
+  const t = raw?.trim() ?? "";
+  if (t === "") {
+    return fallback;
+  }
+  const n = Number(t);
+  return Number.isFinite(n) && n > 0 && n <= 65535 ? Math.trunc(n) : fallback;
+}
+
+/** A single fetch of message views, or a transient/connection failure (no throw). */
+export type ImapLikeFetchOutcome<Msg> =
+  | { readonly ok: true; readonly messages: readonly Msg[] }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Run one single-pass IMAP-style sync cycle: ensure-running → load config (noop
+ * if unconfigured) → rate-limit → fetch (a throw OR `{ok:false}` degrades to a
+ * transient result that preserves the cursor, never crashing the scheduler) →
+ * map + upsert each message → pass-1 success. Generic over the connection-config
+ * and message-view types so it imports nothing from the connector modules (no
+ * dependency cycle). Behaviour-identical to the hand-written imap/protonmail
+ * `sync()` bodies it replaces; the `serviceId` is interpolated into the warn
+ * messages exactly as before (`<serviceId> sync: …`).
+ */
+export async function runImapLikeSync<Cfg, Msg>(
+  ctx: SyncContext,
+  cursor: string | null,
+  opts: {
+    readonly serviceId: Provider;
+    readonly ensureRunning: () => Promise<void>;
+    readonly loadConfig: (ctx: SyncContext) => Promise<Cfg | null>;
+    readonly fetchMessages: (config: Cfg, limit: number) => Promise<ImapLikeFetchOutcome<Msg>>;
+    readonly maxMessages: number;
+    readonly pass1Cursor: () => string;
+    readonly mapMessage: (msg: Msg, syncedAt: number) => SyncUpsertRow | null;
+  },
+): Promise<SyncResult> {
+  const t0 = performance.now();
+  await opts.ensureRunning();
+
+  const config = await opts.loadConfig(ctx);
+  if (config === null) {
+    return syncNoopResult(cursor, t0);
+  }
+
+  await ctx.rateLimiter.acquire(opts.serviceId);
+
+  const transient = (): SyncResult => ({
+    cursor: cursor ?? opts.pass1Cursor(),
+    itemsUpserted: 0,
+    itemsDeleted: 0,
+    hasMore: false,
+    durationMs: Math.round(performance.now() - t0),
+  });
+
+  let outcome: ImapLikeFetchOutcome<Msg>;
+  try {
+    outcome = await opts.fetchMessages(config, opts.maxMessages);
+  } catch (err) {
+    // Defence-in-depth: even if a fetcher throws, the scheduler must not crash.
+    // Treat as a transient failure and preserve the cursor.
+    ctx.logger.warn(
+      { serviceId: opts.serviceId, err: err instanceof Error ? err.message : String(err) },
+      `${opts.serviceId} sync: fetch threw; treating as transient failure`,
+    );
+    return transient();
+  }
+
+  if (!outcome.ok) {
+    ctx.logger.warn(
+      { serviceId: opts.serviceId, error: outcome.error },
+      `${opts.serviceId} sync: connection/fetch failed; preserving cursor`,
+    );
+    return transient();
+  }
+
+  const now = Date.now();
+  let upserted = 0;
+  for (const msg of outcome.messages) {
+    const mapped = opts.mapMessage(msg, now);
+    if (mapped !== null) {
+      upsertIndexedItemForSync(ctx, mapped);
+      upserted += 1;
+    }
+  }
+
+  return syncPassCursorSuccess(t0, 0, opts.pass1Cursor(), upserted);
+}

--- a/packages/gateway/src/connectors/cloudwatch-sync.ts
+++ b/packages/gateway/src/connectors/cloudwatch-sync.ts
@@ -1,13 +1,18 @@
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
+import type { Syncable, SyncContext, SyncResult } from "../sync/types.ts";
 import {
-  syncPassCursorParseEmpty,
-  syncPassCursorSuccess,
-} from "../sync/pass-cursor-sync-result.ts";
-import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
-import { awsCliJson, awsCredentialsExtra } from "./_lib/aws-cli.ts";
+  awsCliJson,
+  awsCredentialsExtra,
+  extractArray,
+  parseJson,
+  type RunAwsCli,
+  runAwsCliPaginatedWalk,
+} from "./_lib/aws-cli.ts";
 import { mapCloudwatchLogGroupToItem } from "./cloudwatch-log-group-mapping.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
+
+export type { RunAwsCli };
 
 const SERVICE_ID = "cloudwatch";
 const CURSOR_PREFIX = "nimbus-cw1:";
@@ -25,43 +30,11 @@ function pass1Cursor(): string {
   return encodeNimbusJsonCursor(CURSOR_PREFIX, { pass: 1 } satisfies CloudwatchCursorV1);
 }
 
-/** Injectable AWS-CLI runner — defaults to the shared `awsCliJson` spawn; tests pass a stub. */
-export type RunAwsCli = (
-  ctx: SyncContext,
-  args: string[],
-) => Promise<{ ok: boolean; text: string }>;
-
 export type CloudwatchSyncableOptions = {
   ensureCloudwatchMcpRunning: () => Promise<void>;
   /** Override the AWS-CLI runner (dependency injection for tests). */
   runAwsCli?: RunAwsCli;
 };
-
-function parseJson(text: string): unknown {
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return undefined;
-  }
-}
-
-function nextToken(parsed: unknown): string | null {
-  const rec = asRecord(parsed);
-  if (rec === undefined) {
-    return null;
-  }
-  const tok = stringField(rec, "nextToken");
-  return tok !== undefined && tok !== "" ? tok : null;
-}
-
-function extractArray(parsed: unknown, key: string): unknown[] {
-  const rec = asRecord(parsed);
-  if (rec === undefined) {
-    return [];
-  }
-  const arr = rec[key];
-  return Array.isArray(arr) ? arr : [];
-}
 
 interface StreamSummary {
   readonly streamCount: number;
@@ -152,68 +125,32 @@ async function processLogGroup(
   }
 }
 
-/** Process a single `describe-log-groups` page, threading counters through `state`. */
-async function processLogGroupPage(
-  run: RunAwsCli,
-  ctx: SyncContext,
-  parsed: unknown,
-  now: number,
-  state: LogGroupWalkState,
-): Promise<void> {
-  for (const entry of extractArray(parsed, "logGroups")) {
-    if (state.seen >= MAX_LOG_GROUPS) {
-      break;
-    }
-    state.seen += 1;
-    await processLogGroup(run, ctx, entry, now, state);
-  }
-}
-
 export function createCloudwatchSyncable(options: CloudwatchSyncableOptions): Syncable {
   const run = options.runAwsCli ?? awsCliJson;
   return {
     serviceId: SERVICE_ID,
     defaultIntervalMs: 10 * 60 * 1000,
     initialSyncDepthDays: 30,
-    async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
-      const t0 = performance.now();
-      await options.ensureCloudwatchMcpRunning();
-
-      // CloudWatch (Tier-3, metadata-only) reuses the existing AWS credentials.
-      const extra = await awsCredentialsExtra(ctx);
-      if (extra === null) {
-        return syncNoopResult(cursor, t0);
-      }
-
-      const now = Date.now();
-      const state: LogGroupWalkState = { upserted: 0, bytes: 0, seen: 0 };
-      let token: string | null = null;
-      let page = 0;
-
-      while (state.seen < MAX_LOG_GROUPS) {
-        const args = ["logs", "describe-log-groups", "--limit", String(PAGE_SIZE)];
-        if (token !== null && token !== "") {
-          args.push("--next-token", token);
-        }
-        const res = await run(ctx, args);
-        state.bytes += res.text.length;
-        if (!res.ok) {
-          if (page === 0) {
-            // Graceful empty pass — no throw past the Syncable boundary.
-            return syncPassCursorParseEmpty(t0, state.bytes, pass1Cursor());
+    sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
+      return runAwsCliPaginatedWalk<LogGroupWalkState>(ctx, cursor, run, {
+        ensureRunning: options.ensureCloudwatchMcpRunning,
+        // CloudWatch (Tier-3, metadata-only) reuses the existing AWS credentials.
+        loadCreds: () => awsCredentialsExtra(ctx),
+        pass1Cursor,
+        maxItems: MAX_LOG_GROUPS,
+        pageSize: PAGE_SIZE,
+        tokenKey: "nextToken",
+        arrayKey: "logGroups",
+        initialState: () => ({ upserted: 0, bytes: 0, seen: 0 }),
+        buildPageArgs: (pageSize, token) => {
+          const args = ["logs", "describe-log-groups", "--limit", String(pageSize)];
+          if (token !== null && token !== "") {
+            args.push("--next-token", token);
           }
-          break;
-        }
-        const parsed = parseJson(res.text);
-        await processLogGroupPage(run, ctx, parsed, now, state);
-        token = nextToken(parsed);
-        page += 1;
-        if (token === null) {
-          break;
-        }
-      }
-
-      return syncPassCursorSuccess(t0, state.bytes, pass1Cursor(), state.upserted);
+          return args;
+        },
+        processEntry: processLogGroup,
+      });
     },
   };
 }

--- a/packages/gateway/src/connectors/imap-email-mapping.ts
+++ b/packages/gateway/src/connectors/imap-email-mapping.ts
@@ -70,15 +70,18 @@ export function imapExternalId(input: {
 }
 
 /**
- * Pure mapper: an IMAP message header/attachment-metadata/preview view → an
- * `imap:email` IndexedItem. Stores HEADERS, a capped plain-text PREVIEW, and
- * attachment METADATA (filename/size/mimetype) ONLY. NEVER attachment bytes and
- * NEVER a full message body. Returns null when the message carries no id basis.
+ * Pure mapper core shared by the IMAP and ProtonMail-Bridge connectors (both
+ * speak plain IMAP, so the message-input shape, id basis, and metadata are
+ * identical — only the `service` literal differs). Stores HEADERS, a capped
+ * plain-text PREVIEW, and attachment METADATA (filename/size/mimetype) ONLY.
+ * NEVER attachment bytes and NEVER a full message body. Returns null when the
+ * message carries no id basis.
  */
-export function mapImapMessageToItem(
+export function mapImapLikeMessageToItem<S extends string>(
+  service: S,
   input: ImapMessageInput,
   ctx: ImapMappingContext,
-): ImapMappedRow | null {
+): MappedRow<S, "email"> | null {
   if (
     (input.messageId === null || input.messageId.trim() === "") &&
     (!Number.isFinite(input.uid) || input.uid <= 0)
@@ -121,7 +124,7 @@ export function mapImapMessageToItem(
   };
 
   return {
-    service: SERVICE,
+    service,
     type: TYPE,
     externalId,
     title,
@@ -132,4 +135,15 @@ export function mapImapMessageToItem(
     metadata,
     syncedAt: ctx.syncedAt,
   };
+}
+
+/**
+ * Pure mapper: an IMAP message header/attachment-metadata/preview view → an
+ * `imap:email` IndexedItem. Thin wrapper over {@link mapImapLikeMessageToItem}.
+ */
+export function mapImapMessageToItem(
+  input: ImapMessageInput,
+  ctx: ImapMappingContext,
+): ImapMappedRow | null {
+  return mapImapLikeMessageToItem(SERVICE, input, ctx);
 }

--- a/packages/gateway/src/connectors/imap-sync.ts
+++ b/packages/gateway/src/connectors/imap-sync.ts
@@ -1,6 +1,5 @@
-import { upsertIndexedItemForSync } from "../index/item-store.ts";
-import { syncPassCursorSuccess } from "../sync/pass-cursor-sync-result.ts";
-import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import type { Syncable, SyncContext, SyncResult } from "../sync/types.ts";
+import { parsePortSecret, runImapLikeSync } from "./_lib/imap-sync-core.ts";
 import { readConnectorSecret } from "./connector-vault.ts";
 import { type ImapMessageInput, mapImapMessageToItem } from "./imap-email-mapping.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
@@ -62,15 +61,6 @@ export type ImapSyncableOptions = {
   fetchMessages: ImapMessageFetcher;
 };
 
-function intFromSecret(raw: string | null | undefined, fallback: number): number {
-  const t = raw?.trim() ?? "";
-  if (t === "") {
-    return fallback;
-  }
-  const n = Number(t);
-  return Number.isFinite(n) && n > 0 && n <= 65535 ? Math.trunc(n) : fallback;
-}
-
 async function loadConfig(ctx: SyncContext): Promise<ImapConnectionConfig | null> {
   const host = (await readConnectorSecret(ctx.vault, "imap", "host"))?.trim() ?? "";
   const username = (await readConnectorSecret(ctx.vault, "imap", "username"))?.trim() ?? "";
@@ -78,7 +68,7 @@ async function loadConfig(ctx: SyncContext): Promise<ImapConnectionConfig | null
   if (host === "" || username === "" || password === "") {
     return null;
   }
-  const port = intFromSecret(await readConnectorSecret(ctx.vault, "imap", "port"), 993);
+  const port = parsePortSecret(await readConnectorSecret(ctx.vault, "imap", "port"), 993);
   const mailbox =
     (await readConnectorSecret(ctx.vault, "imap", "mailbox"))?.trim() || DEFAULT_MAILBOX;
   return { host, port, username, password, mailbox };
@@ -89,61 +79,16 @@ export function createImapSyncable(options: ImapSyncableOptions): Syncable {
     serviceId: SERVICE_ID,
     defaultIntervalMs: 5 * 60 * 1000,
     initialSyncDepthDays: 30,
-    async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
-      const t0 = performance.now();
-      await options.ensureImapMcpRunning();
-
-      const config = await loadConfig(ctx);
-      if (config === null) {
-        return syncNoopResult(cursor, t0);
-      }
-
-      await ctx.rateLimiter.acquire(SERVICE_ID);
-
-      let outcome: ImapFetchOutcome;
-      try {
-        outcome = await options.fetchMessages(config, MAX_MESSAGES);
-      } catch (err) {
-        // Defence-in-depth: even if a fetcher throws, the scheduler must not
-        // crash. Treat as a transient failure and preserve the cursor.
-        ctx.logger.warn(
-          { serviceId: SERVICE_ID, err: err instanceof Error ? err.message : String(err) },
-          "imap sync: fetch threw; treating as transient failure",
-        );
-        return {
-          cursor: cursor ?? pass1Cursor(),
-          itemsUpserted: 0,
-          itemsDeleted: 0,
-          hasMore: false,
-          durationMs: Math.round(performance.now() - t0),
-        };
-      }
-
-      if (!outcome.ok) {
-        ctx.logger.warn(
-          { serviceId: SERVICE_ID, error: outcome.error },
-          "imap sync: connection/fetch failed; preserving cursor",
-        );
-        return {
-          cursor: cursor ?? pass1Cursor(),
-          itemsUpserted: 0,
-          itemsDeleted: 0,
-          hasMore: false,
-          durationMs: Math.round(performance.now() - t0),
-        };
-      }
-
-      const now = Date.now();
-      let upserted = 0;
-      for (const msg of outcome.messages) {
-        const mapped = mapImapMessageToItem(msg, { syncedAt: now });
-        if (mapped !== null) {
-          upsertIndexedItemForSync(ctx, mapped);
-          upserted += 1;
-        }
-      }
-
-      return syncPassCursorSuccess(t0, 0, pass1Cursor(), upserted);
+    sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
+      return runImapLikeSync(ctx, cursor, {
+        serviceId: SERVICE_ID,
+        ensureRunning: options.ensureImapMcpRunning,
+        loadConfig,
+        fetchMessages: options.fetchMessages,
+        maxMessages: MAX_MESSAGES,
+        pass1Cursor,
+        mapMessage: (msg, syncedAt) => mapImapMessageToItem(msg, { syncedAt }),
+      });
     },
   };
 }

--- a/packages/gateway/src/connectors/protonmail-email-mapping.ts
+++ b/packages/gateway/src/connectors/protonmail-email-mapping.ts
@@ -1,5 +1,4 @@
-import { clamp, parseDateMs } from "./_lib/email-mapping.ts";
-import { type ImapMessageInput, imapExternalId } from "./imap-email-mapping.ts";
+import { type ImapMessageInput, mapImapLikeMessageToItem } from "./imap-email-mapping.ts";
 import type { MappedRow } from "./mapped-row.ts";
 
 /**
@@ -16,71 +15,16 @@ export interface ProtonmailMappingContext {
   readonly syncedAt: number;
 }
 
-const TITLE_MAX = 256;
-const PREVIEW_MAX = 2000;
-const SERVICE = "protonmail" as const;
-const TYPE = "email" as const;
-
 /**
  * Pure mapper: a ProtonMail-Bridge IMAP message view → a `protonmail:email`
- * IndexedItem. Stores HEADERS, a capped plain-text PREVIEW, and attachment
- * METADATA (filename/size/mimetype) ONLY. Returns null when the message carries
- * no id basis.
+ * IndexedItem. ProtonMail Bridge speaks plain IMAP, so this is the shared IMAP
+ * mapper core ({@link mapImapLikeMessageToItem}) with the `protonmail` service
+ * literal. Stores HEADERS + capped PREVIEW + attachment METADATA only; returns
+ * null when the message carries no id basis.
  */
 export function mapProtonmailEmailToItem(
   input: ImapMessageInput,
   ctx: ProtonmailMappingContext,
 ): ProtonmailMappedRow | null {
-  if (
-    (input.messageId === null || input.messageId.trim() === "") &&
-    (!Number.isFinite(input.uid) || input.uid <= 0)
-  ) {
-    return null;
-  }
-
-  const externalId = imapExternalId({
-    messageId: input.messageId,
-    mailbox: input.mailbox,
-    uidValidity: input.uidValidity,
-    uid: input.uid,
-  });
-
-  const subject = input.subject?.trim() ?? "";
-  const title = clamp(subject === "" ? "(no subject)" : subject, TITLE_MAX);
-  const bodyPreview = clamp(input.preview ?? "", PREVIEW_MAX);
-  const modifiedAt = parseDateMs(input.date) ?? ctx.syncedAt;
-
-  const attachments = input.attachments.map((a) => ({
-    filename: a.filename,
-    sizeBytes: a.sizeBytes,
-    mimeType: a.mimeType,
-  }));
-
-  const participants = [...input.from, ...input.to, ...(input.cc ?? [])];
-
-  const metadata: Record<string, unknown> = {
-    mailbox: input.mailbox,
-    uid: input.uid,
-    uidValidity: input.uidValidity,
-    messageId: input.messageId,
-    from: [...input.from],
-    to: [...input.to],
-    cc: [...(input.cc ?? [])],
-    participants,
-    attachments,
-    attachmentCount: attachments.length,
-  };
-
-  return {
-    service: SERVICE,
-    type: TYPE,
-    externalId,
-    title,
-    bodyPreview,
-    url: null,
-    canonicalUrl: null,
-    modifiedAt,
-    metadata,
-    syncedAt: ctx.syncedAt,
-  };
+  return mapImapLikeMessageToItem("protonmail", input, ctx);
 }

--- a/packages/gateway/src/connectors/protonmail-sync.ts
+++ b/packages/gateway/src/connectors/protonmail-sync.ts
@@ -1,8 +1,7 @@
-import { upsertIndexedItemForSync } from "../index/item-store.ts";
-import { syncPassCursorSuccess } from "../sync/pass-cursor-sync-result.ts";
-import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
+import type { Syncable, SyncContext, SyncResult } from "../sync/types.ts";
+import { parsePortSecret, runImapLikeSync } from "./_lib/imap-sync-core.ts";
 import { readConnectorSecret } from "./connector-vault.ts";
-import type { ImapConnectionConfig, ImapFetchOutcome, ImapMessageFetcher } from "./imap-sync.ts";
+import type { ImapConnectionConfig, ImapMessageFetcher } from "./imap-sync.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { mapProtonmailEmailToItem } from "./protonmail-email-mapping.ts";
 
@@ -27,15 +26,6 @@ export type ProtonmailSyncableOptions = {
   fetchMessages: ImapMessageFetcher;
 };
 
-function intFromSecret(raw: string | null | undefined, fallback: number): number {
-  const t = raw?.trim() ?? "";
-  if (t === "") {
-    return fallback;
-  }
-  const n = Number(t);
-  return Number.isFinite(n) && n > 0 && n <= 65535 ? Math.trunc(n) : fallback;
-}
-
 async function loadConfig(ctx: SyncContext): Promise<ImapConnectionConfig | null> {
   // ProtonMail Bridge generates a per-machine username + password; the IMAP
   // host/port default to the Bridge loopback listener.
@@ -47,7 +37,7 @@ async function loadConfig(ctx: SyncContext): Promise<ImapConnectionConfig | null
   const host =
     (await readConnectorSecret(ctx.vault, "protonmail", "imap_host"))?.trim() ||
     DEFAULT_BRIDGE_HOST;
-  const port = intFromSecret(
+  const port = parsePortSecret(
     await readConnectorSecret(ctx.vault, "protonmail", "imap_port"),
     DEFAULT_IMAP_PORT,
   );
@@ -57,62 +47,21 @@ async function loadConfig(ctx: SyncContext): Promise<ImapConnectionConfig | null
   return { host, port, username, password, mailbox, secure: false, tlsRejectUnauthorized: false };
 }
 
-function transientResult(cursor: string | null, t0: number): SyncResult {
-  return {
-    cursor: cursor ?? pass1Cursor(),
-    itemsUpserted: 0,
-    itemsDeleted: 0,
-    hasMore: false,
-    durationMs: Math.round(performance.now() - t0),
-  };
-}
-
 export function createProtonmailSyncable(options: ProtonmailSyncableOptions): Syncable {
   return {
     serviceId: SERVICE_ID,
     defaultIntervalMs: 5 * 60 * 1000,
     initialSyncDepthDays: 30,
-    async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
-      const t0 = performance.now();
-      await options.ensureProtonmailMcpRunning();
-
-      const config = await loadConfig(ctx);
-      if (config === null) {
-        return syncNoopResult(cursor, t0);
-      }
-
-      await ctx.rateLimiter.acquire(SERVICE_ID);
-
-      let outcome: ImapFetchOutcome;
-      try {
-        outcome = await options.fetchMessages(config, MAX_MESSAGES);
-      } catch (err) {
-        ctx.logger.warn(
-          { serviceId: SERVICE_ID, err: err instanceof Error ? err.message : String(err) },
-          "protonmail sync: fetch threw; treating as transient failure",
-        );
-        return transientResult(cursor, t0);
-      }
-
-      if (!outcome.ok) {
-        ctx.logger.warn(
-          { serviceId: SERVICE_ID, error: outcome.error },
-          "protonmail sync: connection/fetch failed; preserving cursor",
-        );
-        return transientResult(cursor, t0);
-      }
-
-      const now = Date.now();
-      let upserted = 0;
-      for (const msg of outcome.messages) {
-        const mapped = mapProtonmailEmailToItem(msg, { syncedAt: now });
-        if (mapped !== null) {
-          upsertIndexedItemForSync(ctx, mapped);
-          upserted += 1;
-        }
-      }
-
-      return syncPassCursorSuccess(t0, 0, pass1Cursor(), upserted);
+    sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
+      return runImapLikeSync(ctx, cursor, {
+        serviceId: SERVICE_ID,
+        ensureRunning: options.ensureProtonmailMcpRunning,
+        loadConfig,
+        fetchMessages: options.fetchMessages,
+        maxMessages: MAX_MESSAGES,
+        pass1Cursor,
+        mapMessage: (msg, syncedAt) => mapProtonmailEmailToItem(msg, { syncedAt }),
+      });
     },
   };
 }

--- a/packages/gateway/src/connectors/sagemaker-sync.ts
+++ b/packages/gateway/src/connectors/sagemaker-sync.ts
@@ -1,13 +1,17 @@
 import { upsertIndexedItemForSync } from "../index/item-store.ts";
+import type { Syncable, SyncContext, SyncResult } from "../sync/types.ts";
 import {
-  syncPassCursorParseEmpty,
-  syncPassCursorSuccess,
-} from "../sync/pass-cursor-sync-result.ts";
-import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
-import { awsCliJson, awsCredentialsExtra } from "./_lib/aws-cli.ts";
+  awsCliJson,
+  awsCredentialsExtra,
+  parseJson,
+  type RunAwsCli,
+  runAwsCliPaginatedWalk,
+} from "./_lib/aws-cli.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { mapSagemakerModelToItem } from "./sagemaker-model-mapping.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
+
+export type { RunAwsCli };
 
 const SERVICE_ID = "sagemaker";
 const CURSOR_PREFIX = "nimbus-sm1:";
@@ -25,43 +29,11 @@ function pass1Cursor(): string {
   return encodeNimbusJsonCursor(CURSOR_PREFIX, { pass: 1 } satisfies SagemakerCursorV1);
 }
 
-/** Injectable AWS-CLI runner — defaults to the shared `awsCliJson` spawn; tests pass a stub. */
-export type RunAwsCli = (
-  ctx: SyncContext,
-  args: string[],
-) => Promise<{ ok: boolean; text: string }>;
-
 export type SagemakerSyncableOptions = {
   ensureSagemakerMcpRunning: () => Promise<void>;
   /** Override the AWS-CLI runner (dependency injection for tests). */
   runAwsCli?: RunAwsCli;
 };
-
-function parseJson(text: string): unknown {
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return undefined;
-  }
-}
-
-function nextToken(parsed: unknown): string | null {
-  const rec = asRecord(parsed);
-  if (rec === undefined) {
-    return null;
-  }
-  const tok = stringField(rec, "NextToken");
-  return tok !== undefined && tok !== "" ? tok : null;
-}
-
-function extractArray(parsed: unknown, key: string): unknown[] {
-  const rec = asRecord(parsed);
-  if (rec === undefined) {
-    return [];
-  }
-  const arr = rec[key];
-  return Array.isArray(arr) ? arr : [];
-}
 
 /**
  * Guard a value before it is passed as a positional/flag-value to the spawned
@@ -157,68 +129,32 @@ async function processModel(
   }
 }
 
-/** Process a single `list-models` page, threading counters through `state`. */
-async function processModelPage(
-  run: RunAwsCli,
-  ctx: SyncContext,
-  parsed: unknown,
-  now: number,
-  state: ModelWalkState,
-): Promise<void> {
-  for (const entry of extractArray(parsed, "Models")) {
-    if (state.seen >= MAX_MODELS) {
-      break;
-    }
-    state.seen += 1;
-    await processModel(run, ctx, entry, now, state);
-  }
-}
-
 export function createSagemakerSyncable(options: SagemakerSyncableOptions): Syncable {
   const run = options.runAwsCli ?? awsCliJson;
   return {
     serviceId: SERVICE_ID,
     defaultIntervalMs: 10 * 60 * 1000,
     initialSyncDepthDays: 30,
-    async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
-      const t0 = performance.now();
-      await options.ensureSagemakerMcpRunning();
-
-      // SageMaker (Tier-3, metadata-only) reuses the existing AWS credentials.
-      const extra = await awsCredentialsExtra(ctx);
-      if (extra === null) {
-        return syncNoopResult(cursor, t0);
-      }
-
-      const now = Date.now();
-      const state: ModelWalkState = { upserted: 0, bytes: 0, seen: 0, described: 0 };
-      let token: string | null = null;
-      let page = 0;
-
-      while (state.seen < MAX_MODELS) {
-        const args = ["sagemaker", "list-models", "--max-results", String(PAGE_SIZE)];
-        if (token !== null && token !== "") {
-          args.push("--next-token", token);
-        }
-        const res = await run(ctx, args);
-        state.bytes += res.text.length;
-        if (!res.ok) {
-          if (page === 0) {
-            // Graceful empty pass — no throw past the Syncable boundary.
-            return syncPassCursorParseEmpty(t0, state.bytes, pass1Cursor());
+    sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
+      return runAwsCliPaginatedWalk<ModelWalkState>(ctx, cursor, run, {
+        ensureRunning: options.ensureSagemakerMcpRunning,
+        // SageMaker (Tier-3, metadata-only) reuses the existing AWS credentials.
+        loadCreds: () => awsCredentialsExtra(ctx),
+        pass1Cursor,
+        maxItems: MAX_MODELS,
+        pageSize: PAGE_SIZE,
+        tokenKey: "NextToken",
+        arrayKey: "Models",
+        initialState: () => ({ upserted: 0, bytes: 0, seen: 0, described: 0 }),
+        buildPageArgs: (pageSize, token) => {
+          const args = ["sagemaker", "list-models", "--max-results", String(pageSize)];
+          if (token !== null && token !== "") {
+            args.push("--next-token", token);
           }
-          break;
-        }
-        const parsed = parseJson(res.text);
-        await processModelPage(run, ctx, parsed, now, state);
-        token = nextToken(parsed);
-        page += 1;
-        if (token === null) {
-          break;
-        }
-      }
-
-      return syncPassCursorSuccess(t0, state.bytes, pass1Cursor(), state.upserted);
+          return args;
+        },
+        processEntry: processModel,
+      });
     },
   };
 }

--- a/packages/mcp-connectors/gmail/src/server.ts
+++ b/packages/mcp-connectors/gmail/src/server.ts
@@ -4,8 +4,8 @@ import { z } from "zod";
 
 import {
   createRegisterSimpleTool,
-  type McpListResult,
-  mcpJsonResult,
+  createZodToolRegistrar,
+  mcpJsonResultIfOk,
   requireProcessEnv,
 } from "../../shared/mcp-tool-kit.ts";
 import { makeRestFetcher } from "../../shared/rest-tool-kit.ts";
@@ -45,7 +45,7 @@ function toRawBase64Url(rfc822: string): string {
 
 const server = new McpServer({ name: "nimbus-gmail", version: "0.1.0" });
 
-const registerSimpleTool = createRegisterSimpleTool(server);
+const reg = createZodToolRegistrar(createRegisterSimpleTool(server));
 
 const gmailMessageListArgs = z.object({
   maxResults: z.number().int().min(1).max(100).optional(),
@@ -55,37 +55,29 @@ const gmailMessageListArgs = z.object({
   includeSpamTrash: z.boolean().optional(),
 });
 
-registerSimpleTool(
+reg(
   "gmail_message_list",
   "List Gmail message ids (metadata). Optional Gmail search query `q` (same syntax as Gmail UI).",
-  gmailMessageListArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gmailMessageListArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  gmailMessageListArgs,
+  async (data) => {
     const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
     const u = new URL(`${GMAIL_BASE}/messages`);
-    u.searchParams.set("maxResults", String(parsed.data.maxResults ?? 25));
-    if (parsed.data.pageToken !== undefined && parsed.data.pageToken !== "") {
-      u.searchParams.set("pageToken", parsed.data.pageToken);
+    u.searchParams.set("maxResults", String(data.maxResults ?? 25));
+    if (data.pageToken !== undefined && data.pageToken !== "") {
+      u.searchParams.set("pageToken", data.pageToken);
     }
-    if (parsed.data.q !== undefined && parsed.data.q !== "") {
-      u.searchParams.set("q", parsed.data.q);
+    if (data.q !== undefined && data.q !== "") {
+      u.searchParams.set("q", data.q);
     }
-    if (parsed.data.labelIds !== undefined) {
-      for (const lid of parsed.data.labelIds) {
+    if (data.labelIds !== undefined) {
+      for (const lid of data.labelIds) {
         u.searchParams.append("labelIds", lid);
       }
     }
-    if (parsed.data.includeSpamTrash === true) {
+    if (data.includeSpamTrash === true) {
       u.searchParams.set("includeSpamTrash", "true");
     }
-    const r = await gmailFetch(token, u.toString());
-    if (!r.ok) {
-      throw new Error(`Gmail API ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Gmail API", await gmailFetch(token, u.toString()), 200);
   },
 );
 
@@ -94,18 +86,14 @@ const gmailMessageReadArgs = z.object({
   format: z.enum(["minimal", "full", "metadata", "raw"]).optional(),
 });
 
-registerSimpleTool(
+reg(
   "gmail_message_read",
   "Read a single Gmail message (format minimal | metadata | full | raw).",
-  gmailMessageReadArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gmailMessageReadArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  gmailMessageReadArgs,
+  async (data) => {
     const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const fmt = parsed.data.format ?? "metadata";
-    const u = new URL(`${GMAIL_BASE}/messages/${encodeURIComponent(parsed.data.messageId)}`);
+    const fmt = data.format ?? "metadata";
+    const u = new URL(`${GMAIL_BASE}/messages/${encodeURIComponent(data.messageId)}`);
     u.searchParams.set("format", fmt);
     if (fmt === "metadata") {
       u.searchParams.append("metadataHeaders", "Subject");
@@ -113,11 +101,7 @@ registerSimpleTool(
       u.searchParams.append("metadataHeaders", "To");
       u.searchParams.append("metadataHeaders", "Date");
     }
-    const r = await gmailFetch(token, u.toString());
-    if (!r.ok) {
-      throw new Error(`Gmail API ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Gmail API", await gmailFetch(token, u.toString()), 200);
   },
 );
 
@@ -126,42 +110,25 @@ const gmailThreadReadArgs = z.object({
   format: z.enum(["minimal", "full", "metadata"]).optional(),
 });
 
-registerSimpleTool(
+reg(
   "gmail_thread_read",
   "Read a Gmail thread and its messages.",
-  gmailThreadReadArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gmailThreadReadArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  gmailThreadReadArgs,
+  async (data) => {
     const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const fmt = parsed.data.format ?? "metadata";
-    const u = new URL(`${GMAIL_BASE}/threads/${encodeURIComponent(parsed.data.threadId)}`);
+    const fmt = data.format ?? "metadata";
+    const u = new URL(`${GMAIL_BASE}/threads/${encodeURIComponent(data.threadId)}`);
     u.searchParams.set("format", fmt);
-    const r = await gmailFetch(token, u.toString());
-    if (!r.ok) {
-      throw new Error(`Gmail API ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Gmail API", await gmailFetch(token, u.toString()), 200);
   },
 );
 
 const gmailLabelListArgs = z.object({});
 
-registerSimpleTool(
-  "gmail_label_list",
-  "List all Gmail labels.",
-  gmailLabelListArgs.shape,
-  async (_args: unknown): Promise<McpListResult> => {
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const r = await gmailFetch(token, `${GMAIL_BASE}/labels`);
-    if (!r.ok) {
-      throw new Error(`Gmail API ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
-  },
-);
+reg("gmail_label_list", "List all Gmail labels.", gmailLabelListArgs, async () => {
+  const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
+  return mcpJsonResultIfOk("Gmail API", await gmailFetch(token, `${GMAIL_BASE}/labels`), 200);
+});
 
 const gmailDraftCreateArgs = z.object({
   to: z.string().min(1),
@@ -171,26 +138,22 @@ const gmailDraftCreateArgs = z.object({
   bcc: z.string().optional(),
 });
 
-registerSimpleTool(
+reg(
   "gmail_draft_create",
   "Create a Gmail draft. Requires Gateway HITL email.draft.create.",
-  gmailDraftCreateArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gmailDraftCreateArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  gmailDraftCreateArgs,
+  async (data) => {
     const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
     const msgParams: { to: string; subject: string; body: string; cc?: string; bcc?: string } = {
-      to: parsed.data.to,
-      subject: parsed.data.subject,
-      body: parsed.data.body,
+      to: data.to,
+      subject: data.subject,
+      body: data.body,
     };
-    if (parsed.data.cc !== undefined && parsed.data.cc !== "") {
-      msgParams.cc = parsed.data.cc;
+    if (data.cc !== undefined && data.cc !== "") {
+      msgParams.cc = data.cc;
     }
-    if (parsed.data.bcc !== undefined && parsed.data.bcc !== "") {
-      msgParams.bcc = parsed.data.bcc;
+    if (data.bcc !== undefined && data.bcc !== "") {
+      msgParams.bcc = data.bcc;
     }
     const raw = toRawBase64Url(buildRfc822Message(msgParams));
     const r = await gmailFetch(token, `${GMAIL_BASE}/drafts`, {
@@ -198,10 +161,7 @@ registerSimpleTool(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message: { raw } }),
     });
-    if (!r.ok) {
-      throw new Error(`Gmail API ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Gmail API", r, 200);
   },
 );
 
@@ -209,25 +169,18 @@ const gmailDraftSendArgs = z.object({
   draftId: z.string().min(1),
 });
 
-registerSimpleTool(
+reg(
   "gmail_draft_send",
   "Send an existing Gmail draft by id. Requires Gateway HITL email.draft.send.",
-  gmailDraftSendArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gmailDraftSendArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  gmailDraftSendArgs,
+  async (data) => {
     const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
     const r = await gmailFetch(token, `${GMAIL_BASE}/drafts/send`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id: parsed.data.draftId }),
+      body: JSON.stringify({ id: data.draftId }),
     });
-    if (!r.ok) {
-      throw new Error(`Gmail API ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Gmail API", r, 200);
   },
 );
 
@@ -239,26 +192,22 @@ const gmailMessageSendArgs = z.object({
   bcc: z.string().optional(),
 });
 
-registerSimpleTool(
+reg(
   "gmail_message_send",
   "Send a new Gmail message (not a draft). Requires Gateway HITL email.send.",
-  gmailMessageSendArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gmailMessageSendArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  gmailMessageSendArgs,
+  async (data) => {
     const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
     const sendParams: { to: string; subject: string; body: string; cc?: string; bcc?: string } = {
-      to: parsed.data.to,
-      subject: parsed.data.subject,
-      body: parsed.data.body,
+      to: data.to,
+      subject: data.subject,
+      body: data.body,
     };
-    if (parsed.data.cc !== undefined && parsed.data.cc !== "") {
-      sendParams.cc = parsed.data.cc;
+    if (data.cc !== undefined && data.cc !== "") {
+      sendParams.cc = data.cc;
     }
-    if (parsed.data.bcc !== undefined && parsed.data.bcc !== "") {
-      sendParams.bcc = parsed.data.bcc;
+    if (data.bcc !== undefined && data.bcc !== "") {
+      sendParams.bcc = data.bcc;
     }
     const raw = toRawBase64Url(buildRfc822Message(sendParams));
     const r = await gmailFetch(token, `${GMAIL_BASE}/messages/send`, {
@@ -266,10 +215,7 @@ registerSimpleTool(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ raw }),
     });
-    if (!r.ok) {
-      throw new Error(`Gmail API ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Gmail API", r, 200);
   },
 );
 

--- a/packages/mcp-connectors/imap/src/tools.ts
+++ b/packages/mcp-connectors/imap/src/tools.ts
@@ -1,10 +1,5 @@
-import { emailToolSchemas, viewEmailMessage } from "../../shared/imap-tool-kit.ts";
-import {
-  createRegisterSimpleTool,
-  type McpListResult,
-  mcpJsonResult,
-} from "../../shared/mcp-tool-kit.ts";
-import { clampLimit, formatAddress, type ImapClient, type SmtpMailer } from "./imap-core.ts";
+import { registerEmailConnectorTools } from "../../shared/imap-tool-kit.ts";
+import { formatAddress, type ImapClient, type SmtpMailer } from "./imap-core.ts";
 
 /**
  * Register the IMAP read tools + the SMTP send tool onto an MCP server. The
@@ -16,93 +11,20 @@ export function registerImapTools(
   client: ImapClient,
   mailer: SmtpMailer,
 ): void {
-  const registerSimpleTool = createRegisterSimpleTool(server);
-  const { listArgs, getArgs, searchArgs, sendArgs } = emailToolSchemas;
-
-  registerSimpleTool(
-    "imap_list",
-    "List recent mailbox messages — HEADERS + attachment METADATA + a short capped text preview ONLY. Returns subject, from, to/cc, date, message-id, attachment {filename,size,mimetype}, and a <=2000-char plain-text body preview. NEVER returns attachment bytes or the full message body.",
-    listArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = listArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const opts: { mailbox?: string; limit?: number } = {};
-      if (parsed.data.mailbox !== undefined) {
-        opts.mailbox = parsed.data.mailbox;
-      }
-      opts.limit = clampLimit(parsed.data.limit);
-      const items = await client.list(opts);
-      return mcpJsonResult({ items: items.map((m) => viewEmailMessage(m, formatAddress)) });
+  registerEmailConnectorTools({
+    server,
+    toolPrefix: "imap",
+    descriptions: {
+      list: "List recent mailbox messages — HEADERS + attachment METADATA + a short capped text preview ONLY. Returns subject, from, to/cc, date, message-id, attachment {filename,size,mimetype}, and a <=2000-char plain-text body preview. NEVER returns attachment bytes or the full message body.",
+      get: "Fetch one message by uid — HEADERS + attachment METADATA + a short capped text preview ONLY. NEVER returns attachment bytes or the full message body.",
+      search:
+        "Substring search over message HEADERS (subject/from/to) — returns the same header + attachment-metadata + preview view as imap_list. Searches headers only; NEVER scans or returns document/body content beyond the capped preview.",
+      send: "Send a new email over SMTP. Requires Gateway HITL email.send.",
     },
-  );
-
-  registerSimpleTool(
-    "imap_get",
-    "Fetch one message by uid — HEADERS + attachment METADATA + a short capped text preview ONLY. NEVER returns attachment bytes or the full message body.",
-    getArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = getArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const m = await client.get(parsed.data.uid, parsed.data.mailbox);
-      return mcpJsonResult(
-        m === null ? { item: null } : { item: viewEmailMessage(m, formatAddress) },
-      );
-    },
-  );
-
-  registerSimpleTool(
-    "imap_search",
-    "Substring search over message HEADERS (subject/from/to) — returns the same header + attachment-metadata + preview view as imap_list. Searches headers only; NEVER scans or returns document/body content beyond the capped preview.",
-    searchArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = searchArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const opts: { query: string; mailbox?: string; limit?: number } = {
-        query: parsed.data.query,
-        limit: clampLimit(parsed.data.limit),
-      };
-      if (parsed.data.mailbox !== undefined) {
-        opts.mailbox = parsed.data.mailbox;
-      }
-      const items = await client.search(opts);
-      return mcpJsonResult({ matches: items.map((m) => viewEmailMessage(m, formatAddress)) });
-    },
-  );
-
-  registerSimpleTool(
-    "imap_mail_send",
-    "Send a new email over SMTP. Requires Gateway HITL email.send.",
-    sendArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = sendArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const input: { to: string; subject: string; body: string; cc?: string; bcc?: string } = {
-        to: parsed.data.to,
-        subject: parsed.data.subject,
-        body: parsed.data.body,
-      };
-      if (parsed.data.cc !== undefined && parsed.data.cc !== "") {
-        input.cc = parsed.data.cc;
-      }
-      if (parsed.data.bcc !== undefined && parsed.data.bcc !== "") {
-        input.bcc = parsed.data.bcc;
-      }
-      const res = await mailer.send(input);
-      return mcpJsonResult({
-        messageId: res.messageId,
-        accepted: res.accepted,
-        rejected: res.rejected,
-      });
-    },
-  );
+    client,
+    mailer,
+    formatAddr: formatAddress,
+  });
 }
 
 /** Tool names exposed by this connector — for contract/introspection tests. */

--- a/packages/mcp-connectors/onedrive/src/server.ts
+++ b/packages/mcp-connectors/onedrive/src/server.ts
@@ -4,8 +4,9 @@ import { z } from "zod";
 
 import {
   createRegisterSimpleTool,
-  type McpListResult,
+  createZodToolRegistrar,
   mcpJsonResult,
+  mcpJsonResultIfOk,
   requireProcessEnv,
 } from "../../shared/mcp-tool-kit.ts";
 
@@ -41,7 +42,7 @@ async function graphRequest(
 
 const server = new McpServer({ name: "nimbus-onedrive", version: "0.1.0" });
 
-const registerSimpleTool = createRegisterSimpleTool(server);
+const reg = createZodToolRegistrar(createRegisterSimpleTool(server));
 
 const onedriveItemListArgs = z.object({
   parentId: z.string().min(1).optional(),
@@ -49,35 +50,23 @@ const onedriveItemListArgs = z.object({
   nextLink: z.url().optional(),
 });
 
-registerSimpleTool(
+reg(
   "onedrive_item_list",
   "List drive items under root or a folder (by parentId). Use nextLink from prior response for pagination.",
-  onedriveItemListArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = onedriveItemListArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  onedriveItemListArgs,
+  async (data) => {
     const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
     let path: string;
-    if (parsed.data.nextLink !== undefined && parsed.data.nextLink !== "") {
-      const r = await graphRequest(token, parsed.data.nextLink);
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+    if (data.nextLink !== undefined && data.nextLink !== "") {
+      return mcpJsonResultIfOk("Graph", await graphRequest(token, data.nextLink), 200);
     }
-    const pageSize = parsed.data.pageSize ?? 50;
-    if (parsed.data.parentId !== undefined && parsed.data.parentId !== "") {
-      path = `/me/drive/items/${encodeURIComponent(parsed.data.parentId)}/children?$top=${String(pageSize)}`;
+    const pageSize = data.pageSize ?? 50;
+    if (data.parentId !== undefined && data.parentId !== "") {
+      path = `/me/drive/items/${encodeURIComponent(data.parentId)}/children?$top=${String(pageSize)}`;
     } else {
       path = `/me/drive/root/children?$top=${String(pageSize)}`;
     }
-    const r = await graphRequest(token, path);
-    if (!r.ok) {
-      throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Graph", await graphRequest(token, path), 200);
   },
 );
 
@@ -85,24 +74,14 @@ const onedriveItemGetArgs = z.object({
   itemId: z.string().min(1),
 });
 
-registerSimpleTool(
+reg(
   "onedrive_item_get",
   "Get OneDrive item metadata by id (file or folder).",
-  onedriveItemGetArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = onedriveItemGetArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  onedriveItemGetArgs,
+  async (data) => {
     const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-    const r = await graphRequest(
-      token,
-      `/me/drive/items/${encodeURIComponent(parsed.data.itemId)}`,
-    );
-    if (!r.ok) {
-      throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    const r = await graphRequest(token, `/me/drive/items/${encodeURIComponent(data.itemId)}`);
+    return mcpJsonResultIfOk("Graph", r, 200);
   },
 );
 
@@ -116,20 +95,16 @@ const onedriveItemDownloadArgs = z.object({
     .optional(),
 });
 
-registerSimpleTool(
+reg(
   "onedrive_item_download",
   "Download file content as base64 (capped by maxBytes, default 256 KiB). Folders are rejected.",
-  onedriveItemDownloadArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = onedriveItemDownloadArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  onedriveItemDownloadArgs,
+  async (data) => {
     const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-    const maxBytes = parsed.data.maxBytes ?? 256 * 1024;
+    const maxBytes = data.maxBytes ?? 256 * 1024;
     const meta = await graphRequest(
       token,
-      `/me/drive/items/${encodeURIComponent(parsed.data.itemId)}?$select=id,name,folder,file`,
+      `/me/drive/items/${encodeURIComponent(data.itemId)}?$select=id,name,folder,file`,
     );
     if (!meta.ok) {
       throw new Error(`Graph ${String(meta.status)}: ${meta.text.slice(0, 200)}`);
@@ -142,10 +117,9 @@ registerSimpleTool(
     if (folder !== undefined && folder !== null) {
       throw new Error("Item is a folder; download applies to files only");
     }
-    const res = await fetch(
-      `${GRAPH}/me/drive/items/${encodeURIComponent(parsed.data.itemId)}/content`,
-      { headers: { Authorization: `Bearer ${token}` } },
-    );
+    const res = await fetch(`${GRAPH}/me/drive/items/${encodeURIComponent(data.itemId)}/content`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
     const buf = await res.arrayBuffer();
     if (!res.ok) {
       const err = new TextDecoder().decode(buf);
@@ -155,7 +129,7 @@ registerSimpleTool(
     const slice = truncated ? buf.slice(0, maxBytes) : buf;
     const b64 = Buffer.from(slice).toString("base64");
     const out = {
-      itemId: parsed.data.itemId,
+      itemId: data.itemId,
       encoding: "base64" as const,
       truncated,
       byteLength: buf.byteLength,
@@ -172,29 +146,21 @@ const onedriveItemSearchArgs = z.object({
   nextLink: z.url().optional(),
 });
 
-registerSimpleTool(
+reg(
   "onedrive_item_search",
   "Search OneDrive under /me/drive/root/search.",
-  onedriveItemSearchArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = onedriveItemSearchArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  onedriveItemSearchArgs,
+  async (data) => {
     const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-    const pageSize = parsed.data.pageSize ?? 25;
+    const pageSize = data.pageSize ?? 25;
     let path: string;
-    if (parsed.data.nextLink !== undefined && parsed.data.nextLink !== "") {
-      path = parsed.data.nextLink;
+    if (data.nextLink !== undefined && data.nextLink !== "") {
+      path = data.nextLink;
     } else {
-      const escaped = parsed.data.query.replaceAll("'", "''");
+      const escaped = data.query.replaceAll("'", "''");
       path = `/me/drive/root/search(q='${escaped}')?$top=${String(pageSize)}`;
     }
-    const r = await graphRequest(token, path);
-    if (!r.ok) {
-      throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    return mcpJsonResultIfOk("Graph", await graphRequest(token, path), 200);
   },
 );
 
@@ -202,21 +168,15 @@ const onedriveItemDeleteArgs = z.object({
   itemId: z.string().min(1),
 });
 
-registerSimpleTool(
+reg(
   "onedrive_item_delete",
   "Permanently delete a OneDrive item. Requires Gateway HITL onedrive.delete.",
-  onedriveItemDeleteArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = onedriveItemDeleteArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  onedriveItemDeleteArgs,
+  async (data) => {
     const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-    const r = await graphRequest(
-      token,
-      `/me/drive/items/${encodeURIComponent(parsed.data.itemId)}`,
-      { method: "DELETE" },
-    );
+    const r = await graphRequest(token, `/me/drive/items/${encodeURIComponent(data.itemId)}`, {
+      method: "DELETE",
+    });
     if (!r.ok && r.status !== 204) {
       throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
     }
@@ -230,35 +190,24 @@ const onedriveItemMoveArgs = z.object({
   newName: z.string().min(1).max(500).optional(),
 });
 
-registerSimpleTool(
+reg(
   "onedrive_item_move",
   "Move (and optionally rename) a drive item. Requires Gateway HITL onedrive.move.",
-  onedriveItemMoveArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = onedriveItemMoveArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
+  onedriveItemMoveArgs,
+  async (data) => {
     const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
     const body: Record<string, unknown> = {
-      parentReference: { id: parsed.data.newParentId },
+      parentReference: { id: data.newParentId },
     };
-    if (parsed.data.newName !== undefined) {
-      body["name"] = parsed.data.newName;
+    if (data.newName !== undefined) {
+      body["name"] = data.newName;
     }
-    const r = await graphRequest(
-      token,
-      `/me/drive/items/${encodeURIComponent(parsed.data.itemId)}`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      },
-    );
-    if (!r.ok) {
-      throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-    }
-    return mcpJsonResult(r.json);
+    const r = await graphRequest(token, `/me/drive/items/${encodeURIComponent(data.itemId)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return mcpJsonResultIfOk("Graph", r, 200);
   },
 );
 

--- a/packages/mcp-connectors/outlook/src/server.ts
+++ b/packages/mcp-connectors/outlook/src/server.ts
@@ -13,8 +13,9 @@ import { z } from "zod";
 
 import {
   createRegisterSimpleTool,
-  type McpListResult,
+  createZodToolRegistrar,
   mcpJsonResult,
+  mcpJsonResultIfOk,
   requireProcessEnv,
 } from "../../shared/mcp-tool-kit.ts";
 import { makeRestFetcher } from "../../shared/rest-tool-kit.ts";
@@ -35,7 +36,7 @@ function graphRequest(
 
 const server = new McpServer({ name: "nimbus-outlook", version: "0.1.0" });
 
-const registerSimpleTool = createRegisterSimpleTool(server);
+const reg = createZodToolRegistrar(createRegisterSimpleTool(server));
 const grantedOutlookScopes = parseMicrosoftOAuthScopesFromEnv();
 
 const outlookMailFoldersArgs = z.object({
@@ -44,28 +45,20 @@ const outlookMailFoldersArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_mail_folders", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_mail_folders",
     "List mail folders (pagination via nextLink).",
-    outlookMailFoldersArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookMailFoldersArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookMailFoldersArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
       let path: string;
-      if (parsed.data.nextLink !== undefined && parsed.data.nextLink !== "") {
-        path = parsed.data.nextLink;
+      if (data.nextLink !== undefined && data.nextLink !== "") {
+        path = data.nextLink;
       } else {
-        const top = parsed.data.top ?? 50;
+        const top = data.top ?? 50;
         path = `/me/mailFolders?$top=${String(top)}`;
       }
-      const r = await graphRequest(token, path);
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+      return mcpJsonResultIfOk("Graph", await graphRequest(token, path), 200);
     },
   );
 }
@@ -79,26 +72,19 @@ const outlookMailListArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_mail_list", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_mail_list",
     "List mail messages (default folder inbox if folderId omitted). Pagination via nextLink.",
-    outlookMailListArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookMailListArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookMailListArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-      const top = parsed.data.top ?? 25;
+      const top = data.top ?? 25;
       let path: string;
-      if (parsed.data.nextLink !== undefined && parsed.data.nextLink !== "") {
-        path = parsed.data.nextLink;
+      if (data.nextLink !== undefined && data.nextLink !== "") {
+        path = data.nextLink;
       } else {
-        const fid =
-          parsed.data.folderId !== undefined && parsed.data.folderId !== ""
-            ? parsed.data.folderId
-            : "inbox";
-        const skip = parsed.data.skip ?? 0;
+        const fid = data.folderId !== undefined && data.folderId !== "" ? data.folderId : "inbox";
+        const skip = data.skip ?? 0;
         const u = new URL(`${GRAPH}/me/mailFolders/${encodeURIComponent(fid)}/messages`);
         u.searchParams.set("$top", String(top));
         u.searchParams.set("$skip", String(skip));
@@ -106,16 +92,12 @@ if (outlookToolShouldRegister("outlook_mail_list", grantedOutlookScopes)) {
           "$select",
           "id,subject,bodyPreview,receivedDateTime,lastModifiedDateTime,hasAttachments,webLink",
         );
-        if (parsed.data.filter !== undefined && parsed.data.filter !== "") {
-          u.searchParams.set("$filter", parsed.data.filter);
+        if (data.filter !== undefined && data.filter !== "") {
+          u.searchParams.set("$filter", data.filter);
         }
         path = `${u.pathname}${u.search}`;
       }
-      const r = await graphRequest(token, path);
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+      return mcpJsonResultIfOk("Graph", await graphRequest(token, path), 200);
     },
   );
 }
@@ -125,24 +107,17 @@ const outlookMailReadArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_mail_read", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_mail_read",
     "Read a single message (body, headers, attachments metadata).",
-    outlookMailReadArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookMailReadArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookMailReadArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
       const r = await graphRequest(
         token,
-        `/me/messages/${encodeURIComponent(parsed.data.messageId)}?$expand=attachments`,
+        `/me/messages/${encodeURIComponent(data.messageId)}?$expand=attachments`,
       );
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+      return mcpJsonResultIfOk("Graph", r, 200);
     },
   );
 }
@@ -156,32 +131,28 @@ const outlookMailSendArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_mail_send", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_mail_send",
     "Send an email via Microsoft Graph. Requires Gateway HITL email.send.",
-    outlookMailSendArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookMailSendArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookMailSendArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-      const toList = parsed.data.to
+      const toList = data.to
         .split(",")
         .map((s) => s.trim())
         .filter((s) => s.length > 0);
       const message: Record<string, unknown> = {
-        subject: parsed.data.subject,
+        subject: data.subject,
         body: {
-          contentType: (parsed.data.contentType ?? "text") === "html" ? "HTML" : "Text",
-          content: parsed.data.body,
+          contentType: (data.contentType ?? "text") === "html" ? "HTML" : "Text",
+          content: data.body,
         },
         toRecipients: toList.map((addr) => ({
           emailAddress: { address: addr },
         })),
       };
-      if (parsed.data.cc !== undefined && parsed.data.cc !== "") {
-        const ccList = parsed.data.cc
+      if (data.cc !== undefined && data.cc !== "") {
+        const ccList = data.cc
           .split(",")
           .map((s) => s.trim())
           .filter((s) => s.length > 0);
@@ -210,30 +181,22 @@ const outlookCalendarListArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_calendar_list", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_calendar_list",
     "List calendar events in a time window (ISO 8601 startDateTime / endDateTime).",
-    outlookCalendarListArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookCalendarListArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookCalendarListArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
       let path: string;
-      if (parsed.data.nextLink !== undefined && parsed.data.nextLink !== "") {
-        path = parsed.data.nextLink;
+      if (data.nextLink !== undefined && data.nextLink !== "") {
+        path = data.nextLink;
       } else {
-        const top = parsed.data.top ?? 50;
-        const s = encodeURIComponent(parsed.data.startDateTime);
-        const e = encodeURIComponent(parsed.data.endDateTime);
+        const top = data.top ?? 50;
+        const s = encodeURIComponent(data.startDateTime);
+        const e = encodeURIComponent(data.endDateTime);
         path = `/me/calendarView?startDateTime=${s}&endDateTime=${e}&$top=${String(top)}`;
       }
-      const r = await graphRequest(token, path);
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+      return mcpJsonResultIfOk("Graph", await graphRequest(token, path), 200);
     },
   );
 }
@@ -243,21 +206,14 @@ const outlookCalendarGetArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_calendar_get", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_calendar_get",
     "Get a single calendar event by id.",
-    outlookCalendarGetArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookCalendarGetArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookCalendarGetArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-      const r = await graphRequest(token, `/me/events/${encodeURIComponent(parsed.data.eventId)}`);
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+      const r = await graphRequest(token, `/me/events/${encodeURIComponent(data.eventId)}`);
+      return mcpJsonResultIfOk("Graph", r, 200);
     },
   );
 }
@@ -272,27 +228,23 @@ const outlookCalendarCreateArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_calendar_create", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_calendar_create",
     "Create a calendar event. Requires Gateway HITL calendar.event.create.",
-    outlookCalendarCreateArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookCalendarCreateArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookCalendarCreateArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-      const tz = parsed.data.timeZone ?? "UTC";
+      const tz = data.timeZone ?? "UTC";
       const body: Record<string, unknown> = {
-        subject: parsed.data.subject,
-        start: { dateTime: parsed.data.startDateTime, timeZone: tz },
-        end: { dateTime: parsed.data.endDateTime, timeZone: tz },
+        subject: data.subject,
+        start: { dateTime: data.startDateTime, timeZone: tz },
+        end: { dateTime: data.endDateTime, timeZone: tz },
       };
-      if (parsed.data.body !== undefined && parsed.data.body !== "") {
-        body["body"] = { contentType: "Text", content: parsed.data.body };
+      if (data.body !== undefined && data.body !== "") {
+        body["body"] = { contentType: "Text", content: data.body };
       }
-      if (parsed.data.attendees !== undefined && parsed.data.attendees !== "") {
-        const addrs = parsed.data.attendees
+      if (data.attendees !== undefined && data.attendees !== "") {
+        const addrs = data.attendees
           .split(",")
           .map((s) => s.trim())
           .filter((s) => s.length > 0);
@@ -306,10 +258,7 @@ if (outlookToolShouldRegister("outlook_calendar_create", grantedOutlookScopes)) 
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+      return mcpJsonResultIfOk("Graph", r, 200);
     },
   );
 }
@@ -319,17 +268,13 @@ const outlookCalendarDeleteArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_calendar_delete", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_calendar_delete",
     "Delete a calendar event. Requires Gateway HITL calendar.event.delete.",
-    outlookCalendarDeleteArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookCalendarDeleteArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookCalendarDeleteArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-      const r = await graphRequest(token, `/me/events/${encodeURIComponent(parsed.data.eventId)}`, {
+      const r = await graphRequest(token, `/me/events/${encodeURIComponent(data.eventId)}`, {
         method: "DELETE",
       });
       if (!r.ok && r.status !== 204) {
@@ -347,29 +292,21 @@ const outlookContactListArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_contact_list", grantedOutlookScopes)) {
-  registerSimpleTool(
+  reg(
     "outlook_contact_list",
     "List contacts from the default folder.",
-    outlookContactListArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookContactListArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
+    outlookContactListArgs,
+    async (data) => {
       const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
       let path: string;
-      if (parsed.data.nextLink !== undefined && parsed.data.nextLink !== "") {
-        path = parsed.data.nextLink;
+      if (data.nextLink !== undefined && data.nextLink !== "") {
+        path = data.nextLink;
       } else {
-        const top = parsed.data.top ?? 50;
-        const skip = parsed.data.skip ?? 0;
+        const top = data.top ?? 50;
+        const skip = data.skip ?? 0;
         path = `/me/contacts?$top=${String(top)}&$skip=${String(skip)}`;
       }
-      const r = await graphRequest(token, path);
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
+      return mcpJsonResultIfOk("Graph", await graphRequest(token, path), 200);
     },
   );
 }
@@ -379,26 +316,11 @@ const outlookContactGetArgs = z.object({
 });
 
 if (outlookToolShouldRegister("outlook_contact_get", grantedOutlookScopes)) {
-  registerSimpleTool(
-    "outlook_contact_get",
-    "Get a single contact by id.",
-    outlookContactGetArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = outlookContactGetArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
-      const r = await graphRequest(
-        token,
-        `/me/contacts/${encodeURIComponent(parsed.data.contactId)}`,
-      );
-      if (!r.ok) {
-        throw new Error(`Graph ${String(r.status)}: ${r.text.slice(0, 200)}`);
-      }
-      return mcpJsonResult(r.json);
-    },
-  );
+  reg("outlook_contact_get", "Get a single contact by id.", outlookContactGetArgs, async (data) => {
+    const token = requireProcessEnv("MICROSOFT_OAUTH_ACCESS_TOKEN");
+    const r = await graphRequest(token, `/me/contacts/${encodeURIComponent(data.contactId)}`);
+    return mcpJsonResultIfOk("Graph", r, 200);
+  });
 }
 
 await server.connect(new StdioServerTransport());

--- a/packages/mcp-connectors/protonmail/src/tools.ts
+++ b/packages/mcp-connectors/protonmail/src/tools.ts
@@ -1,10 +1,5 @@
-import { emailToolSchemas, viewEmailMessage } from "../../shared/imap-tool-kit.ts";
-import {
-  createRegisterSimpleTool,
-  type McpListResult,
-  mcpJsonResult,
-} from "../../shared/mcp-tool-kit.ts";
-import { clampLimit, formatAddress, type MailClient, type SmtpMailer } from "./mail-core.ts";
+import { registerEmailConnectorTools } from "../../shared/imap-tool-kit.ts";
+import { formatAddress, type MailClient, type SmtpMailer } from "./mail-core.ts";
 
 /**
  * Register the ProtonMail (Bridge) read tools + the SMTP send tool onto an MCP
@@ -16,93 +11,20 @@ export function registerProtonmailTools(
   client: MailClient,
   mailer: SmtpMailer,
 ): void {
-  const registerSimpleTool = createRegisterSimpleTool(server);
-  const { listArgs, getArgs, searchArgs, sendArgs } = emailToolSchemas;
-
-  registerSimpleTool(
-    "protonmail_list",
-    "List recent ProtonMail messages (via Bridge) — HEADERS + attachment METADATA + a short capped text preview ONLY. Returns subject, from, to/cc, date, message-id, attachment {filename,size,mimetype}, and a <=2000-char plain-text body preview. NEVER returns attachment bytes or the full message body.",
-    listArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = listArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const opts: { mailbox?: string; limit?: number } = {};
-      if (parsed.data.mailbox !== undefined) {
-        opts.mailbox = parsed.data.mailbox;
-      }
-      opts.limit = clampLimit(parsed.data.limit);
-      const items = await client.list(opts);
-      return mcpJsonResult({ items: items.map((m) => viewEmailMessage(m, formatAddress)) });
+  registerEmailConnectorTools({
+    server,
+    toolPrefix: "protonmail",
+    descriptions: {
+      list: "List recent ProtonMail messages (via Bridge) — HEADERS + attachment METADATA + a short capped text preview ONLY. Returns subject, from, to/cc, date, message-id, attachment {filename,size,mimetype}, and a <=2000-char plain-text body preview. NEVER returns attachment bytes or the full message body.",
+      get: "Fetch one ProtonMail message by uid — HEADERS + attachment METADATA + a short capped text preview ONLY. NEVER returns attachment bytes or the full message body.",
+      search:
+        "Substring search over message HEADERS (subject/from/to) — returns the same header + attachment-metadata + preview view as protonmail_list. Searches headers only; NEVER scans or returns document/body content beyond the capped preview.",
+      send: "Send a new email over the ProtonMail Bridge SMTP relay. Requires Gateway HITL email.send.",
     },
-  );
-
-  registerSimpleTool(
-    "protonmail_get",
-    "Fetch one ProtonMail message by uid — HEADERS + attachment METADATA + a short capped text preview ONLY. NEVER returns attachment bytes or the full message body.",
-    getArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = getArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const m = await client.get(parsed.data.uid, parsed.data.mailbox);
-      return mcpJsonResult(
-        m === null ? { item: null } : { item: viewEmailMessage(m, formatAddress) },
-      );
-    },
-  );
-
-  registerSimpleTool(
-    "protonmail_search",
-    "Substring search over message HEADERS (subject/from/to) — returns the same header + attachment-metadata + preview view as protonmail_list. Searches headers only; NEVER scans or returns document/body content beyond the capped preview.",
-    searchArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = searchArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const opts: { query: string; mailbox?: string; limit?: number } = {
-        query: parsed.data.query,
-        limit: clampLimit(parsed.data.limit),
-      };
-      if (parsed.data.mailbox !== undefined) {
-        opts.mailbox = parsed.data.mailbox;
-      }
-      const items = await client.search(opts);
-      return mcpJsonResult({ matches: items.map((m) => viewEmailMessage(m, formatAddress)) });
-    },
-  );
-
-  registerSimpleTool(
-    "protonmail_mail_send",
-    "Send a new email over the ProtonMail Bridge SMTP relay. Requires Gateway HITL email.send.",
-    sendArgs.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = sendArgs.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      const input: { to: string; subject: string; body: string; cc?: string; bcc?: string } = {
-        to: parsed.data.to,
-        subject: parsed.data.subject,
-        body: parsed.data.body,
-      };
-      if (parsed.data.cc !== undefined && parsed.data.cc !== "") {
-        input.cc = parsed.data.cc;
-      }
-      if (parsed.data.bcc !== undefined && parsed.data.bcc !== "") {
-        input.bcc = parsed.data.bcc;
-      }
-      const res = await mailer.send(input);
-      return mcpJsonResult({
-        messageId: res.messageId,
-        accepted: res.accepted,
-        rejected: res.rejected,
-      });
-    },
-  );
+    client,
+    mailer,
+    formatAddr: formatAddress,
+  });
 }
 
 /** Tool names exposed by this connector — for contract/introspection tests. */

--- a/packages/mcp-connectors/shared/imap-tool-kit.test.ts
+++ b/packages/mcp-connectors/shared/imap-tool-kit.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import {
   type EmailMessageMeta,
+  type EmailReadClient,
+  type EmailSendMailer,
   emailToolSchemas,
   envInt,
   previewFromParts,
+  registerEmailConnectorTools,
   viewEmailMessage,
 } from "./imap-tool-kit.ts";
 
@@ -285,5 +288,136 @@ describe("previewFromParts", () => {
     const m = new Map<string, Buffer>([["1", Buffer.from(longText)]]);
     const result = previewFromParts(m, "1");
     expect(result.length).toBeLessThanOrEqual(2000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerEmailConnectorTools
+// ---------------------------------------------------------------------------
+
+type RecordedTool = {
+  name: string;
+  description: string;
+  handler: (args: unknown) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+};
+
+function fakeServer(recorded: RecordedTool[]): { tool: (...args: never) => unknown } {
+  return {
+    tool: ((
+      name: string,
+      description: string,
+      _shape: unknown,
+      handler: RecordedTool["handler"],
+    ) => {
+      recorded.push({ name, description, handler });
+    }) as unknown as (...args: never) => unknown,
+  };
+}
+
+function stubMeta(uid: number): EmailMessageMeta {
+  return {
+    uid,
+    mailbox: "INBOX",
+    uidValidity: "1",
+    envelope: { subject: `s${uid}`, from: [{ address: "a@b.com" }] },
+    attachments: [],
+    preview: `p${uid}`,
+  };
+}
+
+describe("registerEmailConnectorTools", () => {
+  function setup(prefix: string) {
+    const recorded: RecordedTool[] = [];
+    const calls: { list: number; get: number; search: number; send: number } = {
+      list: 0,
+      get: 0,
+      search: 0,
+      send: 0,
+    };
+    const client: EmailReadClient = {
+      list: async () => {
+        calls.list += 1;
+        return [stubMeta(1)];
+      },
+      get: async (uid) => {
+        calls.get += 1;
+        return uid === 999 ? null : stubMeta(uid);
+      },
+      search: async () => {
+        calls.search += 1;
+        return [stubMeta(2)];
+      },
+    };
+    const mailer: EmailSendMailer = {
+      send: async () => {
+        calls.send += 1;
+        return { messageId: "<mid>", accepted: ["a@b.com"], rejected: [] };
+      },
+    };
+    registerEmailConnectorTools({
+      server: fakeServer(recorded),
+      toolPrefix: prefix,
+      descriptions: { list: "L", get: "G", search: "Se", send: "Sd" },
+      client,
+      mailer,
+      formatAddr: fmtAddr,
+    });
+    return { recorded, calls };
+  }
+
+  test("registers the 4 prefixed tools with the supplied descriptions", () => {
+    const { recorded } = setup("imap");
+    expect(recorded.map((r) => r.name)).toEqual([
+      "imap_list",
+      "imap_get",
+      "imap_search",
+      "imap_mail_send",
+    ]);
+    expect(recorded.map((r) => r.description)).toEqual(["L", "G", "Se", "Sd"]);
+  });
+
+  test("honours the toolPrefix", () => {
+    const { recorded } = setup("protonmail");
+    expect(recorded[0]!.name).toBe("protonmail_list");
+    expect(recorded[3]!.name).toBe("protonmail_mail_send");
+  });
+
+  test("list handler calls client.list and wraps items", async () => {
+    const { recorded, calls } = setup("imap");
+    const res = await recorded[0]!.handler({});
+    expect(calls.list).toBe(1);
+    const body = JSON.parse(res.content[0]!.text) as { items: unknown[] };
+    expect(body.items).toHaveLength(1);
+  });
+
+  test("get handler returns item:null when client.get returns null", async () => {
+    const { recorded } = setup("imap");
+    const res = await recorded[1]!.handler({ uid: 999 });
+    expect(JSON.parse(res.content[0]!.text)).toEqual({ item: null });
+  });
+
+  test("search handler calls client.search and wraps matches", async () => {
+    const { recorded, calls } = setup("imap");
+    const res = await recorded[2]!.handler({ query: "x" });
+    expect(calls.search).toBe(1);
+    const body = JSON.parse(res.content[0]!.text) as { matches: unknown[] };
+    expect(body.matches).toHaveLength(1);
+  });
+
+  test("send handler calls mailer.send and returns the result", async () => {
+    const { recorded, calls } = setup("imap");
+    const res = await recorded[3]!.handler({ to: "a@b.com", subject: "S", body: "B" });
+    expect(calls.send).toBe(1);
+    expect(JSON.parse(res.content[0]!.text)).toEqual({
+      messageId: "<mid>",
+      accepted: ["a@b.com"],
+      rejected: [],
+    });
+  });
+
+  test("handler throws on invalid args (zod message)", async () => {
+    const { recorded } = setup("imap");
+    await expect(recorded[0]!.handler({ limit: 0 })).rejects.toThrow();
+    await expect(recorded[1]!.handler({ uid: 0 })).rejects.toThrow();
   });
 });

--- a/packages/mcp-connectors/shared/imap-tool-kit.ts
+++ b/packages/mcp-connectors/shared/imap-tool-kit.ts
@@ -13,7 +13,8 @@
 
 import { z } from "zod";
 
-import { capPreview } from "./imap-mail-core.ts";
+import { capPreview, clampLimit } from "./imap-mail-core.ts";
+import { createRegisterSimpleTool, type McpListResult, mcpJsonResult } from "./mcp-tool-kit.ts";
 
 // ---------------------------------------------------------------------------
 // Shared Zod arg schemas (byte-identical across imap + protonmail tools.ts)
@@ -142,4 +143,135 @@ export function previewFromParts(parts: Map<string, Buffer> | undefined, partKey
     return "";
   }
   return capPreview(buf.toString("utf8"));
+}
+
+// ---------------------------------------------------------------------------
+// Shared tool-registration factory (imap + protonmail tools.ts — the 4 blocks)
+// ---------------------------------------------------------------------------
+
+/** Read surface the email tool factory depends on (imap's ImapClient / protonmail's MailClient both satisfy it). */
+export interface EmailReadClient {
+  list(options: { mailbox?: string; limit?: number }): Promise<EmailMessageMeta[]>;
+  get(uid: number, mailbox?: string): Promise<EmailMessageMeta | null>;
+  search(options: { query: string; mailbox?: string; limit?: number }): Promise<EmailMessageMeta[]>;
+}
+
+/** Send surface the email tool factory depends on (imap's/protonmail's SmtpMailer satisfy it). */
+export interface EmailSendMailer {
+  send(input: { to: string; subject: string; body: string; cc?: string; bcc?: string }): Promise<{
+    messageId: string | null;
+    accepted: readonly string[];
+    rejected: readonly string[];
+  }>;
+}
+
+/** The four tool descriptions, supplied verbatim by each connector. */
+export interface EmailToolDescriptions {
+  readonly list: string;
+  readonly get: string;
+  readonly search: string;
+  readonly send: string;
+}
+
+/**
+ * Register the 4 email tools (`<prefix>_list|_get|_search|_mail_send`) onto an
+ * MCP server. The IMAP client + SMTP mailer are injected so tests exercise the
+ * tool surface without opening sockets. Byte-equivalent to the hand-written
+ * `registerImapTools` / `registerProtonmailTools` bodies it replaces — the tool
+ * names (via `toolPrefix`) and descriptions are the only per-connector inputs.
+ */
+export function registerEmailConnectorTools(opts: {
+  server: { tool: (...args: never) => unknown };
+  toolPrefix: string;
+  descriptions: EmailToolDescriptions;
+  client: EmailReadClient;
+  mailer: EmailSendMailer;
+  formatAddr: (a: { readonly name?: string; readonly address?: string }) => string;
+}): void {
+  const { server, toolPrefix, descriptions, client, mailer, formatAddr } = opts;
+  const registerSimpleTool = createRegisterSimpleTool(server);
+  const { listArgs, getArgs, searchArgs, sendArgs } = emailToolSchemas;
+
+  registerSimpleTool(
+    `${toolPrefix}_list`,
+    descriptions.list,
+    listArgs.shape,
+    async (args: unknown): Promise<McpListResult> => {
+      const parsed = listArgs.safeParse(args);
+      if (!parsed.success) {
+        throw new Error(parsed.error.message);
+      }
+      const o: { mailbox?: string; limit?: number } = {};
+      if (parsed.data.mailbox !== undefined) {
+        o.mailbox = parsed.data.mailbox;
+      }
+      o.limit = clampLimit(parsed.data.limit);
+      const items = await client.list(o);
+      return mcpJsonResult({ items: items.map((m) => viewEmailMessage(m, formatAddr)) });
+    },
+  );
+
+  registerSimpleTool(
+    `${toolPrefix}_get`,
+    descriptions.get,
+    getArgs.shape,
+    async (args: unknown): Promise<McpListResult> => {
+      const parsed = getArgs.safeParse(args);
+      if (!parsed.success) {
+        throw new Error(parsed.error.message);
+      }
+      const m = await client.get(parsed.data.uid, parsed.data.mailbox);
+      return mcpJsonResult(m === null ? { item: null } : { item: viewEmailMessage(m, formatAddr) });
+    },
+  );
+
+  registerSimpleTool(
+    `${toolPrefix}_search`,
+    descriptions.search,
+    searchArgs.shape,
+    async (args: unknown): Promise<McpListResult> => {
+      const parsed = searchArgs.safeParse(args);
+      if (!parsed.success) {
+        throw new Error(parsed.error.message);
+      }
+      const o: { query: string; mailbox?: string; limit?: number } = {
+        query: parsed.data.query,
+        limit: clampLimit(parsed.data.limit),
+      };
+      if (parsed.data.mailbox !== undefined) {
+        o.mailbox = parsed.data.mailbox;
+      }
+      const items = await client.search(o);
+      return mcpJsonResult({ matches: items.map((m) => viewEmailMessage(m, formatAddr)) });
+    },
+  );
+
+  registerSimpleTool(
+    `${toolPrefix}_mail_send`,
+    descriptions.send,
+    sendArgs.shape,
+    async (args: unknown): Promise<McpListResult> => {
+      const parsed = sendArgs.safeParse(args);
+      if (!parsed.success) {
+        throw new Error(parsed.error.message);
+      }
+      const input: { to: string; subject: string; body: string; cc?: string; bcc?: string } = {
+        to: parsed.data.to,
+        subject: parsed.data.subject,
+        body: parsed.data.body,
+      };
+      if (parsed.data.cc !== undefined && parsed.data.cc !== "") {
+        input.cc = parsed.data.cc;
+      }
+      if (parsed.data.bcc !== undefined && parsed.data.bcc !== "") {
+        input.bcc = parsed.data.bcc;
+      }
+      const res = await mailer.send(input);
+      return mcpJsonResult({
+        messageId: res.messageId,
+        accepted: res.accepted,
+        rejected: res.rejected,
+      });
+    },
+  );
 }

--- a/packages/sdk/src/agents/guard-factory.test.ts
+++ b/packages/sdk/src/agents/guard-factory.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+
+import { createBriefGuard } from "./guard-factory.ts";
+
+describe("createBriefGuard", () => {
+  const base = { kind: "x", agentVersion: 1, generatedAt: 0, latencyMs: 0, gaps: [] };
+  const isX = createBriefGuard<unknown>("x", (b) => Array.isArray(b["items"]));
+  const isXq = createBriefGuard<unknown>("x", (b) => Array.isArray(b["items"]), {
+    requireQuery: true,
+  });
+
+  it("matches base shape + extra when requireQuery is off (no query needed)", () => {
+    expect(isX({ ...base, items: [] })).toBe(true);
+    expect(isX({ ...base, items: [], query: { a: 1 } })).toBe(true);
+  });
+
+  it("rejects wrong kind / version / non-array gaps / extra-fail", () => {
+    expect(isX({ ...base, kind: "y", items: [] })).toBe(false);
+    expect(isX({ ...base, agentVersion: 2, items: [] })).toBe(false);
+    expect(isX({ ...base, gaps: "no", items: [] })).toBe(false);
+    expect(isX({ ...base, items: "no" })).toBe(false);
+  });
+
+  it("rejects non-number generatedAt / latencyMs", () => {
+    expect(isX({ ...base, generatedAt: "0", items: [] })).toBe(false);
+    expect(isX({ ...base, latencyMs: null, items: [] })).toBe(false);
+  });
+
+  it("requires a non-null query object only when requireQuery is on", () => {
+    expect(isXq({ ...base, items: [] })).toBe(false);
+    expect(isXq({ ...base, items: [], query: null })).toBe(false);
+    expect(isXq({ ...base, items: [], query: { a: 1 } })).toBe(true);
+  });
+
+  it("rejects null / non-object inputs", () => {
+    expect(isX(null)).toBe(false);
+    expect(isX("s")).toBe(false);
+    expect(isX(42)).toBe(false);
+  });
+});

--- a/packages/sdk/src/agents/guard-factory.ts
+++ b/packages/sdk/src/agents/guard-factory.ts
@@ -1,0 +1,40 @@
+/**
+ * Build a discriminated-union runtime type guard for an agent brief.
+ *
+ * Every brief guard shares the same base shape check — `kind` matches,
+ * `agentVersion === 1`, `gaps` is an array, and `generatedAt`/`latencyMs` are
+ * numbers — plus a connector-supplied `extra` predicate for the brief-specific
+ * fields. Some guards additionally require a non-null `query` object; this is
+ * opt-in via `requireQuery` so each call site preserves its exact historical
+ * behavior (the cli expert/impact/catchup guards omit the query check; every
+ * gateway guard and the remaining cli guards include it).
+ *
+ * The factory exists to remove the byte-mechanical duplication of these guards
+ * across `cli/src/types/agents.ts` and `gateway/src/agents/_lib/findings.ts`.
+ */
+export function createBriefGuard<T>(
+  kind: string,
+  extra: (b: Record<string, unknown>) => boolean,
+  opts?: { requireQuery?: boolean },
+): (x: unknown) => x is T {
+  const requireQuery = opts?.requireQuery ?? false;
+  return (x: unknown): x is T => {
+    if (x === null || typeof x !== "object") {
+      return false;
+    }
+    const b = x as Record<string, unknown>;
+    if (
+      b["kind"] !== kind ||
+      b["agentVersion"] !== 1 ||
+      !Array.isArray(b["gaps"]) ||
+      typeof b["generatedAt"] !== "number" ||
+      typeof b["latencyMs"] !== "number"
+    ) {
+      return false;
+    }
+    if (requireQuery && (typeof b["query"] !== "object" || b["query"] === null)) {
+      return false;
+    }
+    return extra(b);
+  };
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,6 +19,7 @@ export type {
   JanitorPeerTouch,
   PreflightDownstream,
 } from "./agents/brief-types.ts";
+export { createBriefGuard } from "./agents/guard-factory";
 export type { AuditEmit, AuditLogger } from "./audit-logger";
 export { createScopedAuditLogger } from "./audit-logger";
 export {


### PR DESCRIPTION
## Summary

Wave-2 of the jscpd duplication-reduction program (follows #688). Pure extraction — **zero behavior change**: every existing connector/guard/sync test passes **UNEDITED**; each new shared helper got a co-located TDD test. No `.jscpd.json` ignore added.

**Strict `bunx jscpd packages`: 4.38% → 3.98%** (−440 dup-lines). CI duplication ratchet lowered **4.5% → 4.0%** to lock the gain (ci.yml runs the same strict `bunx jscpd packages` that reads `.jscpd.json`, so local == CI).

## Clusters

| # | Cluster | Extraction | Δ strict |
|---|---|---|---|
| C1 | agent-brief guards (`cli/types/agents.ts` ↔ `gateway/agents/_lib/findings.ts`) | `sdk` `createBriefGuard<T>(kind, extra, {requireQuery})` — `requireQuery` is **per-guard** so cli expert/impact/catchup keep their looser check and every gateway guard + the other cli guards keep the query check (exact behaviour preserved) | 4.38→4.32 |
| C2 | imap/protonmail `tools.ts` | `shared/imap-tool-kit.ts` `registerEmailConnectorTools` (4 tool blocks; descriptions passed verbatim per connector) | 4.32→4.26 |
| C3 | cloudwatch/sagemaker sync | `_lib/aws-cli.ts` `runAwsCliPaginatedWalk<S>` + `parseJson`/`awsNextToken`/`extractArray`; per-connector enrichment (`peekStreams`/`describeModel`) stays as the delegated `processEntry`, preserving the two-tier byte accounting + the sagemaker `MAX_DESCRIBE` cap + best-effort enrichment | 4.26→4.20 |
| C4 | gmail/outlook/onedrive `server.ts` | shared `createZodToolRegistrar` (kills the repeated `safeParse` guard) + `mcpJsonResultIfOk(label, r, 200)` (byte-identical error tail). Custom tails (outlook mail_send/calendar_delete, onedrive item_download/item_delete) kept hand-written | 4.20→4.05 |
| C5 | imap/protonmail email-mapping + sync | generic `mapImapLikeMessageToItem<S>` (imap-email-mapping.ts) + generic `runImapLikeSync<Cfg,Msg>` & `parsePortSecret` (`_lib/imap-sync-core.ts`) | 4.05→3.98 |

## Deferrals (recorded, verified — not force-fit)

- **C2 class-body merge** (`ImapFlowClient`/`BridgeImapClient`) + the imapflow-typed free funcs: `imapflow` is installed **per-connector** (not hoisted), and the 5 email connectors (gmail/outlook/teams/google-meet/google-photos) typecheck all of `shared/` but don't depend on imapflow — a shared imapflow import breaks their `tsc`. Confirms #688's documented deferral.
- **C3** athena (3-level nested walk) + the cloud-logging↔vertex-ai gcloud spawn boilerplate (different argv/region).
- **C5** fastmail's mapper (jmapId/receivedAt/name + different metadata) and the imap/protonmail `loadConfig` (different vault keys) — genuinely divergent.
- The `gateway-process` ↔ `gw-state-helpers` twin (documented un-dedupable) is untouched.

## Verification (all green before first push)

All-package `tsc` · biome (2863 files) · static invariant audit · `security-invariants` (83) · gateway-connectors (4046 tests, 0 fail) · sdk/mcp/cli touched suites · coverage-floor (only the documented false-local violations: ipc-transport/ipc/server/socket-listeners/telemetry/collector + the mcp-connector skip — no changed file below floor) · markdownlint · lychee · opus whole-branch review (no Critical/Important findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized brief-type validation used by CLI and gateway for consistent payload checks.
  * Simplified CloudWatch and SageMaker sync paging with shared AWS-CLI pagination helpers.
  * Reworked IMAP/ProtonMail sync and email mapping via shared core helpers.
  * Standardized MCP email tool registration (Gmail/Outlook/IMAP/ProtonMail) with consistent schema validation and Graph/API result handling.
* **Tests**
  * Added/expanded unit tests for shared guard, AWS CLI pagination, IMAP sync core, and connector tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->