### PR TITLE
ci(perf): retry the bench run once on a crashed (SIGSEGV) leg

### DIFF
--- a/.github/workflows/_perf.yml
+++ b/.github/workflows/_perf.yml
@@ -153,19 +153,47 @@ jobs:
           esac
           echo "id=${runner_id}" >> "$GITHUB_OUTPUT"
 
-      - name: Run bench
+      - name: Run bench (retry once on a crashed run)
         if: |
           matrix.os == 'ubuntu-24.04' ||
           github.event_name != 'schedule' ||
           github.event.schedule == '0 4 * * 0'
         shell: bash
+        # The whole bench is one long-lived `bun` process. On the shared GHA
+        # runners it intermittently dies with a SIGSEGV (exit 139) inside the
+        # `bun:sqlite` Worker / `dlopen(sqlite-vec.dylib)` path the S8/S10
+        # surfaces spawn — the same exit-139 class the quarantine-strip step
+        # above guards against, but the surviving residue is transient runtime
+        # jitter, not a deterministic dlopen block (run 27756789856 segfaulted on
+        # macos-15 at SHA 5613f7d3, yet that identical SHA re-ran green twice).
+        # A crashed run yields no measurement at all, so it is never a perf
+        # signal on any OS; retry once on a warm process. Attempt 2's exit code
+        # MUST propagate so two genuine failures still red the leg (no silent
+        # flake-hiding). Mirrors the retry-once shape in `_test-suite.yml` and
+        # `ci.yml`'s `pr-quality-cross-platform`.
         run: |
-          set -euo pipefail
+          set +e
           mkdir -p "${RUNNER_TEMP}/perf-fixtures"
-          bun packages/gateway/src/perf/bench-runner.ts \
-            --all --gha --runs 5 --corpus small \
-            --history "${RUNNER_TEMP}/run-history.jsonl" \
-            --fixture-cache "${RUNNER_TEMP}/perf-fixtures"
+          for attempt in 1 2; do
+            # Each attempt writes the single aggregate history line only on a
+            # clean finish (bench-cli.ts), and a SIGSEGV is uncatchable so it
+            # appends nothing — a retry starts from an empty history, no dupes.
+            : > "${RUNNER_TEMP}/run-history.jsonl"
+            bun packages/gateway/src/perf/bench-runner.ts \
+              --all --gha --runs 5 --corpus small \
+              --history "${RUNNER_TEMP}/run-history.jsonl" \
+              --fixture-cache "${RUNNER_TEMP}/perf-fixtures"
+            code=$?
+            if [ "$code" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "Both bench attempts failed with exit code $code"
+              exit "$code"
+            fi
+            echo "Bench attempt $attempt failed (exit $code), retrying in 5 s..."
+            sleep 5
+          done
 
       - name: Upload run history artifact
         if: |


### PR DESCRIPTION
## Problem

[Run 27756789856 → "Bench (macos-15)"](https://github.com/nimbus-agent/Nimbus/actions/runs/27756789856/job/82120564770) reddened `main` with the **Run bench** step exiting **139 (SIGSEGV)**.

The whole bench is one long-lived `bun packages/gateway/src/perf/bench-runner.ts` process. From the logs it cleared S1/S2 and the soft S4/S6 failures, then `Segmentation fault: 11` right after S7-b — heading into the **S8 embedding / S10 sqlite-contention** surfaces, i.e. the `bun:sqlite` Worker / `dlopen(sqlite-vec.dylib)` path the workflow already documents as the exit-139 culprit (the macOS quarantine-strip step).

That strip step **ran and succeeded**, so this is not the deterministic quarantine block. It is an **intermittent macOS-arm64 / Bun 1.3.14 runtime flake**: the *identical* SHA `5613f7d3` ran 3×, failing only here and passing on both subsequent reruns (runs `27816312729`, `27864726314`).

## Fix

Wrap the **Run bench** step in the repo's established **retry-once (exit-propagating)** shell pattern — the same shape used by `_test-suite.yml` and `ci.yml`'s `pr-quality-cross-platform`.

- A crashed bench produces no measurement, so retrying a warm process is never a perf signal on any OS.
- Attempt 2's exit code **propagates**, so two genuine failures still red the leg — no silent flake-hiding.
- No history-duplication risk: SIGSEGV is uncatchable (the `SIGINT`/`SIGTERM` incomplete-line handler can't fire) and the single aggregate history line is appended only on a clean finish (`bench-cli.ts`). The history file is also truncated before each attempt as a belt-and-braces guard.

## Verification

- YAML parses cleanly; no actionlint/yamllint gate in the repo.
- No test or structure-audit asserts the bench step's name/body (the `_perf.yml` references are `gh`-run-query filename constants only).
- Workflow-only change; no TypeScript touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved performance benchmark step reliability with automatic retry logic to handle transient failures gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->