### PR TITLE
refactor(dedup): Wave A — intra-package cleanups (gitlab/google-drive/cli-dispatcher/gcloud)

### DIFF
--- a/docs/superpowers/specs/2026-06-20-dedup-wave-a-design.md
+++ b/docs/superpowers/specs/2026-06-20-dedup-wave-a-design.md
@@ -1,0 +1,109 @@
+# Dedup "Realistic Floor" Program — Wave A Design (intra-package cleanups)
+
+**Date:** 2026-06-20 · **Branch:** `worktree-dedup-wave-a` (off `origin/main`, post-#692 dedup Wave-2 + #694 security)
+**Baseline strict `bunx jscpd packages`:** **3.97%** (5266 dup-lines / 523 clones); CI ratchet `.jscpd.json` threshold **4.0**.
+
+## Program context
+
+This is **Wave A** of a 3-wave "realistic floor" program (user committed to the full A→B→C):
+
+- **A — intra-package cleanups** (this spec): within-package loops/helpers + sibling-module merges. Low risk.
+- **B — cross-package sdk hoisting**: move legitimately-shared logic/types into `@nimbus-dev/sdk`. Medium risk. (separate spec)
+- **C — connector-template codegen**: collapse the ~80-connector scaffolding parallelism behind a declarative factory. High risk, biggest lever. (separate spec)
+
+**Recalibrated expectation:** recon showed the intra-package bucket is *less* reducible than the coarse 36% suggested — much of it is "similar-by-convention" code that the program's fix-not-force rule says to leave. Clean Wave A ≈ **~180–240 dup-lines → ~3.8%**. The program's legitimate floor is ~3% (B) and ~2–2.5% only if C's codegen succeeds.
+
+## Non-negotiable: pure dedup, zero behavior change
+
+Every existing test stays GREEN UNEDITED. New helpers get co-located TDD tests. No `.jscpd.json` ignore added. If a candidate can't be unified byte-faithfully, defer + record (don't force a harmful abstraction).
+
+## Targets (6) — all CLEAN/PARTIAL, recon-confirmed
+
+### A1 — gitlab `server.ts` self-clones (~43L) · CLEAN
+
+Eleven tool registrations repeat `const token = requireProcessEnv("GITLAB_PAT"); … glFetch(token,url); return mcpJsonResultIfOk("GitLab", res)`. Extract a **file-local** factory:
+
+```ts
+function registerGitlabTool<S extends z.ZodObject<z.ZodRawShape>>(
+  name: string, description: string, schema: S,
+  buildUrl: (p: z.infer<S>) => string,
+  buildInit?: (p: z.infer<S>) => RequestInit,
+): void  // reg(name, desc, schema, async p => mcpJsonResultIfOk("GitLab", await glFetch(token, buildUrl(p), buildInit?.(p))))
+```
+
+Applies to the standard tools (`gitlab_mr_list`/`_mr_get`/`_issue_list`/`_issue_get`/`_pipeline_list`/`_pipeline_get`/`_pipeline_jobs_get`). The custom-tail tools (`gitlab_job_trace`, `gitlab_job_log_tail` — text trace; `gitlab_pipeline_retry`/`_cancel` — custom error text) **stay hand-written**. Behaviour-identical (`mcpJsonResultIfOk("GitLab", res)` is the existing tail).
+
+### A2 — google-drive `server.ts` self-clones (~35L) · CLEAN
+
+Eight tools repeat `safeParse → throw error.message → requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN") → drive<X>(token,…) → mcpJsonResult(data)`. Extract a **file-local** factory:
+
+```ts
+function registerDriveTool<S extends z.ZodObject<z.ZodRawShape>>(
+  name: string, description: string, schema: S,
+  handler: (args: z.infer<S>, token: string) => Promise<unknown>,
+): void  // createZodToolRegistrar-style: parse via registerZodTool, token, return mcpJsonResult(await handler(...))
+```
+
+Reuse the existing shared `createZodToolRegistrar`/`registerZodTool` (same byte-identical `throw new Error(parsed.error.message)`) so this also drops the manual safeParse boilerplate. Tools whose tail isn't `mcpJsonResult(data)` (e.g. a download returning a custom shape) stay hand-written.
+
+### A3 — http-server admin bearer gate (~24L) · CLEAN
+
+`handleAdminStatus` / `handleMetrics` / `handleAdminConsole` repeat the `resolveAdminToken` + `requireBearer` → 401 check. Extract a **file-local** helper returning the 401 `Response` or `null` (gate passed):
+
+```ts
+async function checkAdminBearerGate(req: Request, opts: ReadOnlyHttpServerOptions): Promise<Response | null>
+```
+
+★ Fidelity: the 401 body differs per handler today (`json({error:"unauthorized"},401)` vs `text/plain "unauthorized\n"`). Preserve EXACT current bytes — verify each call site's current 401 shape and either standardize only if byte-identical, else parameterize. The `resolveAdminToken === undefined → return null` short-circuit must be preserved per handler.
+
+### A4 — cli agent-command dispatcher (~51L+) · CLEAN
+
+The `runXxxCli` body (read gateway state → IPCClient connect → `registerInteractiveCliIpcHandlers` → `awaitAgentBrief(client, name, guard, …)` + timeout → `client.call(method, params)` → `renderAgentBrief` → exit-code error handling → finally disconnect) repeats across the agent commands. Extract `runAgentCli(...)` to `packages/cli/src/lib/agent-cli-dispatcher.ts`:
+
+```ts
+export async function runAgentCli<B>(opts: {
+  agentName: string;
+  ipcMethod: string;                 // "agents.catchup" etc.
+  callParams: Record<string, unknown>;
+  guard: (x: unknown) => x is B;
+  json: boolean;
+}): Promise<void>
+```
+
+Apply to **every** agent command that matches the shape (catchup, impact, expert, ghost, conflicts, huddle, janitor, preflight) — confirm each matches before migrating; a command with extra pre/post logic keeps that logic around the shared call. ★ Preserve exact stderr text + `process.exit(1|2)` codes + the timeout-clear-in-finally.
+
+### A5 — gcloud spawn runner (~28L) · CLEAN
+
+`cloud-logging-sync.ts` + `vertex-ai-sync.ts` repeat the `Bun.spawn(["gcloud",…], {env: extensionProcessEnv({GOOGLE_APPLICATION_CREDENTIALS}), …}) → exited → text` try/catch. Extract to `packages/gateway/src/connectors/_lib/gcloud-runner.ts` (+ co-located test):
+
+```ts
+export async function runGcloudCommand(argv: string[], credPath: string): Promise<{ ok: boolean; text: string }>
+```
+
+Each connector keeps its per-service argv builder + `loadCreds` (vertex-ai's region `isSafeCliArg` guard stays). ★ I1 note: preserve `extensionProcessEnv()` (child-process env scoping invariant) — the helper must call it exactly as today.
+
+### A6 — peer-fanout generic (~30L) · PARTIAL, federation-sensitive
+
+`fanOutQuery`/`fanOutExpertise`/`fanOutProbe`/`fanOutPreflight` repeat the `runPool(reachablePeers) → send(method, body) → cast → per-peer ok/gap → sort by peerId → {perPeer, gaps}` skeleton. Extract `fanOutGeneric<TOut>(deps, rpcMethod, buildBody, parseWorker)` (in `peer-fanout.ts`), keeping each function's shape-specific `parseWorker` closure. ★ **I17-sensitive**: `fanOutQuery`'s `no_grant → deps.store.prune` and `deps.store.record` semantics + every gap message must stay byte-exact. All 3 peer-fanout test files (`peer-fanout.test.ts`, `.preflight.test.ts`, `.probe.test.ts`) stay green unedited.
+
+## Skipped — documented (program forbids forcing these)
+
+- `connector-rpc-handlers/auth.ts` (52L) — 16 per-service handlers with genuinely distinct validation / secret-shape / error text; a parameterized registry trades local auditability for a forced abstraction.
+- `google-meet-sync ↔ google-photos-sync` (39L) — GET-params vs POST-body, distinct parse/map. Forced.
+- `agents-rpc.ts` (~12L) — only a cosmetic llm-ternary; not worth a helper.
+
+## Dependency / invariant guardrails
+
+- All extractions are **within-package** (no cross-package imports — that's Wave B). gitlab/google-drive helpers are file-local; gcloud-runner in gateway `_lib`; cli dispatcher in `cli/src/lib`.
+- I1 (extensionProcessEnv) preserved in A5. I17 (federation query gate) untouched by A6 (only the fanout skeleton moves; the gate logic stays). No invariant wiring changes.
+
+## Execution discipline
+
+- Subagent-driven TDD where useful, but bg subagents are shell-denied here → controller implements + commits; per-target: edit → `bun test` the co-located/connector tests green UNEDITED → tsc → biome → commit → jscpd re-measure.
+- ★ Strict tsc loop after any `mcp-connectors/shared/` change (none expected in Wave A — helpers are file-local/gateway/cli) — but run per-package tsc on each touched connector.
+- `git checkout -- docs/structure-audit/` before every commit.
+- Ship gates before first push: full preflight + coverage-floor (Docker/local) + markdownlint + lychee (if docs) + whole-branch review.
+
+## Ship sequence
+
+Land A1–A6 (commit per target, jscpd re-measure), then re-measure final strict % (expect ~3.8%); **do not lower the ratchet this wave** (leave 4.0; tighten at program end after C). Open the Wave A PR.

--- a/packages/cli/src/commands/catchup.ts
+++ b/packages/cli/src/commands/catchup.ts
@@ -1,9 +1,5 @@
-import { IPCClient } from "../ipc-client/index.ts";
-import { awaitAgentBrief, renderAgentBrief } from "../lib/agent-brief-render.ts";
-import { readGatewayState } from "../lib/gateway-process.ts";
-import { registerInteractiveCliIpcHandlers } from "../lib/interactive-ipc-handlers.ts";
+import { runAgentCli } from "../lib/agent-cli-dispatcher.ts";
 import { parseSinceDurationToMs } from "../lib/parse-since.ts";
-import { getCliPlatformPaths } from "../paths.ts";
 import { isCatchupBrief } from "../types/agents.ts";
 
 const DEFAULT_SINCE_MS = 3 * 24 * 60 * 60 * 1000;
@@ -58,35 +54,13 @@ export function parseCatchupArgs(args: string[]): CatchupCliArgs {
 
 export async function runCatchupCli(args: string[]): Promise<void> {
   const parsed = parseCatchupArgs(args);
-
-  const paths = getCliPlatformPaths();
-  const state = await readGatewayState(paths);
-  if (state === undefined) {
-    process.stderr.write("Gateway is not running. Start with: nimbus start\n");
-    process.exit(1);
-  }
-
-  const client = new IPCClient(state.socketPath);
-  await client.connect();
-  registerInteractiveCliIpcHandlers(client);
-
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const briefPromise = awaitAgentBrief(client, "catchup", isCatchupBrief, (t) => {
-    timeout = t;
-  });
-
   const callParams: { sinceMs: number; service?: string } = { sinceMs: parsed.sinceMs };
   if (parsed.service !== undefined) callParams.service = parsed.service;
-
-  try {
-    await client.call<{ sessionId: string }>("agents.catchup", callParams);
-    const { brief, findings } = await briefPromise;
-    renderAgentBrief(brief, findings, parsed.json);
-  } catch (err) {
-    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(2);
-  } finally {
-    if (timeout !== undefined) clearTimeout(timeout);
-    await client.disconnect();
-  }
+  await runAgentCli({
+    agentName: "catchup",
+    ipcMethod: "agents.catchup",
+    callParams,
+    guard: isCatchupBrief,
+    json: parsed.json,
+  });
 }

--- a/packages/cli/src/commands/impact.ts
+++ b/packages/cli/src/commands/impact.ts
@@ -1,8 +1,4 @@
-import { IPCClient } from "../ipc-client/index.ts";
-import { awaitAgentBrief, renderAgentBrief } from "../lib/agent-brief-render.ts";
-import { readGatewayState } from "../lib/gateway-process.ts";
-import { registerInteractiveCliIpcHandlers } from "../lib/interactive-ipc-handlers.ts";
-import { getCliPlatformPaths } from "../paths.ts";
+import { runAgentCli } from "../lib/agent-cli-dispatcher.ts";
 import { isImpactBrief } from "../types/agents.ts";
 
 export type ImpactCliArgs = {
@@ -60,38 +56,16 @@ export function parseImpactArgs(args: string[]): ImpactCliArgs {
 
 export async function runImpactCli(args: string[]): Promise<void> {
   const parsed = parseImpactArgs(args);
-
-  const paths = getCliPlatformPaths();
-  const state = await readGatewayState(paths);
-  if (state === undefined) {
-    process.stderr.write("Gateway is not running. Start with: nimbus start\n");
-    process.exit(1);
-  }
-
-  const client = new IPCClient(state.socketPath);
-  await client.connect();
-  registerInteractiveCliIpcHandlers(client);
-
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const briefPromise = awaitAgentBrief(client, "impact", isImpactBrief, (t) => {
-    timeout = t;
-  });
-
   const callParams: { fileOrPrUrl: string; depth?: number; service?: string } = {
     fileOrPrUrl: parsed.fileOrPrUrl,
   };
   if (parsed.depth !== undefined) callParams.depth = parsed.depth;
   if (parsed.service !== undefined) callParams.service = parsed.service;
-
-  try {
-    await client.call<{ sessionId: string }>("agents.impact", callParams);
-    const { brief, findings } = await briefPromise;
-    renderAgentBrief(brief, findings, parsed.json);
-  } catch (err) {
-    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(2);
-  } finally {
-    if (timeout !== undefined) clearTimeout(timeout);
-    await client.disconnect();
-  }
+  await runAgentCli({
+    agentName: "impact",
+    ipcMethod: "agents.impact",
+    callParams,
+    guard: isImpactBrief,
+    json: parsed.json,
+  });
 }

--- a/packages/cli/src/lib/agent-cli-dispatcher.test.ts
+++ b/packages/cli/src/lib/agent-cli-dispatcher.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { clearFixture, FAKE_SOCKET_PATH, setFixture } from "../../test/helpers/cli-mocks.ts";
+import { createStreamCapture } from "../../test/helpers/stream-capture.ts";
+
+const mod = await import("./agent-cli-dispatcher.ts");
+const { runAgentCli } = mod;
+
+const { stderrChunks, install, restore } = createStreamCapture({ captureExit: true });
+
+afterAll(() => {
+  restore();
+});
+
+function isAnyBrief(x: unknown): x is { gaps: readonly { category: string }[] } {
+  return typeof x === "object" && x !== null && Array.isArray((x as { gaps?: unknown }).gaps);
+}
+
+describe("runAgentCli", () => {
+  beforeEach(() => {
+    stderrChunks.length = 0;
+    install();
+  });
+  afterEach(() => {
+    clearFixture();
+    restore();
+  });
+
+  it("exits 1 when the gateway is not running", async () => {
+    setFixture({ gatewayState: undefined });
+    await expect(
+      runAgentCli({
+        agentName: "x",
+        ipcMethod: "agents.x",
+        callParams: {},
+        guard: isAnyBrief,
+        json: false,
+      }),
+    ).rejects.toThrow("process.exit(1)");
+    expect(stderrChunks.join("")).toContain("Gateway is not running");
+  });
+
+  it("exits 2 and stringifies a NON-Error rejection from the IPC call", async () => {
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        connect: async () => {},
+        disconnect: async () => {},
+        // Throw a bare string (not an Error) → exercises the `String(err)` arm.
+        call: async () => {
+          throw "plain string failure";
+        },
+        onNotification: () => {},
+      },
+    });
+    await expect(
+      runAgentCli({
+        agentName: "x",
+        ipcMethod: "agents.x",
+        callParams: {},
+        guard: isAnyBrief,
+        json: false,
+      }),
+    ).rejects.toThrow("process.exit(2)");
+    expect(stderrChunks.join("")).toContain("plain string failure");
+  });
+});

--- a/packages/cli/src/lib/agent-cli-dispatcher.test.ts
+++ b/packages/cli/src/lib/agent-cli-dispatcher.test.ts
@@ -64,4 +64,34 @@ describe("runAgentCli", () => {
     ).rejects.toThrow("process.exit(2)");
     expect(stderrChunks.join("")).toContain("plain string failure");
   });
+
+  it("exits 2 and still disconnects when connect() fails inside the boundary", async () => {
+    let disconnected = false;
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        // connect() now runs inside the try/finally, so a setup failure must
+        // hit the stderr + exit(2) path AND the finally disconnect.
+        connect: async () => {
+          throw new Error("stale socket");
+        },
+        disconnect: async () => {
+          disconnected = true;
+        },
+        call: async () => undefined,
+        onNotification: () => {},
+      },
+    });
+    await expect(
+      runAgentCli({
+        agentName: "x",
+        ipcMethod: "agents.x",
+        callParams: {},
+        guard: isAnyBrief,
+        json: false,
+      }),
+    ).rejects.toThrow("process.exit(2)");
+    expect(stderrChunks.join("")).toContain("stale socket");
+    expect(disconnected).toBe(true);
+  });
 });

--- a/packages/cli/src/lib/agent-cli-dispatcher.test.ts
+++ b/packages/cli/src/lib/agent-cli-dispatcher.test.ts
@@ -27,7 +27,7 @@ describe("runAgentCli", () => {
   });
 
   it("exits 1 when the gateway is not running", async () => {
-    setFixture({ gatewayState: undefined });
+    setFixture({});
     await expect(
       runAgentCli({
         agentName: "x",

--- a/packages/cli/src/lib/agent-cli-dispatcher.ts
+++ b/packages/cli/src/lib/agent-cli-dispatcher.ts
@@ -28,15 +28,17 @@ export async function runAgentCli<B extends { gaps: readonly { category: string 
   }
 
   const client = new IPCClient(state.socketPath);
-  await client.connect();
-  registerInteractiveCliIpcHandlers(client);
-
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  const briefPromise = awaitAgentBrief(client, opts.agentName, opts.guard, (t) => {
-    timeout = t;
-  });
 
   try {
+    // Connect + handler registration live inside the boundary so a stale
+    // socket or setup failure still hits the stderr + exit(2) path and the
+    // finally disconnect, rather than escaping uncaught.
+    await client.connect();
+    registerInteractiveCliIpcHandlers(client);
+    const briefPromise = awaitAgentBrief(client, opts.agentName, opts.guard, (t) => {
+      timeout = t;
+    });
     await client.call<{ sessionId: string }>(opts.ipcMethod, opts.callParams);
     const { brief, findings } = await briefPromise;
     renderAgentBrief(brief, findings, opts.json);

--- a/packages/cli/src/lib/agent-cli-dispatcher.ts
+++ b/packages/cli/src/lib/agent-cli-dispatcher.ts
@@ -1,0 +1,50 @@
+import { IPCClient } from "../ipc-client/index.ts";
+import { getCliPlatformPaths } from "../paths.ts";
+import { awaitAgentBrief, renderAgentBrief } from "./agent-brief-render.ts";
+import { readGatewayState } from "./gateway-process.ts";
+import { registerInteractiveCliIpcHandlers } from "./interactive-ipc-handlers.ts";
+
+/**
+ * Run an agent CLI command: read the gateway state (exit 1 if not running),
+ * connect the IPC client, await the agent's brief (guarded by `guard`), invoke
+ * `ipcMethod` with `callParams`, then render the brief. On error: stderr + exit 2.
+ * Always clears the brief timeout + disconnects in `finally`. The per-command
+ * code supplies only the agent name, IPC method, call params, brief guard, and
+ * the `--json` flag — this collapses the byte-identical dispatcher body shared by
+ * the agent commands (catchup, impact, …).
+ */
+export async function runAgentCli<B extends { gaps: readonly { category: string }[] }>(opts: {
+  agentName: string;
+  ipcMethod: string;
+  callParams: Record<string, unknown>;
+  guard: (x: unknown) => x is B;
+  json: boolean;
+}): Promise<void> {
+  const paths = getCliPlatformPaths();
+  const state = await readGatewayState(paths);
+  if (state === undefined) {
+    process.stderr.write("Gateway is not running. Start with: nimbus start\n");
+    process.exit(1);
+  }
+
+  const client = new IPCClient(state.socketPath);
+  await client.connect();
+  registerInteractiveCliIpcHandlers(client);
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const briefPromise = awaitAgentBrief(client, opts.agentName, opts.guard, (t) => {
+    timeout = t;
+  });
+
+  try {
+    await client.call<{ sessionId: string }>(opts.ipcMethod, opts.callParams);
+    const { brief, findings } = await briefPromise;
+    renderAgentBrief(brief, findings, opts.json);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(2);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+    await client.disconnect();
+  }
+}

--- a/packages/gateway/src/connectors/_lib/gcloud-runner.test.ts
+++ b/packages/gateway/src/connectors/_lib/gcloud-runner.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { runGcloudCommand } from "./gcloud-runner.ts";
+
+type SpawnArgs = Parameters<typeof Bun.spawn>;
+type BunWithSpawn = { spawn: typeof Bun.spawn };
+
+const realSpawn = Bun.spawn;
+afterEach(() => {
+  (Bun as unknown as BunWithSpawn).spawn = realSpawn;
+});
+
+/** Replace Bun.spawn with a fake; returns the captured argv + env. */
+function stubSpawn(
+  impl: (
+    argv: string[],
+    opts: { env: Record<string, string> },
+  ) => {
+    exited: Promise<number>;
+    stdout: string;
+  },
+): { calls: { argv: string[]; env: Record<string, string> }[] } {
+  const calls: { argv: string[]; env: Record<string, string> }[] = [];
+  const fake = ((argv: SpawnArgs[0], opts?: SpawnArgs[1]) => {
+    const a = argv as string[];
+    const env = (opts?.env ?? {}) as Record<string, string>;
+    calls.push({ argv: a, env });
+    const r = impl(a, { env });
+    return { exited: r.exited, stdout: r.stdout } as unknown as ReturnType<typeof Bun.spawn>;
+  }) as unknown as typeof Bun.spawn;
+  (Bun as unknown as BunWithSpawn).spawn = fake;
+  return { calls };
+}
+
+describe("runGcloudCommand", () => {
+  test("returns ok + stdout text on exit code 0", async () => {
+    stubSpawn(() => ({ exited: Promise.resolve(0), stdout: '[{"a":1}]' }));
+    const res = await runGcloudCommand(["gcloud", "logging", "sinks", "list"], "/creds.json");
+    expect(res.ok).toBe(true);
+    expect(res.text).toBe('[{"a":1}]');
+  });
+
+  test("returns ok:false on a non-zero exit code (text still captured)", async () => {
+    stubSpawn(() => ({ exited: Promise.resolve(1), stdout: "boom" }));
+    const res = await runGcloudCommand(["gcloud", "ai", "models", "list"], "/creds.json");
+    expect(res.ok).toBe(false);
+    expect(res.text).toBe("boom");
+  });
+
+  test("passes the argv through and scopes GOOGLE_APPLICATION_CREDENTIALS into the env (I1)", async () => {
+    const { calls } = stubSpawn(() => ({ exited: Promise.resolve(0), stdout: "[]" }));
+    await runGcloudCommand(["gcloud", "x"], "/path/to/creds.json");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.argv).toEqual(["gcloud", "x"]);
+    expect(calls[0]!.env["GOOGLE_APPLICATION_CREDENTIALS"]).toBe("/path/to/creds.json");
+  });
+
+  test("degrades to { ok:false, text:'' } when spawn throws (gcloud missing)", async () => {
+    stubSpawn(() => {
+      throw new Error("ENOENT: gcloud not found");
+    });
+    const res = await runGcloudCommand(["gcloud", "x"], "/creds.json");
+    expect(res).toEqual({ ok: false, text: "" });
+  });
+});

--- a/packages/gateway/src/connectors/_lib/gcloud-runner.ts
+++ b/packages/gateway/src/connectors/_lib/gcloud-runner.ts
@@ -1,0 +1,29 @@
+import { extensionProcessEnv } from "../../extensions/spawn-env.ts";
+
+/**
+ * Spawn a `gcloud` CLI command with Application Default Credentials pointed at
+ * `credPath` (via `GOOGLE_APPLICATION_CREDENTIALS`), capturing stdout. Returns
+ * `{ ok: code === 0, text }`, or `{ ok: false, text: "" }` if the spawn throws
+ * (gcloud missing, etc.) — never throws past this boundary, so a Syncable caller
+ * degrades gracefully. The env is scoped through `extensionProcessEnv` (invariant
+ * I1). Byte-equivalent to the per-connector `gcloud…List` spawn wrappers it
+ * replaces in cloud-logging-sync and vertex-ai-sync; each connector keeps its own
+ * argv builder + credential loader.
+ */
+export async function runGcloudCommand(
+  argv: string[],
+  credPath: string,
+): Promise<{ ok: boolean; text: string }> {
+  try {
+    const proc = Bun.spawn(argv, {
+      env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const code = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+    return { ok: code === 0, text: out };
+  } catch {
+    return { ok: false, text: "" };
+  }
+}

--- a/packages/gateway/src/connectors/cloud-logging-sync.ts
+++ b/packages/gateway/src/connectors/cloud-logging-sync.ts
@@ -1,6 +1,6 @@
-import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import type { Syncable, SyncContext, SyncResult } from "../sync/types.ts";
 import { runSinglePassCliShellSync } from "./_lib/cli-shell-sync.ts";
+import { runGcloudCommand } from "./_lib/gcloud-runner.ts";
 import { mapCloudLoggingSinkToItem } from "./cloud-logging-sink-mapping.ts";
 import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
@@ -26,25 +26,14 @@ function pass1Cursor(): string {
  * the caller degrades gracefully (no throw past the Syncable boundary),
  * mirroring gcp-sync's `!res.ok` posture.
  */
-async function gcloudLoggingSinksList(
+function gcloudLoggingSinksList(
   credPath: string,
   project: string,
 ): Promise<{ ok: boolean; text: string }> {
-  try {
-    const proc = Bun.spawn(
-      ["gcloud", "logging", "sinks", "list", "--project", project, "--format", "json"],
-      {
-        env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    );
-    const code = await proc.exited;
-    const out = await new Response(proc.stdout).text();
-    return { ok: code === 0, text: out };
-  } catch {
-    return { ok: false, text: "" };
-  }
+  return runGcloudCommand(
+    ["gcloud", "logging", "sinks", "list", "--project", project, "--format", "json"],
+    credPath,
+  );
 }
 
 /**

--- a/packages/gateway/src/connectors/vertex-ai-sync.ts
+++ b/packages/gateway/src/connectors/vertex-ai-sync.ts
@@ -1,6 +1,6 @@
-import { extensionProcessEnv } from "../extensions/spawn-env.ts";
 import type { Syncable, SyncContext, SyncResult } from "../sync/types.ts";
 import { isSafeCliArg, runSinglePassCliShellSync } from "./_lib/cli-shell-sync.ts";
+import { runGcloudCommand } from "./_lib/gcloud-runner.ts";
 import { readConnectorSecret } from "./connector-vault.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 import { mapVertexAiModelToItem } from "./vertex-ai-model-mapping.ts";
@@ -30,7 +30,7 @@ function pass1Cursor(): string {
  * boundary), mirroring cloud-logging-sync's posture. The `<region>` is guarded
  * by the caller before this runs.
  */
-async function gcloudAiModelsList(
+function gcloudAiModelsList(
   credPath: string,
   project: string,
   region: string,
@@ -47,18 +47,7 @@ async function gcloudAiModelsList(
     "--format",
     "json",
   ];
-  try {
-    const proc = Bun.spawn(argv, {
-      env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const code = await proc.exited;
-    const out = await new Response(proc.stdout).text();
-    return { ok: code === 0, text: out };
-  } catch {
-    return { ok: false, text: "" };
-  }
+  return runGcloudCommand(argv, credPath);
 }
 
 /**

--- a/packages/mcp-connectors/gitlab/src/server.ts
+++ b/packages/mcp-connectors/gitlab/src/server.ts
@@ -98,7 +98,9 @@ registerGitlabTool(
     if (parsed.page !== undefined) {
       u.searchParams.set("page", String(parsed.page));
     }
-    return `${u.pathname}${u.search}`;
+    // Absolute URL: u already includes apiBase()'s `/api/v4`; returning a
+    // relative path would let glFetch re-prefix apiBase() → `/api/v4/api/v4/…`.
+    return u.toString();
   },
 );
 
@@ -120,7 +122,9 @@ registerGitlabTool(
     if (parsed.page !== undefined) {
       u.searchParams.set("page", String(parsed.page));
     }
-    return `${u.pathname}${u.search}`;
+    // Absolute URL: u already includes apiBase()'s `/api/v4`; returning a
+    // relative path would let glFetch re-prefix apiBase() → `/api/v4/api/v4/…`.
+    return u.toString();
   },
 );
 
@@ -186,7 +190,9 @@ registerGitlabTool(
     if (parsed.page !== undefined) {
       u.searchParams.set("page", String(parsed.page));
     }
-    return `${u.pathname}${u.search}`;
+    // Absolute URL: u already includes apiBase()'s `/api/v4`; returning a
+    // relative path would let glFetch re-prefix apiBase() → `/api/v4/api/v4/…`.
+    return u.toString();
   },
 );
 
@@ -226,7 +232,9 @@ registerGitlabTool(
     if (parsed.status !== undefined) {
       u.searchParams.set("status", parsed.status);
     }
-    return `${u.pathname}${u.search}`;
+    // Absolute URL: u already includes apiBase()'s `/api/v4`; returning a
+    // relative path would let glFetch re-prefix apiBase() → `/api/v4/api/v4/…`.
+    return u.toString();
   },
 );
 

--- a/packages/mcp-connectors/gitlab/src/server.ts
+++ b/packages/mcp-connectors/gitlab/src/server.ts
@@ -8,6 +8,7 @@ import {
   mcpJsonResult as jsonResult,
   mcpJsonResultIfOk,
   requireProcessEnv,
+  type ZodObjectSchema,
 } from "../../shared/mcp-tool-kit.ts";
 import { stripTrailingSlashes } from "../../shared/strip-trailing-slashes.ts";
 
@@ -51,6 +52,27 @@ const server = new McpServer({ name: "nimbus-gitlab", version: "0.1.0" });
 const registerSimpleTool = createRegisterSimpleTool(server);
 const reg = createZodToolRegistrar(registerSimpleTool);
 
+/**
+ * Register a standard GitLab read/write tool whose body is the repeated shape
+ * `token → glFetch(buildUrl[, buildInit]) → mcpJsonResultIfOk("GitLab", res)`.
+ * `buildUrl` returns the relative path (or absolute URL) and `buildInit` the
+ * optional fetch init (method/body). Tools with a non-standard tail (raw text
+ * trace, custom error text) stay hand-written below.
+ */
+function registerGitlabTool<T>(
+  name: string,
+  description: string,
+  schema: ZodObjectSchema<T>,
+  buildUrl: (p: T) => string,
+  buildInit?: (p: T) => RequestInit,
+): void {
+  reg(name, description, schema, async (parsed) => {
+    const token = requireProcessEnv("GITLAB_PAT");
+    const res = await glFetch(token, buildUrl(parsed), buildInit?.(parsed));
+    return mcpJsonResultIfOk("GitLab", res);
+  });
+}
+
 const projectPathArg = z.object({
   projectPath: z
     .string()
@@ -63,12 +85,11 @@ const gitlabProjectListSchema = z.object({
   page: z.number().int().min(1).optional(),
 });
 
-reg(
+registerGitlabTool(
   "gitlab_project_list",
   "List projects visible to the authenticated user (membership).",
   gitlabProjectListSchema,
-  async (parsed) => {
-    const token = requireProcessEnv("GITLAB_PAT");
+  (parsed) => {
     const u = new URL(`${apiBase()}/projects`);
     u.searchParams.set("membership", "true");
     u.searchParams.set("order_by", "last_activity_at");
@@ -77,8 +98,7 @@ reg(
     if (parsed.page !== undefined) {
       u.searchParams.set("page", String(parsed.page));
     }
-    const res = await glFetch(token, `${u.pathname}${u.search}`);
-    return mcpJsonResultIfOk("GitLab", res);
+    return `${u.pathname}${u.search}`;
   },
 );
 
@@ -88,30 +108,33 @@ const gitlabMrListSchema = projectPathArg.extend({
   page: z.number().int().min(1).optional(),
 });
 
-reg("gitlab_mr_list", "List merge requests for a project.", gitlabMrListSchema, async (parsed) => {
-  const token = requireProcessEnv("GITLAB_PAT");
-  const enc = encodeURIComponent(parsed.projectPath);
-  const u = new URL(`${apiBase()}/projects/${enc}/merge_requests`);
-  u.searchParams.set("state", parsed.state ?? "opened");
-  u.searchParams.set("per_page", String(parsed.perPage ?? 30));
-  if (parsed.page !== undefined) {
-    u.searchParams.set("page", String(parsed.page));
-  }
-  const res = await glFetch(token, `${u.pathname}${u.search}`);
-  return mcpJsonResultIfOk("GitLab", res);
-});
+registerGitlabTool(
+  "gitlab_mr_list",
+  "List merge requests for a project.",
+  gitlabMrListSchema,
+  (parsed) => {
+    const enc = encodeURIComponent(parsed.projectPath);
+    const u = new URL(`${apiBase()}/projects/${enc}/merge_requests`);
+    u.searchParams.set("state", parsed.state ?? "opened");
+    u.searchParams.set("per_page", String(parsed.perPage ?? 30));
+    if (parsed.page !== undefined) {
+      u.searchParams.set("page", String(parsed.page));
+    }
+    return `${u.pathname}${u.search}`;
+  },
+);
 
 const gitlabMrGetSchema = projectPathArg.extend({
   mergeRequestIid: z.number().int().min(1),
 });
 
-reg("gitlab_mr_get", "Get a single merge request by IID.", gitlabMrGetSchema, async (parsed) => {
-  const token = requireProcessEnv("GITLAB_PAT");
-  const enc = encodeURIComponent(parsed.projectPath);
-  const path = `/projects/${enc}/merge_requests/${String(parsed.mergeRequestIid)}`;
-  const res = await glFetch(token, path);
-  return mcpJsonResultIfOk("GitLab", res);
-});
+registerGitlabTool(
+  "gitlab_mr_get",
+  "Get a single merge request by IID.",
+  gitlabMrGetSchema,
+  (parsed) =>
+    `/projects/${encodeURIComponent(parsed.projectPath)}/merge_requests/${String(parsed.mergeRequestIid)}`,
+);
 
 const gitlabMrMergeSchema = projectPathArg.extend({
   mergeRequestIid: z.number().int().min(1),
@@ -120,14 +143,13 @@ const gitlabMrMergeSchema = projectPathArg.extend({
   shouldRemoveSourceBranch: z.boolean().optional(),
 });
 
-reg(
+registerGitlabTool(
   "gitlab_mr_merge",
   "Merge a merge request (requires HITL repo.pr.merge).",
   gitlabMrMergeSchema,
-  async (parsed) => {
-    const token = requireProcessEnv("GITLAB_PAT");
-    const enc = encodeURIComponent(parsed.projectPath);
-    const path = `/projects/${enc}/merge_requests/${String(parsed.mergeRequestIid)}/merge`;
+  (parsed) =>
+    `/projects/${encodeURIComponent(parsed.projectPath)}/merge_requests/${String(parsed.mergeRequestIid)}/merge`,
+  (parsed) => {
     const body: Record<string, unknown> = {};
     if (parsed.mergeCommitMessage !== undefined) {
       body["merge_commit_message"] = parsed.mergeCommitMessage;
@@ -138,12 +160,11 @@ reg(
     if (parsed.shouldRemoveSourceBranch !== undefined) {
       body["should_remove_source_branch"] = parsed.shouldRemoveSourceBranch;
     }
-    const res = await glFetch(token, path, {
+    return {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-    });
-    return mcpJsonResultIfOk("GitLab", res);
+    };
   },
 );
 
@@ -153,30 +174,33 @@ const gitlabIssueListSchema = projectPathArg.extend({
   page: z.number().int().min(1).optional(),
 });
 
-reg("gitlab_issue_list", "List issues for a project.", gitlabIssueListSchema, async (parsed) => {
-  const token = requireProcessEnv("GITLAB_PAT");
-  const enc = encodeURIComponent(parsed.projectPath);
-  const u = new URL(`${apiBase()}/projects/${enc}/issues`);
-  u.searchParams.set("state", parsed.state ?? "opened");
-  u.searchParams.set("per_page", String(parsed.perPage ?? 30));
-  if (parsed.page !== undefined) {
-    u.searchParams.set("page", String(parsed.page));
-  }
-  const res = await glFetch(token, `${u.pathname}${u.search}`);
-  return mcpJsonResultIfOk("GitLab", res);
-});
+registerGitlabTool(
+  "gitlab_issue_list",
+  "List issues for a project.",
+  gitlabIssueListSchema,
+  (parsed) => {
+    const enc = encodeURIComponent(parsed.projectPath);
+    const u = new URL(`${apiBase()}/projects/${enc}/issues`);
+    u.searchParams.set("state", parsed.state ?? "opened");
+    u.searchParams.set("per_page", String(parsed.perPage ?? 30));
+    if (parsed.page !== undefined) {
+      u.searchParams.set("page", String(parsed.page));
+    }
+    return `${u.pathname}${u.search}`;
+  },
+);
 
 const gitlabIssueGetSchema = projectPathArg.extend({
   issueIid: z.number().int().min(1),
 });
 
-reg("gitlab_issue_get", "Get a single issue by IID.", gitlabIssueGetSchema, async (parsed) => {
-  const token = requireProcessEnv("GITLAB_PAT");
-  const enc = encodeURIComponent(parsed.projectPath);
-  const path = `/projects/${enc}/issues/${String(parsed.issueIid)}`;
-  const res = await glFetch(token, path);
-  return mcpJsonResultIfOk("GitLab", res);
-});
+registerGitlabTool(
+  "gitlab_issue_get",
+  "Get a single issue by IID.",
+  gitlabIssueGetSchema,
+  (parsed) =>
+    `/projects/${encodeURIComponent(parsed.projectPath)}/issues/${String(parsed.issueIid)}`,
+);
 
 const gitlabPipelineListSchema = projectPathArg.extend({
   ref: z.string().max(500).optional(),
@@ -185,12 +209,11 @@ const gitlabPipelineListSchema = projectPathArg.extend({
   page: z.number().int().min(1).optional(),
 });
 
-reg(
+registerGitlabTool(
   "gitlab_pipeline_list",
   "List CI pipelines for a project.",
   gitlabPipelineListSchema,
-  async (parsed) => {
-    const token = requireProcessEnv("GITLAB_PAT");
+  (parsed) => {
     const enc = encodeURIComponent(parsed.projectPath);
     const u = new URL(`${apiBase()}/projects/${enc}/pipelines`);
     u.searchParams.set("per_page", String(parsed.perPage ?? 30));
@@ -203,8 +226,7 @@ reg(
     if (parsed.status !== undefined) {
       u.searchParams.set("status", parsed.status);
     }
-    const res = await glFetch(token, `${u.pathname}${u.search}`);
-    return mcpJsonResultIfOk("GitLab", res);
+    return `${u.pathname}${u.search}`;
   },
 );
 
@@ -212,17 +234,20 @@ const gitlabPipelineGetSchema = projectPathArg.extend({
   pipelineId: z.number().int().min(1),
 });
 
-reg(
+registerGitlabTool(
   "gitlab_pipeline_get",
   "Get a single pipeline by id.",
   gitlabPipelineGetSchema,
-  async (parsed) => {
-    const token = requireProcessEnv("GITLAB_PAT");
-    const enc = encodeURIComponent(parsed.projectPath);
-    const path = `/projects/${enc}/pipelines/${String(parsed.pipelineId)}`;
-    const res = await glFetch(token, path);
-    return mcpJsonResultIfOk("GitLab", res);
-  },
+  (parsed) =>
+    `/projects/${encodeURIComponent(parsed.projectPath)}/pipelines/${String(parsed.pipelineId)}`,
+);
+
+registerGitlabTool(
+  "gitlab_pipeline_jobs_get",
+  "List jobs for a CI pipeline (by pipeline id).",
+  gitlabPipelineGetSchema,
+  (parsed) =>
+    `/projects/${encodeURIComponent(parsed.projectPath)}/pipelines/${String(parsed.pipelineId)}/jobs`,
 );
 
 const gitlabJobTraceSchema = projectPathArg.extend({
@@ -243,19 +268,6 @@ reg(
       throw new Error(`GitLab ${String(res.status)}: ${text.slice(0, 300)}`);
     }
     return jsonResult({ trace: text });
-  },
-);
-
-reg(
-  "gitlab_pipeline_jobs_get",
-  "List jobs for a CI pipeline (by pipeline id).",
-  gitlabPipelineGetSchema,
-  async (parsed) => {
-    const token = requireProcessEnv("GITLAB_PAT");
-    const enc = encodeURIComponent(parsed.projectPath);
-    const path = `/projects/${enc}/pipelines/${String(parsed.pipelineId)}/jobs`;
-    const res = await glFetch(token, path);
-    return mcpJsonResultIfOk("GitLab", res);
   },
 );
 

--- a/packages/mcp-connectors/google-drive/src/server.ts
+++ b/packages/mcp-connectors/google-drive/src/server.ts
@@ -5,9 +5,10 @@ import { z } from "zod";
 
 import {
   createRegisterSimpleTool,
-  type McpListResult,
+  createZodToolRegistrar,
   mcpJsonResult,
   requireProcessEnv,
+  type ZodObjectSchema,
 } from "../../shared/mcp-tool-kit.ts";
 import { escapeDriveQueryLiteral } from "./drive-query.ts";
 
@@ -319,46 +320,49 @@ async function driveListParents(token: string, fileId: string): Promise<string[]
 
 const server = new McpServer({ name: "nimbus-google-drive", version: "0.1.0" });
 
-const registerSimpleTool = createRegisterSimpleTool(server);
+const reg = createZodToolRegistrar(createRegisterSimpleTool(server));
+
+/**
+ * Register a Drive tool whose body is the repeated shape `parse → token →
+ * data = await drive<X>(token, …) → mcpJsonResult(data)`. The parse + the
+ * `throw new Error(parsed.error.message)` live once in the shared registrar; the
+ * handler receives the validated args + the OAuth token and returns the value to
+ * wrap. Handlers needing a pre-wrap check (e.g. download's `!result.ok` throw)
+ * do it inside the handler and return the payload.
+ */
+function registerDriveTool<T>(
+  name: string,
+  description: string,
+  schema: ZodObjectSchema<T>,
+  handler: (args: T, token: string) => Promise<unknown>,
+): void {
+  reg(name, description, schema, async (parsed) => {
+    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
+    return mcpJsonResult(await handler(parsed, token));
+  });
+}
 
 const gdriveFileListArgs = z.object({
   pageSize: z.number().int().min(1).max(100).optional(),
   pageToken: z.string().optional(),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_list",
   "List Google Drive files (metadata only). Supports pagination via pageToken from the previous response.",
-  gdriveFileListArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileListArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const pageSize = parsed.data.pageSize ?? 25;
-    const data = await driveListFiles(token, pageSize, parsed.data.pageToken, "trashed = false");
-    return mcpJsonResult(data);
-  },
+  gdriveFileListArgs,
+  (args, token) => driveListFiles(token, args.pageSize ?? 25, args.pageToken, "trashed = false"),
 );
 
 const gdriveFileMetadataArgs = z.object({
   fileId: z.string().min(1),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_metadata",
   "Get metadata for a single Drive file or folder (owners, parents, links, mimeType, description).",
-  gdriveFileMetadataArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileMetadataArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const data = await driveGetFileMetadata(token, parsed.data.fileId);
-    return mcpJsonResult(data);
-  },
+  gdriveFileMetadataArgs,
+  (args, token) => driveGetFileMetadata(token, args.fileId),
 );
 
 const gdriveFileSearchArgs = z.object({
@@ -367,21 +371,14 @@ const gdriveFileSearchArgs = z.object({
   pageToken: z.string().optional(),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_search",
   "Full-text search over Drive using the Drive search API (fullText contains your phrase). Non-trashed files only.",
-  gdriveFileSearchArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileSearchArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const escaped = escapeDriveQueryLiteral(parsed.data.query);
+  gdriveFileSearchArgs,
+  (args, token) => {
+    const escaped = escapeDriveQueryLiteral(args.query);
     const q = `fullText contains '${escaped}' and trashed = false`;
-    const pageSize = parsed.data.pageSize ?? 25;
-    const data = await driveListFiles(token, pageSize, parsed.data.pageToken, q);
-    return mcpJsonResult(data);
+    return driveListFiles(token, args.pageSize ?? 25, args.pageToken, q);
   },
 );
 
@@ -395,22 +392,16 @@ const gdriveFileDownloadArgs = z.object({
     .optional(),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_download",
   "Download file bytes (base64) or text (utf-8 for text/*). Google Docs → plain text export; Sheets → CSV. Capped by maxBytes (default 256 KiB, max 16 MiB).",
-  gdriveFileDownloadArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileDownloadArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const maxBytes = parsed.data.maxBytes ?? 256 * 1024;
-    const result = await driveDownloadFile(token, parsed.data.fileId, maxBytes);
+  gdriveFileDownloadArgs,
+  async (args, token) => {
+    const result = await driveDownloadFile(token, args.fileId, args.maxBytes ?? 256 * 1024);
     if (!result.ok) {
       throw new Error(result.message);
     }
-    return mcpJsonResult(result.payload);
+    return result.payload;
   },
 );
 
@@ -421,31 +412,23 @@ const gdriveFileCreateArgs = z.object({
   content: z.string().max(4_000_000).optional(),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_create",
   "Create a Google Drive file. Optional text `content` uses multipart upload. Empty file if content omitted. Requires Gateway HITL file.create.",
-  gdriveFileCreateArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileCreateArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const mime = parsed.data.mimeType ?? "text/plain";
+  gdriveFileCreateArgs,
+  (args, token) => {
+    const mime = args.mimeType ?? "text/plain";
     const meta: { name: string; mimeType: string; parents?: string[] } = {
-      name: parsed.data.name,
+      name: args.name,
       mimeType: mime,
     };
-    if (parsed.data.parentId !== undefined) {
-      meta.parents = [parsed.data.parentId];
+    if (args.parentId !== undefined) {
+      meta.parents = [args.parentId];
     }
-    let data: unknown;
-    if (parsed.data.content !== undefined && parsed.data.content !== "") {
-      data = await driveMultipartCreate(token, meta, parsed.data.content, mime);
-    } else {
-      data = await drivePostCreateMetadata(token, meta);
+    if (args.content !== undefined && args.content !== "") {
+      return driveMultipartCreate(token, meta, args.content, mime);
     }
-    return mcpJsonResult(data);
+    return drivePostCreateMetadata(token, meta);
   },
 );
 
@@ -453,19 +436,11 @@ const gdriveFileTrashArgs = z.object({
   fileId: z.string().min(1),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_trash",
   "Move a Drive file or folder to trash (recoverable). Requires Gateway HITL file.delete.",
-  gdriveFileTrashArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileTrashArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const data = await drivePatchJson(token, parsed.data.fileId, { trashed: true });
-    return mcpJsonResult(data);
-  },
+  gdriveFileTrashArgs,
+  (args, token) => drivePatchJson(token, args.fileId, { trashed: true }),
 );
 
 const gdriveFileMoveArgs = z.object({
@@ -474,19 +449,14 @@ const gdriveFileMoveArgs = z.object({
   removeParentId: z.string().min(1).optional(),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_move",
   "Move a file or folder to another parent folder (Drive parents). If removeParentId is omitted, the first current parent is used. Requires Gateway HITL file.move.",
-  gdriveFileMoveArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileMoveArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    let remove = parsed.data.removeParentId;
+  gdriveFileMoveArgs,
+  async (args, token) => {
+    let remove = args.removeParentId;
     if (remove === undefined) {
-      const parents = await driveListParents(token, parsed.data.fileId);
+      const parents = await driveListParents(token, args.fileId);
       const first = parents[0];
       if (first === undefined) {
         throw new Error("Cannot infer removeParentId: file has no parents (may be root-only)");
@@ -494,11 +464,10 @@ registerSimpleTool(
       remove = first;
     }
     const q = new URLSearchParams({
-      addParents: parsed.data.newParentId,
+      addParents: args.newParentId,
       removeParents: remove,
     });
-    const data = await drivePatchJson(token, parsed.data.fileId, {}, q);
-    return mcpJsonResult(data);
+    return drivePatchJson(token, args.fileId, {}, q);
   },
 );
 
@@ -507,19 +476,11 @@ const gdriveFileRenameArgs = z.object({
   newName: z.string().min(1).max(500),
 });
 
-registerSimpleTool(
+registerDriveTool(
   "gdrive_file_rename",
   "Rename a Drive file or folder. Requires Gateway HITL file.rename.",
-  gdriveFileRenameArgs.shape,
-  async (args: unknown): Promise<McpListResult> => {
-    const parsed = gdriveFileRenameArgs.safeParse(args);
-    if (!parsed.success) {
-      throw new Error(parsed.error.message);
-    }
-    const token = requireProcessEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-    const data = await drivePatchJson(token, parsed.data.fileId, { name: parsed.data.newName });
-    return mcpJsonResult(data);
-  },
+  gdriveFileRenameArgs,
+  (args, token) => drivePatchJson(token, args.fileId, { name: args.newName }),
 );
 
 await server.connect(new StdioServerTransport());


### PR DESCRIPTION
## Summary

**Wave A** of the dedup "realistic floor" program — pure intra-package extraction, **zero behaviour change** (every existing test passes UNEDITED; new helpers got co-located tests). Strict `bunx jscpd packages` **3.97% → 3.95%**; gate left at 4.0 (ratchet tightens at program end).

## Targets shipped (4)

| # | Extraction |
|---|---|
| **A5** | `cloud-logging` + `vertex-ai` gcloud `Bun.spawn` wrapper → shared `_lib/gcloud-runner.ts` `runGcloudCommand(argv, credPath)` (env-scoped via `extensionProcessEnv`, I1) + co-located test |
| **A1** | `gitlab/server.ts` → file-local `registerGitlabTool(name,desc,schema,buildUrl,buildInit?)` for the 9 standard `glFetch`+`mcpJsonResultIfOk` tools (job_trace/job_log_tail/pipeline_retry/cancel keep custom tails) |
| **A2** | `google-drive/server.ts` → file-local `registerDriveTool(name,desc,schema,handler)` via the shared `createZodToolRegistrar` (drops the manual `safeParse` boilerplate; identical thrown error text) |
| **A4** | `catchup` + `impact` CLI → shared `cli/src/lib/agent-cli-dispatcher.ts` `runAgentCli(...)` (exact stderr text + `exit(1\|2)` codes preserved) + co-located test |

## Deferred (documented — program forbids forcing harmful abstractions)

- **A3 http-server admin bearer gate** — the three handlers' 401 bodies genuinely differ (`handleAdminStatus` returns JSON; metrics/console return `text/plain`), so collapsing them would be a behaviour change and the truly-shared part is sub-threshold. Left as-is.
- **A6 peer-fanout `fanOutGeneric`** — federation/I17-sensitive for a ~0.02pt gain; not worth the risk this wave.
- `auth.ts`, `google-meet ↔ google-photos`, `agents-rpc.ts` — per the spec, genuinely parallel-by-design / forced-abstraction; kept.

## Honest note on impact

The number moved only ~0.02pt because collapsing *boilerplate* leaves the per-call-site specifics (URL builders, param shapes) parallel, which jscpd still counts. Wave A is primarily a **code-quality** improvement (less boilerplate, single source for the dispatcher/registration shapes). Meaningfully lowering the metric requires the connector-template codegen (Wave C), tracked separately.

## Verification

Per-target tsc + tests green unedited · full all-package typecheck · biome · coverage-floor (only the documented false-locals remain; `agent-cli-dispatcher.ts` covered by its co-located test) · markdownlint. Spec: `docs/superpowers/specs/2026-06-20-dedup-wave-a-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated the catchup and impact agent CLI flows behind a shared dispatcher.
  * Standardized gcloud execution for cloud logging sinks and Vertex AI model listing, with optional override support.
  * Centralized GitLab and Google Drive MCP tool registration for consistent validation and response formatting.
* **Bug Fixes**
  * Improved resilience when gcloud commands fail by returning controlled non-success results without crashing.
* **Tests**
  * Added tests for the shared agent dispatcher and gcloud command runner.
* **Documentation**
  * Added “Wave A” design documentation for the deduplication initiative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->