### PR TITLE
fix(client): pin internal deps on publish so the tarball installs standalone

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -53,6 +53,36 @@ jobs:
         env:
           CI: "true"
 
+      # npm publish does NOT rewrite the workspace: protocol, so a published
+      # tarball that declares `@nimbus-dev/sdk: workspace:*` is uninstallable by
+      # any consumer outside this monorepo (`bun add @nimbus-dev/client` fails to
+      # resolve the workspace dep). Rewrite internal workspace deps to the
+      # concrete published sdk version before publishing. The committed
+      # package.json keeps `workspace:*` for local monorepo development; only the
+      # published tarball carries the concrete pin.
+      - name: Pin internal workspace deps to concrete versions
+        working-directory: packages/client
+        run: |
+          node -e '
+            const fs = require("fs");
+            let sdkVer;
+            try {
+              sdkVer = require("../sdk/package.json").version;
+            } catch (err) {
+              throw new Error("cannot read ../sdk/package.json: " + err.message);
+            }
+            if (typeof sdkVer !== "string" || !/^[0-9]+\.[0-9]+\.[0-9]+/.test(sdkVer)) {
+              throw new Error("@nimbus-dev/sdk version is missing or not semver: " + JSON.stringify(sdkVer));
+            }
+            const pkg = require("./package.json");
+            if (pkg.dependencies?.["@nimbus-dev/sdk"] === undefined) {
+              throw new Error("client package.json has no @nimbus-dev/sdk dependency to rewrite");
+            }
+            pkg.dependencies["@nimbus-dev/sdk"] = "^" + sdkVer;
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("rewritten @nimbus-dev/sdk ->", pkg.dependencies["@nimbus-dev/sdk"]);
+          '
+
       # Use `npm publish --provenance` (not `bun publish`) so the published tarball
       # carries an npm provenance attestation. Bun's publish does not yet emit one.
       #


### PR DESCRIPTION
## Problem

The published `@nimbus-dev/client@0.2.3` declares its internal dependency verbatim as `"@nimbus-dev/sdk": "workspace:*"`. `npm publish` (used by `publish-client.yml`) does **not** rewrite the `workspace:` protocol, so the tarball is **uninstallable by any consumer outside this monorepo**:

```text
$ bun add @nimbus-dev/client@0.2.3
error: @nimbus-dev/sdk@workspace:* failed to resolve   (exit 1)
```

The monorepo itself is unaffected (the workspace resolves `client`/`sdk` from source), which is why this went unnoticed — but it blocks any standalone consumer (notably the planned `nimbus-vscode` extraction, Phase 0).

## Fix

- `publish-client.yml`: add a step that rewrites internal `workspace:*` deps to the concrete published sdk version (`^<sdk_ver>`) immediately before `npm publish --provenance`. The **committed** `package.json` keeps `workspace:*` for local monorepo development; only the **published tarball** carries the concrete pin.
- Bump client to `0.2.4` (+ `.release-please-manifest.json` + `CHANGELOG.md`) for the fixed release.

## Verification

- Reproduced the failure and confirmed `sdk` is the only offending dep (`@nimbus-dev/sdk@1.1.2` has no runtime deps; `client` is the only broken package).
- `audit:release-please`, `audit:action-sha-pins`, and YAML parse all green locally.
- Rewrite logic dry-run: reads `packages/sdk/package.json` (1.1.2) → would set `@nimbus-dev/sdk: ^1.1.2`; source `package.json` still keeps `workspace:*`.

## Release note

This PR does **not** publish. After merge, the `client-v0.2.4` tag triggers `publish-client.yml`, which publishes the fixed tarball. (Client releases are normally release-please-driven; a root-level workflow change won't attribute to the `client` component, so this release is handled manually via the bump + tag — see the discussion in the extraction plan, PR #712.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.2.4

* **Bug Fixes**
  * Fixed dependency resolution issue to ensure the client package installs correctly in external projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->