### PR TITLE
fix(sonar): clear the board — S3776/S8786/S7735 sweep + warehouse-mapper dedup

### DIFF
--- a/packages/gateway/src/config/nimbus-toml-workday.ts
+++ b/packages/gateway/src/config/nimbus-toml-workday.ts
@@ -40,7 +40,7 @@ function finalizeReport(r: ReportAccum): WorkdayReport | null {
     ...(r.keyField === undefined || r.keyField === "" ? {} : { keyField: r.keyField }),
     // Preserve a present-but-empty `fields` (e.g. it parsed to []) so applyReportFieldPolicy
     // fails closed (emit nothing) instead of dropping to undefined and widening to the denylist.
-    ...(r.fields !== undefined ? { fields: r.fields } : {}),
+    ...(r.fields === undefined ? {} : { fields: r.fields }),
   };
 }
 
@@ -50,6 +50,12 @@ function parseMainSectionKv(key: string, valRaw: string, current: number): numbe
     if (Number.isFinite(n) && n > 0) return n;
   }
   return current;
+}
+
+function sectionForHeader(t: string): "main" | "report" | "other" {
+  if (t === "[connectors.workday]") return "main";
+  if (t === "[[connectors.workday.reports]]") return "report";
+  return "other";
 }
 
 function parseReportEntryKv(key: string, valRaw: string, cur: ReportAccum): void {
@@ -87,11 +93,8 @@ export function parseNimbusWorkdayToml(
     if (t === "") continue;
     if (isTableHeader(t)) {
       flush();
-      if (t === "[connectors.workday]") section = "main";
-      else if (t === "[[connectors.workday.reports]]") {
-        section = "report";
-        cur = {};
-      } else section = "other";
+      section = sectionForHeader(t);
+      if (section === "report") cur = {};
       continue;
     }
     const kv = splitKeyValue(t);

--- a/packages/gateway/src/connectors/athena-table-mapping.ts
+++ b/packages/gateway/src/connectors/athena-table-mapping.ts
@@ -1,5 +1,6 @@
 import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
+import { BODY_MAX, clamp, parseTimestampMs, TITLE_MAX } from "./warehouse-mapping-primitives.ts";
 
 export interface AthenaMappingContext {
   readonly catalog: string;
@@ -8,36 +9,6 @@ export interface AthenaMappingContext {
 }
 
 export type AthenaMappedRow = MappedRow<"athena", "table">;
-
-const TITLE_MAX = 256;
-const BODY_MAX = 512;
-
-/**
- * Athena `list-table-metadata` timestamps arrive as either ISO-8601 strings or
- * epoch SECONDS (the AWS CLI may render `CreateTime` as a unix-seconds number).
- * Parse defensively to unix MILLIS, else null. A bare number < 1e12 is treated
- * as seconds; a larger number is assumed to already be millis.
- */
-/** Normalise a finite epoch number to millis: a value < 1e12 is seconds. */
-function epochToMs(n: number): number {
-  return n < 1e12 ? Math.round(n * 1000) : Math.round(n);
-}
-
-function parseTimestampMs(v: unknown): number | null {
-  if (typeof v === "number" && Number.isFinite(v)) {
-    return epochToMs(v);
-  }
-  if (typeof v === "string" && v.trim() !== "") {
-    const trimmed = v.trim();
-    if (/^\d+(\.\d+)?$/.test(trimmed)) {
-      const n = Number(trimmed);
-      return Number.isFinite(n) ? epochToMs(n) : null;
-    }
-    const parsed = Date.parse(trimmed);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-}
 
 /**
  * Extract the column name/type pairs — SCHEMA metadata only, NO row/cell data.
@@ -65,10 +36,6 @@ function extractColumns(raw: unknown): Array<{ name: string; type: string }> {
 /** Partition keys mirror column shape (name + type). */
 function extractPartitionKeys(raw: unknown): Array<{ name: string; type: string }> {
   return extractColumns(raw);
-}
-
-function clamp(s: string, max: number): string {
-  return s.length > max ? `${s.slice(0, max)}…` : s;
 }
 
 /**

--- a/packages/gateway/src/connectors/cloudwatch-log-group-mapping.ts
+++ b/packages/gateway/src/connectors/cloudwatch-log-group-mapping.ts
@@ -1,5 +1,6 @@
 import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, numberField, stringField } from "./unknown-record.ts";
+import { BODY_MAX, clamp, parseTimestampMs, TITLE_MAX } from "./warehouse-mapping-primitives.ts";
 
 export interface CloudwatchMappingContext {
   readonly syncedAt: number;
@@ -10,40 +11,6 @@ export interface CloudwatchMappingContext {
 }
 
 export type CloudwatchMappedRow = MappedRow<"cloudwatch", "log_group">;
-
-const TITLE_MAX = 256;
-const BODY_MAX = 512;
-
-/**
- * CloudWatch Logs timestamps (`creationTime`, `lastEventTimestamp`) arrive as
- * epoch MILLIS numbers from the AWS CLI. Parse defensively to unix millis, else
- * null. A bare number < 1e12 is treated as seconds (defensive); larger numbers
- * are assumed to already be millis.
- */
-/** Normalise a finite epoch number to millis: a value < 1e12 is seconds. */
-function epochToMs(n: number): number {
-  return n < 1e12 ? Math.round(n * 1000) : Math.round(n);
-}
-
-function parseTimestampMs(v: unknown): number | null {
-  if (typeof v === "number" && Number.isFinite(v)) {
-    return epochToMs(v);
-  }
-  if (typeof v === "string" && v.trim() !== "") {
-    const trimmed = v.trim();
-    if (/^\d+(\.\d+)?$/.test(trimmed)) {
-      const n = Number(trimmed);
-      return Number.isFinite(n) ? epochToMs(n) : null;
-    }
-    const parsed = Date.parse(trimmed);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-}
-
-function clamp(s: string, max: number): string {
-  return s.length > max ? `${s.slice(0, max)}…` : s;
-}
 
 /**
  * Pure mapper: CloudWatch `describe-log-groups` entry → IndexedItem. Stores

--- a/packages/gateway/src/connectors/obsidian-parsing.ts
+++ b/packages/gateway/src/connectors/obsidian-parsing.ts
@@ -3,7 +3,10 @@ import yaml from "js-yaml";
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 const H1_RE = /^#\s+(\S.*)$/m;
-const WIKILINK_RE = /\[\[([^\]\n]+)\]\]/g;
+// Content excludes `[` (as well as `]`/newline) so the engine fails fast instead of
+// re-scanning `[`-heavy input from every position — keeps matching linear (S8786). A valid
+// Obsidian wikilink target never contains a bare `[`.
+const WIKILINK_RE = /\[\[([^[\]\n]+)\]\]/g;
 const DAILY_NOTE_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
 
 export type ParsedNote = {

--- a/packages/gateway/src/connectors/sagemaker-model-mapping.ts
+++ b/packages/gateway/src/connectors/sagemaker-model-mapping.ts
@@ -1,5 +1,6 @@
 import type { MappedRow } from "./mapped-row.ts";
 import { asRecord, stringField } from "./unknown-record.ts";
+import { BODY_MAX, clamp, parseTimestampMs, TITLE_MAX } from "./warehouse-mapping-primitives.ts";
 
 export interface SagemakerMappingContext {
   readonly syncedAt: number;
@@ -12,40 +13,6 @@ export interface SagemakerMappingContext {
 }
 
 export type SagemakerMappedRow = MappedRow<"sagemaker", "model">;
-
-const TITLE_MAX = 256;
-const BODY_MAX = 512;
-
-/**
- * SageMaker `CreationTime` arrives as either an ISO-8601 string or epoch SECONDS
- * (the AWS CLI may render it as a unix-seconds float). Parse defensively to unix
- * MILLIS, else null. A bare number < 1e12 is treated as seconds; a larger number
- * is assumed to already be millis.
- */
-/** Normalise a finite epoch number to millis: a value < 1e12 is seconds. */
-function epochToMs(n: number): number {
-  return n < 1e12 ? Math.round(n * 1000) : Math.round(n);
-}
-
-function parseTimestampMs(v: unknown): number | null {
-  if (typeof v === "number" && Number.isFinite(v)) {
-    return epochToMs(v);
-  }
-  if (typeof v === "string" && v.trim() !== "") {
-    const trimmed = v.trim();
-    if (/^\d+(\.\d+)?$/.test(trimmed)) {
-      const n = Number(trimmed);
-      return Number.isFinite(n) ? epochToMs(n) : null;
-    }
-    const parsed = Date.parse(trimmed);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-}
-
-function clamp(s: string, max: number): string {
-  return s.length > max ? `${s.slice(0, max)}…` : s;
-}
 
 /**
  * Pure mapper: SageMaker `list-models` entry → IndexedItem. Stores model-REGISTRY

--- a/packages/gateway/src/connectors/warehouse-mapping-primitives.test.ts
+++ b/packages/gateway/src/connectors/warehouse-mapping-primitives.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BODY_MAX,
+  clamp,
+  epochToMs,
+  parseTimestampMs,
+  TITLE_MAX,
+} from "./warehouse-mapping-primitives.ts";
+
+describe("warehouse-mapping-primitives", () => {
+  test("clamp constants are the shared title/body limits", () => {
+    expect(TITLE_MAX).toBe(256);
+    expect(BODY_MAX).toBe(512);
+  });
+
+  test("epochToMs treats < 1e12 as seconds and larger as millis", () => {
+    expect(epochToMs(1_700_000_000)).toBe(1_700_000_000_000);
+    expect(epochToMs(1_700_000_000_000)).toBe(1_700_000_000_000);
+    expect(epochToMs(1_700_000_000.5)).toBe(1_700_000_000_500);
+  });
+
+  describe("parseTimestampMs", () => {
+    test("finite epoch number (seconds) → millis", () => {
+      expect(parseTimestampMs(1_700_000_000)).toBe(1_700_000_000_000);
+    });
+
+    test("finite epoch number already in millis → unchanged", () => {
+      expect(parseTimestampMs(1_700_000_000_000)).toBe(1_700_000_000_000);
+    });
+
+    test("non-finite number → null", () => {
+      expect(parseTimestampMs(Number.NaN)).toBeNull();
+      expect(parseTimestampMs(Number.POSITIVE_INFINITY)).toBeNull();
+    });
+
+    test("bare numeric string → parsed as epoch", () => {
+      expect(parseTimestampMs("1700000000")).toBe(1_700_000_000_000);
+      expect(parseTimestampMs("1700000000.25")).toBe(1_700_000_000_250);
+    });
+
+    test("ISO-8601 string → Date.parse millis", () => {
+      expect(parseTimestampMs("2023-11-14T22:13:20.000Z")).toBe(
+        Date.parse("2023-11-14T22:13:20.000Z"),
+      );
+    });
+
+    test("unparseable string → null", () => {
+      expect(parseTimestampMs("not-a-date")).toBeNull();
+    });
+
+    test("empty / whitespace-only string → null", () => {
+      expect(parseTimestampMs("")).toBeNull();
+      expect(parseTimestampMs("   ")).toBeNull();
+    });
+
+    test("non-string, non-number input → null", () => {
+      expect(parseTimestampMs(undefined)).toBeNull();
+      expect(parseTimestampMs(null)).toBeNull();
+      expect(parseTimestampMs({})).toBeNull();
+    });
+  });
+
+  describe("clamp", () => {
+    test("returns the string unchanged when within the limit", () => {
+      expect(clamp("short", 10)).toBe("short");
+      expect(clamp("exactly-10", 10)).toBe("exactly-10");
+    });
+
+    test("truncates and appends an ellipsis when over the limit", () => {
+      expect(clamp("abcdef", 3)).toBe("abc…");
+    });
+  });
+});

--- a/packages/gateway/src/connectors/warehouse-mapping-primitives.ts
+++ b/packages/gateway/src/connectors/warehouse-mapping-primitives.ts
@@ -1,0 +1,41 @@
+// Shared, pure mapping primitives for the AWS warehouse/ML connector mappers
+// (Athena tables, SageMaker models, CloudWatch log groups). These connectors all
+// receive AWS-CLI-shaped metadata where timestamps arrive as either ISO-8601
+// strings or epoch numbers, and titles/bodies must be length-clamped. Kept in one
+// place so the three mappers don't each re-declare an identical copy.
+
+/** Max length for an item title before it is clamped with an ellipsis. */
+export const TITLE_MAX = 256;
+/** Max length for an item body preview before it is clamped with an ellipsis. */
+export const BODY_MAX = 512;
+
+/** Normalise a finite epoch number to millis: a value < 1e12 is treated as seconds. */
+export function epochToMs(n: number): number {
+  return n < 1e12 ? Math.round(n * 1000) : Math.round(n);
+}
+
+/**
+ * Parse an AWS-CLI timestamp to unix MILLIS, else null. Accepts a finite epoch
+ * number (seconds or millis, via {@link epochToMs}), a bare numeric string, or an
+ * ISO-8601 string. A bare number < 1e12 is treated as seconds; larger as millis.
+ */
+export function parseTimestampMs(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return epochToMs(v);
+  }
+  if (typeof v === "string" && v.trim() !== "") {
+    const trimmed = v.trim();
+    if (/^\d+(\.\d+)?$/.test(trimmed)) {
+      const n = Number(trimmed);
+      return Number.isFinite(n) ? epochToMs(n) : null;
+    }
+    const parsed = Date.parse(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/** Clamp a string to `max` chars, appending an ellipsis when truncated. */
+export function clamp(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}

--- a/packages/gateway/src/connectors/workday-sync.ts
+++ b/packages/gateway/src/connectors/workday-sync.ts
@@ -197,6 +197,73 @@ async function runDomain(args: WalkDomainArgs, domain: string): Promise<DomainRe
   }
 }
 
+interface RaasReportsArgs {
+  ctx: SyncContext;
+  reports: NimbusWorkdayToml["reports"];
+  tenantHost: string;
+  token: string;
+  fetchFn: FetchFn;
+  mapCtx: WorkdayMapContext;
+}
+
+// Fetch each configured RaaS report (one request per URL) under same-host egress enforcement,
+// upserting its rows. A skipped/failed report is logged+swallowed so one bad report does not abort
+// the rest. Extracted to keep `sync` under the cognitive-complexity budget (S3776).
+async function syncRaasReports(
+  args: RaasReportsArgs,
+): Promise<{ bytes: number; upserted: number }> {
+  const { ctx, reports, tenantHost, token, fetchFn, mapCtx } = args;
+  let bytes = 0;
+  let upserted = 0;
+  for (const report of reports) {
+    if (!sameTenantHost(report.url, tenantHost)) {
+      ctx.logger.warn(
+        { serviceId: SERVICE_ID, reportLabel: report.label, url: report.url },
+        "workday report url host does not match tenant host; skipping",
+      );
+      continue;
+    }
+    try {
+      await ctx.rateLimiter.acquire(SERVICE_ID);
+      const res = await fetchFn(report.url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const text = await res.text();
+      bytes += text.length;
+      if (!res.ok) {
+        ctx.logger.warn(
+          { serviceId: SERVICE_ID, reportLabel: report.label, status: res.status },
+          "workday report fetch failed; skipping",
+        );
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text) as unknown;
+      } catch {
+        ctx.logger.warn(
+          { serviceId: SERVICE_ID, reportLabel: report.label },
+          "workday report response is not valid JSON; skipping",
+        );
+        continue;
+      }
+      for (const row of reportRowsFrom(parsed)) {
+        const mapped = mapReportRowToItem(row, report, mapCtx);
+        if (mapped !== null) {
+          upsertIndexedItemForSync(ctx, mapped);
+          upserted += 1;
+        }
+      }
+    } catch (err) {
+      ctx.logger.warn(
+        { serviceId: SERVICE_ID, reportLabel: report.label, err },
+        "workday report fetch error; skipping",
+      );
+    }
+  }
+  return { bytes, upserted };
+}
+
 export type WorkdaySyncableOptions = {
   ensureWorkdayMcpRunning: () => Promise<void>;
   loadWorkdayConfig?: () => NimbusWorkdayToml;
@@ -306,52 +373,16 @@ export function createWorkdaySyncable(options: WorkdaySyncableOptions): Syncable
       }
 
       // RaaS reports: one fetch per report URL, same-host egress enforcement
-      for (const report of workdayConfig.reports) {
-        if (!sameTenantHost(report.url, effectiveTenantHost)) {
-          ctx.logger.warn(
-            { serviceId: SERVICE_ID, reportLabel: report.label, url: report.url },
-            "workday report url host does not match tenant host; skipping",
-          );
-          continue;
-        }
-        try {
-          await ctx.rateLimiter.acquire(SERVICE_ID);
-          const res = await fetchFn(report.url, {
-            headers: { Authorization: `Bearer ${accessToken}` },
-          });
-          const text = await res.text();
-          totalBytes += text.length;
-          if (!res.ok) {
-            ctx.logger.warn(
-              { serviceId: SERVICE_ID, reportLabel: report.label, status: res.status },
-              "workday report fetch failed; skipping",
-            );
-            continue;
-          }
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(text) as unknown;
-          } catch {
-            ctx.logger.warn(
-              { serviceId: SERVICE_ID, reportLabel: report.label },
-              "workday report response is not valid JSON; skipping",
-            );
-            continue;
-          }
-          for (const row of reportRowsFrom(parsed)) {
-            const mapped = mapReportRowToItem(row, report, mapCtx);
-            if (mapped !== null) {
-              upsertIndexedItemForSync(ctx, mapped);
-              totalUpserted += 1;
-            }
-          }
-        } catch (err) {
-          ctx.logger.warn(
-            { serviceId: SERVICE_ID, reportLabel: report.label, err },
-            "workday report fetch error; skipping",
-          );
-        }
-      }
+      const reports = await syncRaasReports({
+        ctx,
+        reports: workdayConfig.reports,
+        tenantHost: effectiveTenantHost,
+        token: accessToken,
+        fetchFn,
+        mapCtx,
+      });
+      totalBytes += reports.bytes;
+      totalUpserted += reports.upserted;
 
       const nextCursor = buildNextCursor(
         domainState.worker.offset,

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -541,6 +541,26 @@ function buildClipsSeam(writeDb: Database, opts: ReadOnlyHttpServerOptions) {
   };
 }
 
+// The deployment-annotation bearer token, or "" when that seam is unwired.
+async function resolveExpectedToken(opts: ReadOnlyHttpServerOptions): Promise<string> {
+  return opts.resolveDeploymentToken === undefined ? "" : await opts.resolveDeploymentToken();
+}
+
+// Lazily lists the configured service ids (empty when no config dir is wired).
+function resolveKnownServices(opts: ReadOnlyHttpServerOptions): () => readonly string[] {
+  const cfgDir = opts.configDir;
+  return cfgDir === undefined
+    ? (): readonly string[] => []
+    : (): readonly string[] => Array.from(loadNimbusServiceConfigsFromConfigDir(cfgDir).keys());
+}
+
+// The Teams events messaging surface, or undefined when that seam is unwired.
+async function resolveMessagingSurface(opts: ReadOnlyHttpServerOptions) {
+  return opts.resolveTeamsEventsSurface === undefined
+    ? undefined
+    : await opts.resolveTeamsEventsSurface();
+}
+
 // Assembles the full I13 dispatcher dependency set. Each write seam (deployment token, SCIM,
 // policy, messaging) is resolved independently — a gateway can enable any surface alone.
 async function resolveWriteRouteDeps(
@@ -548,26 +568,16 @@ async function resolveWriteRouteDeps(
   rateLimiter: HttpWriteRateLimiter,
   opts: ReadOnlyHttpServerOptions,
 ): Promise<WriteRouteDeps> {
-  const expectedToken =
-    opts.resolveDeploymentToken === undefined ? "" : await opts.resolveDeploymentToken();
-  const cfgDir = opts.configDir;
-  const knownServices =
-    cfgDir === undefined
-      ? (): readonly string[] => []
-      : (): readonly string[] => Array.from(loadNimbusServiceConfigsFromConfigDir(cfgDir).keys());
   const scim = await resolveScimWriteDeps(writeDb, opts);
   const policy = await resolvePolicyWriteDeps(opts);
-  const messaging =
-    opts.resolveTeamsEventsSurface === undefined
-      ? undefined
-      : await opts.resolveTeamsEventsSurface();
+  const messaging = await resolveMessagingSurface(opts);
   const clips = buildClipsSeam(writeDb, opts);
   return {
     writeDb,
-    expectedToken,
+    expectedToken: await resolveExpectedToken(opts),
     rateLimiter,
     nowMs: opts.nowMs ?? ((): number => Date.now()),
-    knownServices,
+    knownServices: resolveKnownServices(opts),
     ...(scim === undefined ? {} : { scim }),
     ...(policy === undefined ? {} : { policy }),
     ...(messaging === undefined ? {} : { messaging }),

--- a/packages/gateway/src/tribal/tribal-chat-capture.ts
+++ b/packages/gateway/src/tribal/tribal-chat-capture.ts
@@ -17,7 +17,9 @@ export function parseTribalCaptureCommand(text: string): ParsedTribalCaptureComm
     .replace(/<@[^<>]+>/g, " ")
     .replace(/@\w+/g, " ")
     .trim();
-  const m = /^tribal\s+capture\s+(\S+)(.*)$/i.exec(cleaned);
+  // `(\S+)(?:\s+(.*))?` keeps the cluster id and the optional remainder disjoint (separated by
+  // whitespace) rather than letting `\S+` and `.*` compete over the same chars (S8786 backtracking).
+  const m = /^tribal\s+capture\s+(\S+)(?:\s+(.*))?$/i.exec(cleaned);
   if (m === null) return undefined;
   const clusterId = m[1] ?? "";
   if (clusterId === "" || clusterId.startsWith("--")) return undefined;


### PR DESCRIPTION
## Summary

Takes the SonarCloud board to **zero open issues** (the gate was already PASSED — these 6 were advisory CODE_SMELLs) and trims duplication. No behavior changes; all extractions are behavior-preserving.

## Sonar smells cleared (6 → 0)

**S3776 — cognitive complexity:**
- `ipc/http-server.ts` — extract `resolveExpectedToken` / `resolveKnownServices` / `resolveMessagingSurface` from `resolveWriteRouteDeps` (17 → <15).
- `connectors/workday-sync.ts` — extract the RaaS-reports loop into `syncRaasReports` (19 → <15).
- `config/nimbus-toml-workday.ts` — extract `sectionForHeader` (16 → <15).

**S8786 — super-linear regex:**
- `connectors/obsidian-parsing.ts` — the wikilink content class now also excludes `[`, which is what Sonar flags (content overlapping the `[[` match-restart). Benchmarked: the old regex was genuinely **O(n²)** on `[`-heavy input (130→527→2125 ms at 20k/40k/80k); the new one is **O(n)** (0.08 ms at 160k). All existing wikilink tests unchanged — a valid Obsidian target never contains a bare `[`.
- `tribal/tribal-chat-capture.ts` — replace the `(\S+)(.*)` overlap with `(\S+)(?:\s+(.*))?`. Cluster-id and `--target` parsing are identical for the documented `tribal capture <id> [--target …]` format.

**S7735 — negated condition:**
- `config/nimbus-toml-workday.ts` — invert the `r.fields !== undefined` ternary.

## Duplication (jscpd 3.98% → 3.93%)

Extracted the byte-identical `epochToMs` / `parseTimestampMs` / `clamp` + `TITLE_MAX` / `BODY_MAX` from the three AWS warehouse mappers (athena / sagemaker / cloudwatch) into a shared `connectors/warehouse-mapping-primitives.ts`, with a branch-complete unit test. (The remaining ~3.9% is inherent connector boilerplate that needs codegen, not extraction.)

## Verification

- `tsc --noEmit` clean across all packages.
- Biome clean (`bunx biome check packages scripts`, 2918 files).
- Static structure/invariant audit clean; `audit:boundaries` / `audit:any` / `audit:exclusion-parity` / `audit:cross-platform` clean.
- All affected tests pass (workday-sync, nimbus-toml-workday, tribal-chat-capture, obsidian, http-server, 3 warehouse mappers + syncs, new primitives test).
- All changed/new files pass the per-file coverage floor (new primitives file: 100% line / 94% branch).
- Independent code review confirmed every change behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test suite validating shared mapping utilities for warehouse and ML connectors.

* **Bug Fixes**
  * Tightened Obsidian wikilink parsing to reject invalid characters.
  * Improved Tribal chat command parsing for cluster ID extraction.

* **Refactor**
  * Consolidated shared mapping utilities (timestamp parsing, field clamping) used across AWS connectors.
  * Reorganized Workday report syncing logic into dedicated handler.
  * Simplified HTTP server dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->