### PR TITLE
chore(release): combine component release PRs to stop manifest conflicts

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "a80a81378916457d42d9bb3c76b13f5efee98e53",
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "include-component-in-tag": true,
   "plugins": ["node-workspace"],
   "packages": {


### PR DESCRIPTION
## Problem

PRs like #744 (sdk) and #746 (nimbus) conflict **every time** more than one component release is in flight at once.

**Root cause:** release-please manifest mode stores all component versions in a single shared `.release-please-manifest.json`:

```json
{ ".": "0.18.0", "packages/client": "0.2.6", "packages/sdk": "1.2.0" }
```

With `separate-pull-requests: true`, each component (nimbus / client / sdk) opens its own release PR — but all of them edit that one manifest. release-please only rewrites a component's PR branch when *that* component gets new commits. So when the client release (`0.2.5 → 0.2.6`) merged to main, it did **not** refresh #744/#746, which kept a stale `packages/client: 0.2.5` line and now conflict with main's `0.2.6`.

| | `.` | `packages/client` | `packages/sdk` |
|---|---|---|---|
| main | 0.18.0 | **0.2.6** | 1.2.0 |
| #744 (sdk) | 0.18.0 | **0.2.5** | 1.2.1 |
| #746 (nimbus) | 0.18.1 | **0.2.5** | 1.2.0 |

## Fix

Set `separate-pull-requests: false`. When multiple components are pending simultaneously they land in **one** combined release PR that edits the manifest exactly once → no inter-PR conflicts. A single pending component still produces a single PR, and merging still cuts **separate git tags + GitHub releases per component** (`include-component-in-tag` unchanged).

## Effect on the current jam

Once this merges, the next release-please run will **supersede the conflicting #744 and #746 with one combined release PR** (nimbus 0.18.1 + sdk 1.2.1) — no hand-merging of release branches needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)