### PR TITLE
fix(release): reconcile step never detected a missing tag (gh writes 422 to stdout)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,11 +93,33 @@ jobs:
             # (This is why v0.27.0 sat unreleased.) So: assign ONLY on a zero exit,
             # and additionally require the value to look like a commit sha, so no
             # future error-body shape can impersonate a resolved tag.
+            # Three outcomes must stay distinct — collapsing them is what broke this
+            # step in the first place:
+            #   exit 0            -> the tag resolves; compare it to the merge commit
+            #   HTTP 404 or 422   -> genuinely absent; this is the phantom, so create it
+            #   anything else     -> auth / rate-limit / network: we CANNOT tell whether
+            #                        the tag exists, so fail loudly instead of guessing
+            #                        (creating a tag on a bad read is unrecoverable).
+            # NOTE: a missing ref on the commits endpoint returns **422** ("No commit
+            # found for SHA"), not 404 — verified live. Treating only 404 as absent
+            # would make every real phantom fatal and defeat the recovery entirely.
+            set +e
+            out=$(gh api "repos/${REPO}/commits/${tag}" --jq '.sha' 2>&1)
+            rc=$?
+            set -e
             existing=""
-            if out=$(gh api "repos/${REPO}/commits/${tag}" --jq '.sha' 2>/dev/null); then
+            if [ "$rc" -eq 0 ]; then
               existing="$out"
+              if ! [[ "$existing" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error::${tag} lookup returned a non-sha payload: ${out}"
+                exit 1
+              fi
+            elif grep -qE '\(HTTP (404|422)\)' <<<"$out"; then
+              existing=""
+            else
+              echo "::error::${tag} lookup failed and it is NOT a missing-tag response — refusing to guess: ${out}"
+              exit 1
             fi
-            [[ "$existing" =~ ^[0-9a-f]{40}$ ]] || existing=""
             if [ -z "$existing" ]; then
               echo "Phantom detected: PR #${num} merged as ${ver} but ${tag} is missing. Creating it."
               gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${tag}" -f sha="${sha}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,7 +84,20 @@ jobs:
             tag="v${ver}"
             # Resolve the tag to its COMMIT (the commits endpoint dereferences both
             # lightweight and annotated tags); empty => the tag does not exist.
-            existing=$(gh api "repos/${REPO}/commits/${tag}" --jq '.sha' 2>/dev/null || true)
+            #
+            # `gh` writes its JSON error body to STDOUT, not stderr, so a missing tag
+            # returns exit 1 AND prints {"message":"No commit found for SHA: vX.Y.Z",
+            # "status":"422"}. Capturing that with `$(... || true)` leaves `existing`
+            # NON-empty, which silently defeated the `-z` check below: every phantom
+            # fell through to the "points elsewhere" branch and was never tagged.
+            # (This is why v0.27.0 sat unreleased.) So: assign ONLY on a zero exit,
+            # and additionally require the value to look like a commit sha, so no
+            # future error-body shape can impersonate a resolved tag.
+            existing=""
+            if out=$(gh api "repos/${REPO}/commits/${tag}" --jq '.sha' 2>/dev/null); then
+              existing="$out"
+            fi
+            [[ "$existing" =~ ^[0-9a-f]{40}$ ]] || existing=""
             if [ -z "$existing" ]; then
               echo "Phantom detected: PR #${num} merged as ${ver} but ${tag} is missing. Creating it."
               gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${tag}" -f sha="${sha}"


### PR DESCRIPTION
The phantom-release guard added in #824 has been a **silent no-op since it shipped**. `v0.27.0` has been unreleased since 2026-07-24 as a direct result.

## The bug

```bash
existing=$(gh api "repos/$REPO/commits/$tag" --jq ".sha" 2>/dev/null || true)
```

`gh` writes its JSON error body to **stdout**, not stderr. On a missing tag it exits 1 *and* prints the 422 body — so `$existing` is non-empty, the `[ -z "$existing" ]` → "create the tag" branch never runs, and control falls to the "tag points elsewhere" guard, which `continue`s.

The live warning quotes the raw error JSON where a commit sha belongs:

```
::warning::v0.27.0 exists but points at {"message":"No commit found for SHA: v0.27.0",
...,"status":"422"}, not PR #827's merge commit 1e0b98df; not relabelling — needs manual review.
```

(run `30105358184`). #824 was already live when #827 merged, so the recovery ran and did nothing.

## The fix

Assign only on a zero exit, and require the result to look like a commit sha so no future error-body shape can impersonate a resolved tag.

## Verification (against live state, read-only)

| | old capture | fixed capture |
| --- | --- | --- |
| missing tag `v0.27.0` | `{"message":"No commit found...}` → wrong branch | `""` → **`WOULD CREATE: v0.27.0 at 1e0b98df for PR #827`** |
| existing tag `v0.26.0` | resolves | resolves to `8b8b877b…` — points-elsewhere guard still works |

Also `bash -n` clean, and the non-match path verified safe under `set -euo pipefail`.

## Follow-up

This does not itself tag `v0.27.0` — the pipeline stays stuck until either this merges and the next `release-please` run reconciles it, or the manual playbook is run:

```bash
git tag v0.27.0 1e0b98df && git push origin v0.27.0
gh pr edit 827 --add-label "autorelease: tagged" --remove-label "autorelease: pending"
```

Found by the new `audit:release-staleness` gate on its first live run (see the P2 Release Train PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release recovery when a version tag is missing.
  * Ensured phantom releases are correctly created and pending release items are relabeled after recovery.
  * Prevented API error responses from being misinterpreted as valid tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->