### PR TITLE
fix(security)!: clear all high advisories (react-router v8, postcss, brace-expansion) + scope cla.yml permissions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,11 +6,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Least privilege at the workflow level: every job starts read-only. The single
+# `cla` job re-grants exactly the writes contributor-assistant needs, so the
+# elevated token never leaks to any job added here later.
 permissions:
-  actions: write
   contents: read
-  pull-requests: write
-  statuses: write
 
 concurrency:
   group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
@@ -20,6 +20,17 @@ jobs:
   cla:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    # Scoped to this job only (upstream documents these at top level):
+    #   actions:write       — re-runs the workflow after a `recheck`/sign comment
+    #   pull-requests:write — posts the not-signed / signed PR comment
+    #   statuses:write      — sets the commit status the action reports through
+    # contents stays `read`: signatures are written to the remote `.github` repo
+    # with the App token below, never with GITHUB_TOKEN.
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+      statuses: write
     # Only run on the sign/recheck comment or on a PR event — never on other comments.
     if: >-
       (github.event.issue.pull_request && contains(fromJSON('["I have read the CLA Document and I hereby sign the CLA","recheck"]'), github.event.comment.body))

--- a/bun.lock
+++ b/bun.lock
@@ -1321,7 +1321,7 @@
         "@tauri-apps/plugin-shell": "^2.0.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router-dom": "^7.17.0",
+        "react-router-dom": "^7.18.1",
         "react-window": "^2.2.7",
         "zustand": "^5.0.13",
         "zxcvbn": "^4.4.2",
@@ -1357,6 +1357,7 @@
     "js-yaml": "4.3.0",
     "linkify-it": "5.0.2",
     "nodemailer": "9.0.1",
+    "postcss": "8.5.23",
     "protobufjs": "7.6.4",
     "sharp": "0.35.3",
     "shell-quote": "1.10.0",
@@ -1816,7 +1817,7 @@
 
     "@nimbus-dev/client": ["@nimbus-dev/client@0.5.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.3.0" } }, "sha512-DqIhRNGfwwNNUS9eqc2w3ggGhMB36xMYz4kh6TKut0rDDcOut/XNvIJIm7uqRbTfzMAuZQ9QAdTVGSMcy7uw1A=="],
 
-    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.5.0", "", {}, "sha512-dAa87gn3CHNtJyb3mlg4dXqiLa56bFBiTR1+rtz8YoCPl8DUMyANpU/ZJ8Sym+6bovWuIrB1z8R9ETfKj6dRXw=="],
+    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-dHPSNP7GuNgM6oo0el4oZhqx1Xbtbwi+2XSKLmBfUcBj4zDTIKyqX9JQpmmSU9eaQcZgQNC7u9o5CmQTa8g1qA=="],
 
     "@nimbus/cli": ["@nimbus/cli@workspace:packages/cli"],
 
@@ -3240,7 +3241,7 @@
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -3552,7 +3553,7 @@
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
@@ -3616,9 +3617,9 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.17.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ=="],
+    "react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
 
-    "react-router-dom": ["react-router-dom@7.17.0", "", { "dependencies": { "react-router": "7.17.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw=="],
+    "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
@@ -4154,8 +4155,6 @@
 
     "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.3.0", "", {}, "sha512-mCVlMLbYUowRLsw1dAcDp61AyoLSW6hrfbdrJim7ho3kg78rJlS0DYrKpqQxbng6E83NscJkUHlIFanxp0hp5g=="],
 
-    "@nimbus/gateway/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-dHPSNP7GuNgM6oo0el4oZhqx1Xbtbwi+2XSKLmBfUcBj4zDTIKyqX9JQpmmSU9eaQcZgQNC7u9o5CmQTa8g1qA=="],
-
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg=="],
@@ -4337,194 +4336,6 @@
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "msw/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
-    "nimbus-mcp-airflow/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-apple/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-argocd/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-athena/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-aws/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-azure/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-bigeye/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-bigquery/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-bitbucket/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-bitrise/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-canva/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-circleci/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-cloud-logging/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-cloudwatch/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-codemagic/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-confluence/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-dagster/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-databricks/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-datadog/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-dataprofile/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-dbt/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-dependencytrack/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-discord/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-elasticsearch/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-fastmail/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-figma/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-firebase/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-flagsmith/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-flux/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-gcp/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-github/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-github-actions/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-gitlab/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-gmail/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-google-drive/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-google-meet/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-google-photos/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-grafana/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-great-expectations/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-greenhouse/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-hubspot/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-iac/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-imap/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-intercom/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-jenkins/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-jira/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-kubernetes/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-launchdarkly/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-lever/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-linear/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-localdb/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-looker/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-mendeley/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-mercury/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-metabase/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-miro/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-mlflow/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-monte-carlo/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-netlify/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-newrelic/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-notion/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-obsidian/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-onedrive/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-outlook/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-pagerduty/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-pipedrive/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-powerbi/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-prefect/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-protonmail/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-raindrop/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-ramp/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-readwise/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-sagemaker/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-salesforce/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-semgrep/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-sentry/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-slack/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-snowflake/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-snyk/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-sonarqube/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-stackoverflow/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-storybook/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-stripe/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-superset/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-tableau/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-teams/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-testflight/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-vercel/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-vertex-ai/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-wiz/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-workday/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-zendesk/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-zoom/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
-
-    "nimbus-mcp-zotero/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-kqHQyGrLUoBgZjyrse8gMjD5VMHCJ4Oe02DTlSAPLABQ4RbYNT75b45sxKdfqpuuiUqEfljFlLtv4hZNsWyGrg=="],
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
@@ -4736,8 +4547,6 @@
 
     "astro/vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "astro/vite/postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
-
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
@@ -4785,8 +4594,6 @@
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "vitest/vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
-
-    "vitest/vite/postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
 
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -4890,8 +4697,6 @@
 
     "@vitejs/plugin-react/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
-    "astro/vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
-
     "istanbul-lib-instrument/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "istanbul-lib-instrument/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -4915,8 +4720,6 @@
     "istanbul-lib-instrument/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
     "istanbul-lib-instrument/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "vitest/vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1348,7 +1348,7 @@
   "overrides": {
     "@mastra/core": "1.43.0",
     "@mastra/mcp": "1.10.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "devalue": "5.8.1",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
@@ -2437,7 +2437,7 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1321,7 +1321,7 @@
         "@tauri-apps/plugin-shell": "^2.0.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "react-window": "^2.2.7",
         "zustand": "^5.0.13",
         "zxcvbn": "^4.4.2",
@@ -2521,7 +2521,7 @@
 
     "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
-    "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -3617,9 +3617,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
-
-    "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
+    "react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
@@ -4303,6 +4301,8 @@
 
     "globby/unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
+    "h3/cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
+
     "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
@@ -4354,10 +4354,6 @@
     "protobufjs/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
-
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
-    "react-router/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "nodemailer": "9.0.1",
     "undici": "7.28.0",
     "shell-quote": "1.10.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "tar": "7.5.20",
     "js-yaml": "4.3.0",
     "postcss": "8.5.23"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "shell-quote": "1.10.0",
     "brace-expansion": "5.0.7",
     "tar": "7.5.20",
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.0",
+    "postcss": "8.5.23"
   },
   "workspaces": [
     "packages/admin-console",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,7 @@
     "@tauri-apps/plugin-shell": "^2.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router-dom": "^7.17.0",
+    "react-router-dom": "^7.18.1",
     "react-window": "^2.2.7",
     "zustand": "^5.0.13",
     "zxcvbn": "^4.4.2"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,7 @@
     "@tauri-apps/plugin-shell": "^2.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "react-window": "^2.2.7",
     "zustand": "^5.0.13",
     "zxcvbn": "^4.4.2"

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5,7 +5,7 @@ import {
   Navigate,
   Route,
   RouterProvider,
-} from "react-router-dom";
+} from "react-router";
 import { RootLayout } from "./layouts/RootLayout";
 import { Dashboard } from "./pages/Dashboard";
 import { HitlPopup } from "./pages/HitlPopup";

--- a/packages/ui/src/components/chrome/NavItem.tsx
+++ b/packages/ui/src/components/chrome/NavItem.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 
 interface NavItemProps {
   readonly to: string;

--- a/packages/ui/src/components/dashboard/ConnectorGrid.tsx
+++ b/packages/ui/src/components/dashboard/ConnectorGrid.tsx
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { type ReactNode, useCallback, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useIpcQuery } from "../../hooks/useIpcQuery";
 import { useIpcSubscription } from "../../hooks/useIpcSubscription";
 import type { ConnectorStatus } from "../../ipc/types";

--- a/packages/ui/src/components/settings/SettingsSidebar.tsx
+++ b/packages/ui/src/components/settings/SettingsSidebar.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 
 interface SettingsEntry {
   readonly to: string;

--- a/packages/ui/src/components/settings/data/ImportWizard.tsx
+++ b/packages/ui/src/components/settings/data/ImportWizard.tsx
@@ -1,6 +1,6 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useIpcSubscription } from "../../../hooks/useIpcSubscription";
 import { createIpcClient } from "../../../ipc/client";
 import type {

--- a/packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx
+++ b/packages/ui/src/components/workflows/WorkflowRunHistoryDrawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { createIpcClient } from "../../ipc/client";
 import type { WorkflowRunHistoryEntry } from "../../ipc/types";
 

--- a/packages/ui/src/layouts/RootLayout.tsx
+++ b/packages/ui/src/layouts/RootLayout.tsx
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import { useCallback, useEffect } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router";
 import { Sidebar } from "../components/chrome/Sidebar";
 import { GatewayOfflineBanner } from "../components/GatewayOfflineBanner";
 import { HotkeyFailedBanner } from "../components/HotkeyFailedBanner";

--- a/packages/ui/src/pages/Onboarding.tsx
+++ b/packages/ui/src/pages/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation } from "react-router";
 
 const STEPS = [
   { path: "welcome", label: "Welcome" },

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { SettingsSidebar } from "../components/settings/SettingsSidebar";
 
 export function Settings(): ReactNode {

--- a/packages/ui/src/pages/onboarding/Connect.tsx
+++ b/packages/ui/src/pages/onboarding/Connect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { createIpcClient } from "../../ipc/client";
 import type { ConnectorSummary } from "../../ipc/types";
 import { useNimbusStore } from "../../store";

--- a/packages/ui/src/pages/onboarding/Syncing.tsx
+++ b/packages/ui/src/pages/onboarding/Syncing.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { createIpcClient } from "../../ipc/client";
 import type { DiagSnapshot } from "../../ipc/types";
 

--- a/packages/ui/src/pages/onboarding/Welcome.tsx
+++ b/packages/ui/src/pages/onboarding/Welcome.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { createIpcClient } from "../../ipc/client";
 
 export function Welcome() {

--- a/packages/ui/src/pages/settings/AuditPanel.tsx
+++ b/packages/ui/src/pages/settings/AuditPanel.tsx
@@ -1,7 +1,7 @@
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { List, type RowComponentProps } from "react-window";
 import { AuditFilterChips } from "../../components/settings/audit/AuditFilterChips";
 import { PanelError } from "../../components/settings/PanelError";

--- a/packages/ui/src/pages/settings/ConnectorsPanel.tsx
+++ b/packages/ui/src/pages/settings/ConnectorsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { PanelError } from "../../components/settings/PanelError";
 import { PanelHeader } from "../../components/settings/PanelHeader";
 import { StaleChip } from "../../components/settings/StaleChip";

--- a/packages/ui/src/providers/GatewayConnectionProvider.tsx
+++ b/packages/ui/src/providers/GatewayConnectionProvider.tsx
@@ -1,5 +1,5 @@
 import { type PropsWithChildren, useEffect, useRef } from "react";
-import { type NavigateFunction, useNavigate } from "react-router-dom";
+import { type NavigateFunction, useNavigate } from "react-router";
 import { createIpcClient } from "../ipc/client";
 import type { ConnectionState, DiagSnapshot } from "../ipc/types";
 import { useNimbusStore } from "../store";

--- a/packages/ui/test/components/chrome/Sidebar.test.tsx
+++ b/packages/ui/test/components/chrome/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/store", () => ({

--- a/packages/ui/test/components/dashboard/ConnectorGrid.test.tsx
+++ b/packages/ui/test/components/dashboard/ConnectorGrid.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConnectorStatus } from "../../../src/ipc/types";
 

--- a/packages/ui/test/components/settings/SettingsSidebar.test.tsx
+++ b/packages/ui/test/components/settings/SettingsSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 import { SettingsSidebar } from "../../../src/components/settings/SettingsSidebar";
 

--- a/packages/ui/test/components/settings/data/ImportWizard.test.tsx
+++ b/packages/ui/test/components/settings/data/ImportWizard.test.tsx
@@ -13,8 +13,8 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 }));
 
 const navigateMock = vi.fn<(to: string) => void>();
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
   return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/packages/ui/test/layouts/RootLayout.profile-switched.test.tsx
+++ b/packages/ui/test/layouts/RootLayout.profile-switched.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { invokeMock, listenMap } = vi.hoisted(() => ({

--- a/packages/ui/test/layouts/RootLayout.test.tsx
+++ b/packages/ui/test/layouts/RootLayout.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { invokeMock, listenHandlers } = vi.hoisted(() => ({

--- a/packages/ui/test/pages/Dashboard.test.tsx
+++ b/packages/ui/test/pages/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@tauri-apps/api/core", () => ({

--- a/packages/ui/test/pages/Marketplace.test.tsx
+++ b/packages/ui/test/pages/Marketplace.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/ipc/client");

--- a/packages/ui/test/pages/OnboardingConnect.test.tsx
+++ b/packages/ui/test/pages/OnboardingConnect.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/ipc/client");

--- a/packages/ui/test/pages/OnboardingSyncing.test.tsx
+++ b/packages/ui/test/pages/OnboardingSyncing.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/ipc/client");

--- a/packages/ui/test/pages/OnboardingWelcome.test.tsx
+++ b/packages/ui/test/pages/OnboardingWelcome.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const callMock = vi.fn<(method: string, params?: unknown) => Promise<unknown>>();

--- a/packages/ui/test/pages/QuickQuery.test.tsx
+++ b/packages/ui/test/pages/QuickQuery.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const callMock = vi.fn<(method: string, params?: unknown) => Promise<unknown>>();

--- a/packages/ui/test/pages/Settings.test.tsx
+++ b/packages/ui/test/pages/Settings.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { describe, expect, it } from "vitest";
 import { Settings } from "../../src/pages/Settings";
 

--- a/packages/ui/test/pages/Watchers.test.tsx
+++ b/packages/ui/test/pages/Watchers.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/ipc/client");

--- a/packages/ui/test/pages/Workflows.test.tsx
+++ b/packages/ui/test/pages/Workflows.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/ipc/client");

--- a/packages/ui/test/pages/settings/AuditPanel.test.tsx
+++ b/packages/ui/test/pages/settings/AuditPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 
 vi.mock("../../../src/ipc/client");

--- a/packages/ui/test/pages/settings/ConnectorsPanel.test.tsx
+++ b/packages/ui/test/pages/settings/ConnectorsPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/ipc/client");

--- a/packages/ui/test/pages/settings/ModelPanel.test.tsx
+++ b/packages/ui/test/pages/settings/ModelPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/ipc/client");

--- a/packages/ui/test/pages/settings/ProfilesPanel.test.tsx
+++ b/packages/ui/test/pages/settings/ProfilesPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/ipc/client");

--- a/packages/ui/test/providers/GatewayConnectionProvider.test.tsx
+++ b/packages/ui/test/providers/GatewayConnectionProvider.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, waitFor } from "@testing-library/react";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type Handler<T> = (payload: T) => void;


### PR DESCRIPTION
Takes the repo from **4 high advisories to 0**. `bun audit --audit-level high` and `Trivy vulnerability scan` are both **required checks** and were already failing on `main`, so this also unblocks #834 and #836.

## Advisories cleared

| Advisory | Package | Fix |
| --- | --- | --- |
| GHSA-r28c-9q8g-f849 | postcss 8.5.15 | pinned **8.5.23** via `overrides` (transitive: astro/vite) |
| GHSA-chx6-hx7r-mcp5 — DoS, inefficient route matching | react-router 7.17.0 | **7.18.1** |
| GHSA-mh99-v99m-4gvg | brace-expansion | override was pinned to exactly **5.0.7**, but the advisory range is `<=5.0.7` — the pin *was* the vulnerable version. Now **5.0.8** |
| GHSA-qwww-vcr4-c8h2 — RSC CSRF | react-router | **v8.3.0 migration**, see below |

Note that `bun audit` surfaced more than GitHub's code-scanning alerts did — the brace-expansion and route-matching-DoS advisories were not in the Code Scanning list.

## The react-router v8 migration

GHSA-qwww-vcr4-c8h2's only fix is 8.3.0, and **there is no `react-router-dom` 8.x** — v8 discontinued the separate DOM package and folded it into `react-router`. So this swaps the dependency and rewrites the module specifier across **35 files** (15 `src` + 20 `test`).

**No API changes were required.** Every symbol in use exists in v8 under the same name: `createBrowserRouter`, `createRoutesFromElements`, `RouterProvider`, `Route`, `Navigate`, `Outlet`, `Link`, `NavLink`, `MemoryRouter`, `Routes`, `useNavigate`, `useLocation`, `useSearchParams`, and the `NavigateFunction` type.

Marked `!` because the UI's routing dependency crosses a major version. No public API is affected, and the Tauri desktop app is Phase-13-deferred.

## Scorecard `TokenPermissions` — `cla.yml` (#151, #152)

`actions` / `pull-requests` / `statuses: write` were declared at **top level**, so every job inherited them. They now sit on the single `cla` job; the workflow default drops to `contents: read`. Capabilities are unchanged, so the live required `cla` gate keeps working.

The other 9 `TokenPermissions` alerts are job-level writes that are structurally required (`contents: write` for release-please, `checks: write` for test-report publishing). Scorecard scores *any* write as 0, so they can't be satisfied without breaking those jobs — left for a dismiss-with-justification decision.

## Verification

- **`bun audit --audit-level high`: clean, exit 0** (was 4 high)
- `packages/ui` vitest: **506 tests across 74 files, all pass**
- `packages/ui` `tsc --noEmit` clean; **full monorepo typecheck exit 0**
- `vite build` succeeds (183 modules transformed)
- `biome check` clean on 2957 files; lockfile passes `--frozen-lockfile`

## Rider worth calling out

`bun install` deduped `@nimbus-dev/sdk` to a single hoisted **1.6.0**, collapsing ~100 per-connector 1.4.0/1.5.0 entries (hence the large `bun.lock` delta). All 94 connectors declare `^1.3.0` and the gateway `^1.6.0`, so this is semver-legal and unavoidable through bun's resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)