### PR TITLE
feat(infra): P2 Release Train Phase 1 — release-staleness gate

### DIFF
--- a/.github/release-train.json
+++ b/.github/release-train.json
@@ -1,0 +1,25 @@
+{
+  "$comment": "P2 Release Train edges. audit:release-staleness reads each downstream's LIVE version and fails when it lags the published source past graceHours. See docs/infrastructure-roadmap.md P2 + docs/superpowers/specs/2026-07-24-p2-release-train-design.md.",
+  "graceHours": 6,
+  "trains": [
+    {
+      "name": "nimbus-gateway",
+      "source": {
+        "manifestRepo": "nimbus-agent/Nimbus",
+        "manifestFile": ".release-please-manifest.json",
+        "manifestKey": ".",
+        "releaseAsset": "SHA256SUMS"
+      },
+      "channels": [
+        { "kind": "brew", "repo": "nimbus-agent/homebrew-tap", "path": "Formula/nimbus.rb" },
+        { "kind": "scoop", "repo": "nimbus-agent/scoop-bucket", "path": "bucket/nimbus.json" },
+        {
+          "kind": "linux",
+          "repo": "nimbus-agent/linux-repo",
+          "path": "apt/dists/stable/main/binary-amd64/Packages"
+        },
+        { "kind": "winget", "package": "NimbusAgent.Nimbus", "wingetRepo": "microsoft/winget-pkgs" }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -168,3 +168,24 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.apptoken.outputs.token }}
         run: bun scripts/structure-audit/check-cla-coverage.ts --strict
+
+  release-staleness:
+    name: release-staleness
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # No App token: every read (Nimbus releases + manifest, the channel repos,
+      # microsoft/winget-pkgs) is PUBLIC. The default github.token authenticates
+      # gh at 5000 req/hr, far above this job's handful of reads + one search.
+      - name: Audit release-train staleness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/structure-audit/check-release-staleness.ts --strict

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,19 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-26 — P2 Release Train Phase 1: the `release-staleness` gate.** A declarative
+  `.github/release-train.json` lists every propagation edge; `audit:release-staleness` reads three
+  version heads — intended (release-please manifest + its bump-commit age), published (the latest
+  Release actually carrying its `SHA256SUMS` asset), distributed (each channel's live file, or
+  winget dir-or-open-PR) — and goes red when a channel lags past the 6h grace window, or when a
+  release *phantoms* (manifest bumped, nothing built). Runs `--strict` as a new job on the weekly
+  `org-drift-sweep` cron; all reads are public, so no App token is minted. Unreadable or
+  unparseable inputs degrade to `indeterminate`, never `stale`; under `--strict` a run that
+  evaluated nothing is red, so indeterminate cannot read as "all clear". Its first live run caught
+  a genuine phantom: the manifest claims `0.27.0` with no `v0.27.0` tag or Release built. Also
+  closes the CLA-coverage robustness follow-up — `_gh-audit.ts` now surfaces the `gh` HTTP status,
+  and a non-404 per-repo read failure is indeterminate rather than "cla.yml absent".
+
 - **2026-07-24 — `nimbus index add <path>` registers a blame root.** New local-only
   `filesystem.ensureRoot` IPC method + `nimbus index add` CLI register a git repo as a
   blame/index root (persisted to `registered-roots.json`, merged with `[[filesystem.roots]]` on

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -46,7 +46,7 @@ Design of record:
 | | Sub-program | Status | Gate |
 | --- | --- | --- | --- |
 | P1 | Org CI Foundation | ✅ done | The scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos — proven green end-to-end (run 30060920603) |
-| P2 | Release Train | ⬜ not started | A publish that fails to open its downstream PR fails a staleness check |
+| P2 | Release Train | 🔨 Phase 1 shipped | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, or when a release phantoms (manifest bumped, nothing built). Remaining: Phase 2 (dependency-DAG edges) |
 | P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
 | P4b | Latency | ⬜ not started | Per-job wall-clock tracked; regressions visible |
@@ -142,11 +142,37 @@ moves to P6).
   make the `CLA Assistant` check required in each ruleset; **red-prove** with a
   test PR; confirm `cla-coverage` green.
 - **Deferred:** CCLA employee-roster automation; private repos; retroactive
-  signatures. See `docs/superpowers/specs/2026-07-24-cla-design.md`. Robustness
-  follow-up: `check-cla-coverage` treats any per-repo `gh` failure as "cla.yml
-  absent" (a public-repo 404 is genuine, but a transient 5xx/rate-limit would
-  false-red until the next run) — surface the `gh` exit code in `_gh-audit.ts`
-  and treat a non-404 failure as indeterminate, like `team-reachability`.
+  signatures. See `docs/superpowers/specs/2026-07-24-cla-design.md`.
+- **Robustness follow-up — CLOSED (2026-07-26, in P2 Phase 1):**
+  `check-cla-coverage` used to treat any per-repo `gh` failure as "cla.yml
+  absent", so a transient 5xx/rate-limit would false-red until the next run.
+  `_gh-audit.ts` now surfaces the HTTP status and `classifyReadFailure` treats
+  a non-404 as indeterminate, like `team-reachability`.
+
+### P2 progress log
+
+- **Delivered (Phase 1 — channel staleness):** `.github/release-train.json`
+  declares the propagation edges; `audit:release-staleness`
+  (`scripts/structure-audit/check-release-staleness.ts`) reads three heads —
+  intended (release-please manifest + its bump age), published (latest Release
+  actually carrying its `SHA256SUMS` asset), distributed (each channel's live
+  file, or winget dir-or-open-PR) — and emits a per-edge verdict. A new
+  `release-staleness` job runs it `--strict` on the weekly `org-drift-sweep`
+  cron. Public reads only, so no App token is minted.
+- **Design decisions that matter:** the phantom edge gates on the *bump
+  commit's* age, not the release's, so a normal build window is never red;
+  winget counts as caught-up on a merged dir **or** an open PR, so the gate
+  never waits on Microsoft's merge; every unreadable or unparseable input
+  degrades to `indeterminate`, never `stale`; and under `--strict` a run that
+  evaluated *nothing* is red, so "indeterminate" cannot read as "all clear".
+- **Live proof (2026-07-26, pre-merge):** the gate went **red on a genuine
+  phantom** — `.release-please-manifest.json` on `main` claims `0.27.0`, but no
+  `v0.27.0` tag or Release exists (latest built: `v0.26.0`), bump 54h old. All
+  four channel edges evaluated `ok`. This is the recurring manual-tag-push
+  failure mode the sub-program exists to catch, caught on the first live run.
+- **Remaining:** Phase 2 (dependency-DAG edges — sdk/client → consumers). The
+  sub-program is *done* only once the `release-staleness` job has run green in
+  a scheduled sweep on `main`; record that run number here.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-24-p2-release-train-review.md
+++ b/docs/superpowers/plans/2026-07-24-p2-release-train-review.md
@@ -7,9 +7,11 @@ This document provides a review of the [2026-07-24-p2-release-train.md](./2026-0
 ## 1. Robustness & Error Handling Improvements
 
 ### ⚠️ Semver Comparison Safety (`Bun.semver.order` crashes)
+
 * **Context:** In Task 4 (lines 671-673), `Bun.semver.order(chVer, pubVer)` is called directly.
 * **Risk:** `Bun.semver.order` throws a runtime error if either argument is not a valid semver. While `pubVer` is sanitized by `selectPublished`'s regex filter, `chVer` is parsed directly from external channel files (brew formulas, scoop manifests, apt index files) which could contain unparseable version strings or format variations (e.g., debian revision suffixes like `0.26.0-1` or epoch prefixes). An uncaught throw will crash the entire audit process.
 * **Suggestion:** Wrap `Bun.semver.order` in a try/catch or validate the versions beforehand. If ordering fails, treat the verdict as `"indeterminate"` with a detail message pointing to the semver parse error.
+
   ```ts
   try {
     const isOk = Bun.semver.order(chVer, pubVer) >= 0;
@@ -24,9 +26,11 @@ This document provides a review of the [2026-07-24-p2-release-train.md](./2026-0
   ```
 
 ### ⚠️ `tryLinuxGz` Exception Safety
+
 * **Context:** In Task 5 (lines 923-930), the `tryLinuxGz` function performs decompression and string decoding.
 * **Risk:** If the `.gz` payload is corrupted or is not valid gzip data, `Bun.gunzipSync(bytes)` or `new TextDecoder().decode(...)` will throw an error, causing the script to crash.
 * **Suggestion:** Wrap the decompression and decoding logic in a `try/catch` block, returning `null` or an `"indeterminate"` reading on failure:
+
   ```ts
   async function tryLinuxGz(ch: ChannelSpec): Promise<ChannelReading | null> {
     const gz = runGh(["gh", "api", `repos/${ch.repo}/contents/${ch.path}.gz`, "--jq", ".content"]);
@@ -42,9 +46,11 @@ This document provides a review of the [2026-07-24-p2-release-train.md](./2026-0
   ```
 
 ### 🔍 `ageHours` NaN Handling
+
 * **Context:** In Task 5 (line 819), `ageHours(isoZ)` parses `new Date(isoZ).getTime()`.
 * **Risk:** If `isoZ` is an invalid date string, `getTime()` returns `NaN`, and `ageHours` returns `NaN`. In `evaluateTrain` (lines 618, 641), comparing `NaN > graceHours` evaluates to `false`, which might silently mask a phantom release or a stale channel state as `"ok"`.
 * **Suggestion:** Handle `NaN` explicitly in `ageHours` to return `Number.POSITIVE_INFINITY` (fail-closed) so that aged checks are triggered rather than bypassed:
+
   ```ts
   export function ageHours(isoZ: string): number {
     const t = new Date(isoZ).getTime();
@@ -58,9 +64,11 @@ This document provides a review of the [2026-07-24-p2-release-train.md](./2026-0
 ## 2. Parsing Strategy Enhancements
 
 ### 📦 Linux Multi-Package Index Parsing
+
 * **Context:** In Task 3 (line 393), `parseLinuxVersion` uses a global regex search: `packages.match(/^Version:\s*(.+)$/m)`.
 * **Issue:** An apt `Packages` index file typically lists all packages distributed by the repository, separated by double-newlines. If another helper package or dependency is added to the repository in the future and happens to appear first in the `Packages` file, the regex will extract the version of the wrong package.
 * **Suggestion:** Scan specifically for the relevant package name block (e.g. `nimbus` or `nimbus-headless`) before extracting the version.
+
   ```ts
   export function parseLinuxVersion(packages: string): string | null {
     const blocks = packages.split("\n\n");

--- a/docs/superpowers/plans/2026-07-24-p2-release-train-review.md
+++ b/docs/superpowers/plans/2026-07-24-p2-release-train-review.md
@@ -1,0 +1,82 @@
+# P2 — Release Train Implementation Plan Review
+
+This document provides a review of the [2026-07-24-p2-release-train.md](./2026-07-24-p2-release-train.md) implementation plan.
+
+---
+
+## 1. Robustness & Error Handling Improvements
+
+### ⚠️ Semver Comparison Safety (`Bun.semver.order` crashes)
+* **Context:** In Task 4 (lines 671-673), `Bun.semver.order(chVer, pubVer)` is called directly.
+* **Risk:** `Bun.semver.order` throws a runtime error if either argument is not a valid semver. While `pubVer` is sanitized by `selectPublished`'s regex filter, `chVer` is parsed directly from external channel files (brew formulas, scoop manifests, apt index files) which could contain unparseable version strings or format variations (e.g., debian revision suffixes like `0.26.0-1` or epoch prefixes). An uncaught throw will crash the entire audit process.
+* **Suggestion:** Wrap `Bun.semver.order` in a try/catch or validate the versions beforehand. If ordering fails, treat the verdict as `"indeterminate"` with a detail message pointing to the semver parse error.
+  ```ts
+  try {
+    const isOk = Bun.semver.order(chVer, pubVer) >= 0;
+    results.push(
+      isOk
+        ? { edge, verdict: "ok", detail: `${ch.kind} ${chVer} >= published ${pubVer}` }
+        : { edge, verdict: "stale", detail: `${ch.kind} ${chVer} < published ${pubVer}` }
+    );
+  } catch (err) {
+    results.push({ edge, verdict: "indeterminate", detail: `semver comparison failed for ${chVer} vs ${pubVer}` });
+  }
+  ```
+
+### ⚠️ `tryLinuxGz` Exception Safety
+* **Context:** In Task 5 (lines 923-930), the `tryLinuxGz` function performs decompression and string decoding.
+* **Risk:** If the `.gz` payload is corrupted or is not valid gzip data, `Bun.gunzipSync(bytes)` or `new TextDecoder().decode(...)` will throw an error, causing the script to crash.
+* **Suggestion:** Wrap the decompression and decoding logic in a `try/catch` block, returning `null` or an `"indeterminate"` reading on failure:
+  ```ts
+  async function tryLinuxGz(ch: ChannelSpec): Promise<ChannelReading | null> {
+    const gz = runGh(["gh", "api", `repos/${ch.repo}/contents/${ch.path}.gz`, "--jq", ".content"]);
+    if (!gz.ok) return null;
+    try {
+      const bytes = Buffer.from(gz.stdout.replace(/\s/g, ""), "base64");
+      const text = new TextDecoder().decode(Bun.gunzipSync(bytes));
+      return { kind: ch.kind, status: "read", version: parseLinuxVersion(text), covered: null };
+    } catch {
+      return { kind: ch.kind, status: "indeterminate", version: null, covered: null };
+    }
+  }
+  ```
+
+### 🔍 `ageHours` NaN Handling
+* **Context:** In Task 5 (line 819), `ageHours(isoZ)` parses `new Date(isoZ).getTime()`.
+* **Risk:** If `isoZ` is an invalid date string, `getTime()` returns `NaN`, and `ageHours` returns `NaN`. In `evaluateTrain` (lines 618, 641), comparing `NaN > graceHours` evaluates to `false`, which might silently mask a phantom release or a stale channel state as `"ok"`.
+* **Suggestion:** Handle `NaN` explicitly in `ageHours` to return `Number.POSITIVE_INFINITY` (fail-closed) so that aged checks are triggered rather than bypassed:
+  ```ts
+  export function ageHours(isoZ: string): number {
+    const t = new Date(isoZ).getTime();
+    if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
+    return (Date.now() - t) / 3_600_000;
+  }
+  ```
+
+---
+
+## 2. Parsing Strategy Enhancements
+
+### 📦 Linux Multi-Package Index Parsing
+* **Context:** In Task 3 (line 393), `parseLinuxVersion` uses a global regex search: `packages.match(/^Version:\s*(.+)$/m)`.
+* **Issue:** An apt `Packages` index file typically lists all packages distributed by the repository, separated by double-newlines. If another helper package or dependency is added to the repository in the future and happens to appear first in the `Packages` file, the regex will extract the version of the wrong package.
+* **Suggestion:** Scan specifically for the relevant package name block (e.g. `nimbus` or `nimbus-headless`) before extracting the version.
+  ```ts
+  export function parseLinuxVersion(packages: string): string | null {
+    const blocks = packages.split("\n\n");
+    for (const block of blocks) {
+      if (block.includes("Package: nimbus-headless") || block.includes("Package: nimbus")) {
+        const match = block.match(/^Version:\s*(.+)$/m);
+        if (match) return match[1].trim();
+      }
+    }
+    return null;
+  }
+  ```
+
+---
+
+## 3. Open Questions
+
+1. **Winget Package ID Assumptions:** The `wingetDirPath` helper splits the package ID by the first period (`.`) to separate the publisher from the package name. Are all current and future Winget package IDs guaranteed to follow this two-part format (e.g., `Publisher.Package`), or could there be multi-part names (e.g., `Publisher.Group.Package`)? If so, does the directory structure in `winget-pkgs` match the dot separator mapping?
+2. **Debian Version String Formats:** Debian package managers sometimes append revision numbers or epoch prefixes to versions (e.g. `1:0.26.0` or `0.26.0-1`). We should verify if our release automation strips these, or if `Bun.semver.order` can handle them correctly. If not, sanitizing the parsed linux version to keep only the pure semver portion is recommended.

--- a/docs/superpowers/plans/2026-07-24-p2-release-train.md
+++ b/docs/superpowers/plans/2026-07-24-p2-release-train.md
@@ -41,10 +41,12 @@
 ## Task 1: `_gh-audit.ts` — surface HTTP status + shared read classifier
 
 **Files:**
+
 - Modify: `scripts/structure-audit/_gh-audit.ts`
 - Test: `scripts/structure-audit/_gh-audit.test.ts`
 
 **Interfaces:**
+
 - Produces: `GhResult` gains `stderr: string` and `httpStatus?: number` (additive — existing `.ok`/`.stdout` callers unchanged). `parseHttpStatus(stderr: string): number | undefined`. `classifyReadFailure(httpStatus: number | undefined): "absent" | "indeterminate"`.
 
 - [ ] **Step 1: Write the failing tests** — append to `scripts/structure-audit/_gh-audit.test.ts`:
@@ -143,10 +145,12 @@ git commit -m "feat(audit): surface gh HTTP status + shared read classifier in _
 ## Task 2: CLA-coverage robustness — non-404 failure is indeterminate
 
 **Files:**
+
 - Modify: `scripts/structure-audit/check-cla-coverage.ts`
 - Test: `scripts/structure-audit/check-cla-coverage.test.ts`
 
 **Interfaces:**
+
 - Consumes: `classifyReadFailure` (Task 1).
 - Produces: no signature change to `diffClaCoverage`; the `import.meta.main` shell now short-circuits to `strictSkip` with a reason when any per-repo read fails with a non-404 status.
 
@@ -226,10 +230,12 @@ git commit -m "fix(audit): cla-coverage treats a non-404 read as indeterminate, 
 ## Task 3: Release-staleness pure readers — version parsers, published selector, winget resolver
 
 **Files:**
+
 - Create: `scripts/structure-audit/check-release-staleness.ts`
 - Test: `scripts/structure-audit/check-release-staleness.test.ts`
 
 **Interfaces:**
+
 - Produces:
   - `compareSemver(a: string, b: string): number | null` (never throws; null on unparseable)
   - `parseBrewVersion(rb: string): string | null`
@@ -526,10 +532,12 @@ git commit -m "feat(audit): release-staleness pure readers (brew/scoop/linux/pub
 ## Task 4: The evaluation engine — `evaluateTrain` + `decideExit`
 
 **Files:**
+
 - Modify: `scripts/structure-audit/check-release-staleness.ts`
 - Test: `scripts/structure-audit/check-release-staleness.test.ts`
 
 **Interfaces:**
+
 - Consumes: `PublishedRelease` (Task 3).
 - Produces:
   - `type EdgeVerdict = "ok" | "stale" | "phantom" | "indeterminate"`
@@ -799,6 +807,7 @@ git commit -m "feat(audit): release-staleness evaluation engine (grace-aware, fa
 ## Task 5: The manifest + `loadTrainManifest` + the gh-reading shell + registration
 
 **Files:**
+
 - Create: `.github/release-train.json`
 - Modify: `scripts/structure-audit/check-release-staleness.ts` (add `loadTrainManifest` + `import.meta.main` shell)
 - Test: `scripts/structure-audit/check-release-staleness.test.ts` (`loadTrainManifest`)
@@ -806,6 +815,7 @@ git commit -m "feat(audit): release-staleness evaluation engine (grace-aware, fa
 - Modify: `scripts/lib/preflight-gates.ts`
 
 **Interfaces:**
+
 - Consumes: everything from Tasks 3–4, plus `runGh` / `isStrict` / `strictSkip` / `classifyReadFailure` / `isRecord` from `_gh-audit.ts`.
 - Produces: `interface TrainManifest { graceHours: number; trains: TrainSpec[] }`; `loadTrainManifest(json: string): TrainManifest`.
 
@@ -1065,9 +1075,11 @@ git commit -m "feat(audit): release-train manifest + gh-reading shell + gate reg
 ## Task 6: Wire the org-drift-sweep job + preflight + live proof
 
 **Files:**
+
 - Modify: `.github/workflows/org-drift-sweep.yml`
 
 **Interfaces:**
+
 - Consumes: the `audit:release-staleness` gate (Task 5).
 
 - [ ] **Step 1: Add the job** — append to `.github/workflows/org-drift-sweep.yml` (after the `cla-coverage` job). No App-token mint — public reads use the default `github.token`:
@@ -1109,8 +1121,9 @@ Expected: all green. (If `preflight:fast` soft-warns on the network gates locall
 
 Run: `GH_TOKEN=$(gh auth token) bun scripts/structure-audit/check-release-staleness.ts`
 Expected: one of two correct outcomes —
-  - **GREEN** (`audit:release-staleness: OK`) if `v0.27.0` (or whatever the manifest claims) is published-with-assets and every channel has caught up; **or**
-  - **RED** with a specific `::error::nimbus-gateway:phantom` or `:<channel>` line if there is a genuine live gap (the spec's documented 0.27.0-vs-0.26.0 heads-up — a real phantom the gate correctly surfaces).
+
+- **GREEN** (`audit:release-staleness: OK`) if `v0.27.0` (or whatever the manifest claims) is published-with-assets and every channel has caught up; **or**
+- **RED** with a specific `::error::nimbus-gateway:phantom` or `:<channel>` line if there is a genuine live gap (the spec's documented 0.27.0-vs-0.26.0 heads-up — a real phantom the gate correctly surfaces).
 
 Record which outcome occurred in the PR description. A RED here is the gate working — do **not** "fix" the gate to make it green; if it is a real phantom, note it for the release playbook. If GREEN, proceed.
 
@@ -1140,6 +1153,7 @@ git commit -m "ci(infra): add release-staleness job to org-drift-sweep (P2 Relea
 ## Self-Review
 
 **Spec coverage:**
+
 - Three heads (intended/published/distributed) → Task 3 (`selectPublished`) + Task 4 (`evaluateTrain`). ✓
 - Declarative manifest → Task 5 (`.github/release-train.json` + `loadTrainManifest`). ✓
 - Grace window + PR-opened-for-winget → Task 4 (grace gating) + Task 3 (`resolveWingetCoverage`) + Task 5 (`readChannel` winget dir/PR). ✓

--- a/docs/superpowers/plans/2026-07-24-p2-release-train.md
+++ b/docs/superpowers/plans/2026-07-24-p2-release-train.md
@@ -231,9 +231,10 @@ git commit -m "fix(audit): cla-coverage treats a non-404 read as indeterminate, 
 
 **Interfaces:**
 - Produces:
+  - `compareSemver(a: string, b: string): number | null` (never throws; null on unparseable)
   - `parseBrewVersion(rb: string): string | null`
   - `parseScoopVersion(json: string): string | null`
-  - `parseLinuxVersion(packages: string): string | null`
+  - `parseLinuxVersion(packages: string, pkgName?: string): string | null`
   - `interface ReleaseInfo { tag: string; prerelease: boolean; draft: boolean; assets: string[]; publishedAt: string }`
   - `interface PublishedRelease { version: string; publishedAt: string }`
   - `selectPublished(releases: ReleaseInfo[], asset: string): PublishedRelease | null`
@@ -245,6 +246,7 @@ git commit -m "fix(audit): cla-coverage treats a non-404 read as indeterminate, 
 ```ts
 import { describe, expect, test } from "bun:test";
 import {
+  compareSemver,
   parseBrewVersion,
   parseScoopVersion,
   parseLinuxVersion,
@@ -273,12 +275,34 @@ describe("parseScoopVersion", () => {
 });
 
 describe("parseLinuxVersion", () => {
-  test("reads the Version: control field from a Packages file", () => {
+  test("reads the Version: field from the nimbus-headless block", () => {
     const pkgs = "Package: nimbus-headless\nVersion: 0.26.0\nArchitecture: amd64\n";
     expect(parseLinuxVersion(pkgs)).toBe("0.26.0");
   });
-  test("null when no Version field", () => {
-    expect(parseLinuxVersion("Package: nimbus-headless\n")).toBeNull();
+  test("picks the nimbus-headless block, not another package that sorts first", () => {
+    const pkgs =
+      "Package: aardvark-tool\nVersion: 9.9.9\nArchitecture: amd64\n\n" +
+      "Package: nimbus-headless\nVersion: 0.26.0\nArchitecture: amd64\n";
+    expect(parseLinuxVersion(pkgs)).toBe("0.26.0");
+  });
+  test("strips a Debian epoch prefix and revision suffix to the core version", () => {
+    const pkgs = "Package: nimbus-headless\nVersion: 1:0.26.0-1\nArchitecture: amd64\n";
+    expect(parseLinuxVersion(pkgs)).toBe("0.26.0");
+  });
+  test("null when the package block is absent", () => {
+    expect(parseLinuxVersion("Package: something-else\nVersion: 1.0.0\n")).toBeNull();
+  });
+});
+
+describe("compareSemver", () => {
+  test("orders valid versions (v-prefix tolerated)", () => {
+    expect(compareSemver("v0.26.0", "0.25.0")).toBe(1);
+    expect(compareSemver("0.25.0", "0.26.0")).toBe(-1);
+    expect(compareSemver("0.26.0", "0.26.0")).toBe(0);
+  });
+  test("returns null (never throws) on an unparseable version", () => {
+    expect(compareSemver("not-a-version", "0.26.0")).toBeNull();
+    expect(compareSemver("0.26.0", "garbage")).toBeNull();
   });
 });
 
@@ -322,10 +346,13 @@ describe("selectPublished", () => {
 });
 
 describe("wingetDirPath", () => {
-  test("derives the manifests path from the package id", () => {
+  test("derives the manifests path from a two-part package id", () => {
     expect(wingetDirPath("NimbusAgent.Nimbus", "0.26.0")).toBe(
       "manifests/n/NimbusAgent/Nimbus/0.26.0",
     );
+  });
+  test("maps every dot-segment to its own path segment (multi-part id)", () => {
+    expect(wingetDirPath("Acme.Tools.Cli", "1.2.3")).toBe("manifests/a/Acme/Tools/Cli/1.2.3");
   });
 });
 
@@ -370,6 +397,20 @@ export function stripV(version: string): string {
   return version.replace(/^v/, "");
 }
 
+/**
+ * Semver ordering that never throws. `Bun.semver.order` throws on an unparseable
+ * version ("Invalid SemVer: ..."), and channel files are external — a format
+ * quirk must degrade to "indeterminate", not crash the whole audit. Returns
+ * -1 | 0 | 1, or null when either side is not valid semver.
+ */
+export function compareSemver(a: string, b: string): number | null {
+  try {
+    return Bun.semver.order(stripV(a), stripV(b));
+  } catch {
+    return null;
+  }
+}
+
 /** `version "X.Y.Z"` from a Homebrew Formula .rb. */
 export function parseBrewVersion(rb: string): string | null {
   return rb.match(/version\s+"([^"]+)"/)?.[1] ?? null;
@@ -389,9 +430,25 @@ export function parseScoopVersion(json: string): string | null {
   }
 }
 
-/** First `Version:` control field from an apt Packages list. */
-export function parseLinuxVersion(packages: string): string | null {
-  return packages.match(/^Version:\s*(.+)$/m)?.[1]?.trim() ?? null;
+/**
+ * The upstream version of `pkgName` from an apt Packages index. The index lists
+ * every package as a double-newline-separated block, so we scope to the block
+ * whose `Package:` field equals `pkgName` (a future second package must not be
+ * read by position). The Debian `Version:` field may carry an epoch (`N:`) and a
+ * revision (`-N`); both are stripped to the core upstream version so it compares
+ * as semver. (The current build emits a plain `0.26.0`; the stripping is
+ * defensive — verify against the live linux-repo at impl time.)
+ */
+export function parseLinuxVersion(packages: string, pkgName = "nimbus-headless"): string | null {
+  for (const block of packages.split(/\n\n+/)) {
+    if (block.match(new RegExp(`^Package:\\s*${pkgName}\\s*$`, "m"))) {
+      const raw = block.match(/^Version:\s*(.+)$/m)?.[1]?.trim();
+      if (!raw) return null;
+      // strip epoch "N:" prefix and "-revision" suffix -> core upstream version
+      return raw.replace(/^\d+:/, "").replace(/-.*$/, "");
+    }
+  }
+  return null;
 }
 
 export interface ReleaseInfo {
@@ -417,17 +474,23 @@ export function selectPublished(releases: ReleaseInfo[], asset: string): Publish
     (r) => !r.draft && !r.prerelease && stable.test(r.tag) && r.assets.includes(asset),
   );
   if (eligible.length === 0) return null;
-  eligible.sort((a, b) => Bun.semver.order(stripV(b.tag), stripV(a.tag)));
+  // Tags are pre-filtered to `vX.Y.Z`, so compareSemver never returns null here;
+  // `?? 0` keeps the comparator total-typed for the sort.
+  eligible.sort((a, b) => compareSemver(b.tag, a.tag) ?? 0);
   const top = eligible[0];
   return top ? { version: stripV(top.tag), publishedAt: top.publishedAt } : null;
 }
 
-/** winget-pkgs manifests path: manifests/<first-letter>/<Publisher>/<Package>/<version>. */
+/**
+ * winget-pkgs manifests path. Every dot-segment of the package id becomes its
+ * own directory: `NimbusAgent.Nimbus` -> `manifests/n/NimbusAgent/Nimbus/<ver>`,
+ * `Acme.Tools.Cli` -> `manifests/a/Acme/Tools/Cli/<ver>`. The first segment's
+ * lowercased first letter is the top bucket.
+ */
 export function wingetDirPath(packageId: string, version: string): string {
-  const [publisher, ...rest] = packageId.split(".");
-  const pkg = rest.join(".");
-  const letter = (publisher ?? "").charAt(0).toLowerCase();
-  return `manifests/${letter}/${publisher}/${pkg}/${version}`;
+  const segments = packageId.split(".");
+  const letter = (segments[0] ?? "").charAt(0).toLowerCase();
+  return `manifests/${letter}/${segments.join("/")}/${version}`;
 }
 
 /**
@@ -549,6 +612,16 @@ describe("evaluateTrain", () => {
     const r = evaluateTrain({ ...green, channels: [ch({ kind: "brew", status: "absent" })] });
     expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("stale");
   });
+
+  test("unparseable channel version => indeterminate, never a crash", () => {
+    const r = evaluateTrain({ ...green, channels: [ch({ kind: "brew", version: "not-a-version" })] });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("indeterminate");
+  });
+
+  test("unparseable manifest version => phantom edge indeterminate, never a crash", () => {
+    const r = evaluateTrain({ ...green, intended: "not-a-version", channels: [] });
+    expect(r.find((e) => e.edge === "t:phantom")?.verdict).toBe("indeterminate");
+  });
 });
 
 describe("decideExit", () => {
@@ -613,7 +686,12 @@ export function evaluateTrain(i: TrainEvalInput): EdgeResult[] {
   const pubVer = i.published ? stripV(i.published.version) : null;
 
   // --- phantom edge: intended must have a matching built (asset-bearing) release ---
-  const intendedAhead = pubVer === null || Bun.semver.order(stripV(i.intended), pubVer) > 0;
+  const phantomOrder = pubVer === null ? null : compareSemver(i.intended, pubVer);
+  if (pubVer !== null && phantomOrder === null) {
+    // manifest version itself is unparseable — cannot judge; do not crash.
+    results.push({ edge: `${i.name}:phantom`, verdict: "indeterminate", detail: `manifest version ${i.intended} is not valid semver` });
+  } else {
+  const intendedAhead = pubVer === null || (phantomOrder ?? 0) > 0;
   if (intendedAhead) {
     if (i.intendedBumpAgeHours > i.graceHours) {
       results.push({
@@ -635,6 +713,7 @@ export function evaluateTrain(i: TrainEvalInput): EdgeResult[] {
       detail: `manifest ${i.intended} matches published ${i.published?.version}`,
     });
   }
+  } // end phantom-judgeable branch
 
   // --- channel edges: only meaningful once a release is published AND past grace ---
   if (pubVer === null) return results;
@@ -664,11 +743,16 @@ export function evaluateTrain(i: TrainEvalInput): EdgeResult[] {
     }
     const chVer = ch.version ? stripV(ch.version) : null;
     if (chVer === null) {
-      results.push({ edge, verdict: "indeterminate", detail: "channel version unparseable" });
+      results.push({ edge, verdict: "indeterminate", detail: "channel version missing" });
+      continue;
+    }
+    const ord = compareSemver(chVer, pubVer);
+    if (ord === null) {
+      results.push({ edge, verdict: "indeterminate", detail: `channel version ${chVer} not comparable to ${pubVer}` });
       continue;
     }
     results.push(
-      Bun.semver.order(chVer, pubVer) >= 0
+      ord >= 0
         ? { edge, verdict: "ok", detail: `${ch.kind} ${chVer} >= published ${pubVer}` }
         : { edge, verdict: "stale", detail: `${ch.kind} ${chVer} < published ${pubVer}` },
     );
@@ -754,9 +838,20 @@ git commit -m "feat(audit): release-staleness evaluation engine (grace-aware, fa
 - [ ] **Step 2: Write the failing test** for the manifest loader — add to `check-release-staleness.test.ts`:
 
 ```ts
-import { loadTrainManifest } from "./check-release-staleness.ts";
+import { ageHours, loadTrainManifest } from "./check-release-staleness.ts";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+
+describe("ageHours", () => {
+  test("a valid past timestamp yields a finite non-negative age", () => {
+    const h = ageHours("2020-01-01T00:00:00Z");
+    expect(Number.isFinite(h)).toBe(true);
+    expect(h).toBeGreaterThan(0);
+  });
+  test("an unparseable timestamp fails closed to +Infinity", () => {
+    expect(ageHours("not-a-date")).toBe(Number.POSITIVE_INFINITY);
+  });
+});
 
 describe("loadTrainManifest", () => {
   test("parses graceHours + trains", () => {
@@ -815,9 +910,16 @@ export function loadTrainManifest(json: string): TrainManifest {
 Then the age helper + gh readers + `import.meta.main` shell:
 
 ```ts
-/** Hours between an ISO-8601 (Z-suffixed) timestamp and now, UTC epoch-ms math. */
+/**
+ * Hours between an ISO-8601 (Z-suffixed) timestamp and now, UTC epoch-ms math.
+ * An unparseable date yields `+Infinity` (fail-CLOSED): a NaN age would satisfy
+ * `NaN > graceHours === false` and silently mask a phantom/stale state as "ok",
+ * so an unreadable timestamp instead forces the aged-check to fire.
+ */
 export function ageHours(isoZ: string): number {
-  return (Date.now() - new Date(isoZ).getTime()) / 3_600_000;
+  const t = new Date(isoZ).getTime();
+  if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - t) / 3_600_000;
 }
 
 /** Decode a GitHub contents API base64 `.content` envelope to UTF-8 text. */
@@ -923,9 +1025,14 @@ async function readChannel(ch: ChannelSpec, publishedVersion: string | null): Pr
 async function tryLinuxGz(ch: ChannelSpec): Promise<ChannelReading | null> {
   const gz = runGh(["gh", "api", `repos/${ch.repo}/contents/${ch.path}.gz`, "--jq", ".content"]);
   if (!gz.ok) return null;
-  const bytes = Buffer.from(gz.stdout.replace(/\s/g, ""), "base64");
-  const text = new TextDecoder().decode(Bun.gunzipSync(bytes));
-  return { kind: ch.kind, status: "read", version: parseLinuxVersion(text), covered: null };
+  try {
+    const bytes = Buffer.from(gz.stdout.replace(/\s/g, ""), "base64");
+    const text = new TextDecoder().decode(Bun.gunzipSync(bytes));
+    return { kind: ch.kind, status: "read", version: parseLinuxVersion(text), covered: null };
+  } catch {
+    // corrupt / non-gzip payload — transient, not a staleness finding
+    return { kind: ch.kind, status: "indeterminate", version: null, covered: null };
+  }
 }
 ```
 
@@ -1050,4 +1157,14 @@ git commit -m "ci(infra): add release-staleness job to org-drift-sweep (P2 Relea
 
 **Placeholder scan:** no TBD/TODO; every code step shows complete code. ✓
 
-**Type consistency:** `PublishedRelease`, `ReleaseInfo`, `ChannelReading`, `EdgeResult`, `TrainEvalInput`, `TrainManifest`/`TrainSpec`/`ChannelSpec` are defined once (Tasks 3–5) and used consistently. `evaluateTrain`/`decideExit`/`selectPublished`/`resolveWingetCoverage`/`loadTrainManifest`/`classifyReadFailure`/`parseHttpStatus` names match across tasks. ✓
+**Type consistency:** `PublishedRelease`, `ReleaseInfo`, `ChannelReading`, `EdgeResult`, `TrainEvalInput`, `TrainManifest`/`TrainSpec`/`ChannelSpec` are defined once (Tasks 3–5) and used consistently. `evaluateTrain`/`decideExit`/`selectPublished`/`resolveWingetCoverage`/`loadTrainManifest`/`classifyReadFailure`/`parseHttpStatus`/`compareSemver`/`ageHours` names match across tasks. ✓
+
+## Review disposition (plan hardening pass)
+
+All five points from the plan review were **fixed** (none deferred — all in-scope Phase-1 robustness):
+
+1. **`Bun.semver.order` crash on non-semver** (confirmed live: it throws `Invalid SemVer`) → new `compareSemver` (Task 3) returns `null` instead of throwing; `evaluateTrain` maps `null` to an `indeterminate` verdict (Task 4). Used in `selectPublished` too.
+2. **`tryLinuxGz` throw on corrupt gzip** → wrapped in try/catch → `indeterminate` reading (Task 5).
+3. **`ageHours` NaN masking** → an unparseable timestamp now returns `+Infinity` (fail-closed, so the aged-check fires rather than silently reading "ok") (Task 5).
+4. **Linux multi-package index** → `parseLinuxVersion` now scopes to the `nimbus-headless` `Package:` block (not position) (Task 3).
+5. **Open Q1 (multi-part winget ids)** → `wingetDirPath` now maps every dot-segment to its own path segment (correct for `NimbusAgent.Nimbus` today, future-proof). **Open Q2 (Debian epoch/revision)** → `parseLinuxVersion` strips a `N:` epoch and `-rev` suffix to the core version; residual oddities degrade to `indeterminate` via `compareSemver`, never a crash. Both verified-against-live-repo notes retained.

--- a/docs/superpowers/plans/2026-07-24-p2-release-train.md
+++ b/docs/superpowers/plans/2026-07-24-p2-release-train.md
@@ -1,0 +1,1053 @@
+# P2 — Release Train (Phase 1: channel staleness) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship an independent, scheduled `audit:release-staleness` gate that goes red when the latest built Nimbus Release has not reached a distribution channel (brew/scoop/linux/winget) past a grace window, or when a release phantoms (manifest bumped, no built Release).
+
+**Architecture:** A declarative `.github/release-train.json` manifest lists every propagation edge. A read-only Bun audit script (`scripts/structure-audit/check-release-staleness.ts`) reads the live version at each of three "heads" — intended (release-please manifest), published (latest GitHub Release whose `SHA256SUMS` asset exists), distributed (each channel's live file / winget dir-or-PR) — entirely through public `gh` calls (no App token). Pure comparison functions decide `ok | stale | phantom | indeterminate` per edge; a new job in `org-drift-sweep.yml` runs it `--strict` on the existing weekly cron. This is Phase 1 of the spec; Phase 2 (dependency-DAG edges) is out of scope here.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6 strict, `gh` CLI, `Bun.semver.order()` (built-in, no dependency), `Bun.gunzipSync` (built-in). Follows the existing org-drift-sweep gate pattern (`_gh-audit.ts`).
+
+**Spec:** [`docs/superpowers/specs/2026-07-24-p2-release-train-design.md`](../specs/2026-07-24-p2-release-train-design.md) (+ its review doc).
+
+## Global Constraints
+
+- **Runtime:** Bun v1.2+, TypeScript 6.x strict. **No `any`** — use `unknown` for external (gh/JSON) data and narrow it (`isRecord` from `_gh-audit.ts`).
+- **Linter:** Biome. Run `bunx biome check packages scripts` (NOT `bun run lint` — it reports 0 files in a `.claude/worktrees/` checkout).
+- **Branch:** all work on `dev/asafgolombek/p2-release-train` inside the worktree `.claude/worktrees/p2-release-train`. Never commit on `main`. Verify `git rev-parse --abbrev-ref HEAD` before the first commit.
+- **Gate contract:** fail-soft locally (soft green when `gh` is unavailable/unauthenticated), hard red under `--strict` / `GITHUB_ACTIONS`. Reuse `isStrict` / `strictSkip` from `_gh-audit.ts`.
+- **Staleness semantics:** `graceHours` default **6**. A channel edge is only evaluated once the published Release is older than `graceHours`; the phantom edge only once the manifest-bump commit is older than `graceHours`. winget "caught up" = version dir merged **or** an open PR for the version exists (never gate on Microsoft's merge).
+- **Auth:** all reads are public → no App token. In CI pass `GH_TOKEN: ${{ github.token }}` (authenticated 5000/hr).
+- **Time:** UTC epoch-ms only. `Date.now() - new Date(ts).getTime()`; never parse a timestamp lacking an explicit `Z`/offset.
+- **Version compare:** `Bun.semver.order(a, b)` → `-1 | 0 | 1`. Strip a leading `v` from every version before comparing.
+- **Pre-push:** `bun run preflight:fast` must pass; scoped tests `bun test scripts/structure-audit/` must pass.
+
+---
+
+## File Structure
+
+- **Modify** `scripts/structure-audit/_gh-audit.ts` — add `stderr` + `httpStatus` to `GhResult`; add pure helpers `parseHttpStatus` + `classifyReadFailure`. Shared by both gates (DRY).
+- **Modify** `scripts/structure-audit/_gh-audit.test.ts` — tests for the two new pure helpers.
+- **Modify** `scripts/structure-audit/check-cla-coverage.ts` — use `classifyReadFailure` so a non-404 per-repo failure is *indeterminate*, not "cla.yml absent" (closes the roadmap's CLA-coverage robustness follow-up).
+- **Create** `scripts/structure-audit/check-release-staleness.ts` — the gate: pure parsers + `selectPublished` + `resolveWingetCoverage` + `evaluateTrain` + `decideExit` + `loadTrainManifest` (all exported) behind an `import.meta.main` gh-reading shell.
+- **Create** `scripts/structure-audit/check-release-staleness.test.ts` — table-driven unit tests for every pure function.
+- **Create** `.github/release-train.json` — the declarative edge manifest.
+- **Modify** `package.json` — add the `audit:release-staleness` script.
+- **Modify** `scripts/lib/preflight-gates.ts` — register `audit:release-staleness` in `CI_ONLY_GATES`.
+- **Modify** `.github/workflows/org-drift-sweep.yml` — add the `release-staleness` job.
+
+---
+
+## Task 1: `_gh-audit.ts` — surface HTTP status + shared read classifier
+
+**Files:**
+- Modify: `scripts/structure-audit/_gh-audit.ts`
+- Test: `scripts/structure-audit/_gh-audit.test.ts`
+
+**Interfaces:**
+- Produces: `GhResult` gains `stderr: string` and `httpStatus?: number` (additive — existing `.ok`/`.stdout` callers unchanged). `parseHttpStatus(stderr: string): number | undefined`. `classifyReadFailure(httpStatus: number | undefined): "absent" | "indeterminate"`.
+
+- [ ] **Step 1: Write the failing tests** — append to `scripts/structure-audit/_gh-audit.test.ts`:
+
+```ts
+import { classifyReadFailure, parseHttpStatus } from "./_gh-audit.ts";
+
+describe("parseHttpStatus", () => {
+  test("extracts the status from gh's '(HTTP NNN)' stderr", () => {
+    expect(parseHttpStatus("gh: Not Found (HTTP 404)")).toBe(404);
+    expect(parseHttpStatus("gh: Server Error (HTTP 500)")).toBe(500);
+    expect(parseHttpStatus("API rate limit exceeded (HTTP 403)")).toBe(403);
+  });
+  test("returns undefined when no HTTP status is present", () => {
+    expect(parseHttpStatus("some other failure")).toBeUndefined();
+    expect(parseHttpStatus("")).toBeUndefined();
+  });
+});
+
+describe("classifyReadFailure", () => {
+  test("404 is a genuine absence", () => {
+    expect(classifyReadFailure(404)).toBe("absent");
+  });
+  test("5xx / 403 / unknown are indeterminate (transient), never absent", () => {
+    expect(classifyReadFailure(500)).toBe("indeterminate");
+    expect(classifyReadFailure(403)).toBe("indeterminate");
+    expect(classifyReadFailure(undefined)).toBe("indeterminate");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/_gh-audit.test.ts`
+Expected: FAIL — `classifyReadFailure`/`parseHttpStatus` are not exported.
+
+- [ ] **Step 3: Implement** — edit `scripts/structure-audit/_gh-audit.ts`. Extend `GhResult` and `runGh`, and add the two helpers:
+
+```ts
+export interface GhResult {
+  ok: boolean;
+  stdout: string;
+  /** Captured stderr (gh writes "(HTTP NNN)" here on failure). "" on success or spawn error. */
+  stderr: string;
+  /** Parsed HTTP status when the call failed with one; undefined otherwise. */
+  httpStatus?: number;
+}
+
+/** Pull the numeric status out of gh's `... (HTTP NNN)` error line. */
+export function parseHttpStatus(stderr: string): number | undefined {
+  const m = stderr.match(/\(HTTP (\d{3})\)/);
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
+ * A failed public read is either a genuine 404 (the thing is absent — a real
+ * finding) or a transient failure (5xx, 403 rate-limit, network) that must NOT
+ * be read as a finding. Mirrors the team-reachability "indeterminate" rule.
+ */
+export function classifyReadFailure(httpStatus: number | undefined): "absent" | "indeterminate" {
+  return httpStatus === 404 ? "absent" : "indeterminate";
+}
+```
+
+And update `runGh` to capture stderr + status (keep `ok`/`stdout` behavior identical):
+
+```ts
+export function runGh(args: string[]): GhResult {
+  try {
+    const proc = Bun.spawnSync(args);
+    const stderr = new TextDecoder().decode(proc.stderr);
+    if (!proc.success) {
+      return { ok: false, stdout: "", stderr, httpStatus: parseHttpStatus(stderr) };
+    }
+    return { ok: true, stdout: new TextDecoder().decode(proc.stdout), stderr };
+  } catch {
+    return { ok: false, stdout: "", stderr: "" };
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/structure-audit/_gh-audit.test.ts`
+Expected: PASS (existing `isStrict`/`strictSkip` tests still green — the change is additive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/structure-audit/_gh-audit.ts scripts/structure-audit/_gh-audit.test.ts
+git commit -m "feat(audit): surface gh HTTP status + shared read classifier in _gh-audit"
+```
+
+---
+
+## Task 2: CLA-coverage robustness — non-404 failure is indeterminate
+
+**Files:**
+- Modify: `scripts/structure-audit/check-cla-coverage.ts`
+- Test: `scripts/structure-audit/check-cla-coverage.test.ts`
+
+**Interfaces:**
+- Consumes: `classifyReadFailure` (Task 1).
+- Produces: no signature change to `diffClaCoverage`; the `import.meta.main` shell now short-circuits to `strictSkip` with a reason when any per-repo read fails with a non-404 status.
+
+> **Separable:** this task closes a roadmap follow-up but touches a sibling gate. If the reviewer wants P2 fully isolated, skip Task 2 — Tasks 3–6 do not depend on it. (Task 1's helper is still used by the release-staleness gate regardless.)
+
+- [ ] **Step 1: Write the failing test** — add to `scripts/structure-audit/check-cla-coverage.test.ts` a test for a new exported pure helper that the shell will use:
+
+```ts
+import { classifyRepoRead } from "./check-cla-coverage.ts";
+
+describe("classifyRepoRead", () => {
+  test("ok read yields the parsed value", () => {
+    expect(classifyRepoRead({ ok: true, stdout: "x", stderr: "" })).toEqual({ kind: "read" });
+  });
+  test("404 read is absent (a genuine finding)", () => {
+    expect(classifyRepoRead({ ok: false, stdout: "", stderr: "(HTTP 404)", httpStatus: 404 })).toEqual({ kind: "absent" });
+  });
+  test("500 read is indeterminate, not absent", () => {
+    expect(classifyRepoRead({ ok: false, stdout: "", stderr: "(HTTP 500)", httpStatus: 500 })).toEqual({ kind: "indeterminate" });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/check-cla-coverage.test.ts`
+Expected: FAIL — `classifyRepoRead` not exported.
+
+- [ ] **Step 3: Implement** — in `check-cla-coverage.ts`, add the helper and use it in the shell. Add the import and helper:
+
+```ts
+import { classifyReadFailure, type GhResult, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
+/** Classify one per-repo contents read into read / absent / indeterminate. */
+export function classifyRepoRead(res: GhResult): { kind: "read" | "absent" | "indeterminate" } {
+  if (res.ok) return { kind: "read" };
+  return { kind: classifyReadFailure(res.httpStatus) };
+}
+```
+
+Replace the per-repo loop body (currently `if (!res.ok) { live[repo] = null; continue; }`) with:
+
+```ts
+    const cls = classifyRepoRead(res);
+    if (cls.kind === "indeterminate") {
+      const outcome = strictSkip(
+        label,
+        strict,
+        `cla-coverage indeterminate — ${repo} read failed transiently (HTTP ${res.httpStatus ?? "?"})`,
+      );
+      if (outcome.code === 1) console.error(outcome.message);
+      else console.warn(outcome.message);
+      process.exit(outcome.code);
+    }
+    if (cls.kind === "absent") {
+      live[repo] = null;
+      continue;
+    }
+```
+
+(Leave the subsequent base64-decode + `parseVersion` for the `read` case unchanged.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/structure-audit/check-cla-coverage.test.ts`
+Expected: PASS (existing `diffClaCoverage` tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/structure-audit/check-cla-coverage.ts scripts/structure-audit/check-cla-coverage.test.ts
+git commit -m "fix(audit): cla-coverage treats a non-404 read as indeterminate, not absent"
+```
+
+---
+
+## Task 3: Release-staleness pure readers — version parsers, published selector, winget resolver
+
+**Files:**
+- Create: `scripts/structure-audit/check-release-staleness.ts`
+- Test: `scripts/structure-audit/check-release-staleness.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `parseBrewVersion(rb: string): string | null`
+  - `parseScoopVersion(json: string): string | null`
+  - `parseLinuxVersion(packages: string): string | null`
+  - `interface ReleaseInfo { tag: string; prerelease: boolean; draft: boolean; assets: string[]; publishedAt: string }`
+  - `interface PublishedRelease { version: string; publishedAt: string }`
+  - `selectPublished(releases: ReleaseInfo[], asset: string): PublishedRelease | null`
+  - `wingetDirPath(packageId: string, version: string): string`
+  - `resolveWingetCoverage(dir: boolean | null, pr: boolean | null): { status: "read" | "indeterminate"; covered: boolean }`
+
+- [ ] **Step 1: Write the failing tests** — create `scripts/structure-audit/check-release-staleness.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  parseBrewVersion,
+  parseScoopVersion,
+  parseLinuxVersion,
+  selectPublished,
+  wingetDirPath,
+  resolveWingetCoverage,
+} from "./check-release-staleness.ts";
+
+describe("parseBrewVersion", () => {
+  test("reads version from a Formula .rb", () => {
+    expect(parseBrewVersion('class Nimbus < Formula\n  version "0.26.0"\n  url "..."')).toBe("0.26.0");
+  });
+  test("null when absent", () => {
+    expect(parseBrewVersion("class Nimbus < Formula\n  url \"...\"")).toBeNull();
+  });
+});
+
+describe("parseScoopVersion", () => {
+  test("reads .version from a scoop manifest", () => {
+    expect(parseScoopVersion('{"version":"0.26.0","url":"x"}')).toBe("0.26.0");
+  });
+  test("null on malformed json or missing key", () => {
+    expect(parseScoopVersion("{not json")).toBeNull();
+    expect(parseScoopVersion('{"url":"x"}')).toBeNull();
+  });
+});
+
+describe("parseLinuxVersion", () => {
+  test("reads the Version: control field from a Packages file", () => {
+    const pkgs = "Package: nimbus-headless\nVersion: 0.26.0\nArchitecture: amd64\n";
+    expect(parseLinuxVersion(pkgs)).toBe("0.26.0");
+  });
+  test("null when no Version field", () => {
+    expect(parseLinuxVersion("Package: nimbus-headless\n")).toBeNull();
+  });
+});
+
+describe("selectPublished", () => {
+  const base = { draft: false, prerelease: false, publishedAt: "2026-07-01T00:00:00Z" };
+  test("picks the highest stable tag whose SHA256SUMS asset exists", () => {
+    const r = selectPublished(
+      [
+        { ...base, tag: "v0.25.0", assets: ["SHA256SUMS"] },
+        { ...base, tag: "v0.26.0", assets: ["SHA256SUMS"], publishedAt: "2026-07-10T00:00:00Z" },
+      ],
+      "SHA256SUMS",
+    );
+    expect(r).toEqual({ version: "0.26.0", publishedAt: "2026-07-10T00:00:00Z" });
+  });
+  test("skips a release missing the asset (asset-less phantom)", () => {
+    const r = selectPublished(
+      [
+        { ...base, tag: "v0.26.0", assets: [] },
+        { ...base, tag: "v0.25.0", assets: ["SHA256SUMS"] },
+      ],
+      "SHA256SUMS",
+    );
+    expect(r?.version).toBe("0.25.0");
+  });
+  test("skips prereleases, drafts, and non-vX.Y.Z tags", () => {
+    const r = selectPublished(
+      [
+        { ...base, tag: "v0.27.0-rc.1", prerelease: true, assets: ["SHA256SUMS"] },
+        { ...base, tag: "sdk-v1.6.0", assets: ["SHA256SUMS"] },
+        { ...base, tag: "v0.26.0", draft: true, assets: ["SHA256SUMS"] },
+        { ...base, tag: "v0.25.0", assets: ["SHA256SUMS"] },
+      ],
+      "SHA256SUMS",
+    );
+    expect(r?.version).toBe("0.25.0");
+  });
+  test("null when nothing qualifies", () => {
+    expect(selectPublished([{ ...base, tag: "v0.26.0", assets: [] }], "SHA256SUMS")).toBeNull();
+  });
+});
+
+describe("wingetDirPath", () => {
+  test("derives the manifests path from the package id", () => {
+    expect(wingetDirPath("NimbusAgent.Nimbus", "0.26.0")).toBe(
+      "manifests/n/NimbusAgent/Nimbus/0.26.0",
+    );
+  });
+});
+
+describe("resolveWingetCoverage", () => {
+  test("covered when the dir exists", () => {
+    expect(resolveWingetCoverage(true, false)).toEqual({ status: "read", covered: true });
+  });
+  test("covered when an open PR exists", () => {
+    expect(resolveWingetCoverage(false, true)).toEqual({ status: "read", covered: true });
+  });
+  test("genuinely not covered when both are known-false", () => {
+    expect(resolveWingetCoverage(false, false)).toEqual({ status: "read", covered: false });
+  });
+  test("indeterminate when either signal is unknown and neither is true", () => {
+    expect(resolveWingetCoverage(null, false)).toEqual({ status: "indeterminate", covered: false });
+    expect(resolveWingetCoverage(false, null)).toEqual({ status: "indeterminate", covered: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement** — create `scripts/structure-audit/check-release-staleness.ts` with the pure readers (shell added in Task 5):
+
+```ts
+#!/usr/bin/env bun
+
+/**
+ * audit:release-staleness — the P2 Release Train gate. Reads three version
+ * "heads" for each train in .github/release-train.json (intended = release-please
+ * manifest, published = latest GitHub Release with its SHA256SUMS asset,
+ * distributed = each channel's live version) and fails when a channel lags the
+ * published release past graceHours, or when a release phantoms. All reads are
+ * public gh calls; fail-soft locally, strict in CI. See
+ * docs/superpowers/specs/2026-07-24-p2-release-train-design.md.
+ */
+
+export function stripV(version: string): string {
+  return version.replace(/^v/, "");
+}
+
+/** `version "X.Y.Z"` from a Homebrew Formula .rb. */
+export function parseBrewVersion(rb: string): string | null {
+  return rb.match(/version\s+"([^"]+)"/)?.[1] ?? null;
+}
+
+/** `.version` from a Scoop JSON manifest. */
+export function parseScoopVersion(json: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (typeof parsed === "object" && parsed !== null && "version" in parsed) {
+      const v = (parsed as { version: unknown }).version;
+      return typeof v === "string" ? v : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** First `Version:` control field from an apt Packages list. */
+export function parseLinuxVersion(packages: string): string | null {
+  return packages.match(/^Version:\s*(.+)$/m)?.[1]?.trim() ?? null;
+}
+
+export interface ReleaseInfo {
+  tag: string;
+  prerelease: boolean;
+  draft: boolean;
+  assets: string[];
+  publishedAt: string;
+}
+export interface PublishedRelease {
+  version: string;
+  publishedAt: string;
+}
+
+/**
+ * Highest stable `vX.Y.Z` release whose `asset` is attached. Skips drafts,
+ * prereleases, non-`vX.Y.Z` tags (e.g. component tags), and asset-less phantom
+ * releases. Returns null when nothing qualifies.
+ */
+export function selectPublished(releases: ReleaseInfo[], asset: string): PublishedRelease | null {
+  const stable = /^v\d+\.\d+\.\d+$/;
+  const eligible = releases.filter(
+    (r) => !r.draft && !r.prerelease && stable.test(r.tag) && r.assets.includes(asset),
+  );
+  if (eligible.length === 0) return null;
+  eligible.sort((a, b) => Bun.semver.order(stripV(b.tag), stripV(a.tag)));
+  const top = eligible[0];
+  return top ? { version: stripV(top.tag), publishedAt: top.publishedAt } : null;
+}
+
+/** winget-pkgs manifests path: manifests/<first-letter>/<Publisher>/<Package>/<version>. */
+export function wingetDirPath(packageId: string, version: string): string {
+  const [publisher, ...rest] = packageId.split(".");
+  const pkg = rest.join(".");
+  const letter = (publisher ?? "").charAt(0).toLowerCase();
+  return `manifests/${letter}/${publisher}/${pkg}/${version}`;
+}
+
+/**
+ * winget is "caught up" if the version dir is merged OR an open PR exists.
+ * `dir`/`pr` are true (known present), false (known absent), or null (the read
+ * failed transiently). Covered if either is true; genuinely not covered only
+ * when both are known-false; otherwise indeterminate.
+ */
+export function resolveWingetCoverage(
+  dir: boolean | null,
+  pr: boolean | null,
+): { status: "read" | "indeterminate"; covered: boolean } {
+  if (dir === true || pr === true) return { status: "read", covered: true };
+  if (dir === false && pr === false) return { status: "read", covered: false };
+  return { status: "indeterminate", covered: false };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/structure-audit/check-release-staleness.ts scripts/structure-audit/check-release-staleness.test.ts
+git commit -m "feat(audit): release-staleness pure readers (brew/scoop/linux/published/winget)"
+```
+
+---
+
+## Task 4: The evaluation engine — `evaluateTrain` + `decideExit`
+
+**Files:**
+- Modify: `scripts/structure-audit/check-release-staleness.ts`
+- Test: `scripts/structure-audit/check-release-staleness.test.ts`
+
+**Interfaces:**
+- Consumes: `PublishedRelease` (Task 3).
+- Produces:
+  - `type EdgeVerdict = "ok" | "stale" | "phantom" | "indeterminate"`
+  - `interface EdgeResult { edge: string; verdict: EdgeVerdict; detail: string }`
+  - `interface ChannelReading { kind: string; status: "read" | "absent" | "indeterminate"; version: string | null; covered: boolean | null }`
+  - `interface TrainEvalInput { name: string; intended: string; intendedBumpAgeHours: number; published: PublishedRelease | null; publishedAgeHours: number | null; channels: ChannelReading[]; graceHours: number }`
+  - `evaluateTrain(input: TrainEvalInput): EdgeResult[]`
+  - `decideExit(results: EdgeResult[], strict: boolean): { code: 0 | 1; messages: string[] }`
+
+- [ ] **Step 1: Write the failing tests** — add to `check-release-staleness.test.ts`:
+
+```ts
+import { evaluateTrain, decideExit, type ChannelReading } from "./check-release-staleness.ts";
+
+const ch = (over: Partial<ChannelReading>): ChannelReading => ({
+  kind: "brew", status: "read", version: null, covered: null, ...over,
+});
+
+describe("evaluateTrain", () => {
+  const green = {
+    name: "t", intended: "0.26.0", intendedBumpAgeHours: 48,
+    published: { version: "0.26.0", publishedAt: "x" }, publishedAgeHours: 48, graceHours: 6,
+  };
+
+  test("all heads equal + channels current => all ok", () => {
+    const r = evaluateTrain({
+      ...green,
+      channels: [
+        ch({ kind: "brew", version: "0.26.0" }),
+        ch({ kind: "scoop", version: "0.26.0" }),
+        ch({ kind: "linux", version: "0.26.0" }),
+        ch({ kind: "winget", version: null, covered: true }),
+      ],
+    });
+    expect(r.every((e) => e.verdict === "ok")).toBe(true);
+  });
+
+  test("channel behind published, past grace => stale", () => {
+    const r = evaluateTrain({ ...green, channels: [ch({ kind: "brew", version: "0.25.0" })] });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("stale");
+  });
+
+  test("channel behind published but within grace => ok", () => {
+    const r = evaluateTrain({
+      ...green, publishedAgeHours: 2, channels: [ch({ kind: "brew", version: "0.25.0" })],
+    });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("ok");
+  });
+
+  test("manifest ahead of published + aged bump => phantom", () => {
+    const r = evaluateTrain({
+      ...green, intended: "0.27.0", published: { version: "0.26.0", publishedAt: "x" }, channels: [],
+    });
+    expect(r.find((e) => e.edge === "t:phantom")?.verdict).toBe("phantom");
+  });
+
+  test("manifest ahead but bump within grace => ok (build window)", () => {
+    const r = evaluateTrain({
+      ...green, intended: "0.27.0", intendedBumpAgeHours: 1,
+      published: { version: "0.26.0", publishedAt: "x" }, channels: [],
+    });
+    expect(r.find((e) => e.edge === "t:phantom")?.verdict).toBe("ok");
+  });
+
+  test("winget not covered, past grace => stale", () => {
+    const r = evaluateTrain({
+      ...green, channels: [ch({ kind: "winget", version: null, covered: false })],
+    });
+    expect(r.find((e) => e.edge === "t:winget")?.verdict).toBe("stale");
+  });
+
+  test("transient channel read => indeterminate, never stale", () => {
+    const r = evaluateTrain({
+      ...green, channels: [ch({ kind: "brew", status: "indeterminate" })],
+    });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("indeterminate");
+  });
+
+  test("absent channel file, past grace => stale", () => {
+    const r = evaluateTrain({ ...green, channels: [ch({ kind: "brew", status: "absent" })] });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("stale");
+  });
+});
+
+describe("decideExit", () => {
+  test("a stale or phantom edge => exit 1 with ::error::", () => {
+    const out = decideExit([{ edge: "t:brew", verdict: "stale", detail: "d" }], true);
+    expect(out.code).toBe(1);
+    expect(out.messages.join("\n")).toContain("::error::");
+  });
+  test("only ok + indeterminate => exit 0 with a warning", () => {
+    const out = decideExit(
+      [{ edge: "t:brew", verdict: "ok", detail: "d" }, { edge: "t:scoop", verdict: "indeterminate", detail: "d" }],
+      true,
+    );
+    expect(out.code).toBe(0);
+    expect(out.messages.join("\n")).toContain("::warning::");
+  });
+  test("everything indeterminate under --strict => exit 1 (not 'all clear')", () => {
+    const out = decideExit([{ edge: "t:brew", verdict: "indeterminate", detail: "d" }], true);
+    expect(out.code).toBe(1);
+  });
+  test("everything indeterminate when NOT strict => exit 0 (soft)", () => {
+    const out = decideExit([{ edge: "t:brew", verdict: "indeterminate", detail: "d" }], false);
+    expect(out.code).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: FAIL — `evaluateTrain`/`decideExit` not exported.
+
+- [ ] **Step 3: Implement** — append to `check-release-staleness.ts`:
+
+```ts
+export type EdgeVerdict = "ok" | "stale" | "phantom" | "indeterminate";
+export interface EdgeResult {
+  edge: string;
+  verdict: EdgeVerdict;
+  detail: string;
+}
+export interface ChannelReading {
+  kind: string;
+  status: "read" | "absent" | "indeterminate";
+  /** version-file channels (brew/scoop/linux); null for winget or unread. */
+  version: string | null;
+  /** winget only: is the published version covered; null otherwise. */
+  covered: boolean | null;
+}
+export interface TrainEvalInput {
+  name: string;
+  intended: string;
+  intendedBumpAgeHours: number;
+  published: PublishedRelease | null;
+  publishedAgeHours: number | null;
+  channels: ChannelReading[];
+  graceHours: number;
+}
+
+export function evaluateTrain(i: TrainEvalInput): EdgeResult[] {
+  const results: EdgeResult[] = [];
+  const pubVer = i.published ? stripV(i.published.version) : null;
+
+  // --- phantom edge: intended must have a matching built (asset-bearing) release ---
+  const intendedAhead = pubVer === null || Bun.semver.order(stripV(i.intended), pubVer) > 0;
+  if (intendedAhead) {
+    if (i.intendedBumpAgeHours > i.graceHours) {
+      results.push({
+        edge: `${i.name}:phantom`,
+        verdict: "phantom",
+        detail: `manifest ${i.intended} has no built Release with assets (latest published: ${i.published?.version ?? "none"}); bump is ${Math.round(i.intendedBumpAgeHours)}h old (> ${i.graceHours}h grace)`,
+      });
+    } else {
+      results.push({
+        edge: `${i.name}:phantom`,
+        verdict: "ok",
+        detail: `manifest ${i.intended} ahead of published ${i.published?.version ?? "none"} but within ${i.graceHours}h grace`,
+      });
+    }
+  } else {
+    results.push({
+      edge: `${i.name}:phantom`,
+      verdict: "ok",
+      detail: `manifest ${i.intended} matches published ${i.published?.version}`,
+    });
+  }
+
+  // --- channel edges: only meaningful once a release is published AND past grace ---
+  if (pubVer === null) return results;
+  const pastGrace = i.publishedAgeHours !== null && i.publishedAgeHours > i.graceHours;
+
+  for (const ch of i.channels) {
+    const edge = `${i.name}:${ch.kind}`;
+    if (!pastGrace) {
+      results.push({ edge, verdict: "ok", detail: `within ${i.graceHours}h grace` });
+      continue;
+    }
+    if (ch.status === "indeterminate") {
+      results.push({ edge, verdict: "indeterminate", detail: "channel read failed transiently" });
+      continue;
+    }
+    if (ch.status === "absent") {
+      results.push({ edge, verdict: "stale", detail: "channel file/dir absent" });
+      continue;
+    }
+    if (ch.kind === "winget") {
+      results.push(
+        ch.covered
+          ? { edge, verdict: "ok", detail: `winget covers ${pubVer} (merged dir or open PR)` }
+          : { edge, verdict: "stale", detail: `no winget dir and no open PR for ${pubVer}` },
+      );
+      continue;
+    }
+    const chVer = ch.version ? stripV(ch.version) : null;
+    if (chVer === null) {
+      results.push({ edge, verdict: "indeterminate", detail: "channel version unparseable" });
+      continue;
+    }
+    results.push(
+      Bun.semver.order(chVer, pubVer) >= 0
+        ? { edge, verdict: "ok", detail: `${ch.kind} ${chVer} >= published ${pubVer}` }
+        : { edge, verdict: "stale", detail: `${ch.kind} ${chVer} < published ${pubVer}` },
+    );
+  }
+  return results;
+}
+
+/**
+ * Exit decision. Any stale/phantom edge => red. Otherwise green with a warning
+ * per indeterminate edge — EXCEPT a run where nothing was evaluable (no ok, only
+ * indeterminate) under --strict is red: "indeterminate" must not read as "all
+ * clear" in the scheduled sweep (the team-reachability rule).
+ */
+export function decideExit(results: EdgeResult[], strict: boolean): { code: 0 | 1; messages: string[] } {
+  const messages: string[] = [];
+  const hard = results.filter((r) => r.verdict === "phantom" || r.verdict === "stale");
+  const indet = results.filter((r) => r.verdict === "indeterminate");
+  const ok = results.filter((r) => r.verdict === "ok");
+  for (const r of hard) messages.push(`::error::${r.edge}: ${r.detail}`);
+  for (const r of indet) messages.push(`::warning::${r.edge}: ${r.detail} (indeterminate)`);
+  if (hard.length > 0) return { code: 1, messages };
+  if (ok.length === 0 && indet.length > 0 && strict) {
+    messages.push("::error::release-staleness: indeterminate — nothing could be evaluated (all reads failed transiently)");
+    return { code: 1, messages };
+  }
+  return { code: 0, messages };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/structure-audit/check-release-staleness.ts scripts/structure-audit/check-release-staleness.test.ts
+git commit -m "feat(audit): release-staleness evaluation engine (grace-aware, fail-closed indeterminate)"
+```
+
+---
+
+## Task 5: The manifest + `loadTrainManifest` + the gh-reading shell + registration
+
+**Files:**
+- Create: `.github/release-train.json`
+- Modify: `scripts/structure-audit/check-release-staleness.ts` (add `loadTrainManifest` + `import.meta.main` shell)
+- Test: `scripts/structure-audit/check-release-staleness.test.ts` (`loadTrainManifest`)
+- Modify: `package.json`
+- Modify: `scripts/lib/preflight-gates.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 3–4, plus `runGh` / `isStrict` / `strictSkip` / `classifyReadFailure` / `isRecord` from `_gh-audit.ts`.
+- Produces: `interface TrainManifest { graceHours: number; trains: TrainSpec[] }`; `loadTrainManifest(json: string): TrainManifest`.
+
+- [ ] **Step 1: Create the manifest** — `.github/release-train.json`:
+
+```json
+{
+  "$comment": "P2 Release Train edges. audit:release-staleness reads each downstream's LIVE version and fails when it lags the published source past graceHours. See docs/infrastructure-roadmap.md P2 + docs/superpowers/specs/2026-07-24-p2-release-train-design.md.",
+  "graceHours": 6,
+  "trains": [
+    {
+      "name": "nimbus-gateway",
+      "source": {
+        "manifestRepo": "nimbus-agent/Nimbus",
+        "manifestFile": ".release-please-manifest.json",
+        "manifestKey": ".",
+        "releaseAsset": "SHA256SUMS"
+      },
+      "channels": [
+        { "kind": "brew", "repo": "nimbus-agent/homebrew-tap", "path": "Formula/nimbus.rb" },
+        { "kind": "scoop", "repo": "nimbus-agent/scoop-bucket", "path": "bucket/nimbus.json" },
+        { "kind": "linux", "repo": "nimbus-agent/linux-repo", "path": "apt/dists/stable/main/binary-amd64/Packages" },
+        { "kind": "winget", "package": "NimbusAgent.Nimbus", "wingetRepo": "microsoft/winget-pkgs" }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test** for the manifest loader — add to `check-release-staleness.test.ts`:
+
+```ts
+import { loadTrainManifest } from "./check-release-staleness.ts";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("loadTrainManifest", () => {
+  test("parses graceHours + trains", () => {
+    const m = loadTrainManifest('{"graceHours":6,"trains":[{"name":"x","source":{"manifestRepo":"a/b","manifestFile":"m.json","manifestKey":".","releaseAsset":"S"},"channels":[]}]}');
+    expect(m.graceHours).toBe(6);
+    expect(m.trains[0]?.name).toBe("x");
+  });
+  test("throws on a malformed manifest", () => {
+    expect(() => loadTrainManifest("{}")).toThrow();
+  });
+  test("the committed .github/release-train.json is valid", () => {
+    const raw = readFileSync(join(import.meta.dir, "..", "..", ".github", "release-train.json"), "utf8");
+    const m = loadTrainManifest(raw);
+    expect(m.trains.length).toBeGreaterThan(0);
+    expect(m.trains[0]?.channels.some((c) => c.kind === "winget")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: FAIL — `loadTrainManifest` not exported.
+
+- [ ] **Step 4: Implement `loadTrainManifest` + the types + the shell** — append to `check-release-staleness.ts`. First the manifest types + loader:
+
+```ts
+import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
+export interface ChannelSpec {
+  kind: "brew" | "scoop" | "linux" | "winget";
+  repo?: string;
+  path?: string;
+  package?: string;
+  wingetRepo?: string;
+}
+export interface TrainSpec {
+  name: string;
+  source: { manifestRepo: string; manifestFile: string; manifestKey: string; releaseAsset: string };
+  channels: ChannelSpec[];
+}
+export interface TrainManifest {
+  graceHours: number;
+  trains: TrainSpec[];
+}
+
+export function loadTrainManifest(json: string): TrainManifest {
+  const parsed: unknown = JSON.parse(json);
+  if (!isRecord(parsed) || typeof parsed["graceHours"] !== "number" || !Array.isArray(parsed["trains"])) {
+    throw new Error("release-train.json: expected { graceHours: number, trains: [...] }");
+  }
+  return parsed as unknown as TrainManifest;
+}
+```
+
+Then the age helper + gh readers + `import.meta.main` shell:
+
+```ts
+/** Hours between an ISO-8601 (Z-suffixed) timestamp and now, UTC epoch-ms math. */
+export function ageHours(isoZ: string): number {
+  return (Date.now() - new Date(isoZ).getTime()) / 3_600_000;
+}
+
+/** Decode a GitHub contents API base64 `.content` envelope to UTF-8 text. */
+function decodeContents(base64Envelope: string): string {
+  return Buffer.from(base64Envelope.replace(/\s/g, ""), "base64").toString("utf8");
+}
+
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const label = "audit:release-staleness";
+
+  // Reachability probe (mirrors cla-coverage): one public read. If gh/network is
+  // unavailable at all, soft-skip locally / red in strict.
+  const probe = runGh(["gh", "api", "repos/nimbus-agent/Nimbus", "--jq", ".name"]);
+  if (!probe.ok) {
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const manifest = loadTrainManifest(
+    await Bun.file(new URL("../../.github/release-train.json", import.meta.url)).text(),
+  );
+
+  const allResults: EdgeResult[] = [];
+  for (const train of manifest.trains) {
+    // --- intended (manifest version on main) + bump-commit age ---
+    const manRes = runGh([
+      "gh", "api",
+      `repos/${train.source.manifestRepo}/contents/${train.source.manifestFile}?ref=main`,
+      "--jq", ".content",
+    ]);
+    const intendedJson = manRes.ok ? decodeContents(manRes.stdout) : "{}";
+    const intendedParsed: unknown = JSON.parse(intendedJson);
+    const intended = isRecord(intendedParsed) && typeof intendedParsed[train.source.manifestKey] === "string"
+      ? (intendedParsed[train.source.manifestKey] as string)
+      : "";
+    const bumpRes = runGh([
+      "gh", "api",
+      `repos/${train.source.manifestRepo}/commits?path=${train.source.manifestFile}&per_page=1`,
+      "--jq", ".[0].commit.committer.date",
+    ]);
+    const intendedBumpAgeHours = bumpRes.ok && bumpRes.stdout.trim() ? ageHours(bumpRes.stdout.trim()) : Number.POSITIVE_INFINITY;
+
+    // --- published (latest release-with-assets) ---
+    const relRes = runGh([
+      "gh", "api", `repos/${train.source.manifestRepo}/releases?per_page=100`,
+      "--jq", "[.[] | {tag: .tag_name, prerelease: .prerelease, draft: .draft, publishedAt: .published_at, assets: [.assets[].name]}]",
+    ]);
+    let published: PublishedRelease | null = null;
+    if (relRes.ok) {
+      const rels: unknown = JSON.parse(relRes.stdout);
+      if (Array.isArray(rels)) published = selectPublished(rels as ReleaseInfo[], train.source.releaseAsset);
+    }
+    const publishedAgeHours = published ? ageHours(published.publishedAt) : null;
+
+    // --- channels ---
+    const readings: ChannelReading[] = [];
+    for (const ch of train.channels) {
+      readings.push(await readChannel(ch, published?.version ?? null));
+    }
+
+    allResults.push(...evaluateTrain({
+      name: train.name, intended, intendedBumpAgeHours, published, publishedAgeHours,
+      channels: readings, graceHours: manifest.graceHours,
+    }));
+  }
+
+  const out = decideExit(allResults, strict);
+  for (const m of out.messages) (m.startsWith("::error::") ? console.error : console.warn)(m);
+  if (out.code === 0) console.log(`${label}: OK (${allResults.filter((r) => r.verdict === "ok").length} edges current)`);
+  process.exit(out.code);
+}
+
+/** Read one channel's live version (or winget coverage). Public reads only. */
+async function readChannel(ch: ChannelSpec, publishedVersion: string | null): Promise<ChannelReading> {
+  if (ch.kind === "winget") {
+    if (!publishedVersion) return { kind: "winget", status: "read", version: null, covered: true };
+    const dirRes = runGh(["gh", "api", `repos/${ch.wingetRepo}/contents/${wingetDirPath(ch.package ?? "", publishedVersion)}`, "--jq", "length"]);
+    const dir = dirRes.ok ? true : classifyReadFailure(dirRes.httpStatus) === "absent" ? false : null;
+    let pr: boolean | null = false;
+    if (dir !== true) {
+      const prRes = runGh(["gh", "pr", "list", "--repo", ch.wingetRepo ?? "", "--state", "open", "--search", `in:title ${ch.package} ${publishedVersion}`, "--json", "number", "--jq", "length"]);
+      pr = prRes.ok ? Number(prRes.stdout.trim()) > 0 : null;
+    }
+    const { status, covered } = resolveWingetCoverage(dir, pr);
+    return { kind: "winget", status, version: null, covered };
+  }
+  // version-file channels
+  const res = runGh(["gh", "api", `repos/${ch.repo}/contents/${ch.path}`, "--jq", ".content"]);
+  if (!res.ok) {
+    const linuxGz = ch.kind === "linux" ? await tryLinuxGz(ch) : null;
+    if (linuxGz !== null) return linuxGz;
+    return { kind: ch.kind, status: classifyReadFailure(res.httpStatus), version: null, covered: null };
+  }
+  const text = decodeContents(res.stdout);
+  const version = ch.kind === "brew" ? parseBrewVersion(text) : ch.kind === "scoop" ? parseScoopVersion(text) : parseLinuxVersion(text);
+  return { kind: ch.kind, status: "read", version, covered: null };
+}
+
+/** Fallback: some apt repos serve only Packages.gz — decode it in-memory. */
+async function tryLinuxGz(ch: ChannelSpec): Promise<ChannelReading | null> {
+  const gz = runGh(["gh", "api", `repos/${ch.repo}/contents/${ch.path}.gz`, "--jq", ".content"]);
+  if (!gz.ok) return null;
+  const bytes = Buffer.from(gz.stdout.replace(/\s/g, ""), "base64");
+  const text = new TextDecoder().decode(Bun.gunzipSync(bytes));
+  return { kind: ch.kind, status: "read", version: parseLinuxVersion(text), covered: null };
+}
+```
+
+- [ ] **Step 5: Register the gate** — in `package.json`, add to the scripts block (next to the other `audit:*-drift` entries near line 168):
+
+```json
+    "audit:release-staleness": "bun scripts/structure-audit/check-release-staleness.ts",
+```
+
+In `scripts/lib/preflight-gates.ts`, add to `CI_ONLY_GATES` (after the `audit:cla-coverage` line):
+
+```ts
+  "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+```
+
+- [ ] **Step 6: Run the tests + typecheck + lint**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts && bun run typecheck && bunx biome check scripts`
+Expected: tests PASS; typecheck clean (no `any`); biome clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/structure-audit/check-release-staleness.ts scripts/structure-audit/check-release-staleness.test.ts .github/release-train.json package.json scripts/lib/preflight-gates.ts
+git commit -m "feat(audit): release-train manifest + gh-reading shell + gate registration"
+```
+
+---
+
+## Task 6: Wire the org-drift-sweep job + preflight + live proof
+
+**Files:**
+- Modify: `.github/workflows/org-drift-sweep.yml`
+
+**Interfaces:**
+- Consumes: the `audit:release-staleness` gate (Task 5).
+
+- [ ] **Step 1: Add the job** — append to `.github/workflows/org-drift-sweep.yml` (after the `cla-coverage` job). No App-token mint — public reads use the default `github.token`:
+
+```yaml
+  release-staleness:
+    name: release-staleness
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # No App token: every read (Nimbus releases + manifest, the channel repos,
+      # microsoft/winget-pkgs) is PUBLIC. The default github.token authenticates
+      # gh at 5000 req/hr, far above this job's handful of reads + one search.
+      - name: Audit release-train staleness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/structure-audit/check-release-staleness.ts --strict
+```
+
+- [ ] **Step 2: Verify the drift guard passes** (the new gate must be registered):
+
+Run: `bun test scripts/preflight.test.ts`
+Expected: PASS — `release-staleness` invokes `bun scripts/...ts` directly (not `bun run <id>`), so the workflow-gate extractor does not require it; the `CI_ONLY_GATES` entry from Task 5 keeps intent documented and future-proofs a `bun run` switch.
+
+- [ ] **Step 3: Run the full scoped test suite + preflight:fast**
+
+Run: `bun test scripts/structure-audit/ && bun run preflight:fast`
+Expected: all green. (If `preflight:fast` soft-warns on the network gates locally, that is expected — they are fail-soft off CI.)
+
+- [ ] **Step 4: Live proof — run the gate against the real channels**
+
+Run: `GH_TOKEN=$(gh auth token) bun scripts/structure-audit/check-release-staleness.ts`
+Expected: one of two correct outcomes —
+  - **GREEN** (`audit:release-staleness: OK`) if `v0.27.0` (or whatever the manifest claims) is published-with-assets and every channel has caught up; **or**
+  - **RED** with a specific `::error::nimbus-gateway:phantom` or `:<channel>` line if there is a genuine live gap (the spec's documented 0.27.0-vs-0.26.0 heads-up — a real phantom the gate correctly surfaces).
+
+Record which outcome occurred in the PR description. A RED here is the gate working — do **not** "fix" the gate to make it green; if it is a real phantom, note it for the release playbook. If GREEN, proceed.
+
+- [ ] **Step 5: Red-prove the gate** — confirm it *would* go red on regression, without touching production channels. Add and immediately run a scratch test that feeds `evaluateTrain` a stale channel (this is already covered by Task 4's `"channel behind published, past grace => stale"` test — re-run it as the proof):
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts -t "stale"`
+Expected: the stale/phantom cases PASS (they assert the RED verdict). This is the red-before/green-after evidence the program's definition-of-done requires: the engine returns `stale`/`phantom` on a lagging input and `ok` on a current one.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/org-drift-sweep.yml
+git commit -m "ci(infra): add release-staleness job to org-drift-sweep (P2 Release Train)"
+```
+
+---
+
+## Post-implementation (not a task — for the PR author)
+
+- **Roadmap:** flip the P2 row in `docs/infrastructure-roadmap.md` to reflect the shipped Phase-1 gate + record the run number of the first green `org-drift-sweep` that includes `release-staleness` (the program's *done* bar). Note Phase 2 (dep-DAG edges) as the remaining P2 slice.
+- **CHANGELOG:** add a `docs/CHANGELOG.md` line per the connector-docs-changelog convention (infra gate delivery), NOT the CLAUDE.md status line.
+- **Memory:** update `[[org-infrastructure-program]]` — P2 Phase 1 shipped; the live-proof outcome (green or a caught phantom); Phase 2 remaining.
+- **Live-in-CI proof:** after merge, dispatch `org-drift-sweep.yml` (`gh workflow run org-drift-sweep.yml`) once so the net-new job runs on main; confirm the `release-staleness` job is green (or red on a real gap). Per the branch-only-workflow gotcha, a net-new job's first real run is post-merge.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Three heads (intended/published/distributed) → Task 3 (`selectPublished`) + Task 4 (`evaluateTrain`). ✓
+- Declarative manifest → Task 5 (`.github/release-train.json` + `loadTrainManifest`). ✓
+- Grace window + PR-opened-for-winget → Task 4 (grace gating) + Task 3 (`resolveWingetCoverage`) + Task 5 (`readChannel` winget dir/PR). ✓
+- Pure read-only observer, no publish-workflow changes → confirmed: no publish workflow is touched. ✓
+- No App token / public reads → Task 6 (`GH_TOKEN: github.token`, no mint step). ✓
+- 404-vs-transient + 403 rate-limit → indeterminate → Task 1 (`classifyReadFailure`) + Task 4 (indeterminate verdict) + Task 5 (`readChannel`). ✓
+- `_gh-audit.ts` enhancement closes CLA-coverage follow-up → Task 1 + Task 2. ✓
+- linux Packages.gz fallback → Task 5 (`tryLinuxGz`). ✓
+- UTC epoch-ms time math → Task 5 (`ageHours`). ✓
+- Registration + drift guard → Task 5 (package.json + CI_ONLY_GATES) + Task 6 (verify). ✓
+- Fail-soft-local / strict-in-CI → Task 4 (`decideExit` strict) + Task 5 (probe → `strictSkip`). ✓
+- Scheduled sweep placement → Task 6. ✓
+- Definition of done (red-before/green-after) → Task 6 Step 5. ✓
+- Phase 2 (dep-DAG) → explicitly out of scope; sketched in spec only. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `PublishedRelease`, `ReleaseInfo`, `ChannelReading`, `EdgeResult`, `TrainEvalInput`, `TrainManifest`/`TrainSpec`/`ChannelSpec` are defined once (Tasks 3–5) and used consistently. `evaluateTrain`/`decideExit`/`selectPublished`/`resolveWingetCoverage`/`loadTrainManifest`/`classifyReadFailure`/`parseHttpStatus` names match across tasks. ✓

--- a/docs/superpowers/specs/2026-07-24-p2-release-train-design-review.md
+++ b/docs/superpowers/specs/2026-07-24-p2-release-train-design-review.md
@@ -1,0 +1,59 @@
+# Design Review: P2 — Release Train Design
+
+This document reviews [2026-07-24-p2-release-train-design.md](./2026-07-24-p2-release-train-design.md) and notes questions, suggestions, and improvements.
+
+---
+
+## 1. Rate Limiting on Public GitHub API Calls
+
+### Observation
+- The design notes that "Every source read is public... So this gate needs no App token: `github.token` in CI, the developer's `gh` locally."
+
+### Suggestion
+- Even though the channels and repositories are public, GitHub enforces strict rate limits for unauthenticated requests, and even for default authenticated tokens when executing multiple sequential calls (e.g., fetching contents across several repos, searching PRs in high-traffic repos like `microsoft/winget-pkgs`).
+- The script should explicitly support reading `process.env.GITHUB_TOKEN` or `process.env.GH_TOKEN` when run locally, and handle `403 Rate Limit Exceeded` exit statuses as `indeterminate` (with warning) rather than letting the command crash or report `stale`.
+
+---
+
+## 2. High-Traffic Search Reliability for Winget PRs
+
+### Observation
+- The winget channel is marked as "caught-up" if the version directory exists in `microsoft/winget-pkgs` OR an open PR exists.
+- This is checked via: `gh pr list --repo microsoft/winget-pkgs --search "…NimbusAgent.Nimbus …<published>"`.
+
+### Questions & Suggestions
+- **API Search Index Latency:** Newly opened PRs on GitHub are not immediately indexed by the search backend. There can be a delay of several minutes.
+- **Search Query Precision:** `microsoft/winget-pkgs` is one of the highest-traffic repositories on GitHub. A loose search query can easily hit limitations or match unrelated PRs if not carefully scoped. We should explicitly specify the exact search query format in the script (e.g., `is:pr is:open repo:microsoft/winget-pkgs head:NimbusAgent.Nimbus` or matching the exact title format).
+- **Closed/Failed PRs:** If a winget PR is opened but fails validation and is closed/declined by the Microsoft validation system (or a maintainer), it will no longer match the "open PR" filter and the version directory won't exist. In this case, the gate will correctly transition to **RED** (stale). This is a strong benefit of this design and should be highlighted.
+
+---
+
+## 3. Apt Packages File Compression (`Packages.gz` / `Packages.xz`)
+
+### Observation
+- The linux channel reads from `apt/dists/stable/main/binary-amd64/Packages` via a regex pattern.
+
+### Suggestion
+- Many debian/apt repositories optimize bandwidth by only serving compressed Package lists (e.g., `Packages.gz` or `Packages.xz`), sometimes leaving the uncompressed `Packages` file absent or outdated.
+- We should verify whether `nimbus-agent/linux-repo` guarantees the presence of the uncompressed `Packages` file. If not, the reader should support requesting `Packages.gz` and decompressing it in-memory using Bun's native decompression utilities (e.g., `Bun.gunzip`).
+
+---
+
+## 4. Phase 2 Semver Range Compatibility in `package.json`
+
+### Observation
+- Phase 2 proposes downstream dependency edges: "reader parses `dependencies['@nimbus-dev/...']`, strips the range, and compares to the published version."
+
+### Questions & Suggestions
+- **Stale vs Compatible Ranges:** If a downstream repo specifies a dependency version range (e.g., `^1.2.0`), and the upstream package publishes version `1.3.0`, stripping the range results in comparing `1.2.0` to `1.3.0` which flags it as stale. However, standard package managers (`npm`/`bun`) might resolve it to `1.3.0` upon lockfile generation.
+- **Lockfile-based Verification:** Rather than checking `package.json` and stripping the semver prefix, the dependency check should inspect the lockfile (e.g., `bun.lock` or `package-lock.json`) where the *actual* resolved version is locked down. This guarantees we check the real code running in production.
+
+---
+
+## 5. Grace Period Timezone Robustness
+
+### Observation
+- A release/bump-commit is checked only once its age exceeds `graceHours` (default 6h).
+
+### Suggestion
+- Ensure all timestamp comparisons convert GitHub's ISO-8601 datetime values (e.g. `2026-07-24T18:53:46Z`) and local system times to UTC epoch milliseconds before calculating differences. Relying on local system timezone parsing can cause false-positives when developer machines have offset clocks.

--- a/docs/superpowers/specs/2026-07-24-p2-release-train-design-review.md
+++ b/docs/superpowers/specs/2026-07-24-p2-release-train-design-review.md
@@ -7,9 +7,11 @@ This document reviews [2026-07-24-p2-release-train-design.md](./2026-07-24-p2-re
 ## 1. Rate Limiting on Public GitHub API Calls
 
 ### Observation
+
 - The design notes that "Every source read is public... So this gate needs no App token: `github.token` in CI, the developer's `gh` locally."
 
 ### Suggestion
+
 - Even though the channels and repositories are public, GitHub enforces strict rate limits for unauthenticated requests, and even for default authenticated tokens when executing multiple sequential calls (e.g., fetching contents across several repos, searching PRs in high-traffic repos like `microsoft/winget-pkgs`).
 - The script should explicitly support reading `process.env.GITHUB_TOKEN` or `process.env.GH_TOKEN` when run locally, and handle `403 Rate Limit Exceeded` exit statuses as `indeterminate` (with warning) rather than letting the command crash or report `stale`.
 
@@ -18,10 +20,12 @@ This document reviews [2026-07-24-p2-release-train-design.md](./2026-07-24-p2-re
 ## 2. High-Traffic Search Reliability for Winget PRs
 
 ### Observation
+
 - The winget channel is marked as "caught-up" if the version directory exists in `microsoft/winget-pkgs` OR an open PR exists.
 - This is checked via: `gh pr list --repo microsoft/winget-pkgs --search "…NimbusAgent.Nimbus …<published>"`.
 
 ### Questions & Suggestions
+
 - **API Search Index Latency:** Newly opened PRs on GitHub are not immediately indexed by the search backend. There can be a delay of several minutes.
 - **Search Query Precision:** `microsoft/winget-pkgs` is one of the highest-traffic repositories on GitHub. A loose search query can easily hit limitations or match unrelated PRs if not carefully scoped. We should explicitly specify the exact search query format in the script (e.g., `is:pr is:open repo:microsoft/winget-pkgs head:NimbusAgent.Nimbus` or matching the exact title format).
 - **Closed/Failed PRs:** If a winget PR is opened but fails validation and is closed/declined by the Microsoft validation system (or a maintainer), it will no longer match the "open PR" filter and the version directory won't exist. In this case, the gate will correctly transition to **RED** (stale). This is a strong benefit of this design and should be highlighted.
@@ -31,9 +35,11 @@ This document reviews [2026-07-24-p2-release-train-design.md](./2026-07-24-p2-re
 ## 3. Apt Packages File Compression (`Packages.gz` / `Packages.xz`)
 
 ### Observation
+
 - The linux channel reads from `apt/dists/stable/main/binary-amd64/Packages` via a regex pattern.
 
 ### Suggestion
+
 - Many debian/apt repositories optimize bandwidth by only serving compressed Package lists (e.g., `Packages.gz` or `Packages.xz`), sometimes leaving the uncompressed `Packages` file absent or outdated.
 - We should verify whether `nimbus-agent/linux-repo` guarantees the presence of the uncompressed `Packages` file. If not, the reader should support requesting `Packages.gz` and decompressing it in-memory using Bun's native decompression utilities (e.g., `Bun.gunzip`).
 
@@ -42,9 +48,11 @@ This document reviews [2026-07-24-p2-release-train-design.md](./2026-07-24-p2-re
 ## 4. Phase 2 Semver Range Compatibility in `package.json`
 
 ### Observation
+
 - Phase 2 proposes downstream dependency edges: "reader parses `dependencies['@nimbus-dev/...']`, strips the range, and compares to the published version."
 
 ### Questions & Suggestions
+
 - **Stale vs Compatible Ranges:** If a downstream repo specifies a dependency version range (e.g., `^1.2.0`), and the upstream package publishes version `1.3.0`, stripping the range results in comparing `1.2.0` to `1.3.0` which flags it as stale. However, standard package managers (`npm`/`bun`) might resolve it to `1.3.0` upon lockfile generation.
 - **Lockfile-based Verification:** Rather than checking `package.json` and stripping the semver prefix, the dependency check should inspect the lockfile (e.g., `bun.lock` or `package-lock.json`) where the *actual* resolved version is locked down. This guarantees we check the real code running in production.
 
@@ -53,7 +61,9 @@ This document reviews [2026-07-24-p2-release-train-design.md](./2026-07-24-p2-re
 ## 5. Grace Period Timezone Robustness
 
 ### Observation
+
 - A release/bump-commit is checked only once its age exceeds `graceHours` (default 6h).
 
 ### Suggestion
+
 - Ensure all timestamp comparisons convert GitHub's ISO-8601 datetime values (e.g. `2026-07-24T18:53:46Z`) and local system times to UTC epoch milliseconds before calculating differences. Relying on local system timezone parsing can cause false-positives when developer machines have offset clocks.

--- a/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
+++ b/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
@@ -1,0 +1,292 @@
+# P2 — Release Train Design
+
+A sub-program of the [infrastructure roadmap](../../infrastructure-roadmap.md),
+next in the sequence after P1 (Org CI Foundation) and P6 (Access &
+Contribution). P1 made cross-repo *config* drift a gated property; P6 did the
+same for *access* and *contribution licensing*. P2 makes **release propagation**
+one too: a version that publishes but fails to reach a downstream distribution
+point should make a machine-checkable gate go red.
+
+---
+
+## The pattern this breaks
+
+The infrastructure roadmap's founding observation is *controls stop where they
+were written*. The release pipeline is the sharpest instance. One Nimbus release
+fans out to five downstream landing points — winget (a PR against
+`microsoft/winget-pkgs`), homebrew-tap, scoop-bucket, the apt/yum linux-repo, and
+(for the satellite packages) npm — and **every one is fire-and-forget off a
+`workflow_run` trigger**. Nothing checks, afterward, that the published version
+actually *arrived*. When a publish step silently fails or a release phantoms, the
+channel simply freezes and no signal is emitted.
+
+This is not hypothetical. It is the single most-documented operational pain in
+the project's memory:
+
+- **Phantom releases** — the "chore: release main" PR merges and bumps the
+  manifest, but no tag / no assets are ever created. Six recorded instances;
+  each silently blocked *every* downstream until a human ran the manual
+  tag-and-relabel dance.
+- **Frozen package managers** — winget/scoop/brew froze at `0.16.0` for three
+  releases (`v0.17`–`v0.19`) because each release's build chain failed on a
+  different transient flake, leaving an asset-less GitHub Release that the
+  package-manager publishers had nothing to submit.
+
+The auto-reconcile step now in `release-please.yml` self-heals the phantom case
+*when it works* — but it has its own failure modes (App `issues:write`,
+tag-mismatch skip), and when it silently fails to complete, nothing notices.
+There is no independent observer of the property "the latest built release has
+reached every place it should."
+
+## Operating principle (inherited)
+
+A sub-program is **done** when its gate is green in CI and would go **red** if
+the property regressed — not when its code merges. P2's gate is
+`audit:release-staleness`: it must go red on a phantom release or on any channel
+that lags the latest built release past a grace window, proven by a
+red-before/green-after fixture (as P1's `ruleset-drift` and P6a's two gates
+were).
+
+---
+
+## Decisions taken (this brainstorm)
+
+1. **Unified staleness model, one spec, phased plan.** A single declarative
+   *release-train manifest* models **both** propagation kinds — distribution
+   *channels* and cross-repo *dependency* edges — and one gate reads each
+   downstream's live version. The plan phases delivery: **Phase 1 = channel
+   edges** (the proven pain; ships and goes green first); **Phase 2 = dep-DAG
+   edges** added to the same manifest (plausible but unproven; de-risked by
+   proving the mechanism on Phase 1 first).
+2. **Enforcement = an independent scheduled sweep**, not an inline verify step.
+   An inline step inside `release.yml` structurally cannot catch the worst case
+   (the run that never produced assets — the step never executes). Only an
+   independent check, keyed off nothing but the observable state of the release
+   and the channels, catches the full class including phantom releases. This is
+   also the roadmap's literal wording: a *staleness check*.
+3. **Staleness semantics = grace window + "PR-opened counts" for winget.** A
+   release becomes eligible for checking only once it is older than a grace
+   window (default **6h** — covers the ~18–30 min build plus margin, so a
+   just-merged release is never false-red). For our own repos (brew/scoop/linux)
+   "caught up" = the repo's file shows the version. For winget — whose merge is on
+   *Microsoft's* timeline and can take days — "caught up" = the version is merged
+   **or** we *opened* a PR for it. Gating on Microsoft's merge would produce a
+   red we cannot act on.
+4. **Reader strategy = pure read-only observer** (no publish-workflow changes).
+   The gate reads what is *actually serving users* — the live channel files —
+   rather than a marker we write and hope lands. Zero changes to the four publish
+   workflows (lower risk, faster to green), and the gate stays decoupled from the
+   publishers.
+5. **Placement = a new job in `org-drift-sweep.yml`**, so the property lands in
+   the same green/red scheduled sweep the roadmap already frames as the program's
+   gate. One dashboard, existing cron + `workflow_dispatch`, existing
+   fail-soft-strict conventions.
+
+---
+
+## Architecture
+
+### 1. The three heads
+
+Every train has three version "heads" a healthy pipeline keeps equal:
+
+```
+intended            published                     distributed
+(main claims)       (actually built)              (reached users)
+────────────────    ──────────────────────        ───────────────────────────────
+.release-please     latest stable vX.Y.Z          brew    Formula/nimbus.rb
+-manifest.json      GitHub Release WITH            scoop   bucket/nimbus.json
+  "." : 0.27.0      its SHA256SUMS asset           linux   apt Packages  Version:
+                                                   winget  winget-pkgs dir / open PR
+```
+
+Two comparisons, each catching one documented failure:
+
+- **intended > published** → *phantom release*. Eligible only once the
+  manifest-bump commit is older than `graceHours` (so the build window is not
+  flagged). This is the independent backstop for the `release-please.yml`
+  auto-reconcile step: if reconcile silently failed, this goes red.
+- **published > channel** → *frozen channel*. Eligible once the published
+  Release is older than `graceHours`.
+
+### 2. The manifest — `.github/release-train.json`
+
+Checked in, matching the `.github/org-access.json` and
+`.github/rulesets/*.json` precedent — one declarative place that lists every
+propagation edge, so the edges are *declared* rather than scattered across
+fire-and-forget publish workflows. That declaration *is* the fix for "controls
+stop where they were written."
+
+```jsonc
+{
+  "$comment": "Every propagation edge from a published artifact to its downstream distribution point. The release-staleness gate (scripts/structure-audit/check-release-staleness.ts) reads each downstream's LIVE version and fails when it lags the published source past graceHours. See docs/infrastructure-roadmap.md P2.",
+  "graceHours": 6,
+  "trains": [
+    {
+      "name": "nimbus-gateway",
+      "source": {
+        "manifestRepo": "nimbus-agent/Nimbus",
+        "manifestFile": ".release-please-manifest.json",
+        "manifestKey": ".",
+        "releaseAsset": "SHA256SUMS"
+      },
+      "channels": [
+        { "kind": "brew",   "repo": "nimbus-agent/homebrew-tap", "path": "Formula/nimbus.rb",  "pattern": "version \"([^\"]+)\"" },
+        { "kind": "scoop",  "repo": "nimbus-agent/scoop-bucket", "path": "bucket/nimbus.json", "jsonKey": "version" },
+        { "kind": "linux",  "repo": "nimbus-agent/linux-repo",   "path": "apt/dists/stable/main/binary-amd64/Packages", "pattern": "^Version: (.+)$" },
+        { "kind": "winget", "package": "NimbusAgent.Nimbus", "wingetRepo": "microsoft/winget-pkgs" }
+      ]
+    }
+  ]
+}
+```
+
+Phase 1 = the `nimbus-gateway` train: **1 phantom edge + 4 channel edges = 5
+checks.** A `source.releaseAsset` of `SHA256SUMS` is the definition of
+"published": a Release counts only if that asset exists (an asset-less phantom
+Release does not).
+
+### 3. The gate — `scripts/structure-audit/check-release-staleness.ts`
+
+Reuses `scripts/structure-audit/_gh-audit.ts` (`runGh` / `isStrict` /
+`strictSkip` / `isRecord`). Split into **pure functions** (unit-testable, no
+network) behind a thin gh-reading shell:
+
+- `readPublished(train)` → the latest stable `vX.Y.Z` GitHub Release whose
+  `releaseAsset` exists, plus its publish timestamp. (Stable = tag has no `-`,
+  matching the publishers' own `!contains(head_branch, '-')` gate.)
+- `readChannelVersion(channel)` → one version string per kind:
+  - **brew / linux** — `gh api …/contents/<path>` (base64-decode) → regex `pattern`.
+  - **scoop** — same fetch → `JSON.parse` → `jsonKey`.
+  - **winget** — caught-up iff the version dir
+    `manifests/n/NimbusAgent/Nimbus/<published>/` exists in `winget-pkgs`
+    **or** an open PR titled `…NimbusAgent.Nimbus …<published>` exists
+    (`gh pr list --repo microsoft/winget-pkgs --search`). Author-agnostic title
+    search — robust to whichever account holds `WINGET_PAT`. This is the literal
+    *"failed to open its downstream PR"* check.
+- `compare(intended, published, channel, ages, graceHours)` → one of
+  `ok | stale | phantom | indeterminate`. Pure semver + grace logic, no I/O.
+
+**"Caught up" rules** (decision 3): brew/scoop/linux caught-up iff file-version ≥
+published; winget caught-up iff merged-dir-exists OR open-PR-exists; the phantom
+edge fires iff intended > published AND bump-commit age > `graceHours`; a channel
+edge fires iff published > channel AND release age > `graceHours`.
+
+Version comparison is **semver-aware** (not string equality): a channel ahead of
+`published` — e.g. a hotfix landed directly on a channel — is *not* stale.
+
+### 4. Auth — none needed
+
+Every source read is **public**: homebrew-tap, scoop-bucket, and the linux-repo
+Pages repo are public (users `brew tap` / `scoop bucket add` / add the apt
+source), `winget-pkgs` is public, and the Nimbus release list + manifest are
+public. So — unlike the P6a admin-scoped gates — this gate needs **no App
+token**: `github.token` in CI, the developer's `gh` locally. It therefore also
+runs in local `preflight` for anyone authenticated (fail-soft when not).
+
+### 5. Workflow wiring
+
+- A new job **`release-staleness`** in `.github/workflows/org-drift-sweep.yml`,
+  reusing the workflow's existing `schedule` + `workflow_dispatch` triggers. No
+  App-token mint step (public reads). Runs `bun run audit:release-staleness
+  --strict`.
+- `package.json` script alias **`audit:release-staleness`** →
+  `bun scripts/structure-audit/check-release-staleness.ts`.
+- Registered in `scripts/lib/preflight-gates.ts` alongside the other drift gates
+  (fail-soft locally, so an unauthenticated contributor is never blocked; the
+  drift-manifest test that would otherwise fail on an unregistered CI gate stays
+  green).
+
+---
+
+## Error handling — the false-red trap
+
+A single channel read failing must **not** read as *stale*. The gate
+distinguishes:
+
+- **404** (channel file genuinely absent) → a real regression → **RED**.
+- **non-404** (transient 5xx / rate-limit / network) → **indeterminate**, not
+  stale — the `team-reachability` and CLA-coverage lesson.
+- **version parse fails** (channel file format changed) → indeterminate + a loud
+  `::warning::`; never silently "ok."
+- **nothing readable at all** (no `gh`, no auth) → `strictSkip` (soft green
+  locally, red under `--strict` / `GITHUB_ACTIONS`).
+
+Today `runGh` collapses 404 and transient 5xx into a single `ok:false`, so it
+cannot make the first distinction. **Phase 1 therefore includes a small
+`_gh-audit.ts` enhancement**: surface the `gh` / HTTP exit status so a caller can
+split a genuine 404 from a transient failure. This *also closes the CLA-coverage
+robustness follow-up already recorded in the roadmap* (that gate currently treats
+any `gh` failure as "cla.yml absent"). One fix hardens two gates; the enhancement
+is additive and preserves every existing caller's behavior.
+
+---
+
+## Testing
+
+Per `nimbus-testing`, the pure functions carry table-driven unit tests:
+
+- version parse per channel kind — brew regex, scoop json, linux `Version:`,
+  winget dir-list + PR-search shapes;
+- the semver + grace comparison — `ok` / `stale` / `phantom` boundary cases
+  around `graceHours`;
+- phantom detection (intended > published with an aged bump commit);
+- the **404-vs-transient** branch of the enhanced `_gh-audit.ts`.
+
+No live `gh` in unit tests — the gh-reading shell is injected as a fake reader
+fed captured fixtures. `decideExit` mirrors the org-drift gates
+(fail-soft-strict). **Live proof:** run the gate against the real channels once,
+then red-prove by feeding a stale fixture (channel version pinned an older
+release), confirming red-before / green-after.
+
+> **Live-run heads-up.** At authoring time the manifest is `0.27.0` while the
+> latest release is documented as `v0.26.0`. If no `v0.27.0` Release-with-assets
+> exists and the bump commit is older than `graceHours`, the gate's **first real
+> run will correctly go RED — a live phantom (a 7th instance)**. That is the gate
+> working, not a bug. The implementation step will confirm the actual state:
+> either it is genuinely stale (the gate earns its keep on day one) or `0.27.0`
+> has published (green).
+
+---
+
+## Phase 2 — dependency-DAG edges (sketch, same engine)
+
+Phase 2 adds `dep` edges to the same `trains[]` array; the engine does not
+change, only a new reader kind:
+
+- **source** = the npm `@latest` version of an upstream package
+  (`@nimbus-dev/sdk`, `@nimbus-dev/client`).
+- **downstreams** = consuming repos' `package.json` dependency on that package —
+  `client ← sdk`; `cli` + `vscode ← client`.
+- **reader** parses `dependencies["@nimbus-dev/…"]`, strips the range, and
+  compares to the published version; caught-up iff dep ≥ published **or** an open
+  bump PR referencing it exists. Same grace + indeterminate model.
+
+**Open Phase-2 question (deferred to its own spec pass):** whether the `source`
+for a dep edge is npm `@latest` (what consumers actually install) or the upstream
+repo's latest git release tag. Resolve when Phase 2 is specced; it does not
+affect the Phase 1 engine.
+
+---
+
+## Out of scope
+
+- **Fixing** propagation failures — P2 *detects* staleness; recovery stays the
+  existing manual/auto-reconcile paths. (A future sub-program could auto-remediate.)
+- **Release-build reliability** (flaky-flake hardening of `release.yml`) — a
+  separate concern; P2 observes the outcome, it does not make the build more
+  reliable.
+- **Freshness of pinned action SHAs** — owned by P1's sha-pin audit; a "staleness
+  vs unpinned" distinction already noted there.
+- **Private repos** — all P2 sources are public; no Team-plan dependency.
+
+---
+
+## Definition of done
+
+`audit:release-staleness` is green in the scheduled sweep and **would go red**
+if any channel lags the latest built release past the grace window, or if a
+release phantoms — proven by a red-before / green-after fixture, exactly as P1's
+`ruleset-drift` and P6a's `org-settings-drift` / `team-reachability` were. Phase 1
+closes when that gate is green end-to-end in a real `org-drift-sweep` run and the
+`_gh-audit.ts` enhancement has hardened the CLA-coverage gate alongside.

--- a/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
+++ b/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
@@ -219,10 +219,12 @@ runs in local `preflight` for anyone authenticated (fail-soft when not).
   --strict`.
 - `package.json` script alias **`audit:release-staleness`** →
   `bun scripts/structure-audit/check-release-staleness.ts`.
-- Registered in `scripts/lib/preflight-gates.ts` alongside the other drift gates
-  (fail-soft locally, so an unauthenticated contributor is never blocked; the
-  drift-manifest test that would otherwise fail on an unregistered CI gate stays
-  green).
+- Registered in `scripts/lib/preflight-gates.ts` in **`CI_ONLY_GATES`** — where
+  the sibling `audit:*-drift` / `cla-coverage` gates live (they need network +
+  `gh`, so they never run in the local FAST tier). This satisfies the
+  `scripts/preflight.test.ts` drift guard and documents intent. The gate *script*
+  is still fail-soft when invoked directly, so an unauthenticated contributor who
+  runs it locally is never blocked.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
+++ b/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
@@ -156,14 +156,33 @@ network) behind a thin gh-reading shell:
   `releaseAsset` exists, plus its publish timestamp. (Stable = tag has no `-`,
   matching the publishers' own `!contains(head_branch, '-')` gate.)
 - `readChannelVersion(channel)` → one version string per kind:
-  - **brew / linux** — `gh api …/contents/<path>` (base64-decode) → regex `pattern`.
-  - **scoop** — same fetch → `JSON.parse` → `jsonKey`.
+  - **brew / scoop** — `gh api …/contents/<path>` (base64-decode) → regex
+    `pattern` (brew) or `JSON.parse` → `jsonKey` (scoop). Both are stable
+    single-version files.
+  - **linux** — reprepro emits `dists/stable/main/binary-amd64/Packages` **and**
+    `Packages.gz`; the uncompressed file is not guaranteed to exist (some apt
+    repos serve only the compressed list). The reader therefore reads whichever
+    is present — preferring `Packages`, falling back to `Packages.gz` with an
+    in-memory `Bun.gunzipSync` — then regexes the `Version:` control field.
+    **Impl step verifies against the live `linux-repo` which files reprepro
+    actually publishes**; if the pool layout proves more stable than the index,
+    listing `pool/main/n/nimbus-headless/` (exactly one `.deb` after the
+    workflow's `reprepro remove` + `includedeb`) and parsing the version from the
+    filename is the fallback reader.
   - **winget** — caught-up iff the version dir
     `manifests/n/NimbusAgent/Nimbus/<published>/` exists in `winget-pkgs`
-    **or** an open PR titled `…NimbusAgent.Nimbus …<published>` exists
-    (`gh pr list --repo microsoft/winget-pkgs --search`). Author-agnostic title
-    search — robust to whichever account holds `WINGET_PAT`. This is the literal
-    *"failed to open its downstream PR"* check.
+    **or** an open PR for that version exists. The PR check is an exact
+    **title** search, not a branch (`head:`) filter — wingetcreate's branch name
+    is not the package id, whereas its PR title is deterministic (`New version:
+    NimbusAgent.Nimbus version <published>`):
+    `gh pr list --repo microsoft/winget-pkgs --state open --search 'in:title
+    NimbusAgent.Nimbus <published>' --json number`. Author-agnostic — robust to
+    whichever account holds `WINGET_PAT`. This is the literal *"failed to open
+    its downstream PR"* check. The 6h grace window absorbs GitHub's few-minutes
+    search-index lag on a freshly-opened PR. **Benefit:** a winget PR that opened
+    but was later *closed/rejected* by Microsoft's validation leaves neither a
+    merged dir nor an open PR, so the gate correctly returns to **RED** — the
+    stale state is re-surfaced, not lost.
 - `compare(intended, published, channel, ages, graceHours)` → one of
   `ok | stale | phantom | indeterminate`. Pure semver + grace logic, no I/O.
 
@@ -174,6 +193,14 @@ edge fires iff published > channel AND release age > `graceHours`.
 
 Version comparison is **semver-aware** (not string equality): a channel ahead of
 `published` — e.g. a hotfix landed directly on a channel — is *not* stale.
+
+**Time is UTC epoch-ms throughout.** GitHub timestamps are `Z`-suffixed ISO-8601
+(`2026-07-24T18:53:46Z`); the age math is `Date.now() - new Date(ts).getTime()`,
+which is timezone-agnostic (both sides are UTC epoch ms). The reader never parses
+a timestamp lacking an explicit `Z`/offset (which JS would treat as local time),
+so a developer machine's clock offset cannot skew the grace-window decision.
+(This is a plain audit script, not a Workflow script, so `Date.now()` is
+available.)
 
 ### 4. Auth — none needed
 
@@ -205,8 +232,15 @@ A single channel read failing must **not** read as *stale*. The gate
 distinguishes:
 
 - **404** (channel file genuinely absent) → a real regression → **RED**.
-- **non-404** (transient 5xx / rate-limit / network) → **indeterminate**, not
-  stale — the `team-reachability` and CLA-coverage lesson.
+- **non-404** (transient 5xx / network) → **indeterminate**, not stale — the
+  `team-reachability` and CLA-coverage lesson.
+- **403 rate-limit** (`X-RateLimit-Remaining: 0` / secondary-limit) →
+  **indeterminate**, never stale. All reads go through `gh`, which authenticates
+  with the ambient token (`GH_TOKEN` / `GITHUB_TOKEN` locally, `github.token` in
+  CI) — so the request quota is the authenticated 5000/hr, not the unauthenticated
+  60/hr, and one run's handful of reads plus one `winget-pkgs` search sits far
+  under it. A 403 is therefore rare, but if it happens (e.g. a shared CI token
+  near its ceiling) it must read as *indeterminate*, not as a stale channel.
 - **version parse fails** (channel file format changed) → indeterminate + a loud
   `::warning::`; never silently "ok."
 - **nothing readable at all** (no `gh`, no auth) → `strictSkip` (soft green
@@ -214,8 +248,9 @@ distinguishes:
 
 Today `runGh` collapses 404 and transient 5xx into a single `ok:false`, so it
 cannot make the first distinction. **Phase 1 therefore includes a small
-`_gh-audit.ts` enhancement**: surface the `gh` / HTTP exit status so a caller can
-split a genuine 404 from a transient failure. This *also closes the CLA-coverage
+`_gh-audit.ts` enhancement**: surface the `gh` / HTTP status so a caller can
+split a genuine 404 from a transient failure (5xx, network, or a 403
+rate-limit). This *also closes the CLA-coverage
 robustness follow-up already recorded in the roadmap* (that gate currently treats
 any `gh` failure as "cla.yml absent"). One fix hardens two gates; the enhancement
 is additive and preserves every existing caller's behavior.
@@ -258,14 +293,22 @@ change, only a new reader kind:
   (`@nimbus-dev/sdk`, `@nimbus-dev/client`).
 - **downstreams** = consuming repos' `package.json` dependency on that package —
   `client ← sdk`; `cli` + `vscode ← client`.
-- **reader** parses `dependencies["@nimbus-dev/…"]`, strips the range, and
-  compares to the published version; caught-up iff dep ≥ published **or** an open
-  bump PR referencing it exists. Same grace + indeterminate model.
+- **reader** — reads the consumer's **lockfile** (`bun.lock` /
+  `package-lock.json`), not just the `package.json` range. A range like `^1.2.0`
+  *permits* a newer `1.3.0`, so stripping the caret and comparing `1.2.0` to a
+  published `1.3.0` would false-flag a repo that would resolve to `1.3.0` on the
+  next install. The lockfile carries the *resolved* version — the code that would
+  actually ship — which is the honest "caught up" signal. Caught-up iff the
+  resolved version ≥ published **or** an open bump PR referencing it exists. Same
+  grace + indeterminate model.
 
-**Open Phase-2 question (deferred to its own spec pass):** whether the `source`
-for a dep edge is npm `@latest` (what consumers actually install) or the upstream
-repo's latest git release tag. Resolve when Phase 2 is specced; it does not
-affect the Phase 1 engine.
+**Open Phase-2 questions (deferred to its own spec pass):**
+1. Whether the `source` for a dep edge is npm `@latest` (what consumers actually
+   install) or the upstream repo's latest git release tag.
+2. The exact lockfile parse per consumer (`bun.lock` is the Nimbus/vscode norm;
+   confirm each satellite's lockfile format and that it is committed).
+
+Neither affects the Phase 1 engine; both resolve when Phase 2 is specced.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
+++ b/docs/superpowers/specs/2026-07-24-p2-release-train-design.md
@@ -90,7 +90,7 @@ were).
 
 Every train has three version "heads" a healthy pipeline keeps equal:
 
-```
+```text
 intended            published                     distributed
 (main claims)       (actually built)              (reached users)
 ────────────────    ──────────────────────        ───────────────────────────────
@@ -305,6 +305,7 @@ change, only a new reader kind:
   grace + indeterminate model.
 
 **Open Phase-2 questions (deferred to its own spec pass):**
+
 1. Whether the `source` for a dep edge is npm `@latest` (what consumers actually
    install) or the upstream repo's latest git release tag.
 2. The exact lockfile parse per consumer (`bun.lock` is the Nimbus/vscode norm;

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "audit:org-settings-drift": "bun scripts/structure-audit/check-org-settings-drift.ts",
     "audit:team-reachability": "bun scripts/structure-audit/check-team-reachability.ts",
     "audit:cla-coverage": "bun scripts/structure-audit/check-cla-coverage.ts",
+    "audit:release-staleness": "bun scripts/structure-audit/check-release-staleness.ts",
     "audit:secrets": "gitleaks detect --source . --no-banner --redact --exit-code 1",
     "audit:links": "lychee --no-progress --config lychee.toml \"docs/**/*.md\" \"*.md\"",
     "lint": "biome check --error-on-warnings .",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -67,6 +67,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:org-settings-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:team-reachability", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:cla-coverage", // needs network + gh (reads each public repo's cla.yml, contents:read); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
 ];
 
 export function selectGates(tier: GateTier): Gate[] {

--- a/scripts/structure-audit/_gh-audit.test.ts
+++ b/scripts/structure-audit/_gh-audit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { isStrict, strictSkip } from "./_gh-audit.ts";
+import { classifyReadFailure, isStrict, parseHttpStatus, strictSkip } from "./_gh-audit.ts";
 
 describe("isStrict", () => {
   test("false with neither flag nor env", () => {
@@ -47,5 +47,28 @@ describe("strictSkip", () => {
     expect(out.code).toBe(1);
     expect(out.message).toContain("::error::");
     expect(out.message).toContain("reachability indeterminate");
+  });
+});
+
+describe("parseHttpStatus", () => {
+  test("extracts the status from gh's '(HTTP NNN)' stderr", () => {
+    expect(parseHttpStatus("gh: Not Found (HTTP 404)")).toBe(404);
+    expect(parseHttpStatus("gh: Server Error (HTTP 500)")).toBe(500);
+    expect(parseHttpStatus("API rate limit exceeded (HTTP 403)")).toBe(403);
+  });
+  test("returns undefined when no HTTP status is present", () => {
+    expect(parseHttpStatus("some other failure")).toBeUndefined();
+    expect(parseHttpStatus("")).toBeUndefined();
+  });
+});
+
+describe("classifyReadFailure", () => {
+  test("404 is a genuine absence", () => {
+    expect(classifyReadFailure(404)).toBe("absent");
+  });
+  test("5xx / 403 / unknown are indeterminate (transient), never absent", () => {
+    expect(classifyReadFailure(500)).toBe("indeterminate");
+    expect(classifyReadFailure(403)).toBe("indeterminate");
+    expect(classifyReadFailure(undefined)).toBe("indeterminate");
   });
 });

--- a/scripts/structure-audit/_gh-audit.ts
+++ b/scripts/structure-audit/_gh-audit.ts
@@ -8,6 +8,10 @@
 export interface GhResult {
   ok: boolean;
   stdout: string;
+  /** Captured stderr (gh writes "(HTTP NNN)" here on failure). "" on success or spawn error. */
+  stderr: string;
+  /** Parsed HTTP status when the call failed with one; undefined otherwise. */
+  httpStatus?: number | undefined;
 }
 
 /** Narrow an unknown to a plain object (not null, not an array) before indexing it. */
@@ -15,14 +19,32 @@ export function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+/** Pull the numeric status out of gh's `... (HTTP NNN)` error line. */
+export function parseHttpStatus(stderr: string): number | undefined {
+  const m = stderr.match(/\(HTTP (\d{3})\)/);
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
+ * A failed public read is either a genuine 404 (the thing is absent — a real
+ * finding) or a transient failure (5xx, 403 rate-limit, network) that must NOT
+ * be read as a finding. Mirrors the team-reachability "indeterminate" rule.
+ */
+export function classifyReadFailure(httpStatus: number | undefined): "absent" | "indeterminate" {
+  return httpStatus === 404 ? "absent" : "indeterminate";
+}
+
 /** Wraps `Bun.spawnSync` so a missing `gh` binary or non-zero exit both surface as `ok: false`. */
 export function runGh(args: string[]): GhResult {
   try {
     const proc = Bun.spawnSync(args);
-    if (!proc.success) return { ok: false, stdout: "" };
-    return { ok: true, stdout: new TextDecoder().decode(proc.stdout) };
+    const stderr = new TextDecoder().decode(proc.stderr);
+    if (!proc.success) {
+      return { ok: false, stdout: "", stderr, httpStatus: parseHttpStatus(stderr) };
+    }
+    return { ok: true, stdout: new TextDecoder().decode(proc.stdout), stderr };
   } catch {
-    return { ok: false, stdout: "" };
+    return { ok: false, stdout: "", stderr: "" };
   }
 }
 

--- a/scripts/structure-audit/check-cla-coverage.test.ts
+++ b/scripts/structure-audit/check-cla-coverage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { diffClaCoverage } from "./check-cla-coverage.ts";
+import { classifyRepoRead, diffClaCoverage } from "./check-cla-coverage.ts";
 
 const REPOS = ["Nimbus", "nimbus-sdk", "nimbus-client"];
 
@@ -45,5 +45,21 @@ describe("diffClaCoverage", () => {
     });
     expect(r.ok).toBe(false);
     expect(r.errors.join("\n")).toContain("nimbus-client");
+  });
+});
+
+describe("classifyRepoRead", () => {
+  test("ok read yields the parsed value", () => {
+    expect(classifyRepoRead({ ok: true, stdout: "x", stderr: "" })).toEqual({ kind: "read" });
+  });
+  test("404 read is absent (a genuine finding)", () => {
+    expect(
+      classifyRepoRead({ ok: false, stdout: "", stderr: "(HTTP 404)", httpStatus: 404 }),
+    ).toEqual({ kind: "absent" });
+  });
+  test("500 read is indeterminate, not absent", () => {
+    expect(
+      classifyRepoRead({ ok: false, stdout: "", stderr: "(HTTP 500)", httpStatus: 500 }),
+    ).toEqual({ kind: "indeterminate" });
   });
 });

--- a/scripts/structure-audit/check-cla-coverage.ts
+++ b/scripts/structure-audit/check-cla-coverage.ts
@@ -7,11 +7,17 @@
  * strict-in-CI contract as the other org-drift-sweep gates.
  */
 
-import { isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+import { classifyReadFailure, type GhResult, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
 
 export interface AuditResult {
   ok: boolean;
   errors: string[];
+}
+
+/** Classify one per-repo contents read into read / absent / indeterminate. */
+export function classifyRepoRead(res: GhResult): { kind: "read" | "absent" | "indeterminate" } {
+  if (res.ok) return { kind: "read" };
+  return { kind: classifyReadFailure(res.httpStatus) };
 }
 
 const GATED_REPOS = [
@@ -83,9 +89,23 @@ if (import.meta.main) {
       "--jq",
       ".content",
     ]);
-    // Reachability already confirmed by the probe → a failure here is a genuine
-    // 404 (file absent), recorded as `null` and flagged by diffClaCoverage.
-    if (!res.ok) {
+    // Only a 404 means "cla.yml absent" (a real finding). A transient failure
+    // (5xx, 403 rate-limit, network) must NOT be recorded as absence — that
+    // would turn a blip into a fake "repo lost its CLA gate" red. The probe
+    // above proves reachability at one instant; it cannot vouch for every
+    // subsequent call, so each read is classified on its own status.
+    const cls = classifyRepoRead(res);
+    if (cls.kind === "indeterminate") {
+      const outcome = strictSkip(
+        label,
+        strict,
+        `cla-coverage indeterminate — ${repo} read failed transiently (HTTP ${res.httpStatus ?? "?"})`,
+      );
+      if (outcome.code === 1) console.error(outcome.message);
+      else console.warn(outcome.message);
+      process.exit(outcome.code);
+    }
+    if (cls.kind === "absent") {
       live[repo] = null;
       continue;
     }

--- a/scripts/structure-audit/check-release-staleness.test.ts
+++ b/scripts/structure-audit/check-release-staleness.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import {
+  ageHours,
   type ChannelReading,
   compareSemver,
   decideExit,
   evaluateTrain,
+  loadTrainManifest,
   parseBrewVersion,
   parseLinuxVersion,
   parseScoopVersion,
@@ -257,5 +261,38 @@ describe("decideExit", () => {
   test("everything indeterminate when NOT strict => exit 0 (soft)", () => {
     const out = decideExit([{ edge: "t:brew", verdict: "indeterminate", detail: "d" }], false);
     expect(out.code).toBe(0);
+  });
+});
+
+describe("ageHours", () => {
+  test("a valid past timestamp yields a finite non-negative age", () => {
+    const h = ageHours("2020-01-01T00:00:00Z");
+    expect(Number.isFinite(h)).toBe(true);
+    expect(h).toBeGreaterThan(0);
+  });
+  test("an unparseable timestamp fails closed to +Infinity", () => {
+    expect(ageHours("not-a-date")).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("loadTrainManifest", () => {
+  test("parses graceHours + trains", () => {
+    const m = loadTrainManifest(
+      '{"graceHours":6,"trains":[{"name":"x","source":{"manifestRepo":"a/b","manifestFile":"m.json","manifestKey":".","releaseAsset":"S"},"channels":[]}]}',
+    );
+    expect(m.graceHours).toBe(6);
+    expect(m.trains[0]?.name).toBe("x");
+  });
+  test("throws on a malformed manifest", () => {
+    expect(() => loadTrainManifest("{}")).toThrow();
+  });
+  test("the committed .github/release-train.json is valid", () => {
+    const raw = readFileSync(
+      join(import.meta.dir, "..", "..", ".github", "release-train.json"),
+      "utf8",
+    );
+    const m = loadTrainManifest(raw);
+    expect(m.trains.length).toBeGreaterThan(0);
+    expect(m.trains[0]?.channels.some((c) => c.kind === "winget")).toBe(true);
   });
 });

--- a/scripts/structure-audit/check-release-staleness.test.ts
+++ b/scripts/structure-audit/check-release-staleness.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  type ChannelReading,
   compareSemver,
+  decideExit,
+  evaluateTrain,
   parseBrewVersion,
   parseLinuxVersion,
   parseScoopVersion,
@@ -126,5 +129,133 @@ describe("resolveWingetCoverage", () => {
   test("indeterminate when either signal is unknown and neither is true", () => {
     expect(resolveWingetCoverage(null, false)).toEqual({ status: "indeterminate", covered: false });
     expect(resolveWingetCoverage(false, null)).toEqual({ status: "indeterminate", covered: false });
+  });
+});
+
+const ch = (over: Partial<ChannelReading>): ChannelReading => ({
+  kind: "brew",
+  status: "read",
+  version: null,
+  covered: null,
+  ...over,
+});
+
+describe("evaluateTrain", () => {
+  const green = {
+    name: "t",
+    intended: "0.26.0",
+    intendedBumpAgeHours: 48,
+    published: { version: "0.26.0", publishedAt: "x" },
+    publishedAgeHours: 48,
+    graceHours: 6,
+  };
+
+  test("all heads equal + channels current => all ok", () => {
+    const r = evaluateTrain({
+      ...green,
+      channels: [
+        ch({ kind: "brew", version: "0.26.0" }),
+        ch({ kind: "scoop", version: "0.26.0" }),
+        ch({ kind: "linux", version: "0.26.0" }),
+        ch({ kind: "winget", version: null, covered: true }),
+      ],
+    });
+    expect(r.every((e) => e.verdict === "ok")).toBe(true);
+  });
+
+  test("channel behind published, past grace => stale", () => {
+    const r = evaluateTrain({ ...green, channels: [ch({ kind: "brew", version: "0.25.0" })] });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("stale");
+  });
+
+  test("channel behind published but within grace => ok", () => {
+    const r = evaluateTrain({
+      ...green,
+      publishedAgeHours: 2,
+      channels: [ch({ kind: "brew", version: "0.25.0" })],
+    });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("ok");
+  });
+
+  test("manifest ahead of published + aged bump => phantom", () => {
+    const r = evaluateTrain({
+      ...green,
+      intended: "0.27.0",
+      published: { version: "0.26.0", publishedAt: "x" },
+      channels: [],
+    });
+    expect(r.find((e) => e.edge === "t:phantom")?.verdict).toBe("phantom");
+  });
+
+  test("manifest ahead but bump within grace => ok (build window)", () => {
+    const r = evaluateTrain({
+      ...green,
+      intended: "0.27.0",
+      intendedBumpAgeHours: 1,
+      published: { version: "0.26.0", publishedAt: "x" },
+      channels: [],
+    });
+    expect(r.find((e) => e.edge === "t:phantom")?.verdict).toBe("ok");
+  });
+
+  test("winget not covered, past grace => stale", () => {
+    const r = evaluateTrain({
+      ...green,
+      channels: [ch({ kind: "winget", version: null, covered: false })],
+    });
+    expect(r.find((e) => e.edge === "t:winget")?.verdict).toBe("stale");
+  });
+
+  test("transient channel read => indeterminate, never stale", () => {
+    const r = evaluateTrain({
+      ...green,
+      channels: [ch({ kind: "brew", status: "indeterminate" })],
+    });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("indeterminate");
+  });
+
+  test("absent channel file, past grace => stale", () => {
+    const r = evaluateTrain({ ...green, channels: [ch({ kind: "brew", status: "absent" })] });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("stale");
+  });
+
+  test("unparseable channel version => indeterminate, never a crash", () => {
+    const r = evaluateTrain({
+      ...green,
+      channels: [ch({ kind: "brew", version: "not-a-version" })],
+    });
+    expect(r.find((e) => e.edge === "t:brew")?.verdict).toBe("indeterminate");
+  });
+
+  test("unparseable manifest version => phantom edge indeterminate, never a crash", () => {
+    const r = evaluateTrain({ ...green, intended: "not-a-version", channels: [] });
+    expect(r.find((e) => e.edge === "t:phantom")?.verdict).toBe("indeterminate");
+  });
+});
+
+describe("decideExit", () => {
+  test("a stale or phantom edge => exit 1 with ::error::", () => {
+    const out = decideExit([{ edge: "t:brew", verdict: "stale", detail: "d" }], true);
+    expect(out.code).toBe(1);
+    expect(out.messages.join("\n")).toContain("::error::");
+  });
+  test("only ok + indeterminate => exit 0 with a warning", () => {
+    const out = decideExit(
+      [
+        { edge: "t:brew", verdict: "ok", detail: "d" },
+        { edge: "t:scoop", verdict: "indeterminate", detail: "d" },
+      ],
+      true,
+    );
+    expect(out.code).toBe(0);
+    expect(out.messages.join("\n")).toContain("::warning::");
+  });
+  test("everything indeterminate under --strict => exit 1 (not 'all clear')", () => {
+    const out = decideExit([{ edge: "t:brew", verdict: "indeterminate", detail: "d" }], true);
+    expect(out.code).toBe(1);
+  });
+  test("everything indeterminate when NOT strict => exit 0 (soft)", () => {
+    const out = decideExit([{ edge: "t:brew", verdict: "indeterminate", detail: "d" }], false);
+    expect(out.code).toBe(0);
   });
 });

--- a/scripts/structure-audit/check-release-staleness.test.ts
+++ b/scripts/structure-audit/check-release-staleness.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  compareSemver,
+  parseBrewVersion,
+  parseLinuxVersion,
+  parseScoopVersion,
+  resolveWingetCoverage,
+  selectPublished,
+  wingetDirPath,
+} from "./check-release-staleness.ts";
+
+describe("parseBrewVersion", () => {
+  test("reads version from a Formula .rb", () => {
+    expect(parseBrewVersion('class Nimbus < Formula\n  version "0.26.0"\n  url "..."')).toBe(
+      "0.26.0",
+    );
+  });
+  test("null when absent", () => {
+    expect(parseBrewVersion('class Nimbus < Formula\n  url "..."')).toBeNull();
+  });
+});
+
+describe("parseScoopVersion", () => {
+  test("reads .version from a scoop manifest", () => {
+    expect(parseScoopVersion('{"version":"0.26.0","url":"x"}')).toBe("0.26.0");
+  });
+  test("null on malformed json or missing key", () => {
+    expect(parseScoopVersion("{not json")).toBeNull();
+    expect(parseScoopVersion('{"url":"x"}')).toBeNull();
+  });
+});
+
+describe("parseLinuxVersion", () => {
+  test("reads the Version: field from the nimbus-headless block", () => {
+    const pkgs = "Package: nimbus-headless\nVersion: 0.26.0\nArchitecture: amd64\n";
+    expect(parseLinuxVersion(pkgs)).toBe("0.26.0");
+  });
+  test("picks the nimbus-headless block, not another package that sorts first", () => {
+    const pkgs =
+      "Package: aardvark-tool\nVersion: 9.9.9\nArchitecture: amd64\n\n" +
+      "Package: nimbus-headless\nVersion: 0.26.0\nArchitecture: amd64\n";
+    expect(parseLinuxVersion(pkgs)).toBe("0.26.0");
+  });
+  test("strips a Debian epoch prefix and revision suffix to the core version", () => {
+    const pkgs = "Package: nimbus-headless\nVersion: 1:0.26.0-1\nArchitecture: amd64\n";
+    expect(parseLinuxVersion(pkgs)).toBe("0.26.0");
+  });
+  test("null when the package block is absent", () => {
+    expect(parseLinuxVersion("Package: something-else\nVersion: 1.0.0\n")).toBeNull();
+  });
+});
+
+describe("compareSemver", () => {
+  test("orders valid versions (v-prefix tolerated)", () => {
+    expect(compareSemver("v0.26.0", "0.25.0")).toBe(1);
+    expect(compareSemver("0.25.0", "0.26.0")).toBe(-1);
+    expect(compareSemver("0.26.0", "0.26.0")).toBe(0);
+  });
+  test("returns null (never throws) on an unparseable version", () => {
+    expect(compareSemver("not-a-version", "0.26.0")).toBeNull();
+    expect(compareSemver("0.26.0", "garbage")).toBeNull();
+  });
+});
+
+describe("selectPublished", () => {
+  const base = { draft: false, prerelease: false, publishedAt: "2026-07-01T00:00:00Z" };
+  test("picks the highest stable tag whose SHA256SUMS asset exists", () => {
+    const r = selectPublished(
+      [
+        { ...base, tag: "v0.25.0", assets: ["SHA256SUMS"] },
+        { ...base, tag: "v0.26.0", assets: ["SHA256SUMS"], publishedAt: "2026-07-10T00:00:00Z" },
+      ],
+      "SHA256SUMS",
+    );
+    expect(r).toEqual({ version: "0.26.0", publishedAt: "2026-07-10T00:00:00Z" });
+  });
+  test("skips a release missing the asset (asset-less phantom)", () => {
+    const r = selectPublished(
+      [
+        { ...base, tag: "v0.26.0", assets: [] },
+        { ...base, tag: "v0.25.0", assets: ["SHA256SUMS"] },
+      ],
+      "SHA256SUMS",
+    );
+    expect(r?.version).toBe("0.25.0");
+  });
+  test("skips prereleases, drafts, and non-vX.Y.Z tags", () => {
+    const r = selectPublished(
+      [
+        { ...base, tag: "v0.27.0-rc.1", prerelease: true, assets: ["SHA256SUMS"] },
+        { ...base, tag: "sdk-v1.6.0", assets: ["SHA256SUMS"] },
+        { ...base, tag: "v0.26.0", draft: true, assets: ["SHA256SUMS"] },
+        { ...base, tag: "v0.25.0", assets: ["SHA256SUMS"] },
+      ],
+      "SHA256SUMS",
+    );
+    expect(r?.version).toBe("0.25.0");
+  });
+  test("null when nothing qualifies", () => {
+    expect(selectPublished([{ ...base, tag: "v0.26.0", assets: [] }], "SHA256SUMS")).toBeNull();
+  });
+});
+
+describe("wingetDirPath", () => {
+  test("derives the manifests path from a two-part package id", () => {
+    expect(wingetDirPath("NimbusAgent.Nimbus", "0.26.0")).toBe(
+      "manifests/n/NimbusAgent/Nimbus/0.26.0",
+    );
+  });
+  test("maps every dot-segment to its own path segment (multi-part id)", () => {
+    expect(wingetDirPath("Acme.Tools.Cli", "1.2.3")).toBe("manifests/a/Acme/Tools/Cli/1.2.3");
+  });
+});
+
+describe("resolveWingetCoverage", () => {
+  test("covered when the dir exists", () => {
+    expect(resolveWingetCoverage(true, false)).toEqual({ status: "read", covered: true });
+  });
+  test("covered when an open PR exists", () => {
+    expect(resolveWingetCoverage(false, true)).toEqual({ status: "read", covered: true });
+  });
+  test("genuinely not covered when both are known-false", () => {
+    expect(resolveWingetCoverage(false, false)).toEqual({ status: "read", covered: false });
+  });
+  test("indeterminate when either signal is unknown and neither is true", () => {
+    expect(resolveWingetCoverage(null, false)).toEqual({ status: "indeterminate", covered: false });
+    expect(resolveWingetCoverage(false, null)).toEqual({ status: "indeterminate", covered: false });
+  });
+});

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -10,6 +10,8 @@
  * docs/superpowers/specs/2026-07-24-p2-release-train-design.md.
  */
 
+import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
 export function stripV(version: string): string {
   return version.replace(/^v/, "");
 }
@@ -255,4 +257,221 @@ export function decideExit(
     return { code: 1, messages };
   }
   return { code: 0, messages };
+}
+
+export interface ChannelSpec {
+  kind: "brew" | "scoop" | "linux" | "winget";
+  repo?: string;
+  path?: string;
+  package?: string;
+  wingetRepo?: string;
+}
+export interface TrainSpec {
+  name: string;
+  source: {
+    manifestRepo: string;
+    manifestFile: string;
+    manifestKey: string;
+    releaseAsset: string;
+  };
+  channels: ChannelSpec[];
+}
+export interface TrainManifest {
+  graceHours: number;
+  trains: TrainSpec[];
+}
+
+export function loadTrainManifest(json: string): TrainManifest {
+  const parsed: unknown = JSON.parse(json);
+  if (
+    !isRecord(parsed) ||
+    typeof parsed["graceHours"] !== "number" ||
+    !Array.isArray(parsed["trains"])
+  ) {
+    throw new Error("release-train.json: expected { graceHours: number, trains: [...] }");
+  }
+  return parsed as unknown as TrainManifest;
+}
+
+/**
+ * Hours between an ISO-8601 (Z-suffixed) timestamp and now, UTC epoch-ms math.
+ * An unparseable date yields `+Infinity` (fail-CLOSED): a NaN age would satisfy
+ * `NaN > graceHours === false` and silently mask a phantom/stale state as "ok",
+ * so an unreadable timestamp instead forces the aged-check to fire.
+ */
+export function ageHours(isoZ: string): number {
+  const t = new Date(isoZ).getTime();
+  if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - t) / 3_600_000;
+}
+
+/** Decode a GitHub contents API base64 `.content` envelope to UTF-8 text. */
+function decodeContents(base64Envelope: string): string {
+  return Buffer.from(base64Envelope.replace(/\s/g, ""), "base64").toString("utf8");
+}
+
+/** Fallback: some apt repos serve only Packages.gz — decode it in-memory. */
+function tryLinuxGz(ch: ChannelSpec): ChannelReading | null {
+  const gz = runGh(["gh", "api", `repos/${ch.repo}/contents/${ch.path}.gz`, "--jq", ".content"]);
+  if (!gz.ok) return null;
+  try {
+    const bytes = Buffer.from(gz.stdout.replace(/\s/g, ""), "base64");
+    const text = new TextDecoder().decode(Bun.gunzipSync(bytes));
+    return { kind: ch.kind, status: "read", version: parseLinuxVersion(text), covered: null };
+  } catch {
+    // corrupt / non-gzip payload — transient, not a staleness finding
+    return { kind: ch.kind, status: "indeterminate", version: null, covered: null };
+  }
+}
+
+/** winget coverage: is `publishedVersion` merged as a manifest dir, or PR-open? */
+function readWingetChannel(ch: ChannelSpec, publishedVersion: string | null): ChannelReading {
+  // Nothing published yet => nothing for winget to be behind.
+  if (!publishedVersion) return { kind: "winget", status: "read", version: null, covered: true };
+  const dirRes = runGh([
+    "gh",
+    "api",
+    `repos/${ch.wingetRepo}/contents/${wingetDirPath(ch.package ?? "", publishedVersion)}`,
+    "--jq",
+    "length",
+  ]);
+  const dir = dirRes.ok ? true : classifyReadFailure(dirRes.httpStatus) === "absent" ? false : null;
+  let pr: boolean | null = false;
+  if (dir !== true) {
+    const prRes = runGh([
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      ch.wingetRepo ?? "",
+      "--state",
+      "open",
+      "--search",
+      `in:title ${ch.package} ${publishedVersion}`,
+      "--json",
+      "number",
+      "--jq",
+      "length",
+    ]);
+    pr = prRes.ok ? Number(prRes.stdout.trim()) > 0 : null;
+  }
+  const { status, covered } = resolveWingetCoverage(dir, pr);
+  return { kind: "winget", status, version: null, covered };
+}
+
+/** Read one channel's live version (or winget coverage). Public reads only. */
+function readChannel(ch: ChannelSpec, publishedVersion: string | null): ChannelReading {
+  if (ch.kind === "winget") return readWingetChannel(ch, publishedVersion);
+
+  const res = runGh(["gh", "api", `repos/${ch.repo}/contents/${ch.path}`, "--jq", ".content"]);
+  if (!res.ok) {
+    const linuxGz = ch.kind === "linux" ? tryLinuxGz(ch) : null;
+    if (linuxGz !== null) return linuxGz;
+    return {
+      kind: ch.kind,
+      status: classifyReadFailure(res.httpStatus),
+      version: null,
+      covered: null,
+    };
+  }
+  const text = decodeContents(res.stdout);
+  const version =
+    ch.kind === "brew"
+      ? parseBrewVersion(text)
+      : ch.kind === "scoop"
+        ? parseScoopVersion(text)
+        : parseLinuxVersion(text);
+  return { kind: ch.kind, status: "read", version, covered: null };
+}
+
+/** The intended head: the version release-please claims on main, + its bump age. */
+function readIntended(train: TrainSpec): { intended: string; intendedBumpAgeHours: number } {
+  const manRes = runGh([
+    "gh",
+    "api",
+    `repos/${train.source.manifestRepo}/contents/${train.source.manifestFile}?ref=main`,
+    "--jq",
+    ".content",
+  ]);
+  const intendedJson = manRes.ok ? decodeContents(manRes.stdout) : "{}";
+  const intendedParsed: unknown = JSON.parse(intendedJson);
+  const intended =
+    isRecord(intendedParsed) && typeof intendedParsed[train.source.manifestKey] === "string"
+      ? (intendedParsed[train.source.manifestKey] as string)
+      : "";
+
+  const bumpRes = runGh([
+    "gh",
+    "api",
+    `repos/${train.source.manifestRepo}/commits?path=${train.source.manifestFile}&per_page=1`,
+    "--jq",
+    ".[0].commit.committer.date",
+  ]);
+  const intendedBumpAgeHours =
+    bumpRes.ok && bumpRes.stdout.trim()
+      ? ageHours(bumpRes.stdout.trim())
+      : Number.POSITIVE_INFINITY;
+  return { intended, intendedBumpAgeHours };
+}
+
+/** The published head: the latest stable Release that actually carries assets. */
+function readPublished(train: TrainSpec): PublishedRelease | null {
+  const relRes = runGh([
+    "gh",
+    "api",
+    `repos/${train.source.manifestRepo}/releases?per_page=100`,
+    "--jq",
+    "[.[] | {tag: .tag_name, prerelease: .prerelease, draft: .draft, publishedAt: .published_at, assets: [.assets[].name]}]",
+  ]);
+  if (!relRes.ok) return null;
+  const rels: unknown = JSON.parse(relRes.stdout);
+  if (!Array.isArray(rels)) return null;
+  return selectPublished(rels as ReleaseInfo[], train.source.releaseAsset);
+}
+
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const label = "audit:release-staleness";
+
+  // Reachability probe (mirrors cla-coverage): one public read. If gh/network is
+  // unavailable at all, soft-skip locally / red in strict.
+  const probe = runGh(["gh", "api", "repos/nimbus-agent/Nimbus", "--jq", ".name"]);
+  if (!probe.ok) {
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const manifest = loadTrainManifest(
+    await Bun.file(new URL("../../.github/release-train.json", import.meta.url)).text(),
+  );
+
+  const allResults: EdgeResult[] = [];
+  for (const train of manifest.trains) {
+    const { intended, intendedBumpAgeHours } = readIntended(train);
+    const published = readPublished(train);
+    const publishedAgeHours = published ? ageHours(published.publishedAt) : null;
+    const channels = train.channels.map((ch) => readChannel(ch, published?.version ?? null));
+
+    allResults.push(
+      ...evaluateTrain({
+        name: train.name,
+        intended,
+        intendedBumpAgeHours,
+        published,
+        publishedAgeHours,
+        channels,
+        graceHours: manifest.graceHours,
+      }),
+    );
+  }
+
+  const out = decideExit(allResults, strict);
+  for (const m of out.messages) (m.startsWith("::error::") ? console.error : console.warn)(m);
+  if (out.code === 0) {
+    const current = allResults.filter((r) => r.verdict === "ok").length;
+    console.log(`${label}: OK (${current} edges current)`);
+  }
+  process.exit(out.code);
 }

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:release-staleness — the P2 Release Train gate. Reads three version
+ * "heads" for each train in .github/release-train.json (intended = release-please
+ * manifest, published = latest GitHub Release with its SHA256SUMS asset,
+ * distributed = each channel's live version) and fails when a channel lags the
+ * published release past graceHours, or when a release phantoms. All reads are
+ * public gh calls; fail-soft locally, strict in CI. See
+ * docs/superpowers/specs/2026-07-24-p2-release-train-design.md.
+ */
+
+export function stripV(version: string): string {
+  return version.replace(/^v/, "");
+}
+
+/**
+ * Semver ordering that never throws. `Bun.semver.order` throws on an unparseable
+ * version ("Invalid SemVer: ..."), and channel files are external — a format
+ * quirk must degrade to "indeterminate", not crash the whole audit. Returns
+ * -1 | 0 | 1, or null when either side is not valid semver.
+ */
+export function compareSemver(a: string, b: string): number | null {
+  try {
+    return Bun.semver.order(stripV(a), stripV(b));
+  } catch {
+    return null;
+  }
+}
+
+/** `version "X.Y.Z"` from a Homebrew Formula .rb. */
+export function parseBrewVersion(rb: string): string | null {
+  return rb.match(/version\s+"([^"]+)"/)?.[1] ?? null;
+}
+
+/** `.version` from a Scoop JSON manifest. */
+export function parseScoopVersion(json: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (typeof parsed === "object" && parsed !== null && "version" in parsed) {
+      const v = (parsed as { version: unknown }).version;
+      return typeof v === "string" ? v : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The upstream version of `pkgName` from an apt Packages index. The index lists
+ * every package as a double-newline-separated block, so we scope to the block
+ * whose `Package:` field equals `pkgName` (a future second package must not be
+ * read by position). The Debian `Version:` field may carry an epoch (`N:`) and a
+ * revision (`-N`); both are stripped to the core upstream version so it compares
+ * as semver.
+ */
+export function parseLinuxVersion(packages: string, pkgName = "nimbus-headless"): string | null {
+  for (const block of packages.split(/\n\n+/)) {
+    if (block.match(new RegExp(`^Package:\\s*${pkgName}\\s*$`, "m"))) {
+      const raw = block.match(/^Version:\s*(.+)$/m)?.[1]?.trim();
+      if (!raw) return null;
+      // strip epoch "N:" prefix and "-revision" suffix -> core upstream version
+      return raw.replace(/^\d+:/, "").replace(/-.*$/, "");
+    }
+  }
+  return null;
+}
+
+export interface ReleaseInfo {
+  tag: string;
+  prerelease: boolean;
+  draft: boolean;
+  assets: string[];
+  publishedAt: string;
+}
+export interface PublishedRelease {
+  version: string;
+  publishedAt: string;
+}
+
+/**
+ * Highest stable `vX.Y.Z` release whose `asset` is attached. Skips drafts,
+ * prereleases, non-`vX.Y.Z` tags (e.g. component tags), and asset-less phantom
+ * releases. Returns null when nothing qualifies.
+ */
+export function selectPublished(releases: ReleaseInfo[], asset: string): PublishedRelease | null {
+  const stable = /^v\d+\.\d+\.\d+$/;
+  const eligible = releases.filter(
+    (r) => !r.draft && !r.prerelease && stable.test(r.tag) && r.assets.includes(asset),
+  );
+  if (eligible.length === 0) return null;
+  // Tags are pre-filtered to `vX.Y.Z`, so compareSemver never returns null here;
+  // `?? 0` keeps the comparator total-typed for the sort.
+  eligible.sort((a, b) => compareSemver(b.tag, a.tag) ?? 0);
+  const top = eligible[0];
+  return top ? { version: stripV(top.tag), publishedAt: top.publishedAt } : null;
+}
+
+/**
+ * winget-pkgs manifests path. Every dot-segment of the package id becomes its
+ * own directory: `NimbusAgent.Nimbus` -> `manifests/n/NimbusAgent/Nimbus/<ver>`,
+ * `Acme.Tools.Cli` -> `manifests/a/Acme/Tools/Cli/<ver>`. The first segment's
+ * lowercased first letter is the top bucket.
+ */
+export function wingetDirPath(packageId: string, version: string): string {
+  const segments = packageId.split(".");
+  const letter = (segments[0] ?? "").charAt(0).toLowerCase();
+  return `manifests/${letter}/${segments.join("/")}/${version}`;
+}
+
+/**
+ * winget is "caught up" if the version dir is merged OR an open PR exists.
+ * `dir`/`pr` are true (known present), false (known absent), or null (the read
+ * failed transiently). Covered if either is true; genuinely not covered only
+ * when both are known-false; otherwise indeterminate.
+ */
+export function resolveWingetCoverage(
+  dir: boolean | null,
+  pr: boolean | null,
+): { status: "read" | "indeterminate"; covered: boolean } {
+  if (dir === true || pr === true) return { status: "read", covered: true };
+  if (dir === false && pr === false) return { status: "read", covered: false };
+  return { status: "indeterminate", covered: false };
+}

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -123,3 +123,136 @@ export function resolveWingetCoverage(
   if (dir === false && pr === false) return { status: "read", covered: false };
   return { status: "indeterminate", covered: false };
 }
+
+export type EdgeVerdict = "ok" | "stale" | "phantom" | "indeterminate";
+export interface EdgeResult {
+  edge: string;
+  verdict: EdgeVerdict;
+  detail: string;
+}
+export interface ChannelReading {
+  kind: string;
+  status: "read" | "absent" | "indeterminate";
+  /** version-file channels (brew/scoop/linux); null for winget or unread. */
+  version: string | null;
+  /** winget only: is the published version covered; null otherwise. */
+  covered: boolean | null;
+}
+export interface TrainEvalInput {
+  name: string;
+  intended: string;
+  intendedBumpAgeHours: number;
+  published: PublishedRelease | null;
+  publishedAgeHours: number | null;
+  channels: ChannelReading[];
+  graceHours: number;
+}
+
+/**
+ * The phantom edge: the release-please manifest says vN, so a built Release
+ * carrying assets must exist for vN. "Manifest ahead of published" is legitimate
+ * only inside the build window, hence the grace check on the bump's own age.
+ */
+function evaluatePhantomEdge(i: TrainEvalInput, pubVer: string | null): EdgeResult {
+  const edge = `${i.name}:phantom`;
+  const order = pubVer === null ? null : compareSemver(i.intended, pubVer);
+  if (pubVer !== null && order === null) {
+    // The manifest version itself is unparseable — cannot judge; do not crash.
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `manifest version ${i.intended} is not valid semver`,
+    };
+  }
+  const intendedAhead = pubVer === null || (order ?? 0) > 0;
+  if (!intendedAhead) {
+    return { edge, verdict: "ok", detail: `manifest ${i.intended} matches published ${pubVer}` };
+  }
+  if (i.intendedBumpAgeHours > i.graceHours) {
+    return {
+      edge,
+      verdict: "phantom",
+      detail: `manifest ${i.intended} has no built Release with assets (latest published: ${i.published?.version ?? "none"}); bump is ${Math.round(i.intendedBumpAgeHours)}h old (> ${i.graceHours}h grace)`,
+    };
+  }
+  return {
+    edge,
+    verdict: "ok",
+    detail: `manifest ${i.intended} ahead of published ${i.published?.version ?? "none"} but within ${i.graceHours}h grace`,
+  };
+}
+
+/** One channel edge: has this distribution channel caught up to `pubVer` yet? */
+function evaluateChannelEdge(ch: ChannelReading, edge: string, pubVer: string): EdgeResult {
+  if (ch.status === "indeterminate") {
+    return { edge, verdict: "indeterminate", detail: "channel read failed transiently" };
+  }
+  if (ch.status === "absent") {
+    return { edge, verdict: "stale", detail: "channel file/dir absent" };
+  }
+  if (ch.kind === "winget") {
+    return ch.covered
+      ? { edge, verdict: "ok", detail: `winget covers ${pubVer} (merged dir or open PR)` }
+      : { edge, verdict: "stale", detail: `no winget dir and no open PR for ${pubVer}` };
+  }
+  const chVer = ch.version ? stripV(ch.version) : null;
+  if (chVer === null) {
+    return { edge, verdict: "indeterminate", detail: "channel version missing" };
+  }
+  const ord = compareSemver(chVer, pubVer);
+  if (ord === null) {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `channel version ${chVer} not comparable to ${pubVer}`,
+    };
+  }
+  return ord >= 0
+    ? { edge, verdict: "ok", detail: `${ch.kind} ${chVer} >= published ${pubVer}` }
+    : { edge, verdict: "stale", detail: `${ch.kind} ${chVer} < published ${pubVer}` };
+}
+
+export function evaluateTrain(i: TrainEvalInput): EdgeResult[] {
+  const pubVer = i.published ? stripV(i.published.version) : null;
+  const results: EdgeResult[] = [evaluatePhantomEdge(i, pubVer)];
+
+  // Channel edges are only meaningful once something is actually published.
+  if (pubVer === null) return results;
+  const pastGrace = i.publishedAgeHours !== null && i.publishedAgeHours > i.graceHours;
+
+  for (const ch of i.channels) {
+    const edge = `${i.name}:${ch.kind}`;
+    results.push(
+      pastGrace
+        ? evaluateChannelEdge(ch, edge, pubVer)
+        : { edge, verdict: "ok", detail: `within ${i.graceHours}h grace` },
+    );
+  }
+  return results;
+}
+
+/**
+ * Exit decision. Any stale/phantom edge => red. Otherwise green with a warning
+ * per indeterminate edge — EXCEPT a run where nothing was evaluable (no ok, only
+ * indeterminate) under --strict is red: "indeterminate" must not read as "all
+ * clear" in the scheduled sweep (the team-reachability rule).
+ */
+export function decideExit(
+  results: EdgeResult[],
+  strict: boolean,
+): { code: 0 | 1; messages: string[] } {
+  const messages: string[] = [];
+  const hard = results.filter((r) => r.verdict === "phantom" || r.verdict === "stale");
+  const indet = results.filter((r) => r.verdict === "indeterminate");
+  const ok = results.filter((r) => r.verdict === "ok");
+  for (const r of hard) messages.push(`::error::${r.edge}: ${r.detail}`);
+  for (const r of indet) messages.push(`::warning::${r.edge}: ${r.detail} (indeterminate)`);
+  if (hard.length > 0) return { code: 1, messages };
+  if (ok.length === 0 && indet.length > 0 && strict) {
+    messages.push(
+      "::error::release-staleness: indeterminate — nothing could be evaluated (all reads failed transiently)",
+    );
+    return { code: 1, messages };
+  }
+  return { code: 0, messages };
+}


### PR DESCRIPTION
Ships Phase 1 of the **P2 Release Train** sub-program: an independent, scheduled gate that goes red when a built release has not reached a distribution channel, or when a release *phantoms*. Spec + plan (design → review → plan → review) are the first four commits.

## What it does

A declarative `.github/release-train.json` lists every propagation edge. `audit:release-staleness` reads three version heads and emits a per-edge verdict:

| Head | Source |
| --- | --- |
| **intended** | `.release-please-manifest.json` on `main`, plus its bump-commit age |
| **published** | latest stable `vX.Y.Z` Release that actually carries its `SHA256SUMS` asset |
| **distributed** | each channel's live file (brew / scoop / linux apt) or winget dir-or-open-PR |

A new `release-staleness` job runs it `--strict` on the existing weekly `org-drift-sweep` cron. **No App token is minted** — every read is public, so `github.token` suffices.

## Design decisions that matter

- The **phantom edge gates on the bump commit's age**, not the release's, so a normal build window is never red.
- **winget counts as caught-up on a merged dir OR an open PR** — the gate never waits on Microsoft's merge.
- Every unreadable or unparseable input degrades to `indeterminate`, **never `stale`**. `Bun.semver.order` throws on non-semver, so it is wrapped.
- Under `--strict`, a run that evaluated *nothing* is **red** — "indeterminate" must not read as "all clear" (the team-reachability rule).

## Live proof: RED on a genuine phantom

```
::error::nimbus-gateway:phantom: manifest 0.27.0 has no built Release with assets
(latest published: 0.26.0); bump is 54h old (> 6h grace)
```

Verified real, not a gate bug: **no `v0.27.0` tag exists**, and PR #827 (merged 2026-07-24T06:37Z) still carries `autorelease: pending`. All four channel edges evaluated `ok`. Exit 1 in both default and `--strict` mode.

Chasing that surfaced a second, worse problem — **#824's auto-reconcile has been a silent no-op since it shipped**, fixed in #834. The gate did its job on run 1.

## Also closes the CLA-coverage follow-up

`_gh-audit.ts` now surfaces the `gh` HTTP status; `check-cla-coverage` treats a non-404 read as *indeterminate* rather than "cla.yml absent", so a transient 5xx/rate-limit can no longer fake a "repo lost its CLA gate" red. That was an open robustness item on the infrastructure roadmap.

## Verification

- 39 unit tests for the new gate; **610 scripts tests pass**, 0 fail
- `typecheck` clean; `biome check` clean on 2960 files
- `audit:doc-refs` 616/616 resolve; `audit:readme-cli` clean; lychee 0 errors
- Manifest key, all three channel paths and the `nimbus-headless` Debian format verified against the **live** repos, not assumed from the plan
- Red-prove: the `stale` (5) and `phantom` (4) cases assert the red verdicts

## Remaining

Phase 2 (dependency-DAG edges: sdk/client → consumers). Per the program's definition of done, P2 is only *done* once `release-staleness` has run green in a scheduled sweep on `main` — a net-new job's first real run is post-merge, so dispatch `org-drift-sweep.yml` after this lands and record the run number in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)