### PR TITLE
fix(release): request workflows:write so the App can create the release tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,20 @@ jobs:
           # release PR (labels are an issues-API concept for GitHub Apps) — both
           # for release-please's own pending→tagged flip and the reconcile step below.
           permission-issues: write
+          # `workflows: write` is required to CREATE THE TAG, which is not obvious.
+          # GitHub refuses to let a GitHub App create a ref pointing at a commit whose
+          # `.github/workflows/**` differs from the default branch, unless the App holds
+          # `workflows: write` — it counts as the App "creating or updating a workflow".
+          # A release tag always points at the release PR's merge commit, which falls
+          # behind main the moment any later PR touches a workflow file, so this fires on
+          # exactly the releases we care about. REST reports it only as an opaque
+          # `403 Resource not accessible by integration` on `POST /git/refs`; the git
+          # transport spells it out ("refusing to allow a GitHub App to create or update
+          # workflow ... without `workflows` permission"). Proven by probe: the same token
+          # creating the same ref shape at main's head returns 201, and at PR #827's merge
+          # commit returns 403. This must stay in lockstep with the App's granted
+          # permissions: minting fails outright if the App lacks `Workflows: write`.
+          permission-workflows: write
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
@@ -49,8 +63,13 @@ jobs:
 
       # Phantom-release guard. release-please in this repo intermittently merges the
       # "chore: release main" PR (bumping the manifest) but never creates the tag/GitHub
-      # Release — an internal parse error breaks its release-creation phase, after which it
-      # aborts every run with "untagged, merged release PRs outstanding". The symptom is a
+      # Release — its release-creation phase fails, after which it aborts every run with
+      # "untagged, merged release PRs outstanding". Since the switch to the App token that
+      # failure is consistent with the `workflows: write` gate documented on the mint step
+      # above (release-please tags the release PR's merge commit, which is exactly the
+      # blocked shape), so granting that permission may fix it at the source and reduce
+      # this step to a safety net; the phantoms predating the App had some other cause and
+      # were never attributed. The symptom is the same either way: a
       # merged release PR left labelled `autorelease: pending` with no matching tag. This
       # step automates the standing manual recovery (create the tag + relabel), so releases
       # ship hands-free regardless of why the native step misfired. It is idempotent: on a

--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -45,8 +45,16 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
           repositories: Nimbus,homebrew-tap,scoop-bucket,linux-repo
+          # Must mirror the SUPERSET of what any real consumer requests, or the
+          # probe reports healthy while a release is structurally broken: minting
+          # fails only for permissions it actually asks for, so a permission the
+          # probe omits is a permission this gate cannot see being revoked.
+          # `workflows: write` is what lets release-please.yml tag a commit whose
+          # .github/workflows/** differs from the default branch (see that file).
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
+          permission-workflows: write
       - name: Mint auditor token (read-only credential inventory)
         id: auditor-mint
         continue-on-error: true

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -85,7 +85,26 @@ job that used to consume one of those PATs now runs a mint step first:
     repositories: <only the repos this job writes>
     permission-contents: write
     # permission-pull-requests: write   # release-please.yml only
+    # permission-issues: write          # release-please.yml only — `autorelease:` label flips
+    # permission-workflows: write       # release-please.yml only — see below
 ```
+
+> **`workflows: write` is load-bearing for tagging, which is not obvious.**
+> GitHub refuses to let a GitHub App create a ref pointing at a commit whose
+> `.github/workflows/**` differs from the default branch unless the App holds
+> `Workflows: write` — it counts as the App "creating or updating a workflow".
+> A release tag always points at the release PR's merge commit, which falls
+> behind `main` as soon as any later PR touches a workflow file, so this fires
+> on exactly the releases we care about. REST reports it only as an opaque
+> `403 Resource not accessible by integration`; the response header
+> `X-Accepted-Github-Permissions: contents=write; contents=write,workflows=write`
+> is what names the real requirement. Note the App permission is **Workflows**
+> ("Update GitHub Action workflow files"), *not* **Actions** ("Workflows,
+> workflow runs and artifacts") — the two are easy to confuse in the App UI.
+>
+> The `secret-health.yml` probe therefore mints with the **superset** of every
+> permission a real consumer requests. A permission the probe omits is one it
+> cannot detect being revoked — the probe would stay green while releases break.
 
 and uses `${{ steps.app-token.outputs.token }}` in place of the retired PAT.
 Each minted token is an **installation access token**: scoped to exactly the


### PR DESCRIPTION
## ⚠️ Merge order matters — grant the App permission FIRST

`actions/create-github-app-token` **fails outright** if it requests a permission the App does not hold. Merging this before the grant breaks `release-please.yml` entirely.

**App to change:** `nimbus-release-bot` — app_id **4339400**, installation **147619203** (org-owned, `repository_selection: selected`).
Grant **Repository permissions → Workflows: write**, then approve the updated permissions on the installation.

Current grants (no `workflows` at all):
`administration:read · contents:write · issues:write · members:read · metadata:read · organization_administration:read · pull_requests:write`

## Root cause

This is the 403 that has blocked every hands-free release. GitHub refuses to let a GitHub App create a ref pointing at a commit whose `.github/workflows/**` differs from the default branch unless the App holds `workflows: write` — it counts as the App "creating or updating a workflow".

A release tag **always** points at the release PR's merge commit, which falls behind `main` the moment any later PR touches a workflow file. So this fires on exactly the releases we care about — it is structural, not intermittent.

For v0.27.0 the target `1e0b98df` differs from `main` in **3** workflow files (`cla.yml`, `org-drift-sweep.yml`, `release-please.yml`), all changed by #832/#834/#836 after that commit.

## Evidence

REST surfaces this only as an opaque `403 Resource not accessible by integration` on `POST /git/refs`. The response header names the requirement:

```
X-Accepted-Github-Permissions: contents=write; contents=write,workflows=write
```

Two accepted sets — `contents=write` **or** `contents=write,workflows=write`. The App satisfied the first but never the second.

Confirmed by in-CI probe with the minted token (run `30205855632`):

| probe | result |
| --- | --- |
| `POST refs/heads/<probe>` @ null sha | **422** `Object does not exist` — authorized, bad sha only |
| same ref shape @ `main` head | **201** created |
| same ref shape @ #827's merge commit | **403** |

The git transport spells out what REST hides: *"refusing to allow a GitHub App to create or update workflow ... without `workflows` permission"*.

## Previously ruled out — do not re-investigate

- The **"Protected release tags" ruleset** (15436427) is not involved: rules are `deletion`/`non_fast_forward`/`update` with **no `creation` rule**, and `rule-suites?ref=refs/tags/v0.27.0` returns `[]`, i.e. it was never evaluated.
- The mint step already requested `contents: write`, and the App already held it.
- The same token's reads in the same step always succeeded.

## Likely wider impact

`release-please` authenticates with this same App token. Its own tag-creation almost certainly hits this identical gate, which would explain why it "cannot create releases in this repo" and has aborted on every version since ~#757. If so, this grant fixes the disease at the source and the reconcile step (#834) becomes a safety net rather than the primary path. The `unexpected token ' '` parse error in its logs may be a red herring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release handling by granting the permissions required for release tagging.
  * Added safeguards and guidance to help prevent merged releases from remaining untagged or pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->