### PR TITLE
docs(infra): bring the infrastructure roadmap up to date with 2026-07-26

### DIFF
--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -25,6 +25,7 @@ unrelated areas of the org:
 | `audit:action-sha-pins` | `Nimbus` | the satellites — pins already drifted | never made |
 | `.coderabbit.yaml` (tuned) | the 4 satellites | `Nimbus` — 30 invariants, reviewed stock | never made |
 | `ci-secrets.md` completeness claim | when authored | `secret-health.yml`'s own credentials | never made |
+| the `cla` required check | verified on `nimbus-web-clipper` | `Nimbus` — the only repo with a restricted Actions allowlist | never made |
 
 Two point in opposite directions, so this is not "the periphery lags." A control
 here is scoped to whatever context its author was in, and nothing carries it
@@ -36,6 +37,35 @@ property regressed — not when its code merges. A control that has stopped
 covering the risk looks exactly like one that is passing; only a gate that would
 go red tells them apart.
 
+### The sharpest instance so far (2026-07-26)
+
+The fourth row above is the thesis in its purest form, and it is worth stating
+plainly because it defeats a weaker version of this document's own rule.
+
+The CLA was written, deployed to all six public repos, and made a **required**
+status check. It was red-proved on `nimbus-web-clipper`. Every visible signal
+said *shipped*. It had **never executed on `Nimbus` even once**: 23 of 23 runs
+were `startup_failure`, because `Nimbus` is the only repo whose Actions
+allowlist is set to `selected`, and `contributor-assistant/github-action` was
+not on it. GitHub rejected the workflow before any job started, so the required
+`cla` context was never reported and **every PR was silently unmergeable**.
+
+Two lessons this file should carry:
+
+1. **Verifying a control on one repo proves nothing about another.** The
+   red-prove happened where the allowlist was permissive. That is the same
+   scoping failure as the three rows above, just with the "context" being a repo
+   setting rather than a directory.
+2. **"The gate is green" is not the bar — "the gate ran" is.** `cla-coverage`
+   was green throughout: it verifies each repo *has* `cla.yml` at a consistent
+   version, which was true. A gate that checks a control's *presence* cannot see
+   that the control is structurally unable to execute. Absence of a red signal
+   was indistinguishable from absence of the signal entirely.
+
+The follow-up gate this implies — an Actions-allowlist drift check that would
+fail when a required workflow's action is not permitted to run — is recorded
+under [P5](#p5-progress-log).
+
 ---
 
 ## Sub-programs
@@ -46,12 +76,12 @@ Design of record:
 | | Sub-program | Status | Gate |
 | --- | --- | --- | --- |
 | P1 | Org CI Foundation | ✅ done | The scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos — proven green end-to-end (run 30060920603) |
-| P2 | Release Train | 🔨 Phase 1 shipped | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, or when a release phantoms (manifest bumped, nothing built). Remaining: Phase 2 (dependency-DAG edges) |
+| P2 | Release Train | 🔨 Phase 1 done | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, or when a release phantoms (manifest bumped, nothing built). Red-proved on a real phantom and green after (`OK (5 edges current)`). Remaining: Phase 2 (dependency-DAG edges) |
 | P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
 | P4b | Latency | ⬜ not started | Per-job wall-clock tracked; regressions visible |
-| P5 | Org Legibility | ⬜ not started | `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md` |
-| P6 | Access & Contribution Model | 🔨 P6a done | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config. Remaining: CLA, bypass-actor audit |
+| P5 | Org Legibility | ⬜ not started | `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md`. **Second gate added 2026-07-26:** an Actions-allowlist check that fails when a required workflow's action is not permitted to run |
+| P6 | Access & Contribution Model | 🔨 P6a + CLA done | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config; CLA live and **actually executing** on all 6 repos. Remaining: bypass-actor audit |
 
 **Sequence:** P1 → P6 → P2 → P5 → P3 → P4b. Three items ignore the sequence and
 land immediately: P4a, `nimbus-client` rulesets, and the contribution-licensing
@@ -136,11 +166,30 @@ moves to P6).
   (`docs/cla/`, pending ratification), the reusable `cla.yml` template, the
   `cla-coverage` drift gate (all 6 public repos have `cla.yml` at one version),
   and `CONTRIBUTING.md` terms.
-- **Pending apply (org-owner):** ratify the CLA wording; create the dedicated CLA
-  App + `SELECTED` private-key secret; create the `.github` `cla-signatures`
-  branch + deploy `CLA/ICLA.md`/`CLA/CCLA.md`; deploy `cla.yml` to all 6 repos;
-  make the `CLA Assistant` check required in each ruleset; **red-prove** with a
-  test PR; confirm `cla-coverage` green.
+- **Applied (2026-07-24, org-owner):** the dedicated `nimbus-cla-bot` App
+  (id 4382579) + org secrets `CLA_BOT_CLIENT_ID` / `CLA_BOT_PRIVATE_KEY`
+  (`SELECTED` → the 6 repos); the `.github` `cla-signatures` branch carrying
+  `CLA/ICLA.md` + `CLA/CCLA.md` and `signatures/version1/cla.json`; `cla.yml`
+  deployed to all 6 repos; the **`cla`** check made required in each ruleset.
+  Note the required context name is **`cla`** — the workflow *job* name, not
+  "CLA Assistant". Red-proved on `nimbus-web-clipper` #22.
+- **⚠️ The gate was dead on `Nimbus` for two days — fixed 2026-07-26.** All 23
+  `cla.yml` runs since deployment were `startup_failure`: `Nimbus` is the only
+  org repo with `allowed_actions: "selected"`, and
+  `contributor-assistant/github-action` was absent from its `patterns_allowed`,
+  so GitHub rejected the workflow before any job ran. The required `cla` context
+  was therefore never reported and **every `Nimbus` PR was unmergeable** —
+  presenting as `cla — Expected — Waiting for status to be reported`. Fixed by
+  adding the action to the repo allowlist (the endpoint is a **full replace**;
+  all 13 existing patterns must be re-sent or Trivy/CodeQL/gitleaks silently
+  break). First-ever successful run: **30203619816**; `cla` now passes on real
+  PRs. See [the sharpest instance](#the-sharpest-instance-so-far-2026-07-26).
+  - **Retrigger note:** `startup_failure` runs **cannot** be `gh run rerun`'d
+    ("This workflow run cannot be retried"). Use `gh pr close` + `gh pr reopen`
+    — `cla.yml` listens for `reopened`, and this leaves branch history clean.
+- **Still prove-in-prod:** the sign → green → signature-write leg. It could not
+  have been exercised before now, since the workflow never ran on `Nimbus`; the
+  first real external PR tests it.
 - **Deferred:** CCLA employee-roster automation; private repos; retroactive
   signatures. See `docs/superpowers/specs/2026-07-24-cla-design.md`.
 - **Robustness follow-up — CLOSED (2026-07-26, in P2 Phase 1):**
@@ -165,14 +214,75 @@ moves to P6).
   never waits on Microsoft's merge; every unreadable or unparseable input
   degrades to `indeterminate`, never `stale`; and under `--strict` a run that
   evaluated *nothing* is red, so "indeterminate" cannot read as "all clear".
-- **Live proof (2026-07-26, pre-merge):** the gate went **red on a genuine
-  phantom** — `.release-please-manifest.json` on `main` claims `0.27.0`, but no
-  `v0.27.0` tag or Release exists (latest built: `v0.26.0`), bump 54h old. All
-  four channel edges evaluated `ok`. This is the recurring manual-tag-push
-  failure mode the sub-program exists to catch, caught on the first live run.
+- **Red-proved on a real defect (2026-07-26, pre-merge):** the gate's first live
+  run went **red on a genuine phantom** — `.release-please-manifest.json` on
+  `main` claimed `0.27.0`, but no `v0.27.0` tag or Release existed (latest
+  built: `v0.26.0`), bump 54h old. All four channel edges evaluated `ok`. Caught
+  on run one, exactly the failure mode the sub-program exists to catch.
+- **Green after the defect was fixed (2026-07-26):** `v0.27.0` published with 33
+  assets and all three version channels propagated, after which the same gate
+  reports `audit:release-staleness: OK (5 edges current)`, exit 0. Red-before /
+  green-after on a real defect — this file's definition of *done* for the gate
+  itself.
+- **What the red thread led to — three nested defects, each hidden by the one
+  above it.** Worth recording because the sub-program's value showed up as
+  diagnosis, not just alerting:
+  1. The phantom itself (`v0.27.0` merged, never tagged).
+  2. The auto-reconcile step added to recover phantoms (#824) had been a
+     **silent no-op since it shipped**. It probed for the tag with
+     `existing=$(gh api ... || true)`, but `gh` writes its error body to
+     **stdout**, so a missing tag left `$existing` non-empty and the
+     "create the tag" branch never ran. Fixed in #834 — *test the exit code or
+     validate the output's shape, never `-z` on captured output.*
+  3. With #834 in place the step finally attempted the create — and hit
+     **`403 Resource not accessible by integration`** on `POST /git/refs`. Root
+     cause: GitHub refuses to let a GitHub App create a ref pointing at a commit
+     whose `.github/workflows/**` differs from the default branch unless the App
+     holds **`Workflows: write`**. A release tag always points at the release
+     PR's merge commit, which falls behind `main` as soon as any later PR edits
+     a workflow — so this fired on precisely the releases that matter, and is
+     structural rather than intermittent. Fixed by granting the permission and
+     requesting it in the mint step (#837).
+     - The decisive diagnostic was the response header
+       **`X-Accepted-Github-Permissions: contents=write; contents=write,workflows=write`**,
+       captured with `gh api -i` from inside CI using the minted token. Reach
+       for that header first on any opaque App `403`.
+     - The App permission is **Workflows** ("update GitHub Action workflow
+       files"), *not* **Actions** ("workflows, workflow runs and artifacts") —
+       the two are easy to confuse in the App UI, and we picked the wrong one on
+       the first attempt.
+     - `rulesets/rule-suites?ref=<ref>` returning `[]` is the authoritative,
+       read-only way to prove a ruleset was *not* involved. It exonerated the
+       "Protected release tags" ruleset here and prevented a pointless
+       weakening of it.
 - **Remaining:** Phase 2 (dependency-DAG edges — sdk/client → consumers). The
   sub-program is *done* only once the `release-staleness` job has run green in
-  a scheduled sweep on `main`; record that run number here.
+  a scheduled sweep on `main`; **record that run number here** (dispatch
+  `org-drift-sweep.yml` — it is green locally against live state as of the
+  entry above, so this is the last formality).
+
+### P5 progress log
+
+Not started. Two gates are already specified by findings from other
+sub-programs — record them here so the motivation is not lost:
+
+- **`audit:actions-allowlist`** (from the CLA outage, 2026-07-26). For every
+  repo whose `allowed_actions` is `selected`, assert that every action `uses:`d
+  by a workflow in that repo is permitted by `patterns_allowed` (accounting for
+  `github_owned_allowed` / `verified_allowed`). Would have caught the two-day
+  CLA outage on day zero. `Nimbus` is currently the only repo with a restricted
+  allowlist, and its list must be re-sent in full on every edit — the API is a
+  replace, not a merge, so a careless PUT silently unpermits Trivy/CodeQL/
+  gitleaks. That fragility is itself an argument for checking it in.
+- **`secret-health` permission superset** (from #837, 2026-07-26). The weekly
+  probe mints the release-bot token, but was requesting a *subset* of what real
+  consumers request, so it would have reported healthy after a revoked
+  `Workflows: write`. `create-github-app-token` only fails for permissions it
+  actually asks for, so **a permission the probe omits is one it cannot detect
+  being lost**. Fixed in #837; the general rule — a health probe must exercise
+  the superset of what it guards — belongs in this sub-program.
+- **Known inventory item with a deadline:** `VSCE_PAT` expires **2026-12-01**,
+  and three release PATs retired during the App migration were never deleted.
 
 ---
 


### PR DESCRIPTION
Several rows in `docs/infrastructure-roadmap.md` had gone stale against reality. Given this file's own rule — *"a sub-program is done when its gate is green in CI, not when its code merges"* — that is a correctness problem rather than cosmetics.

## Changes

**Status table**
- **P6** — CLA is done *and now actually executing*; only the bypass-actor audit remains. (The row still said "Remaining: CLA".)
- **P2** — Phase 1 red-proved on a real phantom and green after (`OK (5 edges current)`).
- **P5** — notes the second gate today's findings specify.

**CLA progress log** — the entire "Pending apply (org-owner)" checklist was applied 2026-07-24; rewritten as delivered, with the App id, the `cla-signatures` branch, and the fact that the required context name is **`cla`** (the job name, not "CLA Assistant").

Critically, it now records that **the gate was dead on `Nimbus` for two days**: 23 of 23 runs were `startup_failure` because the repo's Actions allowlist did not permit `contributor-assistant/github-action`, so the required `cla` context was never reported and **every PR was unmergeable**. Plus the retrigger gotcha — `startup_failure` runs cannot be `gh run rerun`'d; close+reopen is the way.

**P2 progress log** — records the three nested defects the red thread uncovered, each hidden by the one above it:

1. the phantom itself (`v0.27.0` merged, never tagged);
2. #824's auto-reconcile had been a **silent no-op since it shipped** — `gh` writes its error body to *stdout*, so `$(... || true)` left the "tag missing" probe non-empty and the create branch never ran (fixed #834);
3. with that fixed, the create hit `403` — GitHub refuses to let an App create a ref at a commit whose `.github/workflows/**` differs from the default branch without **`Workflows: write`** (fixed #837).

With the diagnostics that cracked each, since they generalise: the `X-Accepted-Github-Permissions` response header, `rulesets/rule-suites?ref=…` returning `[]` as proof a ruleset was *not* involved, and the Workflows-vs-Actions permission confusion in the App UI.

**Pattern table** — adds the CLA outage as a **fourth instance**, and a short section arguing it is the sharpest one yet. A control that was written, deployed, made *required*, and red-proved on another repo, yet never executed once. It defeats a weaker reading of this file's own bar: *"the gate is green"* is not the test, *"the gate ran"* is. `cla-coverage` was green throughout — it verifies a control's **presence**, which cannot detect that the control is structurally unable to **execute**.

**New P5 progress log** — captures the two gates today implies, so the motivation survives: `audit:actions-allowlist` (would have caught the outage on day zero; also guards the full-replace fragility of that API), and the health-probe **permission-superset** rule from #837 (a permission the probe omits is one it cannot detect being revoked). Plus the `VSCE_PAT` **2026-12-01** expiry.

## Still outstanding after this

The P2 log carries one deliberate placeholder: the scheduled-sweep run number. The gate is green locally against live state, so dispatching `org-drift-sweep.yml` and recording that number is the last formality before P2 Phase 1 is formally done.

## Verification

`lint:markdown` 0 errors · `audit:doc-refs` 616/616 resolve · lychee 5/5 OK including `--include-fragments` for the two new internal anchors.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)