### PR TITLE
feat(audit): P2 Release Train Phase 2 — dependency-DAG edges

### DIFF
--- a/.github/release-train.json
+++ b/.github/release-train.json
@@ -21,5 +21,28 @@
         { "kind": "winget", "package": "NimbusAgent.Nimbus", "wingetRepo": "microsoft/winget-pkgs" }
       ]
     }
+  ],
+  "packages": [
+    {
+      "name": "sdk",
+      "npm": "@nimbus-dev/sdk",
+      "repo": "nimbus-agent/nimbus-sdk",
+      "tagPattern": "^sdk-v(\\d+\\.\\d+\\.\\d+)$",
+      "consumers": [
+        { "repo": "nimbus-agent/nimbus-client", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/nimbus-vscode", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/Nimbus", "lockfile": "bun.lock" }
+      ]
+    },
+    {
+      "name": "client",
+      "npm": "@nimbus-dev/client",
+      "repo": "nimbus-agent/nimbus-client",
+      "tagPattern": "^client-v(\\d+\\.\\d+\\.\\d+)$",
+      "consumers": [
+        { "repo": "nimbus-agent/nimbus-vscode", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/Nimbus", "lockfile": "bun.lock" }
+      ]
+    }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1817,7 +1817,7 @@
 
     "@nimbus-dev/client": ["@nimbus-dev/client@0.5.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.3.0" } }, "sha512-DqIhRNGfwwNNUS9eqc2w3ggGhMB36xMYz4kh6TKut0rDDcOut/XNvIJIm7uqRbTfzMAuZQ9QAdTVGSMcy7uw1A=="],
 
-    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-dHPSNP7GuNgM6oo0el4oZhqx1Xbtbwi+2XSKLmBfUcBj4zDTIKyqX9JQpmmSU9eaQcZgQNC7u9o5CmQTa8g1qA=="],
+    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.7.0", "", {}, "sha512-ApS6UElKIGABnqWZsBQvKptlERDI5B18NfQFFZSLk/prEDd8473pR6H/17SMi96fk7/1bp4HgYI5ioqVr6Y2dA=="],
 
     "@nimbus/cli": ["@nimbus/cli@workspace:packages/cli"],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-26 — P2 Release Train Phase 2: dependency-DAG edges.** `audit:release-staleness`
+  now also watches the npm propagation graph. A `<pkg>:publish` edge compares each upstream's
+  component-prefixed release tag to npm `@latest`, catching a package that is tagged but never
+  published; a `<pkg>:<consumer>` edge compares every consuming repo's **lockfile-resolved**
+  version to npm `@latest`, since a semver range misleads in both directions (a caret permits
+  newer, but a caret on a `0.x` pins the minor). The lockfile reader counts only the hoisted
+  entry plus the consumer's own workspaces, so a copy nested inside a third-party package is
+  never mistaken for what local code resolves. Registry reads carry a 5s timeout and degrade to
+  indeterminate; bump PRs already open count as caught-up. Ships red on confirmed drift — the
+  CLI resolves client 0.5.0 against a published 0.12.1.
 - **2026-07-26 — P2 Release Train Phase 1: the `release-staleness` gate.** A declarative
   `.github/release-train.json` lists every propagation edge; `audit:release-staleness` reads three
   version heads — intended (release-please manifest + its bump-commit age), published (the latest

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -76,7 +76,7 @@ Design of record:
 | | Sub-program | Status | Gate |
 | --- | --- | --- | --- |
 | P1 | Org CI Foundation | ✅ done | The scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos — proven green end-to-end (run 30060920603) |
-| P2 | Release Train | ✅ Phase 1 done (run 30210246814) | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, or when a release phantoms (manifest bumped, nothing built). Red-proved on a real phantom and green after (`OK (5 edges current)`). Remaining: Phase 2 (dependency-DAG edges) |
+| P2 | Release Train | ✅ done (Phase 1 run 30210246814) | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, or when a release phantoms (manifest bumped, nothing built). Red-proved on a real phantom and green after (`OK (5 edges current)`). Phase 2 adds npm publish-phantom + consumer-lag edges. |
 | P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
 | P4b | Latency | ⬜ not started | Per-job wall-clock tracked; regressions visible |
@@ -268,10 +268,36 @@ moves to P6).
   new jobs, **this was `cla-coverage`'s first-ever real execution**. Fifth
   instance of the pattern at the top of this file, second in one day. Fix is
   org-owner: add `awesome-nimbus` to the `nimbus-release-bot` installation.
-- **Remaining:** Phase 2 (dependency-DAG edges — sdk/client → consumers).
-  Specced, reviewed, planned and plan-reviewed on the branch
-  `dev/asafgolombek/p2-phase2-dep-dag` (design + plan, both dated 2026-07-26);
-  not yet implemented, and not yet on `main`.
+- **Delivered (Phase 2 — dependency DAG, 2026-07-26):** `.github/release-train.json`
+  gains `packages[]`; two new edge kinds run in the same gate. `<pkg>:publish`
+  compares the upstream component-prefixed release tag to npm `@latest`,
+  catching "tagged but never published" — the npm analogue of the release
+  phantom. `<pkg>:<consumer>` compares each consumer's **lockfile-resolved**
+  version to npm `@latest`, because a range misleads in both directions:
+  `^1.2.0` permits a newer `1.3.0`, while a caret on a `0.x` pins the minor, so
+  `^0.5.0` cannot reach `0.12.1` at all.
+- **The lockfile reader is workspace-scoped, not global.** A bun.lock resolution
+  key is a dependency *path*, so a lower version nested under a third-party
+  package is that package's business, not ours. The reader takes the minimum
+  over the hoisted entry plus entries whose prefix is one of the consumer's own
+  workspace names. Getting this wrong reports a version no local code resolves —
+  confirmed live: Nimbus's hoisted sdk is `1.6.0` while the copy inside
+  `@nimbus-dev/client` is `1.3.0`, and the gate correctly reads `1.6.0`.
+- **Shipped RED on real drift (2026-07-26 16:41Z):** `client:Nimbus`
+  (0.5.0 vs npm 0.12.1) and `client:nimbus-vscode` (0.11.0 vs 0.12.1), both past
+  a 52h-old publish. Confirmed drift, not deliberate pins. Both `:publish` edges
+  green. Bumping those consumers is separate remediation work.
+- **The sdk edges were green on that run for the right reason, and the timing is
+  the point.** `@nimbus-dev/sdk` 1.7.0 had been published 0.8h earlier, so the
+  6h grace window suppressed all three consumer edges even though every one of
+  them is behind it (nimbus-vscode 1.5.2, nimbus-client and Nimbus 1.6.0). That
+  is the rule working — a package published minutes ago must not red its whole
+  consumer set — but it means those three edges go red once grace expires unless
+  they are bumped, and the drift is larger than the design's snapshot recorded.
+- **Remaining:** the sweep proof. Phase 1's bar for *done* is green in the
+  scheduled harness, which Phase 2 cannot show while it is legitimately red;
+  dispatch `org-drift-sweep.yml` after the consumer bumps land and record the
+  run number here, same as Phase 1.
 
 ### P5 progress log
 

--- a/docs/superpowers/plans/2026-07-26-p2-phase2-dep-dag-review.md
+++ b/docs/superpowers/plans/2026-07-26-p2-phase2-dep-dag-review.md
@@ -1,0 +1,42 @@
+# Design Review: P2 Phase 2 — dependency-DAG edges Implementation Plan
+
+This document reviews [2026-07-26-p2-phase2-dep-dag.md](./2026-07-26-p2-phase2-dep-dag.md) and notes questions, suggestions, and improvements.
+
+---
+
+## 1. JSONC Parsing / Trailing Commas Regex Limitations
+
+### Observation
+
+- In `resolvedFromBunLock`, the text replacement `text.replace(/,(\s*[}\]])/g, "$1")` is used to clean trailing commas before calling `JSON.parse`.
+
+### Suggestion
+
+- While this regex works for standard `bun.lock` files, a regex replacement of `,(\s*[}\]])` could potentially match and corrupt comma-containing strings that end with a brace or bracket inside a JSON string value (e.g. `"description": "Includes a comma, }"`).
+- Since Bun has a built-in JSONC parser or YAML reader, or we are running in Bun, we could evaluate whether using a more robust parser or wrapping the `JSON.parse` in a helper that handles basic JSONC features is safer.
+- At a minimum, document this limitation in a comment near the regex to ensure future maintainers understand the edge case.
+
+---
+
+## 2. PR List Limits (`--limit 100`)
+
+### Observation
+
+- `readBumpPrOpen` fetches PRs via `gh pr list --state open --limit 100`.
+
+### Suggestion
+
+- For high-traffic or busy repositories, 100 PRs might occasionally prune out older in-flight bump PRs.
+- While the Nimbus satellite repositories are unlikely to have over 100 concurrently open PRs, it is good practice to ensure the query is optimized. Alternatively, adding a search query term like `gh pr list --search "bump"` or matching the package name directly via GitHub API filter can reduce payload size and guarantee the target PR is found without hitting pagination limits.
+
+---
+
+## 3. Grace Period Timezones Consistency
+
+### Observation
+
+- The design matches timestamps but does not explicitly specify timezone alignment.
+
+### Suggestion
+
+- Ensure all comparisons in `ageHours` coerce both local and retrieved times explicitly into UTC epoch milliseconds (using `.getTime()`) to avoid timezone offset discrepancies between the developer machine and CI environments.

--- a/docs/superpowers/plans/2026-07-26-p2-phase2-dep-dag.md
+++ b/docs/superpowers/plans/2026-07-26-p2-phase2-dep-dag.md
@@ -1,0 +1,1253 @@
+# P2 Phase 2 — dependency-DAG edges Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `audit:release-staleness` so it also fails when an npm package is tagged but never published, or when a consuming repo's lockfile-resolved dependency lags npm `@latest` past the grace window.
+
+**Architecture:** The Phase 1 evaluation engine does not change. Shared primitives move to a new `_release-train-core.ts`; Phase 2's pure readers + evaluator live in `_release-train-dep.ts`; `check-release-staleness.ts` keeps the Phase 1 readers and the single `import.meta.main` shell, which now feeds both evaluators into the same `decideExit`.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6 strict, `gh` CLI, `fetch` against `registry.npmjs.org`, Biome. No new dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design.md`](../specs/2026-07-26-p2-phase2-dep-dag-design.md) (+ its review doc).
+
+## Global Constraints
+
+- **Runtime:** Bun v1.2+, TypeScript 6.x strict. **No `any`** — narrow external JSON with `isRecord` from `_gh-audit.ts`.
+- **`exactOptionalPropertyTypes: true`** is on. An optional field needs an explicit `?: T | undefined`; a bare `?: T` will not compile when assigned `undefined`.
+- **Linter:** run `bunx biome check scripts .github docs` — **NOT** `bun run lint`, which reports "Checked 0 files" inside a `.claude/worktrees/` checkout and exits 1.
+- **Branch:** all work on `dev/asafgolombek/p2-phase2-dep-dag` in the worktree `.claude/worktrees/p2-phase2-dep-dag`. Never commit on `main`. Verify with `git rev-parse --abbrev-ref HEAD` before the first commit.
+- **Gate contract:** fail-soft locally, hard red under `--strict` / `GITHUB_ACTIONS`. Reuse `isStrict` / `strictSkip` from `_gh-audit.ts`.
+- **`graceHours` default 6**, read from the manifest — never hard-code it.
+- **Time:** UTC epoch-ms only, via the existing `ageHours()`. Never parse a timestamp lacking an explicit `Z`/offset.
+- **Version compare:** `compareSemver()` only. `Bun.semver.order` throws on non-semver; `compareSemver` returns `null` instead and every caller must handle `null` as *indeterminate*.
+- **Pre-push:** `bun test scripts/structure-audit/` and `bunx tsc -p scripts/tsconfig.json --noEmit` must pass.
+
+---
+
+## File Structure
+
+- **Create** `scripts/structure-audit/_release-train-core.ts` — shared primitives moved verbatim out of `check-release-staleness.ts`: `stripV`, `compareSemver`, `ageHours`, and the types `EdgeVerdict` / `EdgeResult` / `ReleaseInfo` / `PublishedRelease`, plus `decideExit`. Exists to break the import cycle that would otherwise form between the Phase 1 file and the Phase 2 file.
+- **Create** `scripts/structure-audit/_release-train-dep.ts` — Phase 2 pure readers + `evaluatePackage`. Imports only from `_release-train-core.ts` and `_gh-audit.ts`.
+- **Create** `scripts/structure-audit/_release-train-dep.test.ts` — table-driven tests for every function in the above.
+- **Modify** `scripts/structure-audit/check-release-staleness.ts` — re-export the moved primitives for compatibility, add `PackageSpec` to the manifest types, add the impure Phase 2 readers, wire the shell.
+- **Modify** `scripts/structure-audit/check-release-staleness.test.ts` — manifest assertions for `packages[]`.
+- **Modify** `.github/release-train.json` — add the `packages[]` array.
+- **Modify** `docs/infrastructure-roadmap.md`, `docs/CHANGELOG.md` — record the delivery.
+
+---
+
+## Task 1: Extract shared primitives into `_release-train-core.ts`
+
+Pure mechanical move. Phase 2 needs `compareSemver`/`ageHours`/`EdgeResult`; if it imported them from `check-release-staleness.ts` while that file imported Phase 2's evaluator, the two modules would form a cycle. Moving the primitives to a leaf module both files import makes the cycle impossible.
+
+**Files:**
+
+- Create: `scripts/structure-audit/_release-train-core.ts`
+- Modify: `scripts/structure-audit/check-release-staleness.ts`
+- Test: `scripts/structure-audit/check-release-staleness.test.ts` (unchanged — it is the safety net)
+
+**Interfaces:**
+
+- Produces: `stripV`, `compareSemver`, `ageHours`, `decideExit`, and types `EdgeVerdict`, `EdgeResult`, `ReleaseInfo`, `PublishedRelease` — all from `_release-train-core.ts`, signatures **identical** to their current form in `check-release-staleness.ts`.
+
+- [ ] **Step 1: Record the green baseline**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: PASS, 39 tests. Write the number down — Step 5 must match it exactly.
+
+- [ ] **Step 2: Create the core module**
+
+Create `scripts/structure-audit/_release-train-core.ts`. Move these **unchanged** out of `check-release-staleness.ts`: `stripV`, `compareSemver`, `ageHours`, `decideExit`, and the types `EdgeVerdict`, `EdgeResult`, `ReleaseInfo`, `PublishedRelease`. Do not alter a single line of their bodies — this task is a move, not a rewrite.
+
+```ts
+/**
+ * Primitives shared by every release-train edge kind. This module is a LEAF:
+ * it imports nothing from its siblings, which is what lets both the Phase 1
+ * channel readers and the Phase 2 dependency readers depend on it without
+ * forming an import cycle.
+ */
+
+export function stripV(version: string): string {
+  return version.replace(/^v/, "");
+}
+
+/**
+ * Semver ordering that never throws. `Bun.semver.order` throws on an unparseable
+ * version ("Invalid SemVer: ..."), and channel files are external — a format
+ * quirk must degrade to "indeterminate", not crash the whole audit. Returns
+ * -1 | 0 | 1, or null when either side is not valid semver.
+ */
+export function compareSemver(a: string, b: string): number | null {
+  try {
+    return Bun.semver.order(stripV(a), stripV(b));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Hours between an ISO-8601 (Z-suffixed) timestamp and now, UTC epoch-ms math.
+ * An unparseable date yields `+Infinity` (fail-CLOSED): a NaN age would satisfy
+ * `NaN > graceHours === false` and silently mask a phantom/stale state as "ok",
+ * so an unreadable timestamp instead forces the aged-check to fire.
+ */
+export function ageHours(isoZ: string): number {
+  const t = new Date(isoZ).getTime();
+  if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - t) / 3_600_000;
+}
+
+export interface ReleaseInfo {
+  tag: string;
+  prerelease: boolean;
+  draft: boolean;
+  assets: string[];
+  publishedAt: string;
+}
+export interface PublishedRelease {
+  version: string;
+  publishedAt: string;
+}
+
+export type EdgeVerdict = "ok" | "stale" | "phantom" | "indeterminate";
+export interface EdgeResult {
+  edge: string;
+  verdict: EdgeVerdict;
+  detail: string;
+}
+
+/**
+ * Exit decision. Any stale/phantom edge => red. Otherwise green with a warning
+ * per indeterminate edge — EXCEPT a run where nothing was evaluable (no ok, only
+ * indeterminate) under --strict is red: "indeterminate" must not read as "all
+ * clear" in the scheduled sweep (the team-reachability rule).
+ */
+export function decideExit(
+  results: EdgeResult[],
+  strict: boolean,
+): { code: 0 | 1; messages: string[] } {
+  const messages: string[] = [];
+  const hard = results.filter((r) => r.verdict === "phantom" || r.verdict === "stale");
+  const indet = results.filter((r) => r.verdict === "indeterminate");
+  const ok = results.filter((r) => r.verdict === "ok");
+  for (const r of hard) messages.push(`::error::${r.edge}: ${r.detail}`);
+  for (const r of indet) messages.push(`::warning::${r.edge}: ${r.detail} (indeterminate)`);
+  if (hard.length > 0) return { code: 1, messages };
+  if (ok.length === 0 && indet.length > 0 && strict) {
+    messages.push(
+      "::error::release-staleness: indeterminate — nothing could be evaluated (all reads failed transiently)",
+    );
+    return { code: 1, messages };
+  }
+  return { code: 0, messages };
+}
+```
+
+- [ ] **Step 3: Re-export from `check-release-staleness.ts`**
+
+Delete the moved definitions from `check-release-staleness.ts` and add this immediately below the existing `_gh-audit.ts` import. The re-export keeps the existing test file and any future importer working against the original module path — no test edits in this task.
+
+```ts
+export {
+  ageHours,
+  compareSemver,
+  decideExit,
+  type EdgeResult,
+  type EdgeVerdict,
+  type PublishedRelease,
+  type ReleaseInfo,
+  stripV,
+} from "./_release-train-core.ts";
+```
+
+Then add a matching **import** line, because the file's own code still calls them:
+
+```ts
+import {
+  ageHours,
+  compareSemver,
+  decideExit,
+  type EdgeResult,
+  type PublishedRelease,
+  type ReleaseInfo,
+  stripV,
+} from "./_release-train-core.ts";
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bunx tsc -p scripts/tsconfig.json --noEmit`
+Expected: exit 0. A "declared but never read" error means a symbol was re-exported but is no longer used locally — drop it from the `import` line, keep it in the `export` line.
+
+- [ ] **Step 5: Run the baseline tests — the count must be identical**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: PASS with the **same 39 tests** as Step 1. A behaviour change here means the move was not verbatim.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bunx biome check scripts
+git add scripts/structure-audit/_release-train-core.ts scripts/structure-audit/check-release-staleness.ts
+git commit -m "refactor(audit): extract release-train primitives into a leaf core module"
+```
+
+---
+
+## Task 2: Phase 2 pure readers
+
+**Files:**
+
+- Create: `scripts/structure-audit/_release-train-dep.ts`
+- Test: `scripts/structure-audit/_release-train-dep.test.ts`
+
+**Interfaces:**
+
+- Consumes: `compareSemver`, `type ReleaseInfo`, `type PublishedRelease` from `_release-train-core.ts`; `isRecord` from `_gh-audit.ts`.
+- Produces:
+  - `interface NpmLatest { version: string; publishedAt: string }`
+  - `parseNpmLatest(doc: string): NpmLatest | null`
+  - `selectTaggedRelease(releases: readonly ReleaseInfo[], pattern: string): PublishedRelease | null`
+  - `resolvedFromBunLock(text: string, pkg: string): string | null`
+  - `interface PrRef { title: string; headRefName: string }`
+  - `matchesBumpPr(prs: readonly PrRef[], pkg: string): boolean`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/structure-audit/_release-train-dep.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import {
+  matchesBumpPr,
+  parseNpmLatest,
+  resolvedFromBunLock,
+  selectTaggedRelease,
+} from "./_release-train-dep.ts";
+
+describe("parseNpmLatest", () => {
+  const doc = JSON.stringify({
+    "dist-tags": { latest: "0.12.1" },
+    time: { "0.12.0": "2026-07-20T00:00:00Z", "0.12.1": "2026-07-24T12:36:40.942Z" },
+  });
+  test("reads dist-tags.latest and its publish time", () => {
+    expect(parseNpmLatest(doc)).toEqual({
+      version: "0.12.1",
+      publishedAt: "2026-07-24T12:36:40.942Z",
+    });
+  });
+  test("null when dist-tags is absent", () => {
+    expect(parseNpmLatest(JSON.stringify({ time: {} }))).toBeNull();
+  });
+  test("null when the latest version has no time entry", () => {
+    expect(
+      parseNpmLatest(JSON.stringify({ "dist-tags": { latest: "1.0.0" }, time: {} })),
+    ).toBeNull();
+  });
+  test("null on malformed JSON", () => {
+    expect(parseNpmLatest("{not json")).toBeNull();
+  });
+});
+
+describe("selectTaggedRelease", () => {
+  const base = { draft: false, prerelease: false, assets: [] as string[] };
+  const P = "^sdk-v(\\d+\\.\\d+\\.\\d+)$";
+  test("picks the highest component-prefixed tag and returns its publish time", () => {
+    const r = selectTaggedRelease(
+      [
+        { ...base, tag: "sdk-v1.5.2", publishedAt: "2026-07-01T00:00:00Z" },
+        { ...base, tag: "sdk-v1.6.0", publishedAt: "2026-07-10T00:00:00Z" },
+      ],
+      P,
+    );
+    expect(r).toEqual({ version: "1.6.0", publishedAt: "2026-07-10T00:00:00Z" });
+  });
+  test("ignores tags that do not match the pattern", () => {
+    const r = selectTaggedRelease(
+      [
+        { ...base, tag: "v9.9.9", publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "client-v0.1.0", publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "sdk-v1.0.0", publishedAt: "2026-07-01T00:00:00Z" },
+      ],
+      P,
+    );
+    expect(r?.version).toBe("1.0.0");
+  });
+  test("skips drafts and prereleases", () => {
+    const r = selectTaggedRelease(
+      [
+        { ...base, tag: "sdk-v2.0.0", draft: true, publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "sdk-v1.9.0", prerelease: true, publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "sdk-v1.6.0", publishedAt: "2026-07-01T00:00:00Z" },
+      ],
+      P,
+    );
+    expect(r?.version).toBe("1.6.0");
+  });
+  test("null when nothing matches", () => {
+    expect(selectTaggedRelease([{ ...base, tag: "v1.0.0", publishedAt: "x" }], P)).toBeNull();
+  });
+});
+
+describe("resolvedFromBunLock", () => {
+  // Mirrors the real bun.lock shape: workspaces carry RANGES, packages carry
+  // resolutions whose element [0] is "<name>@<version>". Trailing commas are
+  // legal in a real bun.lock, so one is included deliberately.
+  const lock = `{
+    "lockfileVersion": 1,
+    "workspaces": {
+      "": { "name": "nimbus" },
+      "packages/cli": { "name": "@nimbus/cli", "dependencies": { "@nimbus-dev/sdk": "^1.5.0" } },
+      "packages/mcp-connectors/github": { "name": "nimbus-mcp-github" },
+    },
+    "packages": {
+      "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-aaa"],
+      "nimbus-mcp-github/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-bbb"],
+      "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.3.0", "", {}, "sha512-ccc"],
+    },
+  }`;
+
+  test("takes the minimum across our OWN workspaces, ignoring third-party nesting", () => {
+    // 1.4.0 (our workspace) wins over 1.6.0 (hoisted); 1.3.0 is nested under the
+    // external @nimbus-dev/client and must NOT count.
+    expect(resolvedFromBunLock(lock, "@nimbus-dev/sdk")).toBe("1.4.0");
+  });
+
+  test("hoisted-only lockfile returns the hoisted version", () => {
+    const simple = `{
+      "workspaces": { "": { "name": "x" } },
+      "packages": { "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-a"] }
+    }`;
+    expect(resolvedFromBunLock(simple, "@nimbus-dev/sdk")).toBe("1.6.0");
+  });
+
+  test("a range in the workspaces section is never read as a resolution", () => {
+    // The only mention of the package is a "^1.5.0" range — no resolution entry.
+    const rangeOnly = `{
+      "workspaces": { "p": { "name": "p", "dependencies": { "@nimbus-dev/sdk": "^1.5.0" } } },
+      "packages": {}
+    }`;
+    expect(resolvedFromBunLock(rangeOnly, "@nimbus-dev/sdk")).toBeNull();
+  });
+
+  test("null when the package is absent entirely", () => {
+    expect(resolvedFromBunLock(lock, "@nimbus-dev/nope")).toBeNull();
+  });
+
+  test("null on unparseable lockfile", () => {
+    expect(resolvedFromBunLock("{not json", "@nimbus-dev/sdk")).toBeNull();
+  });
+});
+
+describe("matchesBumpPr", () => {
+  const pkg = "@nimbus-dev/sdk";
+  test("matches the full package name in a title", () => {
+    expect(matchesBumpPr([{ title: "Bump @nimbus-dev/sdk from 1.5.0 to 1.6.0", headRefName: "x" }], pkg)).toBe(true);
+  });
+  test("matches the short name in a title, case-insensitively", () => {
+    expect(matchesBumpPr([{ title: "chore(deps): upgrade SDK to 1.6.0", headRefName: "x" }], pkg)).toBe(true);
+  });
+  test("matches the branch name when the title does not mention it", () => {
+    expect(matchesBumpPr([{ title: "chore: deps", headRefName: "dependabot/npm_and_yarn/nimbus-dev/sdk-1.6.0" }], pkg)).toBe(true);
+  });
+  test("an unrelated open PR does not count as an in-flight bump", () => {
+    expect(matchesBumpPr([{ title: "fix: typo in README", headRefName: "fix/readme" }], pkg)).toBe(false);
+  });
+  test("no open PRs => false", () => {
+    expect(matchesBumpPr([], pkg)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/_release-train-dep.test.ts`
+Expected: FAIL — module `./_release-train-dep.ts` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/structure-audit/_release-train-dep.ts`:
+
+```ts
+/**
+ * P2 Phase 2 — dependency-DAG readers. Pure functions only: every one takes
+ * already-fetched text and returns a value, so the whole edge model is testable
+ * without network. The impure fetch/gh callers live in check-release-staleness.ts.
+ * See docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design.md.
+ */
+
+import { isRecord } from "./_gh-audit.ts";
+import { compareSemver, type PublishedRelease, type ReleaseInfo } from "./_release-train-core.ts";
+
+export interface NpmLatest {
+  version: string;
+  publishedAt: string;
+}
+
+/**
+ * `dist-tags.latest` + its publish timestamp from a FULL npm registry document.
+ * The `/<pkg>/latest` endpoint is not usable here: it omits `time`, and the
+ * grace rule is measured from the version's own publish time.
+ */
+export function parseNpmLatest(doc: string): NpmLatest | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(doc);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  const tags = parsed["dist-tags"];
+  if (!isRecord(tags)) return null;
+  const version = tags["latest"];
+  if (typeof version !== "string") return null;
+  const time = parsed["time"];
+  if (!isRecord(time)) return null;
+  const publishedAt = time[version];
+  if (typeof publishedAt !== "string") return null;
+  return { version, publishedAt };
+}
+
+/**
+ * Highest stable release whose tag matches `pattern`, which MUST carry one
+ * capture group holding the bare version. Upstream tags are component-prefixed
+ * (`sdk-v1.6.0`), which Phase 1's `selectPublished` deliberately rejects — so
+ * dep edges need their own selector rather than reusing it.
+ */
+export function selectTaggedRelease(
+  releases: readonly ReleaseInfo[],
+  pattern: string,
+): PublishedRelease | null {
+  const re = new RegExp(pattern);
+  const eligible: PublishedRelease[] = [];
+  for (const r of releases) {
+    if (r.draft || r.prerelease) continue;
+    const version = re.exec(r.tag)?.[1];
+    if (version) eligible.push({ version, publishedAt: r.publishedAt });
+  }
+  if (eligible.length === 0) return null;
+  eligible.sort((a, b) => compareSemver(b.version, a.version) ?? 0);
+  return eligible[0] ?? null;
+}
+
+/** Workspace package names declared by a parsed bun.lock (`workspaces[].name`). */
+function workspaceNames(lock: Record<string, unknown>): Set<string> {
+  const names = new Set<string>();
+  const ws = lock["workspaces"];
+  if (!isRecord(ws)) return names;
+  for (const entry of Object.values(ws)) {
+    if (isRecord(entry) && typeof entry["name"] === "string") names.add(entry["name"]);
+  }
+  return names;
+}
+
+/**
+ * The version of `pkg` a bun.lock actually resolves for the repo's OWN code.
+ *
+ * A bun.lock mentions a package in two places and only one is a version:
+ *   workspaces[].dependencies["<pkg>"] = "^1.5.0"     <- a RANGE, never parse it
+ *   packages["<path>"] = ["<pkg>@1.6.0", ...]         <- the resolution
+ *
+ * A resolution key is a dependency PATH: bare `<pkg>` is the hoisted copy, and
+ * `<prefix>/<pkg>` is the copy `<prefix>` resolved. Only prefixes that are the
+ * repo's own workspaces are this edge's business — a lower version nested under
+ * a THIRD-PARTY package (e.g. `@nimbus-dev/client/@nimbus-dev/sdk`) is that
+ * package's business, not ours, and counting it would report a version no local
+ * code resolves. Returns the minimum of the qualifying entries, because the
+ * oldest version our own code ships is the honest "caught up" signal.
+ */
+export function resolvedFromBunLock(text: string, pkg: string): string | null {
+  let parsed: unknown;
+  try {
+    // A real bun.lock is JSONC-ish and DOES contain trailing commas, so plain
+    // JSON.parse throws on it. Strip `,` before a closing brace/bracket first.
+    parsed = JSON.parse(text.replace(/,(\s*[}\]])/g, "$1"));
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  const packages = parsed["packages"];
+  if (!isRecord(packages)) return null;
+
+  const ours = workspaceNames(parsed);
+  const found: string[] = [];
+  const suffix = `/${pkg}`;
+
+  for (const [key, value] of Object.entries(packages)) {
+    if (key !== pkg && !key.endsWith(suffix)) continue;
+    if (key !== pkg && !ours.has(key.slice(0, key.length - suffix.length))) continue;
+    if (!Array.isArray(value)) continue;
+    const spec = value[0];
+    if (typeof spec !== "string") continue;
+    const at = spec.lastIndexOf("@");
+    if (at <= 0 || spec.slice(0, at) !== pkg) continue;
+    found.push(spec.slice(at + 1));
+  }
+  if (found.length === 0) return null;
+  found.sort((a, b) => compareSemver(a, b) ?? 0);
+  return found[0] ?? null;
+}
+
+export interface PrRef {
+  title: string;
+  headRefName: string;
+}
+
+/**
+ * Is one of these open PRs an in-flight bump of `pkg`? Matched in memory over
+ * title + branch rather than through `gh --search`, so the gate does not depend
+ * on an opaque relevance ranker and every naming variant is testable offline.
+ * Both the full name (`@nimbus-dev/sdk`) and the short name (`sdk`) count —
+ * Dependabot, Renovate and humans all title these differently.
+ */
+export function matchesBumpPr(prs: readonly PrRef[], pkg: string): boolean {
+  const full = pkg.toLowerCase();
+  const short = (pkg.split("/").pop() ?? pkg).toLowerCase();
+  return prs.some((pr) => {
+    const hay = `${pr.title} ${pr.headRefName}`.toLowerCase();
+    return hay.includes(full) || hay.includes(short);
+  });
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/structure-audit/_release-train-dep.test.ts`
+Expected: PASS, 18 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/structure-audit/_release-train-dep.ts scripts/structure-audit/_release-train-dep.test.ts
+git commit -m "feat(audit): Phase 2 pure readers (npm latest, tagged release, bun.lock, bump PR)"
+```
+
+---
+
+## Task 3: `evaluatePackage` — the Phase 2 edge evaluator
+
+**Files:**
+
+- Modify: `scripts/structure-audit/_release-train-dep.ts`
+- Test: `scripts/structure-audit/_release-train-dep.test.ts`
+
+**Interfaces:**
+
+- Consumes: `compareSemver`, `type EdgeResult`, `type PublishedRelease` from `_release-train-core.ts`; `NpmLatest` from Task 2.
+- Produces:
+  - `interface ConsumerReading { repo: string; status: "read" | "absent" | "indeterminate" | "not-a-dependency"; resolved: string | null; bumpPrOpen: boolean }`
+  - `interface PackageEvalInput { name: string; npm: string; taggedRelease: PublishedRelease | null; taggedReleaseAgeHours: number | null; latest: NpmLatest | null; latestAgeHours: number | null; consumers: ConsumerReading[]; graceHours: number }`
+  - `evaluatePackage(i: PackageEvalInput): EdgeResult[]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/structure-audit/_release-train-dep.test.ts`:
+
+```ts
+import { type ConsumerReading, evaluatePackage } from "./_release-train-dep.ts";
+
+const consumer = (over: Partial<ConsumerReading>): ConsumerReading => ({
+  repo: "nimbus-agent/nimbus-vscode",
+  status: "read",
+  resolved: null,
+  bumpPrOpen: false,
+  ...over,
+});
+
+describe("evaluatePackage", () => {
+  const green = {
+    name: "sdk",
+    npm: "@nimbus-dev/sdk",
+    taggedRelease: { version: "1.6.0", publishedAt: "x" },
+    taggedReleaseAgeHours: 48,
+    latest: { version: "1.6.0", publishedAt: "x" },
+    latestAgeHours: 48,
+    graceHours: 6,
+  };
+
+  test("tag and npm equal + consumer current => all ok", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "1.6.0" })],
+    });
+    expect(r.every((e) => e.verdict === "ok")).toBe(true);
+  });
+
+  test("tag ahead of npm past grace => publish phantom", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: { version: "1.7.0", publishedAt: "x" },
+      consumers: [],
+    });
+    expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("phantom");
+  });
+
+  test("tag ahead of npm within grace => ok (publish window)", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: { version: "1.7.0", publishedAt: "x" },
+      taggedReleaseAgeHours: 1,
+      consumers: [],
+    });
+    expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("ok");
+  });
+
+  test("consumer behind past grace => stale", () => {
+    const r = evaluatePackage({ ...green, consumers: [consumer({ resolved: "1.5.2" })] });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("stale");
+  });
+
+  test("consumer behind but the npm version is within grace => ok", () => {
+    const r = evaluatePackage({
+      ...green,
+      latestAgeHours: 2,
+      consumers: [consumer({ resolved: "1.5.2" })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
+  });
+
+  test("consumer behind but a bump PR is open => ok", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "1.5.2", bumpPrOpen: true })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
+  });
+
+  test("consumer ahead of npm => ok, never stale", () => {
+    const r = evaluatePackage({ ...green, consumers: [consumer({ resolved: "1.7.0" })] });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
+  });
+
+  test("npm unreadable => every edge indeterminate, never stale", () => {
+    const r = evaluatePackage({
+      ...green,
+      latest: null,
+      latestAgeHours: null,
+      consumers: [consumer({ resolved: "1.0.0" })],
+    });
+    expect(r.every((e) => e.verdict === "indeterminate")).toBe(true);
+  });
+
+  test("transient consumer read => indeterminate", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ status: "indeterminate" })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("indeterminate");
+  });
+
+  test("absent lockfile => stale", () => {
+    const r = evaluatePackage({ ...green, consumers: [consumer({ status: "absent" })] });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("stale");
+  });
+
+  test("lockfile parsed but package is not a dependency => indeterminate naming the manifest", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ status: "not-a-dependency" })],
+    });
+    const e = r.find((x) => x.edge === "sdk:nimbus-vscode");
+    expect(e?.verdict).toBe("indeterminate");
+    expect(e?.detail).toContain("manifest error");
+    expect(e?.detail).toContain("release-train.json");
+  });
+
+  test("unparseable resolved version => indeterminate, never a crash", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "not-a-version" })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("indeterminate");
+  });
+
+  test("no tagged release => publish edge indeterminate, not phantom", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: null,
+      taggedReleaseAgeHours: null,
+      consumers: [],
+    });
+    expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("indeterminate");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/_release-train-dep.test.ts`
+Expected: FAIL — `evaluatePackage` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/structure-audit/_release-train-dep.ts`:
+
+```ts
+import type { EdgeResult } from "./_release-train-core.ts";
+
+export interface ConsumerReading {
+  repo: string;
+  /**
+   * `read` — lockfile fetched and parsed, `resolved` is set.
+   * `absent` — the lockfile itself is missing (404): a real finding.
+   * `not-a-dependency` — lockfile parsed fine but has no entry: a MANIFEST bug.
+   * `indeterminate` — the read failed transiently.
+   */
+  status: "read" | "absent" | "indeterminate" | "not-a-dependency";
+  resolved: string | null;
+  bumpPrOpen: boolean;
+}
+
+export interface PackageEvalInput {
+  name: string;
+  npm: string;
+  taggedRelease: PublishedRelease | null;
+  taggedReleaseAgeHours: number | null;
+  latest: NpmLatest | null;
+  latestAgeHours: number | null;
+  consumers: ConsumerReading[];
+  graceHours: number;
+}
+
+/** Short repo name for edge labels: `nimbus-agent/nimbus-vscode` -> `nimbus-vscode`. */
+function shortRepo(repo: string): string {
+  return repo.split("/").pop() ?? repo;
+}
+
+/** The publish edge: a tagged release must reach npm. */
+function evaluatePublishEdge(i: PackageEvalInput): EdgeResult {
+  const edge = `${i.name}:publish`;
+  if (i.taggedRelease === null) {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `no release tag matched for ${i.npm} — releases unreadable or none published`,
+    };
+  }
+  if (i.latest === null) {
+    return { edge, verdict: "indeterminate", detail: `npm registry unreadable for ${i.npm}` };
+  }
+  const order = compareSemver(i.taggedRelease.version, i.latest.version);
+  if (order === null) {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `cannot compare tag ${i.taggedRelease.version} to npm ${i.latest.version}`,
+    };
+  }
+  if (order <= 0) {
+    return {
+      edge,
+      verdict: "ok",
+      detail: `${i.npm} tag ${i.taggedRelease.version} published as ${i.latest.version}`,
+    };
+  }
+  const age = i.taggedReleaseAgeHours ?? Number.POSITIVE_INFINITY;
+  if (age > i.graceHours) {
+    return {
+      edge,
+      verdict: "phantom",
+      detail: `${i.npm} ${i.taggedRelease.version} is tagged but npm still serves ${i.latest.version}; release is ${Math.round(age)}h old (> ${i.graceHours}h grace)`,
+    };
+  }
+  return {
+    edge,
+    verdict: "ok",
+    detail: `${i.npm} ${i.taggedRelease.version} tagged within ${i.graceHours}h grace (npm: ${i.latest.version})`,
+  };
+}
+
+/** One consumer edge: has this repo's lockfile caught up to npm @latest? */
+function evaluateConsumerEdge(
+  c: ConsumerReading,
+  edge: string,
+  npm: string,
+  latest: NpmLatest,
+  pastGrace: boolean,
+  graceHours: number,
+): EdgeResult {
+  if (c.status === "indeterminate") {
+    return { edge, verdict: "indeterminate", detail: `lockfile read failed transiently` };
+  }
+  if (c.status === "not-a-dependency") {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `manifest error: ${c.repo} does not depend on ${npm} — remove this consumer from release-train.json`,
+    };
+  }
+  if (c.status === "absent") {
+    return { edge, verdict: "stale", detail: `lockfile absent in ${c.repo}` };
+  }
+  if (c.resolved === null) {
+    return { edge, verdict: "indeterminate", detail: `no resolved version for ${npm}` };
+  }
+  const order = compareSemver(c.resolved, latest.version);
+  if (order === null) {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `resolved ${c.resolved} not comparable to npm ${latest.version}`,
+    };
+  }
+  if (order >= 0) {
+    return { edge, verdict: "ok", detail: `${c.resolved} >= npm ${latest.version}` };
+  }
+  if (!pastGrace) {
+    return { edge, verdict: "ok", detail: `npm ${latest.version} within ${graceHours}h grace` };
+  }
+  if (c.bumpPrOpen) {
+    return { edge, verdict: "ok", detail: `${c.resolved} < ${latest.version} but a bump PR is open` };
+  }
+  return {
+    edge,
+    verdict: "stale",
+    detail: `${c.resolved} < npm ${latest.version} and no bump PR open`,
+  };
+}
+
+export function evaluatePackage(i: PackageEvalInput): EdgeResult[] {
+  const results: EdgeResult[] = [evaluatePublishEdge(i)];
+  const pastGrace = (i.latestAgeHours ?? Number.POSITIVE_INFINITY) > i.graceHours;
+  for (const c of i.consumers) {
+    const edge = `${i.name}:${shortRepo(c.repo)}`;
+    results.push(
+      i.latest === null
+        ? { edge, verdict: "indeterminate", detail: `npm registry unreadable for ${i.npm}` }
+        : evaluateConsumerEdge(c, edge, i.npm, i.latest, pastGrace, i.graceHours),
+    );
+  }
+  return results;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/structure-audit/_release-train-dep.test.ts`
+Expected: PASS, 31 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/structure-audit/_release-train-dep.ts scripts/structure-audit/_release-train-dep.test.ts
+git commit -m "feat(audit): evaluatePackage — publish-phantom + consumer-staleness edges"
+```
+
+---
+
+## Task 4: Manifest — `packages[]` + loader validation
+
+**Files:**
+
+- Modify: `.github/release-train.json`
+- Modify: `scripts/structure-audit/check-release-staleness.ts`
+- Test: `scripts/structure-audit/check-release-staleness.test.ts`
+
+**Interfaces:**
+
+- Produces: `interface ConsumerSpec { repo: string; lockfile: string }`; `interface PackageSpec { name: string; npm: string; repo: string; tagPattern: string; consumers: ConsumerSpec[] }`; `TrainManifest` gains `packages: PackageSpec[]`.
+
+- [ ] **Step 1: Add `packages[]` to the manifest**
+
+Edit `.github/release-train.json` — insert `packages` after the existing `trains` array, leaving `graceHours` and `trains` untouched:
+
+```json
+  "packages": [
+    {
+      "name": "sdk",
+      "npm": "@nimbus-dev/sdk",
+      "repo": "nimbus-agent/nimbus-sdk",
+      "tagPattern": "^sdk-v(\\d+\\.\\d+\\.\\d+)$",
+      "consumers": [
+        { "repo": "nimbus-agent/nimbus-client", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/nimbus-vscode", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/Nimbus", "lockfile": "bun.lock" }
+      ]
+    },
+    {
+      "name": "client",
+      "npm": "@nimbus-dev/client",
+      "repo": "nimbus-agent/nimbus-client",
+      "tagPattern": "^client-v(\\d+\\.\\d+\\.\\d+)$",
+      "consumers": [
+        { "repo": "nimbus-agent/nimbus-vscode", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/Nimbus", "lockfile": "bun.lock" }
+      ]
+    }
+  ]
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `scripts/structure-audit/check-release-staleness.test.ts` (inside the existing `loadTrainManifest` describe block):
+
+```ts
+  test("parses packages[] with consumers", () => {
+    const m = loadTrainManifest(
+      '{"graceHours":6,"trains":[],"packages":[{"name":"sdk","npm":"@x/sdk","repo":"o/r","tagPattern":"^sdk-v(\\\\d+\\\\.\\\\d+\\\\.\\\\d+)$","consumers":[{"repo":"o/c","lockfile":"bun.lock"}]}]}',
+    );
+    expect(m.packages[0]?.name).toBe("sdk");
+    expect(m.packages[0]?.consumers[0]?.lockfile).toBe("bun.lock");
+  });
+  test("throws when packages is present but not an array", () => {
+    expect(() => loadTrainManifest('{"graceHours":6,"trains":[],"packages":{}}')).toThrow();
+  });
+  test("the committed manifest declares both packages with a capture-group tagPattern", () => {
+    const raw = readFileSync(
+      join(import.meta.dir, "..", "..", ".github", "release-train.json"),
+      "utf8",
+    );
+    const m = loadTrainManifest(raw);
+    expect(m.packages.map((p) => p.name).sort()).toEqual(["client", "sdk"]);
+    for (const p of m.packages) {
+      expect(p.tagPattern).toContain("(");
+      expect(p.consumers.length).toBeGreaterThan(0);
+    }
+  });
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: FAIL — `m.packages` is undefined / not validated.
+
+- [ ] **Step 4: Implement**
+
+In `scripts/structure-audit/check-release-staleness.ts`, add the specs next to `TrainSpec` and extend both `TrainManifest` and `loadTrainManifest`:
+
+```ts
+export interface ConsumerSpec {
+  repo: string;
+  lockfile: string;
+}
+export interface PackageSpec {
+  name: string;
+  npm: string;
+  repo: string;
+  /** Anchored regex with ONE capture group holding the bare version. */
+  tagPattern: string;
+  consumers: ConsumerSpec[];
+}
+```
+
+```ts
+export interface TrainManifest {
+  graceHours: number;
+  trains: TrainSpec[];
+  packages: PackageSpec[];
+}
+
+export function loadTrainManifest(json: string): TrainManifest {
+  const parsed: unknown = JSON.parse(json);
+  if (
+    !isRecord(parsed) ||
+    typeof parsed["graceHours"] !== "number" ||
+    !Array.isArray(parsed["trains"])
+  ) {
+    throw new Error("release-train.json: expected { graceHours: number, trains: [...] }");
+  }
+  // `packages` is optional on disk but always an array in memory, so callers
+  // never branch on undefined. A present-but-wrong-shaped value is a hard error
+  // rather than a silent empty list, which would make the Phase 2 edges vanish.
+  const pkgs = parsed["packages"];
+  if (pkgs !== undefined && !Array.isArray(pkgs)) {
+    throw new Error("release-train.json: `packages` must be an array when present");
+  }
+  return { ...(parsed as unknown as TrainManifest), packages: (pkgs ?? []) as PackageSpec[] };
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: PASS, 42 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts .github
+git add .github/release-train.json scripts/structure-audit/check-release-staleness.ts scripts/structure-audit/check-release-staleness.test.ts
+git commit -m "feat(audit): declare the dependency DAG in release-train.json"
+```
+
+---
+
+## Task 5: Wire the readers into the shell + live proof
+
+**Files:**
+
+- Modify: `scripts/structure-audit/check-release-staleness.ts`
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 2–4.
+- Produces: no new exports — impure readers stay module-private; the shell emits Phase 2 `EdgeResult`s into the existing `decideExit`.
+
+- [ ] **Step 1: Add the impure readers**
+
+Add to `scripts/structure-audit/check-release-staleness.ts`, above the `import.meta.main` block. Extend the existing `_release-train-dep.ts` import rather than adding a second one.
+
+```ts
+import {
+  type ConsumerReading,
+  evaluatePackage,
+  matchesBumpPr,
+  type NpmLatest,
+  parseNpmLatest,
+  type PrRef,
+  resolvedFromBunLock,
+  selectTaggedRelease,
+} from "./_release-train-dep.ts";
+```
+
+```ts
+/**
+ * npm `@latest` + its publish time. Bounded by an explicit 5s timeout: the
+ * registry is the only dependency here that is neither GitHub nor local, and an
+ * unbounded fetch would hang the sweep job (and a local run, which is worse).
+ * Any timeout, non-200, or malformed body degrades to null -> indeterminate.
+ */
+async function readNpmLatest(pkg: string): Promise<NpmLatest | null> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${pkg}`, {
+      signal: AbortSignal.timeout(5000),
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    return parseNpmLatest(await res.text());
+  } catch {
+    return null;
+  }
+}
+
+/** The upstream repo's highest release whose tag matches the package pattern. */
+function readTaggedRelease(pkg: PackageSpec): PublishedRelease | null {
+  const res = runGh([
+    "gh",
+    "api",
+    `repos/${pkg.repo}/releases?per_page=100`,
+    "--jq",
+    "[.[] | {tag: .tag_name, prerelease: .prerelease, draft: .draft, publishedAt: .published_at, assets: [.assets[].name]}]",
+  ]);
+  if (!res.ok) return null;
+  try {
+    const rels: unknown = JSON.parse(res.stdout);
+    if (!Array.isArray(rels)) return null;
+    return selectTaggedRelease(rels as ReleaseInfo[], pkg.tagPattern);
+  } catch {
+    return null;
+  }
+}
+
+/** Is there an open PR in `repo` that looks like a bump of `npm`? */
+function readBumpPrOpen(repo: string, npm: string): boolean {
+  const res = runGh([
+    "gh",
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    "title,headRefName",
+  ]);
+  if (!res.ok) return false;
+  try {
+    const prs: unknown = JSON.parse(res.stdout);
+    return Array.isArray(prs) ? matchesBumpPr(prs as PrRef[], npm) : false;
+  } catch {
+    return false;
+  }
+}
+
+/** One consumer's lockfile-resolved version of `npm`. */
+function readConsumer(c: ConsumerSpec, npm: string): ConsumerReading {
+  const res = runGh([
+    "gh",
+    "api",
+    `repos/${c.repo}/contents/${c.lockfile}`,
+    "--jq",
+    ".content",
+  ]);
+  if (!res.ok) {
+    // 404 => the lockfile itself is missing (a real finding). Anything else is
+    // transient and must not be reported as staleness.
+    const kind = classifyReadFailure(res.httpStatus);
+    return { repo: c.repo, status: kind, resolved: null, bumpPrOpen: false };
+  }
+  const resolved = resolvedFromBunLock(decodeContents(res.stdout), npm);
+  if (resolved === null) {
+    // Parsed fine, no entry for the package => the manifest is wrong, not the repo.
+    return { repo: c.repo, status: "not-a-dependency", resolved: null, bumpPrOpen: false };
+  }
+  return { repo: c.repo, status: "read", resolved, bumpPrOpen: readBumpPrOpen(c.repo, npm) };
+}
+```
+
+> **Note on `classifyReadFailure`:** it returns `"absent" | "indeterminate"`, both of which are members of `ConsumerReading["status"]`, so the value assigns directly.
+
+- [ ] **Step 2: Wire the shell**
+
+In the `import.meta.main` block of `check-release-staleness.ts`, insert this loop immediately after the existing `for (const train of manifest.trains) { ... }` loop and before `const out = decideExit(...)`:
+
+```ts
+  for (const pkg of manifest.packages) {
+    const latest = await readNpmLatest(pkg.npm);
+    const taggedRelease = readTaggedRelease(pkg);
+    const consumers = pkg.consumers.map((c) => readConsumer(c, pkg.npm));
+
+    allResults.push(
+      ...evaluatePackage({
+        name: pkg.name,
+        npm: pkg.npm,
+        taggedRelease,
+        taggedReleaseAgeHours: taggedRelease ? ageHours(taggedRelease.publishedAt) : null,
+        latest,
+        latestAgeHours: latest ? ageHours(latest.publishedAt) : null,
+        consumers,
+        graceHours: manifest.graceHours,
+      }),
+    );
+  }
+```
+
+- [ ] **Step 3: Typecheck, lint, and run the whole audit suite**
+
+Run: `bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts .github && bun test scripts/structure-audit/`
+Expected: typecheck exit 0, biome clean, all tests PASS (Phase 1's 42 + Phase 2's 31).
+
+- [ ] **Step 4: Live proof — run the gate against the real graph**
+
+Run: `GH_TOKEN=$(gh auth token) bun scripts/structure-audit/check-release-staleness.ts`
+
+Expected: **RED (exit 1)**, and specifically these three `::error::` lines, because the drift is real and confirmed:
+
+- `client:Nimbus` — resolved `0.5.0` < npm `0.12.1`
+- `client:nimbus-vscode` — resolved `0.11.0` < npm `0.12.1`
+- `sdk:nimbus-vscode` — resolved `1.5.2` < npm `1.6.0`
+
+and these green: `sdk:publish`, `client:publish`, `sdk:nimbus-client`, plus all five Phase 1 edges.
+
+**Do not "fix" the gate to make it green.** A red here is the gate working; the remediation is a separate dependency-bump PR. If an edge is red for a *different* reason than the three above, that is a real bug in this task — debug it.
+
+Capture the exact output for the PR description.
+
+- [ ] **Step 5: Verify the failure paths degrade rather than crash**
+
+Run: `bun scripts/structure-audit/check-release-staleness.ts` with no `GH_TOKEN` and network disabled (or simply unset `GH_TOKEN` and disconnect).
+Expected: a soft `::warning::` skip and **exit 0** — never a stack trace. The reachability probe short-circuits before any Phase 2 read.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/structure-audit/check-release-staleness.ts
+git commit -m "feat(audit): read the dependency DAG (npm latest, tags, lockfiles, bump PRs)"
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+
+- Modify: `docs/infrastructure-roadmap.md`
+- Modify: `docs/CHANGELOG.md`
+
+- [ ] **Step 1: Update the P2 roadmap row**
+
+In `docs/infrastructure-roadmap.md`, change the P2 row's status to `✅ done` and replace its trailing `Remaining: Phase 2 (dependency-DAG edges)` with `Phase 2 adds npm publish-phantom + consumer-lag edges.` Keep the rest of the row's wording.
+
+- [ ] **Step 2: Add a Phase 2 entry to the P2 progress log**
+
+Append to the `### P2 progress log` section, before its `- **Remaining:**` bullet (and delete that bullet's Phase-2 clause):
+
+```markdown
+- **Delivered (Phase 2 — dependency DAG, 2026-07-26):** `.github/release-train.json`
+  gains `packages[]`; two new edge kinds run in the same gate. `<pkg>:publish`
+  compares the upstream component-prefixed release tag to npm `@latest`,
+  catching "tagged but never published" — the npm analogue of the release
+  phantom. `<pkg>:<consumer>` compares each consumer's **lockfile-resolved**
+  version to npm `@latest`, because a range misleads in both directions:
+  `^1.2.0` permits a newer `1.3.0`, while a caret on a `0.x` pins the minor, so
+  `^0.5.0` cannot reach `0.12.1` at all.
+- **The lockfile reader is workspace-scoped, not global.** A bun.lock resolution
+  key is a dependency *path*, so a lower version nested under a third-party
+  package is that package's business, not ours. The reader takes the minimum
+  over the hoisted entry plus entries whose prefix is one of the consumer's own
+  workspace names. Getting this wrong reports a version no local code resolves —
+  Nimbus's hoisted sdk is `1.6.0` while the copy inside `@nimbus-dev/client` is
+  `1.3.0`.
+- **Shipped RED on real drift (2026-07-26):** `client:Nimbus` (0.5.0 vs 0.12.1),
+  `client:nimbus-vscode` (0.11.0), `sdk:nimbus-vscode` (1.5.2). Confirmed drift,
+  not deliberate pins. Both `:publish` edges green. Bumping those three
+  consumers is separate remediation work.
+```
+
+- [ ] **Step 3: Add the CHANGELOG entry**
+
+Add to the top of the `## Post-Phase-6 deliveries` list in `docs/CHANGELOG.md`:
+
+```markdown
+- **2026-07-26 — P2 Release Train Phase 2: dependency-DAG edges.** `audit:release-staleness`
+  now also watches the npm propagation graph. A `<pkg>:publish` edge compares each upstream's
+  component-prefixed release tag to npm `@latest`, catching a package that is tagged but never
+  published; a `<pkg>:<consumer>` edge compares every consuming repo's **lockfile-resolved**
+  version to npm `@latest`, since a semver range misleads in both directions (a caret permits
+  newer, but a caret on a `0.x` pins the minor). The lockfile reader counts only the hoisted
+  entry plus the consumer's own workspaces, so a copy nested inside a third-party package is
+  never mistaken for what local code resolves. Registry reads carry a 5s timeout and degrade to
+  indeterminate; bump PRs already open count as caught-up. Ships red on confirmed drift — the
+  CLI resolves client 0.5.0 against a published 0.12.1.
+```
+
+- [ ] **Step 4: Validate the docs**
+
+Run: `bun run lint:markdown && bun run audit:doc-refs && "$HOME/.cargo/bin/lychee" --offline --no-progress docs/infrastructure-roadmap.md docs/CHANGELOG.md`
+Expected: 0 markdown errors, all doc refs resolve, 0 link errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/infrastructure-roadmap.md docs/CHANGELOG.md
+git commit -m "docs(infra): record P2 Phase 2 — dependency-DAG edges"
+```
+
+---
+
+## Post-implementation (not a task — for the PR author)
+
+- **PR description:** paste the Task 5 Step 4 output verbatim. Say explicitly that red is expected and why, or a reviewer will read the gate as broken.
+- **Remediation follow-up:** bumping `@nimbus-dev/client` in `packages/cli` (0.5.0 → 0.12.1) and in `nimbus-vscode`, plus `@nimbus-dev/sdk` in `nimbus-vscode`, is separate work. The client jump crosses seven minors and may touch call sites.
+- **Sweep proof:** after merge, dispatch `org-drift-sweep.yml` and record the run number in the P2 progress log, same as Phase 1.
+- **Parked, unrelated:** `docs/infrastructure-roadmap.md` currently says `VSCE_PAT` expires 2026-12-01. The SSoT (`scripts/release/credential-registry.ts`) says **2026-09-20** — the token's own expiry; the December date is the global-PAT decommission, which does not apply because the token is org-scoped. Fix that line in any docs-touching PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Two edge kinds (`:publish`, `:<consumer>`) → Task 3 `evaluatePackage`. ✓
+- New top-level `packages[]`, not `trains[]` → Task 4. ✓
+- Per-package `tagPattern` with capture group; Phase 1's selector unusable → Task 2 `selectTaggedRelease` + Task 4 test asserting `(` present. ✓
+- Lockfile over range, both directions → Task 2 `resolvedFromBunLock` + tests. ✓
+- Minimum over hoisted + own workspaces, third-party nesting excluded → Task 2 (impl + the three-entry test). ✓
+- Ranges never parsed as resolutions → Task 2 (`range in the workspaces section` test). ✓
+- Grace from the npm version's publish time → Task 3 (`latestAgeHours`) + Task 5 wiring. ✓
+- Full registry doc, not `/latest` → Task 5 `readNpmLatest` + Task 2 `parseNpmLatest` requiring `time`. ✓
+- 5s timeout, non-200 → indeterminate → Task 5 Step 1. ✓
+- In-memory PR matching, not `--search` → Task 2 `matchesBumpPr` + Task 5 `readBumpPrOpen`. ✓
+- Manifest-error diagnostic distinct from a read failure → Task 3 (`not-a-dependency` status + test asserting the wording). ✓
+- Engine unchanged; same `decideExit` → Tasks 1 + 5. ✓
+- Ships red on the three known-stale edges → Task 5 Step 4. ✓
+- Fail-soft local / strict CI unchanged → Task 5 Step 5. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step carries complete code. ✓
+
+**Type consistency:** `NpmLatest`, `PrRef`, `ConsumerReading`, `PackageEvalInput`, `EdgeResult`, `PublishedRelease`, `ReleaseInfo`, `ConsumerSpec`, `PackageSpec` are each defined once and referenced with identical names and shapes across tasks. `evaluatePackage` / `parseNpmLatest` / `selectTaggedRelease` / `resolvedFromBunLock` / `matchesBumpPr` keep one signature throughout. `ConsumerReading["status"]` is a superset of `classifyReadFailure`'s return type, which Task 5 Step 1 calls out explicitly. ✓

--- a/docs/superpowers/plans/2026-07-26-p2-phase2-dep-dag.md
+++ b/docs/superpowers/plans/2026-07-26-p2-phase2-dep-dag.md
@@ -184,11 +184,59 @@ Expected: exit 0. A "declared but never read" error means a symbol was re-export
 Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
 Expected: PASS with the **same 39 tests** as Step 1. A behaviour change here means the move was not verbatim.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Harden `ageHours` against a timezone-less timestamp**
+
+Only now that the move is proven verbatim. `ageHours` is already timezone-safe
+for well-formed input — `Date.now()` and `new Date(iso).getTime()` are both UTC
+epoch-ms, so no offset can creep in. The gap is narrower and nastier: a string
+*without* a `Z` or offset (`"2026-07-26T12:00:00"`) parses as **local time**
+and silently yields an age that is wrong by the machine's UTC offset — up to 14
+hours, enough to move an edge across a 6-hour grace boundary, and it differs
+between a developer's laptop and a UTC CI runner.
+
+The Global Constraints already forbid such a timestamp. Make that enforced
+rather than merely documented. Add to `_release-train-core.ts`:
+
+```ts
+/** ISO-8601 with an explicit UTC designator or numeric offset. */
+const HAS_TIMEZONE = /(?:Z|[+-]\d{2}:?\d{2})$/;
+```
+
+and change the guard inside `ageHours` to:
+
+```ts
+export function ageHours(isoZ: string): number {
+  // A timestamp without an explicit zone would be parsed as LOCAL time, making
+  // the age differ between a laptop and a UTC runner. Treat it as unreadable
+  // and fail CLOSED, exactly like an unparseable date.
+  if (!HAS_TIMEZONE.test(isoZ.trim())) return Number.POSITIVE_INFINITY;
+  const t = new Date(isoZ).getTime();
+  if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - t) / 3_600_000;
+}
+```
+
+Add to `scripts/structure-audit/check-release-staleness.test.ts`, inside the
+existing `ageHours` describe block:
+
+```ts
+  test("a timestamp with no timezone fails closed rather than being read as local", () => {
+    expect(ageHours("2026-07-26T12:00:00")).toBe(Number.POSITIVE_INFINITY);
+  });
+  test("an explicit numeric offset is accepted", () => {
+    expect(Number.isFinite(ageHours("2020-01-01T00:00:00+02:00"))).toBe(true);
+  });
+```
+
+Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
+Expected: PASS, **41 tests** (39 + 2). Both real sources — GitHub `published_at`
+and npm `time[version]` — are `Z`-suffixed, so no production edge changes.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-bunx biome check scripts
-git add scripts/structure-audit/_release-train-core.ts scripts/structure-audit/check-release-staleness.ts
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/structure-audit/_release-train-core.ts scripts/structure-audit/check-release-staleness.ts scripts/structure-audit/check-release-staleness.test.ts
 git commit -m "refactor(audit): extract release-train primitives into a leaf core module"
 ```
 
@@ -224,6 +272,7 @@ import {
   parseNpmLatest,
   resolvedFromBunLock,
   selectTaggedRelease,
+  stripTrailingCommas,
 } from "./_release-train-dep.ts";
 
 describe("parseNpmLatest", () => {
@@ -340,6 +389,25 @@ describe("resolvedFromBunLock", () => {
   });
 });
 
+describe("stripTrailingCommas", () => {
+  test("removes trailing commas before } and ]", () => {
+    expect(JSON.parse(stripTrailingCommas('{"a":[1,2,],"b":{"c":1,},}'))).toEqual({
+      a: [1, 2],
+      b: { c: 1 },
+    });
+  });
+  test("does NOT touch a comma inside a string value", () => {
+    // The naive regex /,(\s*[}\]])/g corrupts this silently — it parses, but
+    // with the comma eaten. That is the bug this function exists to avoid.
+    const src = JSON.stringify({ note: "a comma, }" });
+    expect(JSON.parse(stripTrailingCommas(src)).note).toBe("a comma, }");
+  });
+  test("handles escaped quotes inside strings", () => {
+    const src = '{"k":"he said \\", }"}';
+    expect(JSON.parse(stripTrailingCommas(src)).k).toBe('he said ", }');
+  });
+});
+
 describe("matchesBumpPr", () => {
   const pkg = "@nimbus-dev/sdk";
   test("matches the full package name in a title", () => {
@@ -431,6 +499,46 @@ export function selectTaggedRelease(
   return eligible[0] ?? null;
 }
 
+/**
+ * Remove trailing commas so a real bun.lock (which is JSONC-ish and DOES carry
+ * them) survives `JSON.parse`.
+ *
+ * This walks the text tracking string state rather than using a regex. The
+ * obvious `text.replace(/,(\s*[}\]])/g, "$1")` is WRONG in a way that fails
+ * silently: it also strips a comma inside a string value that happens to end
+ * with `, }`, so `"note: a comma, }"` parses cleanly as `"note: a comma }"`.
+ * A corrupted-but-parseable lockfile is precisely the class of defect this gate
+ * exists to prevent, so the parser must not introduce one.
+ */
+export function stripTrailingCommas(text: string): string {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i] as string;
+    if (inString) {
+      out += ch;
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < text.length && /\s/.test(text[j] as string)) j++;
+      const next = text[j];
+      if (next === "}" || next === "]") continue; // trailing comma — drop it
+    }
+    out += ch;
+  }
+  return out;
+}
+
 /** Workspace package names declared by a parsed bun.lock (`workspaces[].name`). */
 function workspaceNames(lock: Record<string, unknown>): Set<string> {
   const names = new Set<string>();
@@ -460,9 +568,7 @@ function workspaceNames(lock: Record<string, unknown>): Set<string> {
 export function resolvedFromBunLock(text: string, pkg: string): string | null {
   let parsed: unknown;
   try {
-    // A real bun.lock is JSONC-ish and DOES contain trailing commas, so plain
-    // JSON.parse throws on it. Strip `,` before a closing brace/bracket first.
-    parsed = JSON.parse(text.replace(/,(\s*[}\]])/g, "$1"));
+    parsed = JSON.parse(stripTrailingCommas(text));
   } catch {
     return null;
   }
@@ -514,7 +620,7 @@ export function matchesBumpPr(prs: readonly PrRef[], pkg: string): boolean {
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `bun test scripts/structure-audit/_release-train-dep.test.ts`
-Expected: PASS, 18 tests.
+Expected: PASS, 21 tests (4 parseNpmLatest + 4 selectTaggedRelease + 5 resolvedFromBunLock + 5 matchesBumpPr + 3 stripTrailingCommas).
 
 - [ ] **Step 5: Commit**
 
@@ -616,6 +722,14 @@ describe("evaluatePackage", () => {
     expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
   });
 
+  test("consumer behind but the PR list was unreadable => indeterminate, not stale", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "1.5.2", bumpPrOpen: null })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("indeterminate");
+  });
+
   test("consumer ahead of npm => ok, never stale", () => {
     const r = evaluatePackage({ ...green, consumers: [consumer({ resolved: "1.7.0" })] });
     expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
@@ -697,7 +811,8 @@ export interface ConsumerReading {
    */
   status: "read" | "absent" | "indeterminate" | "not-a-dependency";
   resolved: string | null;
-  bumpPrOpen: boolean;
+  /** `null` = could not determine (read failed, or the PR list may be truncated). */
+  bumpPrOpen: boolean | null;
 }
 
 export interface PackageEvalInput {
@@ -798,8 +913,18 @@ function evaluateConsumerEdge(
   if (!pastGrace) {
     return { edge, verdict: "ok", detail: `npm ${latest.version} within ${graceHours}h grace` };
   }
-  if (c.bumpPrOpen) {
+  if (c.bumpPrOpen === true) {
     return { edge, verdict: "ok", detail: `${c.resolved} < ${latest.version} but a bump PR is open` };
+  }
+  if (c.bumpPrOpen === null) {
+    // We know it is behind, but not whether a bump is already in flight. Report
+    // unknown rather than staleness — an unread PR list must not manufacture a
+    // finding.
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `${c.resolved} < npm ${latest.version}, but the open-PR list could not be read conclusively`,
+    };
   }
   return {
     edge,
@@ -826,7 +951,7 @@ export function evaluatePackage(i: PackageEvalInput): EdgeResult[] {
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `bun test scripts/structure-audit/_release-train-dep.test.ts`
-Expected: PASS, 31 tests.
+Expected: PASS, 35 tests (21 from Task 2 + 14 evaluatePackage).
 
 - [ ] **Step 5: Commit**
 
@@ -963,7 +1088,7 @@ export function loadTrainManifest(json: string): TrainManifest {
 - [ ] **Step 5: Run to verify it passes**
 
 Run: `bun test scripts/structure-audit/check-release-staleness.test.ts`
-Expected: PASS, 42 tests.
+Expected: PASS, 44 tests (41 after Task 1 + 3 manifest).
 
 - [ ] **Step 6: Commit**
 
@@ -1042,8 +1167,21 @@ function readTaggedRelease(pkg: PackageSpec): PublishedRelease | null {
   }
 }
 
-/** Is there an open PR in `repo` that looks like a bump of `npm`? */
-function readBumpPrOpen(repo: string, npm: string): boolean {
+/** How many open PRs we ask for. Exported-as-const so the truncation guard below
+ *  can compare against the exact same number. */
+const PR_LIST_LIMIT = 100;
+
+/**
+ * Is there an open PR in `repo` that looks like a bump of `npm`?
+ * `null` means "cannot tell" — the caller must degrade to indeterminate rather
+ * than concluding "no bump PR", which would turn an unknown into a `stale`.
+ *
+ * Deliberately NOT `gh pr list --search`: matching happens in memory (see
+ * `matchesBumpPr`) so the gate does not depend on GitHub's opaque relevance
+ * ranker, per the design review. The cost of that choice is the page limit
+ * below, which is why truncation is detected instead of ignored.
+ */
+function readBumpPrOpen(repo: string, npm: string): boolean | null {
   const res = runGh([
     "gh",
     "pr",
@@ -1053,16 +1191,21 @@ function readBumpPrOpen(repo: string, npm: string): boolean {
     "--state",
     "open",
     "--limit",
-    "100",
+    String(PR_LIST_LIMIT),
     "--json",
     "title,headRefName",
   ]);
-  if (!res.ok) return false;
+  if (!res.ok) return null;
   try {
     const prs: unknown = JSON.parse(res.stdout);
-    return Array.isArray(prs) ? matchesBumpPr(prs as PrRef[], npm) : false;
+    if (!Array.isArray(prs)) return null;
+    if (matchesBumpPr(prs as PrRef[], npm)) return true;
+    // A full page means the list may have been cut off, so "not found" is not
+    // trustworthy — report unknown rather than a false negative that would
+    // present as staleness.
+    return prs.length >= PR_LIST_LIMIT ? null : false;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -1120,7 +1263,7 @@ In the `import.meta.main` block of `check-release-staleness.ts`, insert this loo
 - [ ] **Step 3: Typecheck, lint, and run the whole audit suite**
 
 Run: `bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts .github && bun test scripts/structure-audit/`
-Expected: typecheck exit 0, biome clean, all tests PASS (Phase 1's 42 + Phase 2's 31).
+Expected: typecheck exit 0, biome clean, all tests PASS (44 in check-release-staleness.test.ts + 35 in _release-train-dep.test.ts = 79).
 
 - [ ] **Step 4: Live proof — run the gate against the real graph**
 

--- a/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design-review.md
+++ b/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design-review.md
@@ -7,12 +7,14 @@ This document reviews [2026-07-26-p2-phase2-dep-dag-design.md](./2026-07-26-p2-p
 ## 1. Structure of `bun.lock` (JSON) and Resolution Parsing
 
 ### Observation
+
 - The design proposes: `"resolvedFromBunLock(text, pkg)` collects every resolved version for the package and returns the lowest."
 - In Bun v1.2+, `bun.lock` is a JSON file. However, it contains two distinct sections:
   1. The top section lists workspaces and their `dependencies` / `devDependencies` (which still contain semver ranges, e.g. `"@nimbus-dev/sdk": "^1.5.0"`).
   2. The bottom section contains flat dependency resolutions mapping package/dependency paths to arrays, where the first element is the exact pinned/resolved version (e.g., `"@nimbus/cli/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.5.0", ...]`).
 
 ### Suggestion
+
 - The parsing logic for `resolvedFromBunLock` must explicitly target the **resolution keys** (the bottom section) rather than the `dependencies` keys of individual workspaces/packages in the top section.
 - Parsing should scan keys or values matching the format `"<package-name>@<version>"` inside the array values at index 0 of the lockfile's resolution dictionary to extract the actual resolved semver version.
 
@@ -21,9 +23,11 @@ This document reviews [2026-07-26-p2-phase2-dep-dag-design.md](./2026-07-26-p2-p
 ## 2. Robust PR Search Strategy for `hasOpenBumpPr`
 
 ### Observation
+
 - The design checks: `hasOpenBumpPr(repo, pkg) -> gh pr list --state open --search`.
 
 ### Questions & Suggestions
+
 - **Search Query Precision:** We need to define what the query looks for. If Dependabot or a developer opens a PR, the title/branch might not explicitly name the package in a uniform way (e.g., `Bump @nimbus-dev/sdk` vs `upgrade sdk to 1.6.0`).
 - **Recommendation:** Define a clear, standard search pattern. For example:
   - Match PRs where the branch name or PR title contains the short name or full name of the package (e.g., `sdk` or `@nimbus-dev/sdk`).
@@ -34,9 +38,11 @@ This document reviews [2026-07-26-p2-phase2-dep-dag-design.md](./2026-07-26-p2-p
 ## 3. Network Resilience and Timeout for npm Registry Queries
 
 ### Observation
+
 - The reader `npmLatest(pkg)` makes an unauthenticated HTTPS request to `https://registry.npmjs.org/<pkg>`.
 
 ### Suggestion
+
 - Registry requests can easily hang or slow down CI and local preflight runs if the registry is experiencing latency.
 - We should enforce a strict timeout (e.g., 3–5 seconds) on the HTTP request. If the request times out or returns a non-200 status, it should fail-gracefully to `indeterminate` with a clear warning, rather than blocking the preflight command or throwing an unhandled exception.
 
@@ -45,8 +51,10 @@ This document reviews [2026-07-26-p2-phase2-dep-dag-design.md](./2026-07-26-p2-p
 ## 4. Distinction Between Missing Dependencies and Manifest Errors
 
 ### Observation
+
 - "Package present in the manifest but absent from a consumer's lockfile → `indeterminate`, not `ok`."
 
 ### Suggestion
+
 - While returning `indeterminate` is safe, we should distinguish between "the lockfile couldn't be parsed/fetched" and "the lockfile parsed successfully but the package is not a dependency at all."
 - If the lockfile is successfully parsed and does not contain the package, we should log a specific diagnostic: `"Manifest configuration error: <consumer-repo> does not depend on upstream package <pkg>"` so that the maintainer knows to update `release-train.json` rather than debugging lockfile/network issues.

--- a/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design-review.md
+++ b/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design-review.md
@@ -1,0 +1,52 @@
+# Design Review: P2 Phase 2 — dependency-DAG edges
+
+This document reviews [2026-07-26-p2-phase2-dep-dag-design.md](./2026-07-26-p2-phase2-dep-dag-design.md) and notes questions, suggestions, and improvements.
+
+---
+
+## 1. Structure of `bun.lock` (JSON) and Resolution Parsing
+
+### Observation
+- The design proposes: `"resolvedFromBunLock(text, pkg)` collects every resolved version for the package and returns the lowest."
+- In Bun v1.2+, `bun.lock` is a JSON file. However, it contains two distinct sections:
+  1. The top section lists workspaces and their `dependencies` / `devDependencies` (which still contain semver ranges, e.g. `"@nimbus-dev/sdk": "^1.5.0"`).
+  2. The bottom section contains flat dependency resolutions mapping package/dependency paths to arrays, where the first element is the exact pinned/resolved version (e.g., `"@nimbus/cli/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.5.0", ...]`).
+
+### Suggestion
+- The parsing logic for `resolvedFromBunLock` must explicitly target the **resolution keys** (the bottom section) rather than the `dependencies` keys of individual workspaces/packages in the top section.
+- Parsing should scan keys or values matching the format `"<package-name>@<version>"` inside the array values at index 0 of the lockfile's resolution dictionary to extract the actual resolved semver version.
+
+---
+
+## 2. Robust PR Search Strategy for `hasOpenBumpPr`
+
+### Observation
+- The design checks: `hasOpenBumpPr(repo, pkg) -> gh pr list --state open --search`.
+
+### Questions & Suggestions
+- **Search Query Precision:** We need to define what the query looks for. If Dependabot or a developer opens a PR, the title/branch might not explicitly name the package in a uniform way (e.g., `Bump @nimbus-dev/sdk` vs `upgrade sdk to 1.6.0`).
+- **Recommendation:** Define a clear, standard search pattern. For example:
+  - Match PRs where the branch name or PR title contains the short name or full name of the package (e.g., `sdk` or `@nimbus-dev/sdk`).
+  - Search both title and branch name: `gh pr list --repo <repo> --state open --json title,headRefName`. Then, do a case-insensitive match on both fields in memory to avoid query limitations.
+
+---
+
+## 3. Network Resilience and Timeout for npm Registry Queries
+
+### Observation
+- The reader `npmLatest(pkg)` makes an unauthenticated HTTPS request to `https://registry.npmjs.org/<pkg>`.
+
+### Suggestion
+- Registry requests can easily hang or slow down CI and local preflight runs if the registry is experiencing latency.
+- We should enforce a strict timeout (e.g., 3–5 seconds) on the HTTP request. If the request times out or returns a non-200 status, it should fail-gracefully to `indeterminate` with a clear warning, rather than blocking the preflight command or throwing an unhandled exception.
+
+---
+
+## 4. Distinction Between Missing Dependencies and Manifest Errors
+
+### Observation
+- "Package present in the manifest but absent from a consumer's lockfile → `indeterminate`, not `ok`."
+
+### Suggestion
+- While returning `indeterminate` is safe, we should distinguish between "the lockfile couldn't be parsed/fetched" and "the lockfile parsed successfully but the package is not a dependency at all."
+- If the lockfile is successfully parsed and does not contain the package, we should log a specific diagnostic: `"Manifest configuration error: <consumer-repo> does not depend on upstream package <pkg>"` so that the maintainer knows to update `release-train.json` rather than debugging lockfile/network issues.

--- a/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design.md
+++ b/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design.md
@@ -1,0 +1,247 @@
+# P2 Phase 2 — dependency-DAG edges
+
+**Status:** design approved 2026-07-26, not yet implemented.
+**Sub-program:** [P2 Release Train](../../infrastructure-roadmap.md) — Phase 1
+(channel staleness) shipped 2026-07-26 (#836).
+**Phase 1 design:** [`2026-07-24-p2-release-train-design.md`](./2026-07-24-p2-release-train-design.md).
+
+## Problem
+
+Phase 1 answers *"did the release reach its distribution channels?"* for the
+gateway. It says nothing about the other propagation graph the org runs: the
+npm packages `@nimbus-dev/sdk` and `@nimbus-dev/client`, and the repos that
+consume them.
+
+That graph is measurably stale right now (verified live, 2026-07-26):
+
+| Edge | npm `@latest` | consumer resolves | |
+| --- | --- | --- | --- |
+| `sdk` → `nimbus-client` | 1.6.0 | 1.6.0 | current |
+| `sdk` → `nimbus-vscode` | 1.6.0 | 1.5.2 | behind |
+| `client` → `nimbus-vscode` | 0.12.1 | 0.11.0 | behind |
+| `client` → **Nimbus (CLI)** | 0.12.1 | **0.5.0** | 7 minors behind |
+
+Nothing detected this. The client advanced 0.5 → 0.12 across the narrow-waist
+work and its consumers were never bumped. Confirmed as **drift, not a
+deliberate pin** (owner, 2026-07-26).
+
+A second, invisible failure mode sits upstream of that: a package can be
+**tagged and released on GitHub but never published to npm**. Every consumer
+edge then reads green, because npm `@latest` is stale in the same way the
+consumers are. This is the npm analogue of the release phantom Phase 1 catches,
+and the same class of defect that kept `v0.27.0` unreleased for two days.
+
+## Goal
+
+Extend `audit:release-staleness` so the same gate also fails when:
+
+1. an upstream package is tagged but not published to npm past the grace
+   window (**publish phantom**), or
+2. a consumer's **actually-resolved** dependency lags npm `@latest` past the
+   grace window with no open bump PR (**consumer staleness**).
+
+Non-goal: fixing either. P2 detects; remediation stays manual.
+
+## Architecture
+
+**The engine does not change.** `evaluateTrain`, `decideExit`, `compareSemver`,
+`stripV`, `ageHours`, `classifyReadFailure` and the `EdgeResult` vocabulary
+(`ok` / `stale` / `phantom` / `indeterminate`) are reused verbatim. Phase 2 adds
+a sibling reader + evaluator that emits `EdgeResult[]` into the **same**
+`decideExit`, so exit semantics, the strict rule, and the annotation format are
+identical by construction.
+
+```text
+.github/release-train.json
+  trains[]    → Phase 1 readers → evaluateTrain   ─┐
+  packages[]  → Phase 2 readers → evaluatePackage ─┴→ decideExit → exit 0|1
+```
+
+### Manifest — a new top-level `packages[]`
+
+The Phase 1 sketch proposed adding `dep` entries to `trains[]`. **This design
+deviates:** a dep edge's source is an npm dist-tag and its downstreams are
+repo+lockfile pairs, so sharing `trains[]` would make nearly every field
+optional-and-conditional and push the validation into runtime branching. A
+separate key in the same file keeps both shapes total, and `graceHours` stays
+shared.
+
+```json
+{
+  "graceHours": 6,
+  "trains": [ /* unchanged, Phase 1 */ ],
+  "packages": [
+    {
+      "name": "sdk",
+      "npm": "@nimbus-dev/sdk",
+      "repo": "nimbus-agent/nimbus-sdk",
+      "tagPattern": "^sdk-v(\\d+\\.\\d+\\.\\d+)$",
+      "consumers": [
+        { "repo": "nimbus-agent/nimbus-client", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/nimbus-vscode", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/Nimbus", "lockfile": "bun.lock" }
+      ]
+    },
+    {
+      "name": "client",
+      "npm": "@nimbus-dev/client",
+      "repo": "nimbus-agent/nimbus-client",
+      "tagPattern": "^client-v(\\d+\\.\\d+\\.\\d+)$",
+      "consumers": [
+        { "repo": "nimbus-agent/nimbus-vscode", "lockfile": "bun.lock" },
+        { "repo": "nimbus-agent/Nimbus", "lockfile": "bun.lock" }
+      ]
+    }
+  ]
+}
+```
+
+`tagPattern` is **required per package**, not inferred. Upstream tags are
+component-prefixed (`sdk-v1.6.0`, `client-v0.12.1`), and Phase 1's
+`selectPublished` deliberately filters to `^v\d+\.\d+\.\d+$` — it *skips*
+component tags by design. Phase 2 therefore needs its own selector; reusing
+Phase 1's would silently match nothing.
+
+## Edges
+
+### `<name>:publish` — tagged but not on npm
+
+- **source:** the highest non-draft, non-prerelease release whose tag matches
+  `tagPattern`, on the package's own repo.
+- **compare:** that version vs npm `@latest`.
+- **verdict:** tag ahead of npm and the *release* older than `graceHours` →
+  `phantom`. Equal or npm ahead → `ok`. Within grace → `ok` (publish window).
+
+Gating on the release's age (not "now") mirrors Phase 1's rule that a normal
+publish window must never be red.
+
+### `<name>:<consumer-repo>` — consumer lags npm
+
+- **source:** npm `@latest`.
+- **downstream:** the version the consumer's **lockfile resolves**, not the
+  `package.json` range.
+- **verdict:** resolved ≥ npm → `ok`. Resolved < npm **and the npm version was
+  published more than `graceHours` ago** → `stale`, **unless** an open PR in
+  that repo references the package (an in-flight bump, incl. Dependabot) → `ok`.
+
+Grace is measured from the **npm version's own publish timestamp**, mirroring
+Phase 1's rule that a channel is only judged once the release it should carry is
+past grace. A package published ten minutes ago must not red every consumer.
+
+**Why the lockfile.** A range can be wrong in both directions. `^1.2.0` *permits*
+a newer `1.3.0`, so comparing the range would false-flag a repo that already
+resolves to `1.3.0`. Conversely — and this is the live case — **caret on a `0.x`
+version pins the minor**: `^0.5.0` cannot resolve past `0.5.x`, so the range is
+itself the blocker. The lockfile is the only reading that is honest in both
+directions, because it is the code that actually ships.
+
+Note the practical consequence for whoever fixes a red edge: for a `0.x`
+package the remedy is a `package.json` bump, not `bun install`. The edge detail
+string should say which by comparing the declared range against npm, so the
+message is actionable rather than merely true.
+
+## Readers
+
+All reads are public and unauthenticated except GitHub reads, which reuse the
+existing `runGh` path.
+
+| Reader | Source | Notes |
+| --- | --- | --- |
+| `npmLatest(pkg)` | `GET https://registry.npmjs.org/<pkg>` | **New network dependency** — Phase 1 was `gh`-only |
+| `selectTaggedRelease(releases, pattern)` | `gh api repos/<repo>/releases` | pure; skips drafts + prereleases |
+| `resolvedFromBunLock(text, pkg)` | `gh api .../contents/<lockfile>` | pure |
+| `hasOpenBumpPr(repo, pkg)` | `gh pr list --state open --search` | mirrors the winget rule |
+
+`npmLatest` fetches the **full** registry document, not `/<pkg>/latest`. The
+`/latest` endpoint omits `time`, and the grace rule needs the publish
+timestamp; the full doc carries both `dist-tags.latest` and `time[<version>]`
+in one request (~48 KB, verified 2026-07-26). It returns
+`{ version, publishedAt } | null` — `null` on any transport or shape failure,
+which the evaluator maps to `indeterminate`.
+
+### `resolvedFromBunLock` returns the **minimum**, not the hoisted version
+
+A `bun.lock` can carry the same package at several versions — a hoisted entry
+plus per-workspace overrides. This is not hypothetical: on 2026-07-26 this
+monorepo held `@nimbus-dev/sdk` hoisted at `1.5.0` while ~100 connector
+workspaces pinned `1.4.0` beneath it.
+
+The reader therefore collects every resolved version for the package and returns
+the **lowest**. The oldest version that actually ships is the honest "caught up"
+signal; reporting the hoisted version would call that tree current when most of
+it was two minors behind.
+
+## Failure model
+
+Unchanged from Phase 1, and fail-closed in the same direction:
+
+- npm registry unreachable / non-JSON → `indeterminate` (never `stale`).
+- Lockfile read 404 → `absent` → `stale` (the file should exist).
+- Any other lockfile/release read failure → `indeterminate` via
+  `classifyReadFailure`.
+- Package present in the manifest but absent from a consumer's lockfile →
+  `indeterminate`, not `ok`: a consumer that no longer depends on the package is
+  a manifest error, not a passing edge.
+- Unparseable version on either side → `indeterminate` (`compareSemver`
+  returns `null`; it never throws).
+- Under `--strict`, a run where nothing was evaluable is **red** — a Phase-2
+  outage must not read as "all clear".
+
+## Expected outcome on arrival
+
+**RED**, deliberately, matching the Phase 1 precedent (which shipped red and
+caught a genuine phantom on its first run):
+
+- `client:Nimbus` — resolved 0.5.0 < 0.12.1 → `stale`
+- `client:nimbus-vscode` — resolved 0.11.0 < 0.12.1 → `stale`
+- `sdk:nimbus-vscode` — resolved 1.5.2 < 1.6.0 → `stale`
+- `sdk:nimbus-client` — 1.6.0 → `ok`
+- `sdk:publish`, `client:publish` — tags match npm → `ok`
+
+Remediation (bumping three consumer edges) is **separate work**, tracked but not
+in this slice. Shipping the gate red is the red-before evidence; the green-after
+comes when those bumps land.
+
+## Testing
+
+Table-driven unit tests over the pure functions, matching Phase 1's file layout
+(`check-release-staleness.test.ts`):
+
+- `parseNpmLatest` — valid doc (`dist-tags.latest` + `time`), missing
+  `dist-tags`, missing `time` entry, malformed JSON.
+- `selectTaggedRelease` — component-prefixed match, drafts/prereleases skipped,
+  non-matching tags ignored, highest wins, empty → `null`.
+- `resolvedFromBunLock` — single entry; **multiple entries → minimum**; nested
+  workspace entries; package absent → `null`.
+- `evaluatePackage` — every verdict: publish phantom, publish within grace,
+  consumer stale, consumer current, consumer stale-but-PR-open, each
+  indeterminate path.
+- The committed `.github/release-train.json` parses and declares both packages.
+
+No new coverage-gate wiring: `scripts/` is covered by the existing
+`bun test scripts/structure-audit/` run.
+
+## Out of scope
+
+- **Fixing** any red edge — no auto-bump, no PR generation.
+- **Non-`bun.lock` formats.** All four repos commit `bun.lock` (verified
+  2026-07-26). A future npm/pnpm consumer needs a new reader.
+- **An "intentionally pinned" escape hatch.** Every current edge should be
+  current; adding an optional `pinned` field later is a one-line manifest
+  change, so YAGNI until a real pin exists.
+- **Transitive depth.** Only the declared direct edges are checked, not the full
+  transitive closure.
+- **Registry-side integrity** (provenance, signatures) — already owned by
+  `secret-health.yml`'s npm provenance probes.
+
+## Open questions
+
+None. The Phase 1 spec's two deferred questions are both resolved here:
+
+1. **Source for a dep edge** → npm `@latest`, *plus* a separate `:publish` edge
+   comparing the upstream git tag to npm. This keeps "consumers are behind" and
+   "we never published" as distinct, separately actionable verdicts rather than
+   conflating them into one.
+2. **Lockfile format per consumer** → all four repos commit `bun.lock`
+   (`nimbus-sdk`, `nimbus-client`, `nimbus-vscode`, `Nimbus`; verified live
+   2026-07-26), so one reader covers the graph.

--- a/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design.md
+++ b/docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design.md
@@ -147,10 +147,10 @@ existing `runGh` path.
 
 | Reader | Source | Notes |
 | --- | --- | --- |
-| `npmLatest(pkg)` | `GET https://registry.npmjs.org/<pkg>` | **New network dependency** — Phase 1 was `gh`-only |
+| `npmLatest(pkg)` | `GET https://registry.npmjs.org/<pkg>` | **New network dependency** — Phase 1 was `gh`-only; 5s timeout |
 | `selectTaggedRelease(releases, pattern)` | `gh api repos/<repo>/releases` | pure; skips drafts + prereleases |
-| `resolvedFromBunLock(text, pkg)` | `gh api .../contents/<lockfile>` | pure |
-| `hasOpenBumpPr(repo, pkg)` | `gh pr list --state open --search` | mirrors the winget rule |
+| `resolvedFromBunLock(text, pkg)` | `gh api .../contents/<lockfile>` | pure; resolutions section only |
+| `matchesBumpPr(prs, pkg)` | `gh pr list --json title,headRefName` | pure; mirrors the winget rule |
 
 `npmLatest` fetches the **full** registry document, not `/<pkg>/latest`. The
 `/latest` endpoint omits `time`, and the grace rule needs the publish
@@ -159,17 +159,62 @@ in one request (~48 KB, verified 2026-07-26). It returns
 `{ version, publishedAt } | null` — `null` on any transport or shape failure,
 which the evaluator maps to `indeterminate`.
 
-### `resolvedFromBunLock` returns the **minimum**, not the hoisted version
+**Timeout is mandatory.** The request carries
+`AbortSignal.timeout(5000)`, and any non-200 status, timeout, or malformed body
+resolves to `null` → `indeterminate` with a message naming the cause. The
+registry is the one dependency in this gate that is neither GitHub nor local,
+so an unbounded `fetch` would let a slow registry hang the sweep job — and the
+gate is runnable locally, where a hang is worse than a red.
 
-A `bun.lock` can carry the same package at several versions — a hoisted entry
-plus per-workspace overrides. This is not hypothetical: on 2026-07-26 this
-monorepo held `@nimbus-dev/sdk` hoisted at `1.5.0` while ~100 connector
-workspaces pinned `1.4.0` beneath it.
+`hasOpenBumpPr` does **not** rely on GitHub's search-query semantics. It lists
+open PRs with `gh pr list --repo <repo> --state open --json title,headRefName
+--limit 100` and matches in memory, case-insensitively, against both the title
+and the branch name, accepting either the full package name
+(`@nimbus-dev/sdk`) or its short name (`sdk`). Dependabot, Renovate and humans
+all title bump PRs differently ("Bump @nimbus-dev/sdk from 1.5.0 to 1.6.0",
+"chore(deps): upgrade sdk"), and `--search` would make the gate's behaviour
+depend on an opaque relevance ranker. Matching locally also makes the predicate
+a **pure function** over `{title, headRefName}[]`, so every naming variant is
+table-testable without network.
 
-The reader therefore collects every resolved version for the package and returns
-the **lowest**. The oldest version that actually ships is the honest "caught up"
-signal; reporting the hoisted version would call that tree current when most of
-it was two minors behind.
+### `resolvedFromBunLock` — parse the resolutions section, scoped to our own workspaces
+
+A `bun.lock` (Bun v1.2+, JSON) has **two** sections that both mention a package,
+and only one of them carries a resolved version:
+
+```text
+workspaces: { "packages/cli": { name, dependencies: { "@nimbus-dev/sdk": "^1.5.0" } } }
+                                                       └─ a RANGE, never parse this
+"@nimbus-dev/sdk":                    ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-…"]
+"nimbus-mcp-github/@nimbus-dev/sdk":  ["@nimbus-dev/sdk@1.4.0", …]
+"@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.3.0", …]
+ └─ resolution keys; the version lives in element [0] as "<name>@<version>"
+```
+
+The reader parses **only** the resolution entries — element `[0]` of each array
+value — never the workspace `dependencies` maps. A range and a resolution are
+both `"@nimbus-dev/sdk"`-keyed, so a scan that is not section-aware will happily
+return `^1.5.0` and compare a caret string as a version.
+
+**Which resolution entries count.** Not all of them. A resolution key is a
+dependency *path*: an unprefixed key is the hoisted copy, and `<prefix>/<pkg>`
+is the copy `<prefix>` resolved. Some prefixes are the repo's **own
+workspaces** (`nimbus-mcp-github/…`), and some are **third-party packages that
+happen to bundle the same dep** (`@nimbus-dev/client/@nimbus-dev/sdk`).
+
+Only the first kind is this edge's business. In this monorepo today the hoisted
+`@nimbus-dev/sdk` is `1.6.0` while the copy nested under the external
+`@nimbus-dev/client` is `1.3.0` — reporting `1.3.0` as "Nimbus's resolved sdk"
+would be wrong, since no Nimbus code resolves it. Conversely the ~100
+connector workspaces really did sit at `1.4.0` under a hoisted `1.5.0` earlier
+on 2026-07-26, and that *is* this edge's business.
+
+So the rule is: **the minimum over the hoisted entry plus every entry whose
+prefix is one of the consumer's own workspace names.** Workspace names are
+derivable from the same file — `Object.values(lock.workspaces).map(w => w.name)`
+— so no extra fetch is needed. The oldest version *our* code resolves is the
+honest "caught up" signal; the hoisted entry alone would call the tree current
+while most of it lagged.
 
 ## Failure model
 
@@ -181,7 +226,21 @@ Unchanged from Phase 1, and fail-closed in the same direction:
   `classifyReadFailure`.
 - Package present in the manifest but absent from a consumer's lockfile →
   `indeterminate`, not `ok`: a consumer that no longer depends on the package is
-  a manifest error, not a passing edge.
+  a manifest error, not a passing edge. **This case must not share a message
+  with a failed read.** When the lockfile fetched and parsed cleanly and simply
+  contains no entry for the package, the detail reads
+  `manifest error: <repo> does not depend on <pkg> — remove this consumer from
+  release-train.json`, so the operator edits the manifest instead of chasing a
+  network or parse fault. A read failure keeps the transient wording.
+
+  The **verdict** stays `indeterminate` rather than becoming a hard failure,
+  deliberately: a fifth verdict would ripple through `decideExit` and the strict
+  rule for one configuration mistake. The trade-off is real and worth naming —
+  unlike a transient, this condition never self-heals, so it warns forever if
+  nobody reads warnings. That is mitigated by the wording above and by the
+  strict rule (a run with no `ok` edges is red anyway); if a stale manifest
+  entry is ever observed surviving more than a sweep or two, promote it to a
+  hard failure rather than leaving a permanent warning.
 - Unparseable version on either side → `indeterminate` (`compareSemver`
   returns `null`; it never throws).
 - Under `--strict`, a run where nothing was evaluable is **red** — a Phase-2
@@ -211,8 +270,14 @@ Table-driven unit tests over the pure functions, matching Phase 1's file layout
   `dist-tags`, missing `time` entry, malformed JSON.
 - `selectTaggedRelease` — component-prefixed match, drafts/prereleases skipped,
   non-matching tags ignored, highest wins, empty → `null`.
-- `resolvedFromBunLock` — single entry; **multiple entries → minimum**; nested
-  workspace entries; package absent → `null`.
+- `resolvedFromBunLock` — hoisted entry only; **own-workspace entry lower than
+  hoisted → minimum wins**; **a lower version nested under a third-party
+  prefix is IGNORED** (the live `@nimbus-dev/client/@nimbus-dev/sdk@1.3.0`
+  case); a range in the `workspaces` section is never mistaken for a resolution
+  (`"^1.5.0"` must not parse as a version); package absent → `null`.
+- `matchesBumpPr` — full-name title match, short-name title match, branch-name
+  match, case-insensitive, and a non-match (an unrelated open PR must not count
+  as an in-flight bump).
 - `evaluatePackage` — every verdict: publish phantom, publish within grace,
   consumer stale, consumer current, consumer stale-but-PR-open, each
   indeterminate path.

--- a/scripts/structure-audit/_release-train-core.ts
+++ b/scripts/structure-audit/_release-train-core.ts
@@ -1,0 +1,88 @@
+/**
+ * Primitives shared by every release-train edge kind. This module is a LEAF:
+ * it imports nothing from its siblings, which is what lets both the Phase 1
+ * channel readers and the Phase 2 dependency readers depend on it without
+ * forming an import cycle.
+ */
+
+export function stripV(version: string): string {
+  return version.replace(/^v/, "");
+}
+
+/**
+ * Semver ordering that never throws. `Bun.semver.order` throws on an unparseable
+ * version ("Invalid SemVer: ..."), and channel files are external — a format
+ * quirk must degrade to "indeterminate", not crash the whole audit. Returns
+ * -1 | 0 | 1, or null when either side is not valid semver.
+ */
+export function compareSemver(a: string, b: string): number | null {
+  try {
+    return Bun.semver.order(stripV(a), stripV(b));
+  } catch {
+    return null;
+  }
+}
+
+/** ISO-8601 with an explicit UTC designator or numeric offset. */
+const HAS_TIMEZONE = /(?:Z|[+-]\d{2}:?\d{2})$/;
+
+/**
+ * Hours between an ISO-8601 (Z-suffixed) timestamp and now, UTC epoch-ms math.
+ * An unparseable date yields `+Infinity` (fail-CLOSED): a NaN age would satisfy
+ * `NaN > graceHours === false` and silently mask a phantom/stale state as "ok",
+ * so an unreadable timestamp instead forces the aged-check to fire.
+ */
+export function ageHours(isoZ: string): number {
+  // A timestamp without an explicit zone would be parsed as LOCAL time, making
+  // the age differ between a laptop and a UTC runner. Treat it as unreadable
+  // and fail CLOSED, exactly like an unparseable date.
+  if (!HAS_TIMEZONE.test(isoZ.trim())) return Number.POSITIVE_INFINITY;
+  const t = new Date(isoZ).getTime();
+  if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - t) / 3_600_000;
+}
+
+export interface ReleaseInfo {
+  tag: string;
+  prerelease: boolean;
+  draft: boolean;
+  assets: string[];
+  publishedAt: string;
+}
+export interface PublishedRelease {
+  version: string;
+  publishedAt: string;
+}
+
+export type EdgeVerdict = "ok" | "stale" | "phantom" | "indeterminate";
+export interface EdgeResult {
+  edge: string;
+  verdict: EdgeVerdict;
+  detail: string;
+}
+
+/**
+ * Exit decision. Any stale/phantom edge => red. Otherwise green with a warning
+ * per indeterminate edge — EXCEPT a run where nothing was evaluable (no ok, only
+ * indeterminate) under --strict is red: "indeterminate" must not read as "all
+ * clear" in the scheduled sweep (the team-reachability rule).
+ */
+export function decideExit(
+  results: EdgeResult[],
+  strict: boolean,
+): { code: 0 | 1; messages: string[] } {
+  const messages: string[] = [];
+  const hard = results.filter((r) => r.verdict === "phantom" || r.verdict === "stale");
+  const indet = results.filter((r) => r.verdict === "indeterminate");
+  const ok = results.filter((r) => r.verdict === "ok");
+  for (const r of hard) messages.push(`::error::${r.edge}: ${r.detail}`);
+  for (const r of indet) messages.push(`::warning::${r.edge}: ${r.detail} (indeterminate)`);
+  if (hard.length > 0) return { code: 1, messages };
+  if (ok.length === 0 && indet.length > 0 && strict) {
+    messages.push(
+      "::error::release-staleness: indeterminate — nothing could be evaluated (all reads failed transiently)",
+    );
+    return { code: 1, messages };
+  }
+  return { code: 0, messages };
+}

--- a/scripts/structure-audit/_release-train-dep.test.ts
+++ b/scripts/structure-audit/_release-train-dep.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  type ConsumerReading,
+  evaluatePackage,
   matchesBumpPr,
   parseNpmLatest,
   resolvedFromBunLock,
@@ -168,5 +170,139 @@ describe("matchesBumpPr", () => {
   });
   test("no open PRs => false", () => {
     expect(matchesBumpPr([], pkg)).toBe(false);
+  });
+});
+
+const consumer = (over: Partial<ConsumerReading>): ConsumerReading => ({
+  repo: "nimbus-agent/nimbus-vscode",
+  status: "read",
+  resolved: null,
+  bumpPrOpen: false,
+  ...over,
+});
+
+describe("evaluatePackage", () => {
+  const green = {
+    name: "sdk",
+    npm: "@nimbus-dev/sdk",
+    taggedRelease: { version: "1.6.0", publishedAt: "x" },
+    taggedReleaseAgeHours: 48,
+    latest: { version: "1.6.0", publishedAt: "x" },
+    latestAgeHours: 48,
+    graceHours: 6,
+  };
+
+  test("tag and npm equal + consumer current => all ok", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "1.6.0" })],
+    });
+    expect(r.every((e) => e.verdict === "ok")).toBe(true);
+  });
+
+  test("tag ahead of npm past grace => publish phantom", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: { version: "1.7.0", publishedAt: "x" },
+      consumers: [],
+    });
+    expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("phantom");
+  });
+
+  test("tag ahead of npm within grace => ok (publish window)", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: { version: "1.7.0", publishedAt: "x" },
+      taggedReleaseAgeHours: 1,
+      consumers: [],
+    });
+    expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("ok");
+  });
+
+  test("consumer behind past grace => stale", () => {
+    const r = evaluatePackage({ ...green, consumers: [consumer({ resolved: "1.5.2" })] });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("stale");
+  });
+
+  test("consumer behind but the npm version is within grace => ok", () => {
+    const r = evaluatePackage({
+      ...green,
+      latestAgeHours: 2,
+      consumers: [consumer({ resolved: "1.5.2" })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
+  });
+
+  test("consumer behind but a bump PR is open => ok", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "1.5.2", bumpPrOpen: true })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
+  });
+
+  test("consumer behind but the PR list was unreadable => indeterminate, not stale", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "1.5.2", bumpPrOpen: null })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("indeterminate");
+  });
+
+  test("consumer ahead of npm => ok, never stale", () => {
+    const r = evaluatePackage({ ...green, consumers: [consumer({ resolved: "1.7.0" })] });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("ok");
+  });
+
+  test("npm unreadable => every edge indeterminate, never stale", () => {
+    const r = evaluatePackage({
+      ...green,
+      latest: null,
+      latestAgeHours: null,
+      consumers: [consumer({ resolved: "1.0.0" })],
+    });
+    expect(r.every((e) => e.verdict === "indeterminate")).toBe(true);
+  });
+
+  test("transient consumer read => indeterminate", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ status: "indeterminate" })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("indeterminate");
+  });
+
+  test("absent lockfile => stale", () => {
+    const r = evaluatePackage({ ...green, consumers: [consumer({ status: "absent" })] });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("stale");
+  });
+
+  test("lockfile parsed but package is not a dependency => indeterminate naming the manifest", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ status: "not-a-dependency" })],
+    });
+    const e = r.find((x) => x.edge === "sdk:nimbus-vscode");
+    expect(e?.verdict).toBe("indeterminate");
+    expect(e?.detail).toContain("manifest error");
+    expect(e?.detail).toContain("release-train.json");
+  });
+
+  test("unparseable resolved version => indeterminate, never a crash", () => {
+    const r = evaluatePackage({
+      ...green,
+      consumers: [consumer({ resolved: "not-a-version" })],
+    });
+    expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("indeterminate");
+  });
+
+  test("no tagged release => publish edge indeterminate, not phantom", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: null,
+      taggedReleaseAgeHours: null,
+      consumers: [],
+    });
+    expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("indeterminate");
   });
 });

--- a/scripts/structure-audit/_release-train-dep.test.ts
+++ b/scripts/structure-audit/_release-train-dep.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  matchesBumpPr,
+  parseNpmLatest,
+  resolvedFromBunLock,
+  selectTaggedRelease,
+  stripTrailingCommas,
+} from "./_release-train-dep.ts";
+
+describe("parseNpmLatest", () => {
+  const doc = JSON.stringify({
+    "dist-tags": { latest: "0.12.1" },
+    time: { "0.12.0": "2026-07-20T00:00:00Z", "0.12.1": "2026-07-24T12:36:40.942Z" },
+  });
+  test("reads dist-tags.latest and its publish time", () => {
+    expect(parseNpmLatest(doc)).toEqual({
+      version: "0.12.1",
+      publishedAt: "2026-07-24T12:36:40.942Z",
+    });
+  });
+  test("null when dist-tags is absent", () => {
+    expect(parseNpmLatest(JSON.stringify({ time: {} }))).toBeNull();
+  });
+  test("null when the latest version has no time entry", () => {
+    expect(
+      parseNpmLatest(JSON.stringify({ "dist-tags": { latest: "1.0.0" }, time: {} })),
+    ).toBeNull();
+  });
+  test("null on malformed JSON", () => {
+    expect(parseNpmLatest("{not json")).toBeNull();
+  });
+});
+
+describe("selectTaggedRelease", () => {
+  const base = { draft: false, prerelease: false, assets: [] as string[] };
+  const P = "^sdk-v(\\d+\\.\\d+\\.\\d+)$";
+  test("picks the highest component-prefixed tag and returns its publish time", () => {
+    const r = selectTaggedRelease(
+      [
+        { ...base, tag: "sdk-v1.5.2", publishedAt: "2026-07-01T00:00:00Z" },
+        { ...base, tag: "sdk-v1.6.0", publishedAt: "2026-07-10T00:00:00Z" },
+      ],
+      P,
+    );
+    expect(r).toEqual({ version: "1.6.0", publishedAt: "2026-07-10T00:00:00Z" });
+  });
+  test("ignores tags that do not match the pattern", () => {
+    const r = selectTaggedRelease(
+      [
+        { ...base, tag: "v9.9.9", publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "client-v0.1.0", publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "sdk-v1.0.0", publishedAt: "2026-07-01T00:00:00Z" },
+      ],
+      P,
+    );
+    expect(r?.version).toBe("1.0.0");
+  });
+  test("skips drafts and prereleases", () => {
+    const r = selectTaggedRelease(
+      [
+        { ...base, tag: "sdk-v2.0.0", draft: true, publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "sdk-v1.9.0", prerelease: true, publishedAt: "2026-07-10T00:00:00Z" },
+        { ...base, tag: "sdk-v1.6.0", publishedAt: "2026-07-01T00:00:00Z" },
+      ],
+      P,
+    );
+    expect(r?.version).toBe("1.6.0");
+  });
+  test("null when nothing matches", () => {
+    expect(selectTaggedRelease([{ ...base, tag: "v1.0.0", publishedAt: "x" }], P)).toBeNull();
+  });
+});
+
+describe("resolvedFromBunLock", () => {
+  // Mirrors the real bun.lock shape: workspaces carry RANGES, packages carry
+  // resolutions whose element [0] is "<name>@<version>". Trailing commas are
+  // legal in a real bun.lock, so one is included deliberately.
+  const lock = `{
+    "lockfileVersion": 1,
+    "workspaces": {
+      "": { "name": "nimbus" },
+      "packages/cli": { "name": "@nimbus/cli", "dependencies": { "@nimbus-dev/sdk": "^1.5.0" } },
+      "packages/mcp-connectors/github": { "name": "nimbus-mcp-github" },
+    },
+    "packages": {
+      "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-aaa"],
+      "nimbus-mcp-github/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.4.0", "", {}, "sha512-bbb"],
+      "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.3.0", "", {}, "sha512-ccc"],
+    },
+  }`;
+
+  test("takes the minimum across our OWN workspaces, ignoring third-party nesting", () => {
+    // 1.4.0 (our workspace) wins over 1.6.0 (hoisted); 1.3.0 is nested under the
+    // external @nimbus-dev/client and must NOT count.
+    expect(resolvedFromBunLock(lock, "@nimbus-dev/sdk")).toBe("1.4.0");
+  });
+
+  test("hoisted-only lockfile returns the hoisted version", () => {
+    const simple = `{
+      "workspaces": { "": { "name": "x" } },
+      "packages": { "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-a"] }
+    }`;
+    expect(resolvedFromBunLock(simple, "@nimbus-dev/sdk")).toBe("1.6.0");
+  });
+
+  test("a range in the workspaces section is never read as a resolution", () => {
+    // The only mention of the package is a "^1.5.0" range — no resolution entry.
+    const rangeOnly = `{
+      "workspaces": { "p": { "name": "p", "dependencies": { "@nimbus-dev/sdk": "^1.5.0" } } },
+      "packages": {}
+    }`;
+    expect(resolvedFromBunLock(rangeOnly, "@nimbus-dev/sdk")).toBeNull();
+  });
+
+  test("null when the package is absent entirely", () => {
+    expect(resolvedFromBunLock(lock, "@nimbus-dev/nope")).toBeNull();
+  });
+
+  test("null on unparseable lockfile", () => {
+    expect(resolvedFromBunLock("{not json", "@nimbus-dev/sdk")).toBeNull();
+  });
+});
+
+describe("stripTrailingCommas", () => {
+  test("removes trailing commas before } and ]", () => {
+    expect(JSON.parse(stripTrailingCommas('{"a":[1,2,],"b":{"c":1,},}'))).toEqual({
+      a: [1, 2],
+      b: { c: 1 },
+    });
+  });
+  test("does NOT touch a comma inside a string value", () => {
+    // The naive regex /,(\s*[}\]])/g corrupts this silently — it parses, but
+    // with the comma eaten. That is the bug this function exists to avoid.
+    const src = JSON.stringify({ note: "a comma, }" });
+    expect(JSON.parse(stripTrailingCommas(src)).note).toBe("a comma, }");
+  });
+  test("handles escaped quotes inside strings", () => {
+    const src = '{"k":"he said \\", }"}';
+    expect(JSON.parse(stripTrailingCommas(src)).k).toBe('he said ", }');
+  });
+});
+
+describe("matchesBumpPr", () => {
+  const pkg = "@nimbus-dev/sdk";
+  test("matches the full package name in a title", () => {
+    expect(
+      matchesBumpPr([{ title: "Bump @nimbus-dev/sdk from 1.5.0 to 1.6.0", headRefName: "x" }], pkg),
+    ).toBe(true);
+  });
+  test("matches the short name in a title, case-insensitively", () => {
+    expect(
+      matchesBumpPr([{ title: "chore(deps): upgrade SDK to 1.6.0", headRefName: "x" }], pkg),
+    ).toBe(true);
+  });
+  test("matches the branch name when the title does not mention it", () => {
+    expect(
+      matchesBumpPr(
+        [{ title: "chore: deps", headRefName: "dependabot/npm_and_yarn/nimbus-dev/sdk-1.6.0" }],
+        pkg,
+      ),
+    ).toBe(true);
+  });
+  test("an unrelated open PR does not count as an in-flight bump", () => {
+    expect(matchesBumpPr([{ title: "fix: typo in README", headRefName: "fix/readme" }], pkg)).toBe(
+      false,
+    );
+  });
+  test("no open PRs => false", () => {
+    expect(matchesBumpPr([], pkg)).toBe(false);
+  });
+});

--- a/scripts/structure-audit/_release-train-dep.ts
+++ b/scripts/structure-audit/_release-train-dep.ts
@@ -6,7 +6,12 @@
  */
 
 import { isRecord } from "./_gh-audit.ts";
-import { compareSemver, type PublishedRelease, type ReleaseInfo } from "./_release-train-core.ts";
+import {
+  compareSemver,
+  type EdgeResult,
+  type PublishedRelease,
+  type ReleaseInfo,
+} from "./_release-train-core.ts";
 
 export interface NpmLatest {
   version: string;
@@ -174,4 +179,154 @@ export function matchesBumpPr(prs: readonly PrRef[], pkg: string): boolean {
     const hay = `${pr.title} ${pr.headRefName}`.toLowerCase();
     return hay.includes(full) || hay.includes(short);
   });
+}
+
+export interface ConsumerReading {
+  repo: string;
+  /**
+   * `read` — lockfile fetched and parsed, `resolved` is set.
+   * `absent` — the lockfile itself is missing (404): a real finding.
+   * `not-a-dependency` — lockfile parsed fine but has no entry: a MANIFEST bug.
+   * `indeterminate` — the read failed transiently.
+   */
+  status: "read" | "absent" | "indeterminate" | "not-a-dependency";
+  resolved: string | null;
+  /** `null` = could not determine (read failed, or the PR list may be truncated). */
+  bumpPrOpen: boolean | null;
+}
+
+export interface PackageEvalInput {
+  name: string;
+  npm: string;
+  taggedRelease: PublishedRelease | null;
+  taggedReleaseAgeHours: number | null;
+  latest: NpmLatest | null;
+  latestAgeHours: number | null;
+  consumers: ConsumerReading[];
+  graceHours: number;
+}
+
+/** Short repo name for edge labels: `nimbus-agent/nimbus-vscode` -> `nimbus-vscode`. */
+function shortRepo(repo: string): string {
+  return repo.split("/").pop() ?? repo;
+}
+
+/** The publish edge: a tagged release must reach npm. */
+function evaluatePublishEdge(i: PackageEvalInput): EdgeResult {
+  const edge = `${i.name}:publish`;
+  if (i.taggedRelease === null) {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `no release tag matched for ${i.npm} — releases unreadable or none published`,
+    };
+  }
+  if (i.latest === null) {
+    return { edge, verdict: "indeterminate", detail: `npm registry unreadable for ${i.npm}` };
+  }
+  const order = compareSemver(i.taggedRelease.version, i.latest.version);
+  if (order === null) {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `cannot compare tag ${i.taggedRelease.version} to npm ${i.latest.version}`,
+    };
+  }
+  if (order <= 0) {
+    return {
+      edge,
+      verdict: "ok",
+      detail: `${i.npm} tag ${i.taggedRelease.version} published as ${i.latest.version}`,
+    };
+  }
+  const age = i.taggedReleaseAgeHours ?? Number.POSITIVE_INFINITY;
+  if (age > i.graceHours) {
+    return {
+      edge,
+      verdict: "phantom",
+      detail: `${i.npm} ${i.taggedRelease.version} is tagged but npm still serves ${i.latest.version}; release is ${Math.round(age)}h old (> ${i.graceHours}h grace)`,
+    };
+  }
+  return {
+    edge,
+    verdict: "ok",
+    detail: `${i.npm} ${i.taggedRelease.version} tagged within ${i.graceHours}h grace (npm: ${i.latest.version})`,
+  };
+}
+
+/** One consumer edge: has this repo's lockfile caught up to npm @latest? */
+function evaluateConsumerEdge(
+  c: ConsumerReading,
+  edge: string,
+  npm: string,
+  latest: NpmLatest,
+  pastGrace: boolean,
+  graceHours: number,
+): EdgeResult {
+  if (c.status === "indeterminate") {
+    return { edge, verdict: "indeterminate", detail: `lockfile read failed transiently` };
+  }
+  if (c.status === "not-a-dependency") {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `manifest error: ${c.repo} does not depend on ${npm} — remove this consumer from release-train.json`,
+    };
+  }
+  if (c.status === "absent") {
+    return { edge, verdict: "stale", detail: `lockfile absent in ${c.repo}` };
+  }
+  if (c.resolved === null) {
+    return { edge, verdict: "indeterminate", detail: `no resolved version for ${npm}` };
+  }
+  const order = compareSemver(c.resolved, latest.version);
+  if (order === null) {
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `resolved ${c.resolved} not comparable to npm ${latest.version}`,
+    };
+  }
+  if (order >= 0) {
+    return { edge, verdict: "ok", detail: `${c.resolved} >= npm ${latest.version}` };
+  }
+  if (!pastGrace) {
+    return { edge, verdict: "ok", detail: `npm ${latest.version} within ${graceHours}h grace` };
+  }
+  if (c.bumpPrOpen === true) {
+    return {
+      edge,
+      verdict: "ok",
+      detail: `${c.resolved} < ${latest.version} but a bump PR is open`,
+    };
+  }
+  if (c.bumpPrOpen === null) {
+    // We know it is behind, but not whether a bump is already in flight. Report
+    // unknown rather than staleness — an unread PR list must not manufacture a
+    // finding.
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `${c.resolved} < npm ${latest.version}, but the open-PR list could not be read conclusively`,
+    };
+  }
+  return {
+    edge,
+    verdict: "stale",
+    detail: `${c.resolved} < npm ${latest.version} and no bump PR open`,
+  };
+}
+
+export function evaluatePackage(i: PackageEvalInput): EdgeResult[] {
+  const results: EdgeResult[] = [evaluatePublishEdge(i)];
+  const pastGrace = (i.latestAgeHours ?? Number.POSITIVE_INFINITY) > i.graceHours;
+  for (const c of i.consumers) {
+    const edge = `${i.name}:${shortRepo(c.repo)}`;
+    results.push(
+      i.latest === null
+        ? { edge, verdict: "indeterminate", detail: `npm registry unreadable for ${i.npm}` }
+        : evaluateConsumerEdge(c, edge, i.npm, i.latest, pastGrace, i.graceHours),
+    );
+  }
+  return results;
 }

--- a/scripts/structure-audit/_release-train-dep.ts
+++ b/scripts/structure-audit/_release-train-dep.ts
@@ -1,0 +1,177 @@
+/**
+ * P2 Phase 2 — dependency-DAG readers. Pure functions only: every one takes
+ * already-fetched text and returns a value, so the whole edge model is testable
+ * without network. The impure fetch/gh callers live in check-release-staleness.ts.
+ * See docs/superpowers/specs/2026-07-26-p2-phase2-dep-dag-design.md.
+ */
+
+import { isRecord } from "./_gh-audit.ts";
+import { compareSemver, type PublishedRelease, type ReleaseInfo } from "./_release-train-core.ts";
+
+export interface NpmLatest {
+  version: string;
+  publishedAt: string;
+}
+
+/**
+ * `dist-tags.latest` + its publish timestamp from a FULL npm registry document.
+ * The `/<pkg>/latest` endpoint is not usable here: it omits `time`, and the
+ * grace rule is measured from the version's own publish time.
+ */
+export function parseNpmLatest(doc: string): NpmLatest | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(doc);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  const tags = parsed["dist-tags"];
+  if (!isRecord(tags)) return null;
+  const version = tags["latest"];
+  if (typeof version !== "string") return null;
+  const time = parsed["time"];
+  if (!isRecord(time)) return null;
+  const publishedAt = time[version];
+  if (typeof publishedAt !== "string") return null;
+  return { version, publishedAt };
+}
+
+/**
+ * Highest stable release whose tag matches `pattern`, which MUST carry one
+ * capture group holding the bare version. Upstream tags are component-prefixed
+ * (`sdk-v1.6.0`), which Phase 1's `selectPublished` deliberately rejects — so
+ * dep edges need their own selector rather than reusing it.
+ */
+export function selectTaggedRelease(
+  releases: readonly ReleaseInfo[],
+  pattern: string,
+): PublishedRelease | null {
+  const re = new RegExp(pattern);
+  const eligible: PublishedRelease[] = [];
+  for (const r of releases) {
+    if (r.draft || r.prerelease) continue;
+    const version = re.exec(r.tag)?.[1];
+    if (version) eligible.push({ version, publishedAt: r.publishedAt });
+  }
+  if (eligible.length === 0) return null;
+  eligible.sort((a, b) => compareSemver(b.version, a.version) ?? 0);
+  return eligible[0] ?? null;
+}
+
+/**
+ * Remove trailing commas so a real bun.lock (which is JSONC-ish and DOES carry
+ * them) survives `JSON.parse`.
+ *
+ * This walks the text tracking string state rather than using a regex. The
+ * obvious `text.replace(/,(\s*[}\]])/g, "$1")` is WRONG in a way that fails
+ * silently: it also strips a comma inside a string value that happens to end
+ * with `, }`, so `"note: a comma, }"` parses cleanly as `"note: a comma }"`.
+ * A corrupted-but-parseable lockfile is precisely the class of defect this gate
+ * exists to prevent, so the parser must not introduce one.
+ */
+export function stripTrailingCommas(text: string): string {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i] as string;
+    if (inString) {
+      out += ch;
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < text.length && /\s/.test(text[j] as string)) j++;
+      const next = text[j];
+      if (next === "}" || next === "]") continue; // trailing comma — drop it
+    }
+    out += ch;
+  }
+  return out;
+}
+
+/** Workspace package names declared by a parsed bun.lock (`workspaces[].name`). */
+function workspaceNames(lock: Record<string, unknown>): Set<string> {
+  const names = new Set<string>();
+  const ws = lock["workspaces"];
+  if (!isRecord(ws)) return names;
+  for (const entry of Object.values(ws)) {
+    if (isRecord(entry) && typeof entry["name"] === "string") names.add(entry["name"]);
+  }
+  return names;
+}
+
+/**
+ * The version of `pkg` a bun.lock actually resolves for the repo's OWN code.
+ *
+ * A bun.lock mentions a package in two places and only one is a version:
+ *   workspaces[].dependencies["<pkg>"] = "^1.5.0"     <- a RANGE, never parse it
+ *   packages["<path>"] = ["<pkg>@1.6.0", ...]         <- the resolution
+ *
+ * A resolution key is a dependency PATH: bare `<pkg>` is the hoisted copy, and
+ * `<prefix>/<pkg>` is the copy `<prefix>` resolved. Only prefixes that are the
+ * repo's own workspaces are this edge's business — a lower version nested under
+ * a THIRD-PARTY package (e.g. `@nimbus-dev/client/@nimbus-dev/sdk`) is that
+ * package's business, not ours, and counting it would report a version no local
+ * code resolves. Returns the minimum of the qualifying entries, because the
+ * oldest version our own code ships is the honest "caught up" signal.
+ */
+export function resolvedFromBunLock(text: string, pkg: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripTrailingCommas(text));
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  const packages = parsed["packages"];
+  if (!isRecord(packages)) return null;
+
+  const ours = workspaceNames(parsed);
+  const found: string[] = [];
+  const suffix = `/${pkg}`;
+
+  for (const [key, value] of Object.entries(packages)) {
+    if (key !== pkg && !key.endsWith(suffix)) continue;
+    if (key !== pkg && !ours.has(key.slice(0, key.length - suffix.length))) continue;
+    if (!Array.isArray(value)) continue;
+    const spec = value[0];
+    if (typeof spec !== "string") continue;
+    const at = spec.lastIndexOf("@");
+    if (at <= 0 || spec.slice(0, at) !== pkg) continue;
+    found.push(spec.slice(at + 1));
+  }
+  if (found.length === 0) return null;
+  found.sort((a, b) => compareSemver(a, b) ?? 0);
+  return found[0] ?? null;
+}
+
+export interface PrRef {
+  title: string;
+  headRefName: string;
+}
+
+/**
+ * Is one of these open PRs an in-flight bump of `pkg`? Matched in memory over
+ * title + branch rather than through `gh --search`, so the gate does not depend
+ * on an opaque relevance ranker and every naming variant is testable offline.
+ * Both the full name (`@nimbus-dev/sdk`) and the short name (`sdk`) count —
+ * Dependabot, Renovate and humans all title these differently.
+ */
+export function matchesBumpPr(prs: readonly PrRef[], pkg: string): boolean {
+  const full = pkg.toLowerCase();
+  const short = (pkg.split("/").pop() ?? pkg).toLowerCase();
+  return prs.some((pr) => {
+    const hay = `${pr.title} ${pr.headRefName}`.toLowerCase();
+    return hay.includes(full) || hay.includes(short);
+  });
+}

--- a/scripts/structure-audit/check-release-staleness.test.ts
+++ b/scripts/structure-audit/check-release-staleness.test.ts
@@ -273,6 +273,12 @@ describe("ageHours", () => {
   test("an unparseable timestamp fails closed to +Infinity", () => {
     expect(ageHours("not-a-date")).toBe(Number.POSITIVE_INFINITY);
   });
+  test("a timestamp with no timezone fails closed rather than being read as local", () => {
+    expect(ageHours("2026-07-26T12:00:00")).toBe(Number.POSITIVE_INFINITY);
+  });
+  test("an explicit numeric offset is accepted", () => {
+    expect(Number.isFinite(ageHours("2020-01-01T00:00:00+02:00"))).toBe(true);
+  });
 });
 
 describe("loadTrainManifest", () => {

--- a/scripts/structure-audit/check-release-staleness.test.ts
+++ b/scripts/structure-audit/check-release-staleness.test.ts
@@ -301,4 +301,26 @@ describe("loadTrainManifest", () => {
     expect(m.trains.length).toBeGreaterThan(0);
     expect(m.trains[0]?.channels.some((c) => c.kind === "winget")).toBe(true);
   });
+  test("parses packages[] with consumers", () => {
+    const m = loadTrainManifest(
+      '{"graceHours":6,"trains":[],"packages":[{"name":"sdk","npm":"@x/sdk","repo":"o/r","tagPattern":"^sdk-v(\\\\d+\\\\.\\\\d+\\\\.\\\\d+)$","consumers":[{"repo":"o/c","lockfile":"bun.lock"}]}]}',
+    );
+    expect(m.packages[0]?.name).toBe("sdk");
+    expect(m.packages[0]?.consumers[0]?.lockfile).toBe("bun.lock");
+  });
+  test("throws when packages is present but not an array", () => {
+    expect(() => loadTrainManifest('{"graceHours":6,"trains":[],"packages":{}}')).toThrow();
+  });
+  test("the committed manifest declares both packages with a capture-group tagPattern", () => {
+    const raw = readFileSync(
+      join(import.meta.dir, "..", "..", ".github", "release-train.json"),
+      "utf8",
+    );
+    const m = loadTrainManifest(raw);
+    expect(m.packages.map((p) => p.name).sort()).toEqual(["client", "sdk"]);
+    for (const p of m.packages) {
+      expect(p.tagPattern).toContain("(");
+      expect(p.consumers.length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -11,24 +11,29 @@
  */
 
 import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+import {
+  ageHours,
+  compareSemver,
+  decideExit,
+  type EdgeResult,
+  type PublishedRelease,
+  type ReleaseInfo,
+  stripV,
+} from "./_release-train-core.ts";
 
-export function stripV(version: string): string {
-  return version.replace(/^v/, "");
-}
-
-/**
- * Semver ordering that never throws. `Bun.semver.order` throws on an unparseable
- * version ("Invalid SemVer: ..."), and channel files are external — a format
- * quirk must degrade to "indeterminate", not crash the whole audit. Returns
- * -1 | 0 | 1, or null when either side is not valid semver.
- */
-export function compareSemver(a: string, b: string): number | null {
-  try {
-    return Bun.semver.order(stripV(a), stripV(b));
-  } catch {
-    return null;
-  }
-}
+// The primitives live in the leaf core module (so the Phase 2 dependency readers
+// can share them without an import cycle), but they are re-exported here so this
+// module path stays the single entry point for the gate's callers and tests.
+export {
+  ageHours,
+  compareSemver,
+  decideExit,
+  type EdgeResult,
+  type EdgeVerdict,
+  type PublishedRelease,
+  type ReleaseInfo,
+  stripV,
+} from "./_release-train-core.ts";
 
 /** `version "X.Y.Z"` from a Homebrew Formula .rb. */
 export function parseBrewVersion(rb: string): string | null {
@@ -67,18 +72,6 @@ export function parseLinuxVersion(packages: string, pkgName = "nimbus-headless")
     }
   }
   return null;
-}
-
-export interface ReleaseInfo {
-  tag: string;
-  prerelease: boolean;
-  draft: boolean;
-  assets: string[];
-  publishedAt: string;
-}
-export interface PublishedRelease {
-  version: string;
-  publishedAt: string;
 }
 
 /**
@@ -126,12 +119,6 @@ export function resolveWingetCoverage(
   return { status: "indeterminate", covered: false };
 }
 
-export type EdgeVerdict = "ok" | "stale" | "phantom" | "indeterminate";
-export interface EdgeResult {
-  edge: string;
-  verdict: EdgeVerdict;
-  detail: string;
-}
 export interface ChannelReading {
   kind: string;
   status: "read" | "absent" | "indeterminate";
@@ -233,32 +220,6 @@ export function evaluateTrain(i: TrainEvalInput): EdgeResult[] {
   return results;
 }
 
-/**
- * Exit decision. Any stale/phantom edge => red. Otherwise green with a warning
- * per indeterminate edge — EXCEPT a run where nothing was evaluable (no ok, only
- * indeterminate) under --strict is red: "indeterminate" must not read as "all
- * clear" in the scheduled sweep (the team-reachability rule).
- */
-export function decideExit(
-  results: EdgeResult[],
-  strict: boolean,
-): { code: 0 | 1; messages: string[] } {
-  const messages: string[] = [];
-  const hard = results.filter((r) => r.verdict === "phantom" || r.verdict === "stale");
-  const indet = results.filter((r) => r.verdict === "indeterminate");
-  const ok = results.filter((r) => r.verdict === "ok");
-  for (const r of hard) messages.push(`::error::${r.edge}: ${r.detail}`);
-  for (const r of indet) messages.push(`::warning::${r.edge}: ${r.detail} (indeterminate)`);
-  if (hard.length > 0) return { code: 1, messages };
-  if (ok.length === 0 && indet.length > 0 && strict) {
-    messages.push(
-      "::error::release-staleness: indeterminate — nothing could be evaluated (all reads failed transiently)",
-    );
-    return { code: 1, messages };
-  }
-  return { code: 0, messages };
-}
-
 export interface ChannelSpec {
   kind: "brew" | "scoop" | "linux" | "winget";
   repo?: string;
@@ -291,18 +252,6 @@ export function loadTrainManifest(json: string): TrainManifest {
     throw new Error("release-train.json: expected { graceHours: number, trains: [...] }");
   }
   return parsed as unknown as TrainManifest;
-}
-
-/**
- * Hours between an ISO-8601 (Z-suffixed) timestamp and now, UTC epoch-ms math.
- * An unparseable date yields `+Infinity` (fail-CLOSED): a NaN age would satisfy
- * `NaN > graceHours === false` and silently mask a phantom/stale state as "ok",
- * so an unreadable timestamp instead forces the aged-check to fire.
- */
-export function ageHours(isoZ: string): number {
-  const t = new Date(isoZ).getTime();
-  if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
-  return (Date.now() - t) / 3_600_000;
 }
 
 /** Decode a GitHub contents API base64 `.content` envelope to UTF-8 text. */

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -237,9 +237,22 @@ export interface TrainSpec {
   };
   channels: ChannelSpec[];
 }
+export interface ConsumerSpec {
+  repo: string;
+  lockfile: string;
+}
+export interface PackageSpec {
+  name: string;
+  npm: string;
+  repo: string;
+  /** Anchored regex with ONE capture group holding the bare version. */
+  tagPattern: string;
+  consumers: ConsumerSpec[];
+}
 export interface TrainManifest {
   graceHours: number;
   trains: TrainSpec[];
+  packages: PackageSpec[];
 }
 
 export function loadTrainManifest(json: string): TrainManifest {
@@ -251,7 +264,14 @@ export function loadTrainManifest(json: string): TrainManifest {
   ) {
     throw new Error("release-train.json: expected { graceHours: number, trains: [...] }");
   }
-  return parsed as unknown as TrainManifest;
+  // `packages` is optional on disk but always an array in memory, so callers
+  // never branch on undefined. A present-but-wrong-shaped value is a hard error
+  // rather than a silent empty list, which would make the Phase 2 edges vanish.
+  const pkgs = parsed["packages"];
+  if (pkgs !== undefined && !Array.isArray(pkgs)) {
+    throw new Error("release-train.json: `packages` must be an array when present");
+  }
+  return { ...(parsed as unknown as TrainManifest), packages: (pkgs ?? []) as PackageSpec[] };
 }
 
 /** Decode a GitHub contents API base64 `.content` envelope to UTF-8 text. */

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -20,6 +20,16 @@ import {
   type ReleaseInfo,
   stripV,
 } from "./_release-train-core.ts";
+import {
+  type ConsumerReading,
+  evaluatePackage,
+  matchesBumpPr,
+  type NpmLatest,
+  type PrRef,
+  parseNpmLatest,
+  resolvedFromBunLock,
+  selectTaggedRelease,
+} from "./_release-train-dep.ts";
 
 // The primitives live in the leaf core module (so the Phase 2 dependency readers
 // can share them without an import cycle), but they are re-exported here so this
@@ -398,6 +408,105 @@ function readPublished(train: TrainSpec): PublishedRelease | null {
   return selectPublished(rels as ReleaseInfo[], train.source.releaseAsset);
 }
 
+/**
+ * npm `@latest` + its publish time. Bounded by an explicit 5s timeout: the
+ * registry is the only dependency here that is neither GitHub nor local, and an
+ * unbounded fetch would hang the sweep job (and a local run, which is worse).
+ * Any timeout, non-200, or malformed body degrades to null -> indeterminate.
+ */
+async function readNpmLatest(pkg: string): Promise<NpmLatest | null> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${pkg}`, {
+      signal: AbortSignal.timeout(5000),
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    return parseNpmLatest(await res.text());
+  } catch {
+    return null;
+  }
+}
+
+/** The upstream repo's highest release whose tag matches the package pattern. */
+function readTaggedRelease(pkg: PackageSpec): PublishedRelease | null {
+  const res = runGh([
+    "gh",
+    "api",
+    `repos/${pkg.repo}/releases?per_page=100`,
+    "--jq",
+    "[.[] | {tag: .tag_name, prerelease: .prerelease, draft: .draft, publishedAt: .published_at, assets: [.assets[].name]}]",
+  ]);
+  if (!res.ok) return null;
+  try {
+    const rels: unknown = JSON.parse(res.stdout);
+    if (!Array.isArray(rels)) return null;
+    return selectTaggedRelease(rels as ReleaseInfo[], pkg.tagPattern);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How many open PRs we ask for. Named so the truncation guard below can compare
+ * against the exact same number.
+ */
+const PR_LIST_LIMIT = 100;
+
+/**
+ * Is there an open PR in `repo` that looks like a bump of `npm`?
+ * `null` means "cannot tell" — the caller must degrade to indeterminate rather
+ * than concluding "no bump PR", which would turn an unknown into a `stale`.
+ *
+ * Deliberately NOT `gh pr list --search`: matching happens in memory (see
+ * `matchesBumpPr`) so the gate does not depend on GitHub's opaque relevance
+ * ranker, per the design review. The cost of that choice is the page limit
+ * below, which is why truncation is detected instead of ignored.
+ */
+function readBumpPrOpen(repo: string, npm: string): boolean | null {
+  const res = runGh([
+    "gh",
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--limit",
+    String(PR_LIST_LIMIT),
+    "--json",
+    "title,headRefName",
+  ]);
+  if (!res.ok) return null;
+  try {
+    const prs: unknown = JSON.parse(res.stdout);
+    if (!Array.isArray(prs)) return null;
+    if (matchesBumpPr(prs as PrRef[], npm)) return true;
+    // A full page means the list may have been cut off, so "not found" is not
+    // trustworthy — report unknown rather than a false negative that would
+    // present as staleness.
+    return prs.length >= PR_LIST_LIMIT ? null : false;
+  } catch {
+    return null;
+  }
+}
+
+/** One consumer's lockfile-resolved version of `npm`. */
+function readConsumer(c: ConsumerSpec, npm: string): ConsumerReading {
+  const res = runGh(["gh", "api", `repos/${c.repo}/contents/${c.lockfile}`, "--jq", ".content"]);
+  if (!res.ok) {
+    // 404 => the lockfile itself is missing (a real finding). Anything else is
+    // transient and must not be reported as staleness.
+    const kind = classifyReadFailure(res.httpStatus);
+    return { repo: c.repo, status: kind, resolved: null, bumpPrOpen: false };
+  }
+  const resolved = resolvedFromBunLock(decodeContents(res.stdout), npm);
+  if (resolved === null) {
+    // Parsed fine, no entry for the package => the manifest is wrong, not the repo.
+    return { repo: c.repo, status: "not-a-dependency", resolved: null, bumpPrOpen: false };
+  }
+  return { repo: c.repo, status: "read", resolved, bumpPrOpen: readBumpPrOpen(c.repo, npm) };
+}
+
 if (import.meta.main) {
   const strict = isStrict(process.argv.slice(2), process.env);
   const label = "audit:release-staleness";
@@ -431,6 +540,25 @@ if (import.meta.main) {
         published,
         publishedAgeHours,
         channels,
+        graceHours: manifest.graceHours,
+      }),
+    );
+  }
+
+  for (const pkg of manifest.packages) {
+    const latest = await readNpmLatest(pkg.npm);
+    const taggedRelease = readTaggedRelease(pkg);
+    const consumers = pkg.consumers.map((c) => readConsumer(c, pkg.npm));
+
+    allResults.push(
+      ...evaluatePackage({
+        name: pkg.name,
+        npm: pkg.npm,
+        taggedRelease,
+        taggedReleaseAgeHours: taggedRelease ? ageHours(taggedRelease.publishedAt) : null,
+        latest,
+        latestAgeHours: latest ? ageHours(latest.publishedAt) : null,
+        consumers,
         graceHours: manifest.graceHours,
       }),
     );


### PR DESCRIPTION
## Summary

P2 Release Train **Phase 2**. Phase 1 (#836) watches whether a gateway release reaches brew/scoop/linux/winget. This extends the *same* `audit:release-staleness` gate to the other propagation graph the org runs — the npm packages `@nimbus-dev/sdk` and `@nimbus-dev/client` and the repos that consume them — with two new edge kinds:

- **`<pkg>:publish`** — the upstream component-prefixed release tag vs npm `@latest`. Catches a package that is *tagged but never published to npm*, the npm analogue of the release phantom Phase 1 catches. It has to be its own edge: if a package is tagged and never published, every consumer edge reads green, because npm is stale in exactly the same way the consumers are.
- **`<pkg>:<consumer>`** — each consuming repo's **lockfile-resolved** version vs npm `@latest`. The lockfile, not the `package.json` range, because a range misleads in *both* directions: `^1.2.0` permits a newer `1.3.0` (false positive), while a caret on a `0.x` **pins the minor**, so `^0.5.0` cannot reach `0.12.1` at all (the live case).

The evaluation engine is unchanged — Phase 2 emits ordinary `EdgeResult`s into the same `decideExit`, so exit semantics, the strict rule, and the annotation format are identical by construction.

## ⚠️ This gate ships RED, and that is the point

**Do not read the red as a broken gate.** It is detecting confirmed drift (owner-confirmed 2026-07-26 — drift, not deliberate pins). Phase 1 shipped red the same way and caught a genuine phantom on its first run.

Live proof, `2026-07-26 16:41Z`, verbatim:

```
::error::client:nimbus-vscode: 0.11.0 < npm 0.12.1 and no bump PR open
::error::client:Nimbus: 0.5.0 < npm 0.12.1 and no bump PR open
EXIT=1
```

Everything else evaluated `ok` — no `::warning::` lines, so no edge was indeterminate. Full edge table at run time:

| edge | verdict | detail |
| --- | --- | --- |
| `sdk:publish` | ok | tag 1.7.0 published as 1.7.0 |
| `sdk:nimbus-client` | ok | npm 1.7.0 within 6h grace (resolves 1.6.0) |
| `sdk:nimbus-vscode` | ok | npm 1.7.0 within 6h grace (resolves 1.5.2) |
| `sdk:Nimbus` | ok | npm 1.7.0 within 6h grace (resolves 1.6.0) |
| `client:publish` | ok | tag 0.12.1 published as 0.12.1 |
| **`client:nimbus-vscode`** | **stale** | 0.11.0 < npm 0.12.1, no bump PR |
| **`client:Nimbus`** | **stale** | 0.5.0 < npm 0.12.1, no bump PR |

plus all five Phase 1 edges green.

**One deviation from the plan's predicted output, and it is the grace rule working.** The plan expected `sdk:nimbus-vscode` red as a third edge. Between the plan being written and the gate being run, `@nimbus-dev/sdk` **1.7.0 was published** (15:52Z, 0.8h before the run), so the 6h grace window correctly suppressed all three sdk consumer edges — a package published minutes ago must not red its entire consumer set. All three consumers are nevertheless behind 1.7.0, so **those edges go red once grace expires unless they are bumped**. The drift is larger than the design's snapshot recorded, not smaller.

### Remediation folded in / opened alongside

The sdk drift is fixed rather than left to expire into red:

- **This PR** — `bun.lock` resolves sdk 1.6.0 → **1.7.0**. Lockfile-only: every declared range here is a caret on `1.x` (`^1.3.0` across connectors, `^1.5.0` cli, `^1.6.0` gateway), all of which already permit 1.7.0. (`bun update` also injects sdk into the *root* `package.json`; that edit was reverted on purpose — the root is a workspace shell that doesn't consume it.) Verified: typecheck exit 0 across all 96 packages, 933 connector tests pass.
- **nimbus-agent/nimbus-client#38** — lockfile-only refresh to sdk 1.7.0. Declared floor deliberately left at `^1.6.0`: it's a published library, and requiring `>=1.7.0` of *its* consumers is a semver statement nothing needs. 396 tests pass.
- **nimbus-agent/nimbus-vscode#58** — `@nimbus-dev/client` `^0.11.0` → `^0.12.1`, which re-resolves sdk 1.5.2 → 1.7.0 underneath. This one needed a **manifest** edit: a caret on a `0.x` pins the minor, so `^0.11.0` could never reach 0.12.1 — the range was itself the blocker, exactly the failure mode this gate exists to surface. 638 vitest tests pass, bundle verified.

Note the `sdk:Nimbus` edge only flips green **on merge** — the gate reads consumers' lockfiles from GitHub's default branch, not a working tree.

**Still red after all of the above:** `client:Nimbus` (0.5.0 → 0.12.1 in `packages/cli`). Seven minors on a `0.x`, so it may touch call sites and deserves its own PR with real review. P2 detects; that remediation stays manual.

## Notes for Reviewers

**The lockfile reader is workspace-scoped, and that subtlety is load-bearing.** A `bun.lock` resolution key is a dependency *path*: a bare key is the hoisted copy, `<prefix>/<pkg>` is the copy `<prefix>` resolved. Only the hoisted entry plus entries whose prefix is one of the consumer's **own workspace names** count. A lower version nested under a *third-party* package is that package's business, not ours — counting it would report a version no local code resolves. Confirmed live: this repo's hoisted sdk is `1.6.0` while the copy inside `@nimbus-dev/client` is `1.3.0`, and the gate correctly reports `1.6.0`. There is a test for exactly this.

**`stripTrailingCommas` is a string-aware scanner, not a regex, on purpose.** A real `bun.lock` carries trailing commas, so plain `JSON.parse` throws. The obvious `/,(\s*[}\]])/g` fails *silently*: it also eats a comma inside a string value ending in `", }"`, and the corrupted result still parses. A corrupted-but-parseable lockfile is precisely the defect class this gate exists to prevent, so the parser must not introduce one. Please don't "simplify" it back.

**Task 1 is a verbatim move, proven by test count.** `stripV`/`compareSemver`/`ageHours`/`decideExit` + the `EdgeResult` vocabulary moved into a leaf `_release-train-core.ts` so the Phase 1 file and the Phase 2 file can share them without an import cycle; `check-release-staleness.ts` re-exports them so no caller path changed. 39 tests before the move, 39 after.

**One behaviour change rides along:** `ageHours` now fails closed on a timestamp with no explicit zone. `new Date("2026-07-26T12:00:00")` parses as **local** time, so the age would differ by up to 14h between a laptop and a UTC runner — enough to move an edge across the 6h grace boundary. Both real sources (GitHub `published_at`, npm `time[version]`) are `Z`-suffixed, so no production edge changes.

**Failure model is fail-closed in Phase 1's direction.** Registry unreachable / non-JSON → `indeterminate`, never `stale`. Lockfile 404 → `absent` → `stale`. A lockfile that parses cleanly but has no entry for the package is a **manifest error**, and says so explicitly (`remove this consumer from release-train.json`) rather than sharing wording with a read failure. A full PR page is treated as possibly-truncated, so "no bump PR found" degrades to `indeterminate` rather than manufacturing a `stale`. npm reads carry a mandatory 5s timeout — the registry is the one dependency here that is neither GitHub nor local, and the gate runs locally, where a hang is worse than a red.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome) — validated as `bunx biome check --error-on-warnings packages scripts .github docs`, 2963 files clean; the packaged `bun run lint` script reports "Checked 0 files" and exits 1 inside a `.claude/worktrees/` checkout, a known local-only false-fail
- [x] All existing tests pass — 219 pass across `scripts/structure-audit/` (79 are this gate's: 44 + 35); 933 connector tests pass against the bumped sdk
- [x] New behaviour is covered by tests
- [x] No `any` types introduced — external JSON is narrowed with `isRecord`
- [x] No credentials, tokens, or secret values in logs/IPC/config/fixtures — all reads are public and unauthenticated
- [x] Platform-specific code behind `PlatformServices` — n/a, no OS-specific logic
- [x] The HITL consent gate has not been weakened — n/a, no engine surface touched

## Coverage

n/a — no `engine/` or `vault/` change. `scripts/` is covered by the existing `bun test scripts/structure-audit/` run; no new coverage-gate wiring needed.

## Testing

- `bun test scripts/structure-audit/` — 219 pass, 0 fail (79 in the two files this PR touches: 44 in `check-release-staleness.test.ts`, 35 in `_release-train-dep.test.ts`).
- `bunx tsc -p scripts/tsconfig.json --noEmit` — exit 0.
- `bun run lint:markdown` — 0 errors; `bun run audit:doc-refs` — 618 refs across 16 docs all resolve; `lychee --config lychee.toml 'docs/**/*.md' '*.md'` — 1054 links, 0 errors.
- **Live run against the real graph** — output above, exit 1 on two confirmed-stale edges.
- **Degradation path** — with `gh` unavailable the reachability probe short-circuits before any Phase 2 read: `::warning::` + exit 0 locally, `::error::` + exit 1 under `--strict`. No stack trace either way.

## Related Issue

Relates to P2 Release Train (`docs/infrastructure-roadmap.md`), Phase 1 shipped in #836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
