### PR TITLE
feat(audit): action-pin freshness — pinned is not the same as current

### DIFF
--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -189,3 +189,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bun scripts/structure-audit/check-release-staleness.ts --strict
+
+  pin-freshness:
+    name: pin-freshness
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # No App token: every read (each pinned action's latest release + tag) is
+      # PUBLIC. Results are cached per action, so this is a handful of requests.
+      - name: Audit action-pin freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/structure-audit/check-pin-freshness.ts --strict

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "audit:cross-platform": "bun scripts/audit/check-cross-platform.ts",
     "audit:status-drift": "bun scripts/structure-audit/check-status-drift.ts",
     "audit:action-sha-pins": "bun scripts/structure-audit/check-action-sha-pins.ts",
+    "audit:pin-freshness": "bun scripts/structure-audit/check-pin-freshness.ts",
     "audit:consumed-by": "bun scripts/structure-audit/check-consumed-by.ts",
     "audit:ruleset-drift": "bun scripts/structure-audit/check-ruleset-drift.ts",
     "audit:org-settings-drift": "bun scripts/structure-audit/check-org-settings-drift.ts",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -67,6 +67,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:org-settings-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:team-reachability", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:cla-coverage", // needs network + gh (reads each public repo's cla.yml, contents:read); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:pin-freshness", // needs network + gh (release + tag reads per pinned action); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
 ];
 

--- a/scripts/structure-audit/check-pin-freshness.test.ts
+++ b/scripts/structure-audit/check-pin-freshness.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectPinnedActions,
+  DEFAULT_GRACE_DAYS,
+  evaluatePin,
+  type PinnedAction,
+  parseCommitDate,
+  parseLatestRelease,
+  parseTagObjectType,
+  parseTagSha,
+  summarize,
+} from "./check-pin-freshness.ts";
+
+const pin = (over: Partial<PinnedAction> = {}): PinnedAction => ({
+  ownerRepo: "actions/checkout",
+  sha: "a".repeat(40),
+  file: "ci.yml",
+  ...over,
+});
+
+describe("collectPinnedActions", () => {
+  test("collects a SHA-pinned third-party ref with its owner/repo", () => {
+    const p = collectPinnedActions([
+      { path: "ci.yml", text: `  - uses: actions/checkout@${"a".repeat(40)} # v7.0.1\n` },
+    ]);
+    expect(p).toEqual([{ ownerRepo: "actions/checkout", sha: "a".repeat(40), file: "ci.yml" }]);
+  });
+
+  test("reduces a subdirectory action to its owner/repo", () => {
+    const p = collectPinnedActions([
+      { path: "a.yml", text: `  - uses: github/codeql-action/init@${"b".repeat(40)}\n` },
+    ]);
+    expect(p[0]?.ownerRepo).toBe("github/codeql-action");
+  });
+
+  test("ignores tag-pinned refs — that is the EXISTING gate's job, not this one", () => {
+    expect(
+      collectPinnedActions([{ path: "a.yml", text: "  - uses: actions/checkout@v4\n" }]),
+    ).toEqual([]);
+  });
+
+  test("ignores local and docker refs", () => {
+    const p = collectPinnedActions([
+      { path: "a.yml", text: "  - uses: ./.github/actions/x\n  - uses: docker://alpine:3\n" },
+    ]);
+    expect(p).toEqual([]);
+  });
+
+  test("deduplicates one action pinned to the same SHA in several files", () => {
+    const sha = "c".repeat(40);
+    const p = collectPinnedActions([
+      { path: "a.yml", text: `  - uses: o/r@${sha}\n` },
+      { path: "b.yml", text: `  - uses: o/r@${sha}\n` },
+    ]);
+    expect(p).toHaveLength(1);
+  });
+
+  test("keeps two DIFFERENT pins of the same action — that is itself drift", () => {
+    const p = collectPinnedActions([
+      { path: "a.yml", text: `  - uses: o/r@${"a".repeat(40)}\n` },
+      { path: "b.yml", text: `  - uses: o/r@${"b".repeat(40)}\n` },
+    ]);
+    expect(p).toHaveLength(2);
+  });
+});
+
+describe("evaluatePin", () => {
+  const sha = "a".repeat(40);
+  const old = "2020-01-01T00:00:00Z";
+  const fresh = new Date(Date.now() - 2 * 86_400_000).toISOString();
+
+  test("pinned to the latest release SHA => ok", () => {
+    const r = evaluatePin(
+      pin({ sha }),
+      { tag: "v7.0.1", publishedAt: old },
+      sha,
+      DEFAULT_GRACE_DAYS,
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  test("behind a release older than grace => stale, naming both versions", () => {
+    const r = evaluatePin(pin({ sha }), { tag: "v7.0.1", publishedAt: old }, "b".repeat(40), 30);
+    expect(r.verdict).toBe("stale");
+    expect(r.detail).toContain("v7.0.1");
+  });
+
+  test("behind a release published INSIDE the grace window => ok", () => {
+    // A release cut two days ago must not red the org: humans and Dependabot
+    // need time to move, and a gate that reds instantly is one people mute.
+    const r = evaluatePin(pin({ sha }), { tag: "v8.0.0", publishedAt: fresh }, "b".repeat(40), 30);
+    expect(r.verdict).toBe("ok");
+  });
+
+  test("unreadable release => indeterminate, never stale", () => {
+    expect(evaluatePin(pin(), null, null, 30).verdict).toBe("indeterminate");
+  });
+
+  test("release readable but its tag SHA is not => indeterminate", () => {
+    const r = evaluatePin(pin(), { tag: "v1", publishedAt: old }, null, 30);
+    expect(r.verdict).toBe("indeterminate");
+  });
+
+  test("an unparseable publish date fails closed to stale, not silently ok", () => {
+    // Mirrors ageHours in the release-train core: a NaN age would satisfy
+    // `NaN > grace === false` and mask staleness as current.
+    const r = evaluatePin(
+      pin({ sha }),
+      { tag: "v9", publishedAt: "not-a-date" },
+      "b".repeat(40),
+      30,
+    );
+    expect(r.verdict).toBe("stale");
+  });
+
+  test("a timestamp with no timezone also fails closed", () => {
+    const r = evaluatePin(
+      pin({ sha }),
+      { tag: "v9", publishedAt: "2020-01-01T00:00:00" },
+      "b".repeat(40),
+      30,
+    );
+    expect(r.verdict).toBe("stale");
+  });
+});
+
+describe("summarize", () => {
+  const res = (verdict: "ok" | "stale" | "indeterminate") => ({
+    ownerRepo: "o/r",
+    verdict,
+    detail: "d",
+  });
+
+  test("any stale pin => exit 1", () => {
+    expect(summarize([res("ok"), res("stale")], true).code).toBe(1);
+  });
+
+  test("ok + indeterminate => exit 0 with a warning", () => {
+    const out = summarize([res("ok"), res("indeterminate")], true);
+    expect(out.code).toBe(0);
+    expect(out.messages.join("\n")).toContain("::warning::");
+  });
+
+  test("nothing evaluable under --strict => exit 1, not 'all clear'", () => {
+    expect(summarize([res("indeterminate")], true).code).toBe(1);
+  });
+
+  test("nothing evaluable when NOT strict => exit 0 (soft locally)", () => {
+    expect(summarize([res("indeterminate")], false).code).toBe(0);
+  });
+});
+
+describe("parseLatestRelease / parseTagSha", () => {
+  test("reads tag_name and published_at", () => {
+    expect(
+      parseLatestRelease('{"tag_name":"v7.0.1","published_at":"2026-01-01T00:00:00Z"}'),
+    ).toEqual({ tag: "v7.0.1", publishedAt: "2026-01-01T00:00:00Z" });
+  });
+  test("null on malformed json or a missing tag", () => {
+    expect(parseLatestRelease("{nope")).toBeNull();
+    expect(parseLatestRelease("{}")).toBeNull();
+  });
+  test("reads a lightweight tag's commit sha", () => {
+    expect(parseTagSha(`{"object":{"sha":"${"a".repeat(40)}","type":"commit"}}`)).toBe(
+      "a".repeat(40),
+    );
+  });
+  test("null on malformed json", () => {
+    expect(parseTagSha("{nope")).toBeNull();
+  });
+  test("reads an annotated tag's object type so it can be dereferenced", () => {
+    expect(parseTagObjectType(`{"object":{"sha":"x","type":"tag"}}`)).toBe("tag");
+    expect(parseTagObjectType(`{"object":{"sha":"x","type":"commit"}}`)).toBe("commit");
+  });
+});
+
+describe("parseCommitDate", () => {
+  test("reads commit.committer.date", () => {
+    expect(parseCommitDate('{"commit":{"committer":{"date":"2026-07-01T00:00:00Z"}}}')).toBe(
+      "2026-07-01T00:00:00Z",
+    );
+  });
+  test("null on malformed json or a missing date", () => {
+    expect(parseCommitDate("{nope")).toBeNull();
+    expect(parseCommitDate('{"commit":{}}')).toBeNull();
+  });
+});

--- a/scripts/structure-audit/check-pin-freshness.ts
+++ b/scripts/structure-audit/check-pin-freshness.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:pin-freshness — a SHA-pinned action must be pinned to something CURRENT.
+ *
+ * `audit:action-sha-pins` proves every `uses:` is a 40-hex SHA rather than a
+ * moving tag. It is structurally unable to notice that the SHA is two years
+ * old: to that gate an ancient pin and a fresh pin are identical. P1's first
+ * sweep recorded exactly this — `harden-runner` v2.20.0 vs v2.19.4,
+ * `actions/checkout` v7.0.1 vs v7.0.0 — and classified it as staleness rather
+ * than unpinning, deferring a freshness check as "Plan B". This is that check.
+ *
+ * The two gates are complementary and deliberately separate: pinning is a
+ * SECURITY property (a moving tag is a supply-chain hole) and is checkable
+ * offline, so it stays in the local fast tier. Freshness is a MAINTENANCE
+ * property needing network, so it runs in the scheduled sweep.
+ *
+ * See docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
+/**
+ * How stale a pin may be before it is a finding.
+ *
+ * 30 days, not the release-train's 6 hours, because these are different failure
+ * classes. A release-train edge is an automated pipeline that should propagate
+ * in minutes, so hours of lag is a defect. An action pin moves when a human or
+ * Dependabot updates it; a 6-hour window would mean a permanently red sweep,
+ * and a gate that is always red is one everybody learns to ignore. Thirty days
+ * says "this pin sat through a full release cycle and nobody noticed", which is
+ * the condition actually worth alerting on.
+ */
+export const DEFAULT_GRACE_DAYS = 30;
+
+export interface PinnedAction {
+  ownerRepo: string;
+  sha: string;
+  file: string;
+}
+
+export interface LatestRelease {
+  tag: string;
+  publishedAt: string;
+}
+
+export type PinVerdict = "ok" | "stale" | "indeterminate";
+
+export interface PinResult {
+  ownerRepo: string;
+  verdict: PinVerdict;
+  detail: string;
+}
+
+export interface WorkflowFile {
+  path: string;
+  text: string;
+}
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+/** ISO-8601 carrying an explicit UTC designator or numeric offset. */
+const HAS_TIMEZONE = /(?:Z|[+-]\d{2}:?\d{2})$/;
+
+/**
+ * Days between an ISO-8601 timestamp and now, UTC epoch-ms.
+ *
+ * Fails CLOSED to `+Infinity` on anything unreadable — including a timestamp
+ * with no explicit zone, which would otherwise parse as LOCAL time and differ
+ * by up to 14h between a laptop and a UTC runner. `+Infinity`, not `-Infinity`:
+ * the age is compared with `age > graceDays`, so a NaN or `-Infinity` age would
+ * satisfy `> grace === false` and silently mask a stale pin as CURRENT. An
+ * unreadable date must instead push the pin past grace.
+ */
+function daysSince(iso: string): number {
+  if (!HAS_TIMEZONE.test(iso.trim())) return Number.POSITIVE_INFINITY;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - t) / 86_400_000;
+}
+
+function collectYaml(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...collectYaml(full));
+    else if (entry.endsWith(".yml") || entry.endsWith(".yaml")) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Every SHA-pinned third-party action, reduced to `owner/repo` + the pinned SHA.
+ *
+ * Tag-pinned refs are skipped: an unpinned ref is `audit:action-sha-pins`'s
+ * finding, and reporting it here too would double-count one defect. Two
+ * DIFFERENT pins of the same action are both kept — that divergence is itself
+ * drift worth seeing.
+ */
+export function collectPinnedActions(files: readonly WorkflowFile[]): PinnedAction[] {
+  const usesRe = /^\s*-?\s*uses:\s*["']?([^"'\s#]+)["']?/gm;
+  const out: PinnedAction[] = [];
+  const seen = new Set<string>();
+  for (const f of files) {
+    for (const m of f.text.matchAll(usesRe)) {
+      const ref = m[1];
+      if (!ref || ref.startsWith("./") || ref.startsWith(".\\") || ref.startsWith("docker://")) {
+        continue;
+      }
+      const at = ref.lastIndexOf("@");
+      if (at <= 0) continue;
+      const sha = ref.slice(at + 1);
+      if (!SHA_RE.test(sha)) continue;
+      const parts = ref.slice(0, at).split("/");
+      if (parts.length < 2) continue;
+      const ownerRepo = `${parts[0]}/${parts[1]}`;
+      const key = `${ownerRepo}@${sha}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ ownerRepo, sha, file: f.path });
+    }
+  }
+  return out;
+}
+
+export function evaluatePin(
+  pin: PinnedAction,
+  latest: LatestRelease | null,
+  latestSha: string | null,
+  graceDays: number,
+): PinResult {
+  if (latest === null) {
+    return {
+      ownerRepo: pin.ownerRepo,
+      verdict: "indeterminate",
+      detail: `no readable latest release for ${pin.ownerRepo}`,
+    };
+  }
+  if (latestSha === null) {
+    return {
+      ownerRepo: pin.ownerRepo,
+      verdict: "indeterminate",
+      detail: `cannot resolve ${pin.ownerRepo}@${latest.tag} to a commit SHA`,
+    };
+  }
+  if (latestSha === pin.sha) {
+    return {
+      ownerRepo: pin.ownerRepo,
+      verdict: "ok",
+      detail: `${pin.ownerRepo} pinned to ${latest.tag}`,
+    };
+  }
+  const age = daysSince(latest.publishedAt);
+  if (age > graceDays) {
+    return {
+      ownerRepo: pin.ownerRepo,
+      verdict: "stale",
+      detail: `${pin.ownerRepo} is pinned to ${pin.sha.slice(0, 7)} but ${latest.tag} has been out ${Math.round(age)}d (> ${graceDays}d grace) — ${pin.file}`,
+    };
+  }
+  return {
+    ownerRepo: pin.ownerRepo,
+    verdict: "ok",
+    detail: `${pin.ownerRepo} behind ${latest.tag}, published ${Math.max(0, Math.round(age))}d ago (within ${graceDays}d grace)`,
+  };
+}
+
+/** Same exit contract as the release-train gate, for one obvious reason: consistency. */
+export function summarize(
+  results: readonly PinResult[],
+  strict: boolean,
+): { code: 0 | 1; messages: string[] } {
+  const messages: string[] = [];
+  const stale = results.filter((r) => r.verdict === "stale");
+  const indet = results.filter((r) => r.verdict === "indeterminate");
+  const ok = results.filter((r) => r.verdict === "ok");
+  for (const r of stale) messages.push(`::error::${r.detail}`);
+  for (const r of indet) messages.push(`::warning::${r.detail} (indeterminate)`);
+  if (stale.length > 0) return { code: 1, messages };
+  if (ok.length === 0 && indet.length > 0 && strict) {
+    messages.push("::error::audit:pin-freshness: nothing could be evaluated (all reads failed)");
+    return { code: 1, messages };
+  }
+  return { code: 0, messages };
+}
+
+export function parseLatestRelease(json: string): LatestRelease | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const tag = p["tag_name"];
+    const publishedAt = p["published_at"];
+    if (typeof tag !== "string") return null;
+    return { tag, publishedAt: typeof publishedAt === "string" ? publishedAt : "" };
+  } catch {
+    return null;
+  }
+}
+
+/** A git ref's object SHA. An ANNOTATED tag points at a tag object, not a commit. */
+export function parseTagSha(json: string): string | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const obj = p["object"];
+    if (!isRecord(obj)) return null;
+    const sha = obj["sha"];
+    return typeof sha === "string" ? sha : null;
+  } catch {
+    return null;
+  }
+}
+
+/** `commit.committer.date` from a commit object. */
+export function parseCommitDate(json: string): string | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const commit = p["commit"];
+    if (!isRecord(commit)) return null;
+    const committer = commit["committer"];
+    if (!isRecord(committer)) return null;
+    const d = committer["date"];
+    return typeof d === "string" ? d : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseTagObjectType(json: string): string | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const obj = p["object"];
+    if (!isRecord(obj)) return null;
+    const t = obj["type"];
+    return typeof t === "string" ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The commit a release tag points at. An annotated tag resolves to a tag object
+ * first, so it needs a second dereference — comparing a pin against the tag
+ * OBJECT's sha would report every annotated-tag action as stale forever.
+ */
+function readTagCommitSha(ownerRepo: string, tag: string): string | null {
+  const res = runGh(["gh", "api", `repos/${ownerRepo}/git/ref/tags/${tag}`]);
+  if (!res.ok) return null;
+  const sha = parseTagSha(res.stdout);
+  if (sha === null) return null;
+  if (parseTagObjectType(res.stdout) !== "tag") return sha;
+
+  const deref = runGh(["gh", "api", `repos/${ownerRepo}/git/tags/${sha}`]);
+  if (!deref.ok) return null;
+  return parseTagSha(deref.stdout);
+}
+
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const label = "audit:pin-freshness";
+  const root = join(import.meta.dir, "..", "..");
+
+  const probe = runGh(["gh", "api", "repos/actions/checkout", "--jq", ".name"]);
+  if (!probe.ok) {
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const files = [
+    ...collectYaml(join(root, ".github/workflows")),
+    ...collectYaml(join(root, ".github/actions")),
+  ].map((f) => ({ path: f.slice(root.length + 1), text: readFileSync(f, "utf8") }));
+
+  const results: PinResult[] = [];
+  // One release lookup per distinct action, not per call site — the same action
+  // appears in a dozen workflows and the API is rate-limited.
+  const cache = new Map<
+    string,
+    { latest: LatestRelease | null; sha: string | null; skip?: boolean }
+  >();
+
+  for (const pin of collectPinnedActions(files)) {
+    let entry = cache.get(pin.ownerRepo);
+    if (!entry) {
+      const relRes = runGh(["gh", "api", `repos/${pin.ownerRepo}/releases/latest`]);
+      if (!relRes.ok && classifyReadFailure(relRes.httpStatus) === "absent") {
+        // The repo publishes no releases at all (our own `nimbus-agent/.github`
+        // composite actions, for one). There is nothing to be behind, and no
+        // amount of retrying changes that — so skip it rather than warn
+        // forever. A permanent unknown reported as indeterminate is noise that
+        // trains people to ignore the gate.
+        cache.set(pin.ownerRepo, { latest: null, sha: null, skip: true });
+        continue;
+      }
+      const latest = relRes.ok ? parseLatestRelease(relRes.stdout) : null;
+      const sha = latest ? readTagCommitSha(pin.ownerRepo, latest.tag) : null;
+
+      // Measure grace from the TARGET COMMIT's date, not the release's
+      // published_at. Many actions ship a ROLLING major tag: `dtolnay/rust-toolchain`'s
+      // latest release is `v1` from 2022, but the tag has moved many times
+      // since. Using the release date there would report "v1 has been out
+      // 1472d" — technically true, wildly misleading, and it makes the grace
+      // window meaningless. The commit's own date answers the question the gate
+      // is actually asking: how long has the thing you should be pinned to been
+      // available? Falls back to the release date when the commit is unreadable.
+      let availableSince = latest?.publishedAt ?? "";
+      if (sha !== null) {
+        const commitRes = runGh(["gh", "api", `repos/${pin.ownerRepo}/commits/${sha}`]);
+        const d = commitRes.ok ? parseCommitDate(commitRes.stdout) : null;
+        if (d !== null) availableSince = d;
+      }
+      entry = { latest: latest ? { ...latest, publishedAt: availableSince } : null, sha };
+      cache.set(pin.ownerRepo, entry);
+    }
+    if (entry.skip) continue;
+    results.push(evaluatePin(pin, entry.latest, entry.sha, DEFAULT_GRACE_DAYS));
+  }
+
+  const out = summarize(results, strict);
+  for (const m of out.messages) (m.startsWith("::error::") ? console.error : console.warn)(m);
+  if (out.code === 0) {
+    const current = results.filter((r) => r.verdict === "ok").length;
+    console.log(`${label}: OK (${current}/${results.length} pins current)`);
+  }
+  process.exit(out.code);
+}


### PR DESCRIPTION
## Summary

`audit:action-sha-pins` proves every `uses:` is a 40-hex SHA rather than a moving tag. It is **structurally unable** to notice that the SHA is two years old — to that gate, an ancient pin and a fresh pin are identical.

P1's first sweep recorded exactly this (`harden-runner` v2.20.0 vs v2.19.4, `actions/checkout` v7.0.1 vs v7.0.0), classified it as *staleness* rather than *unpinning*, and deferred a freshness check as **"Plan B"**. This is that check.

The two gates stay separate on purpose: **pinning is a security property** (a moving tag is a supply-chain hole) and is checkable offline, so it stays in the local fast tier. **Freshness is a maintenance property** needing network, so it runs in the scheduled sweep.

## ⚠️ Ships RED on three real stale pins

A sweep gate, so red here does **not** block PRs:

```
::error::actions/cache is pinned to 27d5ce7 but v6.1.0 has been out 33d (> 30d grace) — .github/workflows/ci.yml
::error::dtolnay/rust-toolchain is pinned to 29eef33 but v1 has been out 338d (> 30d grace) — .github/workflows/codeql.yml
::error::actions/attest-build-provenance is pinned to a2bbfa2 but v4.1.1 has been out 30d (> 30d grace) — .github/workflows/release.yml
```

Bumping them is separate, reviewed work — a pin bump needs its own CI run to prove the new SHA behaves.

## Three corrections that came from running it

Each changed a reported number, and each is the kind of thing that only shows up on contact with the real graph.

**1. Grace is measured from the target commit's date, not the release's `published_at`.** Many actions ship a **rolling major tag**: `dtolnay/rust-toolchain`'s latest release is `v1` from 2022, but the tag has moved many times since. Using the release date reported *"v1 has been out 1472d"* — technically true, wildly misleading, and it makes the grace window meaningless for every rolling-tag action. The commit's own date answers the question the gate is actually asking — *how long has the thing you should be pinned to been available?* — and now reports **338d**.

**2. A repo that publishes no releases is skipped, not reported `indeterminate`.** Our own `nimbus-agent/.github` composite actions have none. There is nothing to be behind, and no amount of retrying changes that, so warning forever would be pure noise. (Same lesson as the `unverifiable` verdict in #845: a permanent unknown must not be reported as a transient one.)

**3. `daysSince` fails closed to `+Infinity`, not `-Infinity`.** My first version had the sign inverted, so an unreadable date made the age *smaller* than grace and reported the pin as **current** — fail-open, the exact inversion the release-train's `ageHours` comment warns about. The tests caught it; the comment now explains why the direction matters.

## Design notes

- **Grace: 30 days**, not the release train's 6 hours. Different failure classes — a release-train edge is an automated pipeline that should propagate in minutes, so hours of lag is a defect; an action pin moves when a human or Dependabot gets to it, and a 6-hour window would mean a permanently red sweep.
- **Annotated tags are dereferenced.** A release tag can point at a *tag object*, not a commit; comparing the pin against the tag object's SHA would report every annotated-tag action as stale forever.
- **Tag-pinned refs are ignored** — an unpinned ref is `audit:action-sha-pins`'s finding, and reporting it here too would double-count one defect.
- **One release lookup per distinct action**, cached — the same action appears in a dozen workflows and the API is rate-limited.
- Two *different* pins of the same action are both kept: that divergence is itself drift worth seeing.

## Testing

- `bun test scripts/` — **654 pass, 20 skip, 0 fail** (24 new)
- `bunx tsc -p scripts/tsconfig.json --noEmit` — exit 0
- biome — clean
- Live run above; no-`gh` degradation returns `::warning::` + exit 0 locally, red under `--strict`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` (Biome) — clean via `bunx biome check --error-on-warnings scripts .github`
- [x] All existing tests pass — 654
- [x] New behaviour is covered by tests — 24
- [x] No `any` — external JSON narrowed with `isRecord`
- [x] No credentials in logs/IPC/config — all reads public
- [x] Platform-specific code behind `PlatformServices` — n/a
- [x] HITL gate untouched — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)